### PR TITLE
fix(ci): upload-artifact@v6 + download-artifact@v7 (v2.1.1 pins were still Node 20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: mv dist/Ferry.exe dist/Ferry-windows-x86_64.exe
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: ferry-windows
           path: dist/Ferry-windows-x86_64.exe
@@ -83,7 +83,7 @@ jobs:
       - name: Zip .app bundle
         run: cd dist && zip -r ../Ferry-macos-arm64.zip Ferry.app
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: ferry-macos
           path: Ferry-macos-arm64.zip
@@ -104,13 +104,13 @@ jobs:
           enable-cache: true
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ferry-windows
           path: release-assets/
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ferry-macos
           path: release-assets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-05-14
+
+### Fixed
+
+- **CI hygiene correction — `upload-artifact` and `download-artifact` were still on Node 20 in v2.1.1**: the v2.1.1 pins `actions/upload-artifact@v5` and `actions/download-artifact@v6` were chosen based on release-notes wording ("supports Node v24.x") that turned out to mean *compatible with Node 24 runners*, not *runs on Node 24 by default*. The action.yml's `runs.using:` field is authoritative — for `upload-artifact` that flipped from `node20` to `node24` at v6.0.0; for `download-artifact` at v7.0.0. GitHub's release.yml run for v2.1.1 surfaced this with a `Node.js 20 actions are deprecated` annotation. Bumped both pins to their actual lowest Node-24 majors: `upload-artifact@v5 → @v6`, `download-artifact@v6 → @v7`. All other v2.1.1 pins (`checkout@v6`, `setup-uv@v7`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `action-gh-release@v3`) were verified against `action.yml` and are genuinely on Node 24.
+
 ## [2.1.1] - 2026-05-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.1"
+version = "2.1.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Corrects two pins from PR #28 (v2.1.1) that were still Node 20 despite the citation table claiming otherwise. GitHub's deprecation annotation on the v2.1.1 release.yml run surfaced this:

> ! Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/upload-artifact@v5`.

## Root cause

PR #28 cited release-notes wording ("supports Node v24.x") that I interpreted as "runs on Node 24 by default" — but for both upload-artifact and download-artifact, that wording meant *compatible with Node 24 runners* (preliminary support) while the action itself continued to default to Node 20. The cutover happened one major later:

| Action | Pinned in v2.1.1 | Real `runs.using:` | Lowest Node-24 |
|---|---|---|---|
| `actions/upload-artifact` | `@v5` | `node20` | **`@v6`** |
| `actions/download-artifact` | `@v6` | `node20` | **`@v7`** |

`upload-artifact@v6.0.0` release notes say it plainly: *"v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24."*

## The lesson — verify against `action.yml`, not release notes

Release-notes prose can be ambiguous. The action's `action.yml` `runs.using:` field is binary truth. Future Node-version bumps should verify each pin via:

\`\`\`bash
curl -sf https://raw.githubusercontent.com/<owner>/<action>/refs/tags/<ref>/action.yml | grep using:
\`\`\`

All other v2.1.1 pins re-verified against `action.yml` and confirmed Node 24:

| Action | Pin | `runs.using:` |
|---|---|---|
| `actions/checkout` | `@v6` | `node24` ✓ |
| `astral-sh/setup-uv` | `@v7` | `\"node24\"` ✓ |
| `actions/upload-pages-artifact` | `@v5` | `composite` (wraps `upload-artifact@v7` = `node24`) ✓ |
| `actions/deploy-pages` | `@v5` | `'node24'` ✓ |
| `softprops/action-gh-release` | `@v3` | `\"node24\"` ✓ |
| `pypa/gh-action-pypi-publish` | `@release/v1` | Docker action (unaffected) ✓ |

## Test plan

- [x] Local verification: \`uv run ruff check && ruff format --check && mypy && pytest\` — 764/764 passed
- [x] Diff scope: only `release.yml` `@version` strings + version bump + CHANGELOG + uv.lock — no logic changes
- [x] release.yml run for v2.1.2 shows **no** Node 20 deprecation annotations ✓

## Post-merge verification

The auto-tag → release.yml cascade will need the same manual tag re-push as v2.1.1 (GITHUB_TOKEN doesn't trigger downstream workflows — known deferred issue, separate from this PR).

- [x] `auto-tag.yml` run (creates `v2.1.2`): https://github.com/nordscope-fi/Discord-stoat-ferry/actions/runs/25853715668
- [x] `release.yml` run on `v2.1.2`: https://github.com/nordscope-fi/Discord-stoat-ferry/actions/runs/25853739728 — **verified zero Node 20 deprecation annotations** (v2.1.1 had 1, v2.1.2 has 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
