### PR TITLE
chore: migrate GitHub URL references to nordscope-fi

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for your interest in contributing!
 
 ## Development setup
 
-1. Clone the repo: `git clone https://github.com/psthubhorizon/Discord-stoat-ferry.git`
+1. Clone the repo: `git clone https://github.com/nordscope-fi/Discord-stoat-ferry.git`
 2. Install uv: `pip install uv`
 3. Install dependencies: `uv sync --all-extras`
 4. Run tests: `uv run pytest`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions & Discussion
-    url: https://github.com/psthubhorizon/Discord-stoat-ferry/discussions
+    url: https://github.com/nordscope-fi/Discord-stoat-ferry/discussions
     about: Ask questions or start a discussion (please don't use issues for questions)

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -8,7 +8,7 @@ Pick your operating system below to get started.
 
 === "Windows"
 
-    1. Go to the [Discord Ferry releases page](https://github.com/psthubhorizon/Discord-stoat-ferry/releases) on GitHub.
+    1. Go to the [Discord Ferry releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases) on GitHub.
     2. Under the latest release, click **Ferry.exe** to download it.
     3. Double-click **Ferry.exe** to run it. Your browser will open automatically.
 
@@ -26,7 +26,7 @@ Pick your operating system below to get started.
 
 === "macOS"
 
-    1. Go to the [Discord Ferry releases page](https://github.com/psthubhorizon/Discord-stoat-ferry/releases) on GitHub.
+    1. Go to the [Discord Ferry releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases) on GitHub.
     2. Under the latest release, click **Ferry-macos-arm64.zip** to download it.
     3. Unzip the downloaded file.
     4. Drag the **Ferry.app** icon into your **Applications** folder.
@@ -113,4 +113,4 @@ sudo apt install python3.11
 ```
 
 !!! tip "Still stuck?"
-    Open an issue on the [Discord Ferry GitHub page](https://github.com/psthubhorizon/Discord-stoat-ferry/issues) and include the error message you saw. Someone from the community will help you out.
+    Open an issue on the [Discord Ferry GitHub page](https://github.com/nordscope-fi/Discord-stoat-ferry/issues) and include the error message you saw. Someone from the community will help you out.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -104,7 +104,7 @@ This page covers the most common problems encountered during migration, their ca
 |---|---|
 | **Symptom** | Windows Defender or another antivirus quarantines or blocks `ferry.exe` |
 | **Cause** | Ferry is packaged as a single-file app using PyInstaller (a Python packaging tool). These self-extracting apps are frequently flagged as false positives by antivirus software because the extraction technique resembles some malware behavior. |
-| **Solution** | Add `ferry.exe` to your antivirus exclusion list. If your organization's policy prevents this, use the Python source distribution instead: clone the [GitHub repository](https://github.com/psthubhorizon/Discord-stoat-ferry) and install with `uv pip install .`, then run with `ferry` directly. The source distribution is not affected by this issue. |
+| **Solution** | Add `ferry.exe` to your antivirus exclusion list. If your organization's policy prevents this, use the Python source distribution instead: clone the [GitHub repository](https://github.com/nordscope-fi/Discord-stoat-ferry) and install with `uv pip install .`, then run with `ferry` directly. The source distribution is not affected by this issue. |
 
 ### macOS "app is damaged and can't be opened"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Discord Ferry
 site_description: Migrate Discord servers to Stoat (formerly Revolt)
-repo_url: https://github.com/psthubhorizon/Discord-stoat-ferry
-repo_name: psthubhorizon/Discord-stoat-ferry
+repo_url: https://github.com/nordscope-fi/Discord-stoat-ferry
+repo_name: nordscope-fi/Discord-stoat-ferry
 theme:
   name: material
   palette:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ ferry-gui = "discord_ferry.gui:main"
 ferry-desktop = "discord_ferry.gui:main"
 
 [project.urls]
-Homepage = "https://github.com/psthubhorizon/Discord-stoat-ferry"
-Issues = "https://github.com/psthubhorizon/Discord-stoat-ferry/issues"
+Homepage = "https://github.com/nordscope-fi/Discord-stoat-ferry"
+Issues = "https://github.com/nordscope-fi/Discord-stoat-ferry/issues"
 
 [project.optional-dependencies]
 native = [


### PR DESCRIPTION
## Summary

The repo was transferred from `psthubhorizon` to `nordscope-fi`. The git remote was updated as part of the transfer, but hardcoded URLs in user-visible places still point at the old owner. They currently work via GitHub's transfer redirect, but the redirect leaves a stale-looking owner in PyPI metadata, rendered docs, and the install guide. This PR fixes the references.

## Files

- `pyproject.toml` — `Homepage` + `Issues` (visible on PyPI page)
- `mkdocs.yml` — `repo_url` + `repo_name` (rendered docs GitHub-corner)
- `.github/CONTRIBUTING.md` — clone command in contributor docs
- `.github/ISSUE_TEMPLATE/config.yml` — discussions link
- `docs/getting-started/install.md` — releases + issues URLs (3 occurrences)
- `docs/guides/troubleshooting.md` — source-install instructions

Net change: 6 files, 10 line edits. No code or test changes.

## Verification

- [x] `git grep -nE "psthubhorizon/Discord-stoat-ferry"` returns nothing
- [x] `pytest -q` passes (764/764 tests, verified before the rewrite as a smoke test of the new Mac dev environment)
- [x] All replacement URLs resolve to the canonical `nordscope-fi/Discord-stoat-ferry` repo

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>