### PR TITLE
content: remove orphan [Unreleased] block from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,23 +138,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Resilience**: Oversized attachments are pre-checked against size limits before upload attempt, with text placeholder injected into message content.
 - **Resilience**: Expired CDN URLs produce `[Attachment expired: filename]` placeholder in message content instead of silent failure.
 
-## [Unreleased]
-
-### Changed
-
-- Docs accuracy pass: correct false CLI flag references (`--max-concurrent-channels`, `--reaction-mode`, `--min-thread-messages`, `--checkpoint-interval`, `--max-concurrent-requests`) — these are GUI-only settings not yet exposed as Click options. Added "GUI Only Options" section to CLI reference. Updated large-servers, self-hosted-tips, known-limitations, and pre-flight-checklist to reflect accurate availability.
-- Docs readability pass: split overwhelming 35-row feature table in README and index.md into "What gets migrated" (data table) and "Reliability features" (bulleted list). Updated pre-flight time estimates from v1 sequential to v2 parallel defaults.
-- Fix broken mkdocs rendering: code fence `title=` attribute in cli-reference.md and self-hosted-tips.md requires `pymdownx.superfences` (not configured) — replaced with comment-based titles. Bottom half of CLI reference page was rendering as raw markdown on the live docs site.
-- Plain English audit across all user-facing docs: define jargon on first use (CLI, JSON, API, CDN, DCE, token, terminal, developer tools), add parenthetical explanations for technical terms, use direct language throughout.
-- Comprehensive architecture doc rewrite (`docs/reference/architecture.md`): expanded from ~200 lines to ~1200 lines covering every module, data model, migration phase, API pattern, async design, and design decision.
-- Clean up public repo: remove internal design docs, briefs, and plans from git tracking; move community files to `.github/`; gitignore local dev config.
-
-### Fixed
-
-- Fix misleading "bot token" terminology across entire project: GUI labels, CLI help, all user-facing docs, code comments, and reference docs now consistently say "user token" with plain-English explanations for non-technical users. Expanded token setup guide with step-by-step browser instructions and Local Storage troubleshooting.
-- Exclude internal design docs (`docs/plans/`, brief) from public docs site via `exclude_docs`.
-- Add dark/light mode toggle and GitHub repo link to docs site theme.
-
 ## [1.4.0] — 2026-03-09
 
 ### Fixed


### PR DESCRIPTION
## Summary

Removes the orphan \`## [Unreleased]\` heading that sat between \`[1.5.0]\` and \`[1.4.0]\` in CHANGELOG.md. The block contained 9 docs-pass bullet points (CLI flag accuracy, mkdocs rendering fix, plain English audit, architecture.md rewrite, public repo cleanup, bot-token terminology fix, dark mode toggle) that were never folded into a versioned release.

Closes the last remaining "Open follow-up" listed in MEMORY.md [STATE].

## Why delete vs fold vs rename?

| Option | Result | Rejected because |
|--------|--------|------------------|
| **Delete (chosen)** | Single \`[Unreleased]\` at line 7; orphan content lives only in git log | Clean. CHANGELOG is curated user-facing log, not complete history. |
| Fold into \`[1.5.0]\` | \`[1.5.0]\` grows by 9 bullets | Falsely attributes content; most was likely v1.6.0/v1.7.0-era work |
| Assign retroactive \`[1.5.1]\` / \`[1.7.2]\` | New version header for content that shipped | Fabricates a tag that never existed in git |
| Leave as-is | Orphan stays | Recurring gotcha; designs/plans had to special-case "do NOT touch line-141" |

All described work IS live on main and reflected in current docs/source — verifiable by inspection. Git log preserves authoritative attribution.

## Diff

1 file, 17 deletions:
\`\`\`
CHANGELOG.md | 17 -----------------
\`\`\`

## Test plan

- [x] Local verification: 764/764 tests pass + ruff + format + mypy clean
- [x] CHANGELOG now has exactly ONE \`## [Unreleased]\` heading (line 7)
- [x] \`[1.5.0]\` → \`[1.4.0]\` boundary clean (single blank line separator, matching other section boundaries)

## No version bump

Per CLAUDE.md version-numbering rules: "**No bump**: Content-only (docs, CLAUDE.md, CI config)". This PR is content-only — \`pyproject.toml\` and \`__init__.py\` unchanged. \`auto-tag.yml\` will not fire on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)