### PR TITLE
chore: release v2.1.3 (cascade-fix verification probe — PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.3] - 2026-05-14
+
 ### Fixed
 
 - **GITHUB_TOKEN cascade gap closed (Option C)**: `auto-tag.yml` now uses a GitHub App installation token (minted via `actions/create-github-app-token@v3`) instead of the default `GITHUB_TOKEN` for tag pushes. The default token by GitHub safety does NOT trigger downstream workflows — three sequential releases (v2.1.0, v2.1.1, v2.1.2) all required a manual `git push --delete origin v<tag>` + re-push protocol to fire `release.yml`. After this fix, `v*.*.*` tag pushes from `auto-tag.yml` fire `release.yml` automatically. Credentials live in the new `auto-tag` GitHub Environment (`AUTO_TAG_APP_CLIENT_ID` variable + `AUTO_TAG_APP_PRIVATE_KEY` secret). The App (`Ferry Auto-Tag Bot`, owned by `nordscope-fi`, installed on this repo only) has `Contents: Read and write` permission — minimum scope. No user-visible code changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.2"
+version = "2.1.3"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.2"
+version = "2.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Version bump 2.1.2 → 2.1.3 to release the GITHUB_TOKEN cascade fix from #30 (Option C) and **verify the cascade fires automatically end-to-end** on this PR's merge.

This is **PR-B of the two-PR cascade-fix sequence** (#30 was PR-A — the credential swap). PR-B's role is verification: if PR-A's App-based credential swap works correctly, this PR's merge will trigger \`auto-tag.yml\` → tag \`v2.1.3\` → \`release.yml\` **automatically, with no manual nudge**.

## Diff

4 files, +5/-3:
- \`pyproject.toml\`: \`2.1.2\` → \`2.1.3\`
- \`src/discord_ferry/__init__.py\`: \`2.1.2\` → \`2.1.3\`
- \`CHANGELOG.md\`: rename \`[Unreleased]\` heading to \`[2.1.3] - 2026-05-14\`, add fresh empty \`[Unreleased]\` above
- \`uv.lock\`: auto-updated by \`uv run\` (project version metadata)

The v2.1.3 release notes inherit the cascade-fix entry that's been sitting under \`[Unreleased]\` since #30's merge. No code changes beyond the version-bump trinity.

## Expected cascade flow on merge

1. PR merge → \`auto-tag.yml\` fires on the \`pyproject.toml\` change.
2. \`auto-tag.yml\` mints an App installation token via \`actions/create-github-app-token@v3\` (using \`AUTO_TAG_APP_CLIENT_ID\` + \`AUTO_TAG_APP_PRIVATE_KEY\` from the \`auto-tag\` environment).
3. Pushes tag \`v2.1.3\` — **from the Ferry Auto-Tag Bot App identity, not \`GITHUB_TOKEN\`**.
4. **The cascade-mechanism success criterion**: \`release.yml\` fires automatically on the tag push event (NOT requiring a manual \`git push --delete origin v2.1.3\` + re-push).
5. \`release.yml\` builds Windows + macOS binaries, creates the GitHub Release, publishes \`discord-ferry==2.1.3\` to PyPI.

## Test plan

- [x] Local verification: 764/764 tests pass + ruff + format + mypy clean
- [x] Diff scope: 4 files, ≤20 lines (skips full code review + second opinion per \`/df-ship\` thresholds)
- [x] auto-tag.yml fires on merge: https://github.com/nordscope-fi/Discord-stoat-ferry/actions/runs/25856665319 (first attempt failed — App install was missing on the org; user fixed the install, workflow was re-run, then green)
- [x] release.yml fires automatically on the v2.1.3 tag (NO manual nudge): https://github.com/nordscope-fi/Discord-stoat-ferry/actions/runs/25857437099 — **CASCADE VERIFIED**
- [x] release.yml completes green end-to-end (Windows + macOS + GitHub Release + PyPI publish): **YES** — all 3 jobs SUCCESS, v2.1.3 binaries on GitHub Releases, PyPI publish complete

## Failure mode handling

**If release.yml does NOT fire after auto-tag.yml succeeds**: the App auth or installation is misconfigured. Diagnose via App settings page. Fall back to manual nudge protocol (\`git push --delete origin v2.1.3 && git tag -a v2.1.3 -m v2.1.3 <sha> && git push origin v2.1.3\`) as the bridge while diagnosing.

**If release.yml fires but its own run is red (e.g. PyPI hiccup, binary-signing fail)**: this STILL counts as cascade-mechanism success per the design's Failure Modes table. The cascade-mechanism fix is verified by the *existence* of the auto-triggered run. release.yml-body success is a separate concern (Spec S3 AC #4) that may need a follow-up fix unrelated to PR-A's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
