### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,10 +20,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --extra docs
@@ -32,7 +32,7 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
     name: Build Windows executable
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           enable-cache: true
@@ -47,7 +47,7 @@ jobs:
         run: mv dist/Ferry.exe dist/Ferry-windows-x86_64.exe
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ferry-windows
           path: dist/Ferry-windows-x86_64.exe
@@ -57,10 +57,10 @@ jobs:
     name: Build macOS executable
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           enable-cache: true
@@ -83,7 +83,7 @@ jobs:
       - name: Zip .app bundle
         run: cd dist && zip -r ../Ferry-macos-arm64.zip Ferry.app
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ferry-macos
           path: Ferry-macos-arm64.zip
@@ -95,28 +95,28 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           enable-cache: true
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ferry-windows
           path: release-assets/
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ferry-macos
           path: release-assets/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-05-14
+
+### Changed
+
+- **CI hygiene — Node 20 → Node 24 Actions runtime**: bumped every Node-20 `actions/*` reference across all four workflows (`ci.yml`, `release.yml`, `auto-tag.yml`, `docs.yml`) to its lowest version that ships Node 24, ahead of GitHub's June 2026 runtime retirement. Specifically: `actions/checkout@v4 → @v6`, `actions/upload-artifact@v4 → @v5`, `actions/download-artifact@v4 → @v6`, `actions/upload-pages-artifact@v3 → @v5`, `actions/deploy-pages@v4 → @v5`, `astral-sh/setup-uv@v5/@v6 → @v7` (also fixes the version drift in `docs.yml`), `softprops/action-gh-release@v2 → @v3`. `pypa/gh-action-pypi-publish` unchanged (Docker action, unaffected). No user-visible code changes; pure CI maintenance.
+
 ## [2.1.0] - 2026-05-14
 
 ### Features

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -26,6 +26,12 @@ that configure the engine, subscribe to its event stream, and render progress in
 
 ---
 
+## CI / Build Tooling
+
+All Ferry workflows run on the Node 24 GitHub Actions runtime as of v2.1.1, ahead of GitHub's June 2026 Node 20 retirement. Action pins follow the lowest-Node-24-major principle (for example, `actions/checkout@v6` and `actions/upload-artifact@v5`) to minimise behavior delta versus the previous Node 20 versions. The `pypa/gh-action-pypi-publish` step is Docker-based and unaffected by Node runtime deprecation.
+
+---
+
 ## Project Layout
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.0"
+version = "2.1.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bumps every Node-20 `actions/*` reference across all four workflows to its lowest version that ships Node 24, ahead of GitHub's June 2026 runtime retirement. Pure CI maintenance — no user-visible code changes.
- Bumps version 2.1.0 → 2.1.1 to trigger the `auto-tag.yml` → `release.yml` cascade on merge, which naturally exercises three of four workflow trigger surfaces. The `docs/reference/architecture.md` touch (a real `CI / Build Tooling` subsection) fires the fourth (`docs.yml`'s `paths: docs/**` filter).
- Pinning principle: **lowest version** of each action that ships Node 24, NOT the absolute latest. Minimises behavior delta. Keeps the `release.yml` diff to `@version` strings only (no logic, ordering, or input-arg changes).

## Citation table

Every pin is sourced from the action's own release notes:

| Action | From | To | Citation (release notes) |
|--------|------|----|--------------------------|
| `actions/checkout` | `@v4` | `@v6` | v6.0.0: *"Update README to include Node.js 24 support details and requirements"* |
| `actions/upload-artifact` | `@v4` | `@v5` | v5.0.0: *"BREAKING CHANGE: this update supports Node v24.x"* |
| `actions/download-artifact` | `@v4` | `@v6` | v6.0.0: *"BREAKING CHANGE: this update supports Node v24.x"*. v5 was a Node-20 path-fix release; Node 24 landed in v6. |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | v5.0.0: *"Update upload-artifact action to version 7"* — transitive Node 24 via the `upload-artifact@v7` dependency (the v5.0.0 release notes do not themselves contain the string "Node 24"). |
| `actions/deploy-pages` | `@v4` | `@v5` | v5.0.0: *"Update Node.js version to 24.x"* |
| `astral-sh/setup-uv` | `@v6` (ci, release) and `@v5` (docs) | `@v7` (all four) | v7.0.0: *"switching from node20 to node24"*. Also fixes the `@v5` drift that was lurking in `docs.yml`. Staying on `@v7` not `@v8` because v8.0.0 removed floating major/minor tags — pinning to `@v8` would force immutable patch pins everywhere, which is a pin-strategy change outside this PR's scope. |
| `softprops/action-gh-release` | `@v2` | `@v3` | v3.0.0: *"moves the action runtime from Node 20 to Node 24"* |
| `pypa/gh-action-pypi-publish` | `@release/v1` | (unchanged) | Docker action — Node deprecation does not apply. |

## Test plan

- [x] Local verification: \`uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src/ && uv run pytest\` — 764/764 passed
- [x] \`release.yml\` diff inspected: only \`@version\` strings changed, no logic/ordering/input-arg changes (spec compliance gate)
- [x] \`pypa/gh-action-pypi-publish@release/v1\` confirmed unchanged
- [x] CHANGELOG \`[2.1.1]\` entry placed under the canonical \`[Unreleased]\`; stale second \`[Unreleased]\` block (docs-pass content between \`[1.5.0]\` and \`[1.4.0]\`) was deliberately not touched (out of scope)

## Post-merge verification (recorded after merge)

Spec requires all four workflow trigger surfaces exercised green on real triggers. Filled in after merge:

- [ ] \`ci.yml\` run: _<URL>_
- [ ] \`auto-tag.yml\` run (creates \`v2.1.1\` tag): _<URL>_
- [ ] \`release.yml\` run (publishes Windows + macOS binaries + PyPI \`discord-ferry 2.1.1\`): _<URL>_
- [ ] \`docs.yml\` run (triggered by \`docs/reference/architecture.md\` touch): _<URL>_

## Next-time note

Action versions were chosen against the Node 24 cutover (June 2026). For the next deprecation cycle, repeat this pattern: check release notes per action, pin to the lowest Node-24 major, exercise all four trigger surfaces on their natural triggers via a version-bump-triggered cascade. The pinning rationale is captured in CHANGELOG and the new architecture-doc subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
