### PR TITLE
fix: close GUI progress emit gap during DCE export (issue #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixes
+- **GUI progress emit gap during DCE export** (issue #23): the GUI used to freeze on `"Checking for DCE binary..."` for the entire DCE channel-enumeration phase, which on large servers can run several minutes before DCE prints its first per-channel progress line. Added three intermediate emits: `"Verifying .NET 8 runtime..."` (before `detect_dotnet()`), `"Launching DiscordChatExporter..."` (before the subprocess spawn), and `"DiscordChatExporter started — enumerating channels..."` (inside `run_dce_export` immediately after the subprocess is alive but before the first stdout line). Applied symmetrically to the GUI shell and the CLI/engine path.
+
 ## [2.0.2] - 2026-04-21
 
 ### Fixes

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -191,6 +191,13 @@ async def run_migration(
     if not config.skip_export:
         on_event(MigrationEvent(phase="export", status="started", message="Starting export..."))
         await validate_discord_token(config.discord_token or "")
+        on_event(
+            MigrationEvent(
+                phase="export",
+                status="progress",
+                message="Verifying .NET 8 runtime...",
+            )
+        )
         if not detect_dotnet():
             raise DotNetMissingError(
                 "DCE requires .NET 8 runtime. "
@@ -199,6 +206,13 @@ async def run_migration(
         dce_path = get_dce_path()
         if dce_path is None:
             dce_path = await download_dce(on_event, skip_verify=config.skip_dce_verify)
+        on_event(
+            MigrationEvent(
+                phase="export",
+                status="progress",
+                message="Launching DiscordChatExporter...",
+            )
+        )
         await run_dce_export(config, dce_path, on_event)
         state.export_completed = True
         save_state(state, config.output_dir)

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -126,6 +126,20 @@ async def run_dce_export(
         stderr=asyncio.subprocess.PIPE,
     )
 
+    # DCE prints nothing while it enumerates the guild's channels — on large
+    # servers that pre-output phase can run several minutes and previously
+    # left the GUI looking frozen on the last emitted status.
+    on_event(
+        MigrationEvent(
+            phase="export",
+            status="progress",
+            message=(
+                "DiscordChatExporter started — enumerating channels "
+                "(large servers may take several minutes before per-channel progress appears)..."
+            ),
+        )
+    )
+
     stderr_lines: list[str] = []
 
     try:

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -655,6 +655,13 @@ def export_page() -> None:
                 )
                 dce_path = await download_dce(on_export_event)
 
+            on_export_event(
+                _MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message="Verifying .NET 8 runtime...",
+                )
+            )
             if not detect_dotnet():
                 raise DotNetMissingError(
                     "DCE requires .NET 8 runtime. "
@@ -670,6 +677,13 @@ def export_page() -> None:
                 cancel_event=cancel_event,
             )
 
+            on_export_event(
+                _MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message="Launching DiscordChatExporter...",
+                )
+            )
             await run_dce_export(config, dce_path, on_export_event)
 
             on_export_event(

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aioresponses import aioresponses
@@ -13,6 +13,7 @@ from discord_ferry.exporter.runner import (
     _DCE_PROGRESS_RE,
     _build_dce_command,
     _check_disk_space,
+    run_dce_export,
     validate_discord_token,
 )
 
@@ -123,3 +124,55 @@ class TestValidateDiscordToken:
             m.get("https://discord.com/api/v10/users/@me", status=500)
             with pytest.raises(DiscordAuthError, match="unexpected status"):
                 await validate_discord_token("some-token")
+
+
+class TestRunDceExportProgressEmits:
+    """Lock in the progress-emit contract that closes the silent-window UX gap.
+
+    Without an emit between subprocess spawn and the first stdout regex match,
+    the GUI used to freeze on the last status for the entire DCE enumeration
+    phase (minutes on large servers — see issue #23).
+    """
+
+    @pytest.mark.asyncio
+    async def test_enumerating_emit_fires_before_stdout_progress(self, tmp_path: Path) -> None:
+        async def _empty_iter():
+            for _ in ():
+                yield b""
+
+        async def _stdout_iter():
+            yield b"[1/3] Exporting #general... 50.0%\n"
+
+        process = MagicMock()
+        process.stdout = _stdout_iter()
+        process.stderr = _empty_iter()
+        process.wait = AsyncMock(return_value=0)
+        process.returncode = 0
+
+        cfg = FerryConfig(
+            export_dir=tmp_path / "exports",
+            stoat_url="https://stoat.example",
+            token="st",
+            discord_token="dt",
+            discord_server_id="12345",
+        )
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        messages = [e.message for e in events]
+        enumerating_idx = next(
+            (i for i, m in enumerate(messages) if "enumerating channels" in m), None
+        )
+        exporting_idx = next(
+            (i for i, m in enumerate(messages) if m.startswith("Exporting #")), None
+        )
+        assert enumerating_idx is not None, f"missing 'enumerating channels' emit; got {messages!r}"
+        assert exporting_idx is not None, f"missing per-channel emit; got {messages!r}"
+        assert enumerating_idx < exporting_idx, (
+            "enumeration emit must precede the first per-channel progress emit"
+        )


### PR DESCRIPTION
## Summary
Closes the silent-window UX gap reported in #23: the GUI emitted `"Checking for DCE binary..."` and then went quiet for the entire DCE channel-enumeration phase, which on large servers can run several minutes before DCE prints its first per-channel progress line. To the user it looked frozen.

Three intermediate emits added, applied symmetrically to both shells:

| When | Where | Message |
|---|---|---|
| Before `detect_dotnet()` | `gui.py`, `engine.py` | `Verifying .NET 8 runtime...` |
| Before `await run_dce_export(...)` | `gui.py`, `engine.py` | `Launching DiscordChatExporter...` |
| After subprocess spawn, before stdout loop | `exporter/runner.py` | `DiscordChatExporter started — enumerating channels (large servers may take several minutes before per-channel progress appears)...` |

The runner emit is the load-bearing one — it covers the multi-minute silent enumeration phase that was the actual cause of the "stuck" reports. The two shell emits cover smaller gaps (`dotnet --info` can hang for tens of seconds on first run after a Windows update; subprocess spawn is fast but worth announcing).

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest` — **702 pass** (+1 new test in `TestRunDceExportProgressEmits` that mocks `asyncio.create_subprocess_exec` and asserts the enumeration emit fires before any per-channel progress emit)
- [ ] CI Python 3.10 / 3.11 / 3.12 / 3.13 green

No version bump — the version-bump-on-release pattern is handled at ship time via `/df-ship`.

Refs #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)