### PR TITLE
chore: harden release + auto-tag workflows

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -30,6 +30,12 @@ jobs:
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Configure git identity
+        if: steps.version.outputs.bumped == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Create and push tag
         if: steps.version.outputs.bumped == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
     name: Create release and publish
     needs: [build-windows, build-macos]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- **`auto-tag.yml`:** add a "Configure git identity" step before `git tag -a`. Without it the annotated-tag step fails with `empty ident name (for <runner@...>) not allowed` (hit manually on the v2.0.2 release — the tag was pushed out-of-band to work around this).
- **`release.yml`:** bind the `release:` job to a GitHub Environment named `release`. Environment was pre-created with **zero protection rules**, so this is behaviorally a no-op today. The wiring enables future hardening (required reviewers, tag pattern gates, deployment branches) via repo Settings → Environments without further workflow edits. It also makes the OIDC token carry an `environment` claim, which PyPI's Trusted Publisher can gate on if ever narrowed from `(Any)` to `release`.

Both changes are additive-only — no behavior change on existing green-path runs.

## Why this is safe to merge without a follow-up release

- `auto-tag.yml` only fires on `pyproject.toml` changes to `main` with a real version bump. No version bump in this PR → step stays dormant.
- `release.yml` only fires on `v*.*.*` tag push. No tag in this PR → job doesn't run. On the next tag push, the `release` environment already exists (created ungated) so the reference resolves and the job runs exactly as before.

## Test plan

- [ ] CI green (ruff + mypy + pytest; no code files touched so should be trivially green)
- [ ] Next patch release cycle exercises both changes end-to-end:
  - [ ] Bump version in `pyproject.toml` + `__init__.py` → `auto-tag.yml` creates and pushes the `v*.*.*` tag (no ident error)
  - [ ] Release workflow runs against `environment: release` → both GitHub Release and PyPI publish succeed
- [ ] Optional post-merge: add protection rules (required reviewers / tag pattern) to the `release` environment in repo Settings → Environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)