### PR TITLE
content: Update docs for v1.3.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Ferry can **pause and resume** — close it anytime, pick up where you left off.
 |---------|--------|
 | Text channels | Supported |
 | Categories | Supported |
-| Roles (with colours) | Supported |
+| Roles (with colours and permissions) | Supported — Discord permissions translated to Stoat equivalents |
+| Channel permissions | Supported — per-role and @everyone overrides migrated |
+| NSFW channels | Supported — NSFW flag set during channel creation |
 | Messages + author names | Supported (each message shows the original author's name and avatar) |
 | File attachments | Supported |
 | Custom emoji | Supported (up to 100) |
@@ -79,6 +81,8 @@ Ferry can **pause and resume** — close it anytime, pick up where you left off.
 | Voice channels | Partial (created but may not function — Stoat bug) |
 | Stickers | Image upload with text fallback for Lottie/missing |
 | Original timestamps | Shown in message text, not metadata |
+| Pre-creation review | Summary and confirmation before anything is created on Stoat |
+| Server blueprints | Export migration structure as reusable JSON templates |
 
 ---
 

--- a/docs/getting-started/first-migration.md
+++ b/docs/getting-started/first-migration.md
@@ -184,11 +184,28 @@ Ferry checks your export files locally before making any API calls. Nothing is s
 
 ---
 
+## Step 3.5: Review what will be created
+
+Before creating anything on Stoat, Ferry shows a review summary.
+
+=== "GUI (Windows / macOS)"
+
+    A dialog appears showing how many roles, categories, channels, emoji, and messages will be migrated. Review the numbers and any warnings, then click **Proceed** to continue or **Cancel** to go back.
+
+=== "CLI (Linux / advanced)"
+
+    The CLI prints a summary table before proceeding. In orchestrated mode this happens automatically; in offline mode it appears after validation.
+
+!!! info "Permission migration"
+    When you provide a Discord token (1-Click mode), Ferry fetches role permissions and channel overrides directly from the Discord API and translates them to Stoat equivalents. In offline mode (no Discord token), roles are created without permissions — you will need to set them manually on Stoat.
+
+---
+
 ## Step 4: Start the migration
 
 === "GUI (Windows / macOS)"
 
-    1. Click **Start Migration**.
+    1. Click **Proceed** on the review dialog (or **Start Migration** if review was skipped).
     2. The Progress screen appears and shows:
         - Phase indicator — 12 phases, each with a checkmark when complete
         - Progress bar during the message import phase
@@ -244,8 +261,10 @@ Ferry checks your export files locally before making any API calls. Nothing is s
 After a successful migration:
 
 - All channels and categories are created in the same structure as Discord
+- NSFW channels are correctly flagged
+- Channel permission overrides (@everyone and per-role) are applied
 - Forum posts are grouped into dedicated categories named after the parent forum
-- Roles are recreated with colours and rank ordering preserved
+- Roles are recreated with colours, rank ordering, and permissions preserved
 - Messages appear under the original author's name and avatar, so conversations look natural
 - Original timestamps appear at the start of each message: `*[2024-01-15 14:30 UTC]*`
 - Embeds are preserved with uploaded thumbnails and images

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -9,7 +9,7 @@ Ferry's command-line interface provides the same migration capability as the GUI
 
 ## Commands
 
-Ferry has two top-level commands: `migrate` and `validate`.
+Ferry has four top-level commands: `migrate`, `validate`, `build`, and `export-blueprint`.
 
 ---
 
@@ -188,3 +188,75 @@ ferry migrate --export-dir ~/exports/my-discord-server/ \
 
 !!! info "Verbose mode"
     Add `-v` or `--verbose` to any `migrate` command to see a line of output for every message sent. This is useful for diagnosing problems but produces a large amount of output for large servers.
+
+---
+
+## `ferry build`
+
+Create a new Stoat server from a preset template or a custom blueprint file.
+
+```
+ferry build [OPTIONS]
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--template TEXT` | Use a preset template: `gaming`, `community`, or `education` |
+| `--blueprint PATH` | Path to a custom blueprint JSON file |
+| `--stoat-url TEXT` | Stoat API base URL *(required)* |
+| `--token TEXT` | Your Stoat user token *(required)* |
+| `--name TEXT` | Override the server name from the template/blueprint |
+
+You must provide either `--template` or `--blueprint`, but not both.
+
+### Preset Templates
+
+Ferry includes three built-in server templates:
+
+- **gaming** — Admin, Moderator, and Member roles with General, Voice, and Gaming categories
+- **community** — Admin, Moderator, Helper, and Member roles with Welcome, General, and Voice categories
+- **education** — Instructor, TA, and Student roles with Announcements, Coursework, and Discussion categories
+
+Each template includes appropriate role permissions and channel structures.
+
+**Examples:**
+
+```bash
+# Create a gaming server from a preset template
+ferry build --template gaming --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN"
+
+# Create from a custom blueprint with a custom name
+ferry build --blueprint my-server.json --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN" --name "My Server"
+```
+
+---
+
+## `ferry export-blueprint`
+
+Convert a DiscordChatExporter export directory into a reusable server blueprint JSON file. The blueprint captures server structure (roles, categories, channels) but not messages.
+
+```
+ferry export-blueprint [OPTIONS]
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--from PATH` | Path to DCE export directory *(required)* |
+| `--output PATH` | Output path for the blueprint JSON file (default: `blueprint.json`) |
+
+**Example:**
+
+```bash
+# Export a blueprint from an existing DCE export
+ferry export-blueprint --from ~/exports/my-discord-server/ --output my-server-blueprint.json
+
+# Then use it to create a new server
+ferry build --blueprint my-server-blueprint.json --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN"
+```
+
+!!! tip "Blueprints use names, not IDs"
+    Blueprints store role and channel names rather than Discord IDs, making them portable across different Stoat instances.

--- a/docs/guides/gui-walkthrough.md
+++ b/docs/guides/gui-walkthrough.md
@@ -138,6 +138,43 @@ When the export completes, Ferry automatically moves to the Validate screen.
 
 ---
 
+## Review Dialog
+
+Before creating anything on Stoat, Ferry shows a confirmation dialog summarising what will be created.
+
+<!-- screenshot: review dialog showing summary table -->
+
+### What It Shows
+
+The dialog displays a summary table:
+
+| Item | Description |
+|------|-------------|
+| Roles | Number of roles to create (excluding @everyone) |
+| Categories | Number of channel categories |
+| Channels | Number of text and voice channels |
+| Custom emoji | Number of emoji to upload |
+| Messages | Total messages to migrate |
+| Threads | Number of threads/forum posts |
+
+### Warnings
+
+If potential issues are detected, they appear below the summary:
+
+- **No Discord token provided** — permissions and NSFW flags will not be migrated (these require the Discord API)
+- **Channel limit may be exceeded** — combined channel and thread count is close to or over 200
+- **Emoji limit may be exceeded** — more than 100 custom emoji detected
+
+### Actions
+
+- **Proceed** — start creating the server on Stoat
+- **Cancel** — return to the Validate screen without creating anything
+
+!!! info "Why review before creating?"
+    Server creation on Stoat is not easily undone. The review step lets you verify the scope of the migration before any API calls are made. This is especially useful for large servers where mistakes are costly.
+
+---
+
 ## Migrate Screen
 
 The main migration screen. Ferry works through 12 sequential phases.
@@ -152,14 +189,14 @@ The 12 phases are shown in order, with a checkmark as each completes:
 2. **Validate** — confirm export is readable
 3. **Connect** — verify Stoat credentials
 4. **Server** — create or connect to the target server
-5. **Roles** — create all server roles
+5. **Roles** — create all server roles, then apply Discord permissions (translated to Stoat equivalents)
 6. **Categories** — create channel categories
-7. **Channels** — create all channels
+7. **Channels** — create all channels with NSFW flags, then apply per-channel permission overrides
 8. **Emoji** — upload custom emoji
 9. **Messages** — send all messages
 10. **Reactions** — add message reactions
 11. **Pins** — pin messages
-12. **Report** — write summary report
+12. **Report** — write summary report with post-migration checklist
 
 ### Progress Bar
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,9 @@ Ferry can **pause and resume** — close it anytime and pick up where you left o
 |---------|--------|
 | Text channels | Supported |
 | Categories | Supported |
-| Roles (with colours) | Supported |
+| Roles (with colours and permissions) | Supported — Discord permissions translated to Stoat equivalents |
+| Channel permissions | Supported — per-role and @everyone overrides migrated |
+| NSFW channels | Supported — NSFW flag set during channel creation |
 | Messages + author names | Supported (each message shows the original author's name and avatar) |
 | File attachments | Supported |
 | Custom emoji | Supported (up to 100) |
@@ -52,6 +54,8 @@ Ferry can **pause and resume** — close it anytime and pick up where you left o
 | Voice channels | Partial (created but may not function — Stoat bug) |
 | Stickers | Image upload with text fallback for Lottie/missing |
 | Original timestamps | Shown in message text, not metadata |
+| Pre-creation review | Supported — summary and confirmation before anything is created on Stoat |
+| Server blueprints | Supported — export migration structure as reusable JSON templates |
 
 ---
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -57,14 +57,14 @@ and resumed, a completed phase is skipped entirely.
 | 1 | **VALIDATE** | Parse all DCE JSON files, verify media was downloaded, detect format issues |
 | 2 | **CONNECT** | Test Stoat API credentials, resolve Autumn upload URL, verify server accessibility (if using `--server-id`) |
 | 3 | **SERVER** | Create a new Stoat server or attach to an existing one |
-| 4 | **ROLES** | Create roles with colours (British spelling), then set rank ordering from Discord position data |
+| 4 | **ROLES** | Create roles with colours (British spelling), set rank ordering from Discord position data, then apply Discord permissions translated to Stoat equivalents (if Discord metadata is available) |
 | 5 | **CATEGORIES** | Create category structure on the server |
-| 6 | **CHANNELS** | Create channels, assign to categories, flatten threads to text channels, group forum threads into dedicated categories |
+| 6 | **CHANNELS** | Create channels with NSFW flags, assign to categories, flatten threads to text channels, group forum threads into dedicated categories, then apply per-channel permission overrides |
 | 7 | **EMOJI** | Download Discord emoji, upload to Autumn, register on Stoat server |
 | 8 | **MESSAGES** | Import messages with masquerade, attachments, embeds (with media), stickers, polls, mention remapping, and reply threading |
 | 9 | **REACTIONS** | Re-apply emoji reactions to migrated messages |
 | 10 | **PINS** | Re-pin messages that were pinned in Discord |
-| 11 | **REPORT** | Write a markdown migration report summarising counts, skips, and errors |
+| 11 | **REPORT** | Write a migration report summarising counts, skips, errors, and a post-migration checklist |
 
 !!! note "Phase ordering"
     Phases cannot be reordered. Each phase depends on ID mappings produced by earlier phases.
@@ -117,6 +117,7 @@ finer-grained resume; messages already sent are deduplicated via the `nonce` fie
 | Path | Purpose |
 |------|---------|
 | `src/discord_ferry/core/` | Engine (`engine.py`) and event system (`events.py`) |
+| `src/discord_ferry/discord/` | Discord REST API client, permission bit translator, and metadata persistence |
 | `src/discord_ferry/exporter/` | DCE binary management and subprocess execution (orchestrated mode) |
 | `src/discord_ferry/parser/` | DCE JSON parsing and data model dataclasses |
 | `src/discord_ferry/uploader/` | Autumn file upload client with caching |
@@ -125,9 +126,12 @@ finer-grained resume; messages already sent are deduplicated via the `nonce` fie
 | `src/discord_ferry/config.py` | `FerryConfig` dataclass — all user-supplied settings |
 | `src/discord_ferry/errors.py` | Custom exception hierarchy |
 | `src/discord_ferry/parser/transforms.py` | Mention/emoji remapping, embed flattening, poll/sticker rendering |
-| `src/discord_ferry/reporter.py` | Migration report generation |
+| `src/discord_ferry/reporter.py` | Migration report generation with post-migration checklist |
+| `src/discord_ferry/review.py` | Pre-creation review summary builder |
+| `src/discord_ferry/blueprint.py` | Server blueprint export/import (JSON) |
+| `src/discord_ferry/templates/` | Preset server templates (gaming, community, education) |
 | `src/discord_ferry/gui.py` | NiceGUI shell — 4-screen workflow (Setup, Export, Validate, Migrate) |
-| `src/discord_ferry/cli.py` | Click shell — `migrate` and `validate` commands |
+| `src/discord_ferry/cli.py` | Click shell — `migrate`, `validate`, `build`, and `export-blueprint` commands |
 
 The `exporter/` module has the following structure:
 
@@ -138,6 +142,22 @@ src/discord_ferry/exporter/
 └── runner.py      # Async subprocess execution and progress parsing
 ```
 
+The `discord/` module handles Discord REST API access for permission migration:
+
+```
+src/discord_ferry/discord/
+├── __init__.py       # fetch_and_translate_guild_metadata() orchestration
+├── client.py         # Async HTTP client for Discord API v10
+├── models.py         # DiscordRole, DiscordChannel, PermissionOverwrite dataclasses
+├── metadata.py       # DiscordMetadata persistence (discord_metadata.json)
+└── permissions.py    # Discord → Stoat permission bit translation
+```
+
+The `discord/` module is only active when a Discord token is available. It fetches guild
+roles and channels from the Discord REST API, translates permission bitfields to Stoat
+equivalents, and persists the results to `discord_metadata.json`. This file is read by
+the ROLES and CHANNELS phases to apply permissions during migration.
+
 ---
 
 ## Data Flow Summary
@@ -145,14 +165,18 @@ src/discord_ferry/exporter/
 ```
 Discord API (orchestrated mode only)
       │
-      ▼
-  exporter/        Download DCE binary → run export → produce DCE JSON files
+      ├── exporter/    Download DCE binary → run export → produce DCE JSON files
+      │
+      └── discord/     Fetch guild roles + channels → translate permissions → save metadata
       │
       ▼
-DCE JSON files
+DCE JSON files + discord_metadata.json
       │
       ▼
   parser/          Parse JSON → typed dataclasses (Channel, Message, Attachment, …)
+      │
+      ▼
+  review.py        Build pre-creation summary → show confirmation dialog/table
       │
       ▼
   engine.py        Orchestrate phases, maintain MigrationState
@@ -160,10 +184,12 @@ DCE JSON files
       ├── uploader/    Download Discord media → upload to Autumn → return CDN URLs
       │
       ├── migrator/    Phase implementations — call migrator/api.py, emit MigrationEvents
+      │                (ROLES and CHANNELS phases read discord_metadata.json for permissions)
       │
       └── state.py     Persist ID mappings after each phase
 ```
 
-The exporter is only active in orchestrated mode; offline mode starts directly at the parser step.
-The parser is pure (no I/O beyond reading files). The uploader is the only component that talks to
-Autumn. The migrator modules are the only components that talk to the Stoat API.
+The exporter and discord modules are only active when a Discord token is provided; offline mode
+starts directly at the parser step and skips permission migration. The parser is pure (no I/O
+beyond reading files). The uploader is the only component that talks to Autumn. The migrator
+modules are the only components that talk to the Stoat API.


### PR DESCRIPTION
## Summary

- Update feature tables in README and docs landing page with permissions, NSFW, review, and blueprints
- Add `ferry build` and `ferry export-blueprint` to CLI reference
- Add review confirmation dialog section to GUI walkthrough
- Add Step 3.5 (review) and permission migration note to first migration guide
- Update architecture reference with `discord/` module, `review.py`, `blueprint.py`, and updated data flow diagram

Docs-only change, no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)