### PR TITLE
fix: rewrite DCE stdout parser (issue #23, ships v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-16
+
+### Changed
+
+- **`MigrationEvent.current` / `MigrationEvent.total` semantics changed for export-phase events** (issue #23). Previously these fields held the per-channel percentage (`current=NN, total=100`). They now hold the overall channel count (`current=channels_done, total=total_channels`). The progress-bar fraction `current / total` is unchanged in shape (still 0-1) but its meaning is "fraction of channels completed" instead of "fraction of current channel completed." Any external consumer of `MigrationEvent` reading these fields needs to know.
+
+### Fixed
+
+- **DCE export progress was invisible -- bug latent since 2026-02-28** (issue #23): the per-channel progress regex never matched any line that DCE 2.47.1 actually emits. Verified by reading `Tyrrrz/DiscordChatExporter@2.47.1` source -- DCE uses Spectre.Console's `FallbackProgressRenderer` when stdout is piped, which emits `<channel name>: NN%` (no brackets, no `#`, hierarchical names joined with ` / `). User-visible symptom: GUI sat on `"Discord Chat Exporter -- Started"` for 5-30 minutes on large servers. Replaced with a typed-union parser (`src/discord_ferry/exporter/dce_output.py`) handling all DCE 2.47.1 line types: `PerChannel`, `Phase` (Fetching/Fetched/Exporting headlines), `Success`, `Banner`, `StatusDot`, and `Raw` fallthrough for unknown lines. Unknown lines now surface to the GUI as `[dce] <line>` instead of being lost to `logger.debug`. Reported by @The-Red-Priest.
+- **Windows console flash during DCE startup**: DCE child process was spawned without `CREATE_NO_WINDOW`, briefly flashing a console window before the parent claimed the pipes. Now spawned with `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` on Windows.
+- **Stderr drain task leaked on cancel path**: cancelling an export mid-stream left the `_read_stderr` task running until garbage collection. Now cleaned up via `try/finally` on every exit path.
+- **`asyncio.LimitOverrunError` would crash the GUI on long lines**: a single DCE stdout line exceeding 64 KiB (improbable, but possible from malformed JSON paths in error traces) would bubble out of the stdout loop, bypassing cancel checks and crashing the event loop. Now caught and reported as `[dce] <truncated N bytes; line exceeded 64 KiB>` while the loop continues.
+- **Windows cancel left partial JSON files**: hard-kill on Windows gave DCE no chance to flush. Now sends `CTRL_BREAK_EVENT` to the DCE process group (DCE has a `CancelKeyPress` handler), with a 3-second graceful-shutdown window before falling back to hard kill. POSIX behavior unchanged (already used `SIGTERM`). Caveat: the channel currently being exported may still produce a partial JSON file -- users should expect to delete the export folder before retrying after a cancel.
+
 ## [2.1.6] - 2026-05-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.6"
+version = "2.2.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.6"
+__version__ = "2.2.0"

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -10,6 +10,7 @@ calls parse_dce_line on each decoded stdout line and dispatches on the union.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -87,9 +88,24 @@ class Raw:
 ParsedDceLine = PerChannel | Phase | Success | Banner | StatusDot | Error | Raw
 
 
+_PHASE_PATTERNS: tuple[tuple[PhaseKind, re.Pattern[str]], ...] = (
+    ("fetching_channels", re.compile(r"^Fetching channels\.\.\.$")),
+    ("fetching_threads", re.compile(r"^Fetching threads\.\.\.$")),
+    ("fetched_channels", re.compile(r"^Fetched (?P<n>\d+) channel\(s\)\.$")),
+    ("fetched_threads", re.compile(r"^Fetched (?P<n>\d+) thread\(s\)\.$")),
+    ("exporting_header", re.compile(r"^Exporting (?P<n>\d+) channel\(s\)\.\.\.$")),
+)
+
+
 def parse_dce_line(line: str) -> ParsedDceLine:
     """Map one DCE stdout line to a typed ParsedDceLine.
 
     Total function: every input maps to some result; never raises.
     """
+    for kind, pattern in _PHASE_PATTERNS:
+        match = pattern.match(line)
+        if match:
+            count = int(match.group("n")) if "n" in match.groupdict() and match.group("n") else None
+            return Phase(kind=kind, count=count, message=line)
+
     return Raw(message=line)

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -1,0 +1,95 @@
+"""Pure parser for DiscordChatExporter (DCE) 2.47.1 stdout lines.
+
+Public surface:
+  - parse_dce_line(line: str) -> ParsedDceLine  (total, no I/O)
+  - ParsedDceLine = PerChannel | Phase | Success | Banner | StatusDot | Error | Raw
+
+This module has zero side effects and zero subprocess interaction. The runner
+calls parse_dce_line on each decoded stdout line and dispatches on the union.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True, slots=True)
+class PerChannel:
+    """A `<channel>: NN%` progress line from DCE's Spectre.Console fallback renderer."""
+
+    channel: str
+    pct: int  # 0-100, integer (DCE emits milestones {25, 50, 75, 95, 96, 97, 98, 99, 100})
+
+
+PhaseKind = Literal[
+    "fetching_channels",
+    "fetched_channels",
+    "fetching_threads",
+    "fetched_threads",
+    "exporting_header",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Phase:
+    """Headline phase line from DCE.
+
+    `count` is None for `fetching_*` (no integer in the line); int for
+    `fetched_*` and `exporting_header`.
+    """
+
+    kind: PhaseKind
+    count: int | None
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class Success:
+    """Final `Successfully exported N channel(s).` line."""
+
+    count: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class Banner:
+    """One line of the Ukraine-support banner DCE prints first."""
+
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class StatusDot:
+    """Spectre status-ticker fallback: a line of `...`."""
+
+    message: str  # always "..." but preserved for log faithfulness
+
+
+@dataclass(frozen=True, slots=True)
+class Error:
+    """Reserved for future use; parser does not currently emit Error.
+
+    DCE writes errors to stderr (handled by _read_stderr in runner). Kept in
+    the union so error-path lines added later are non-breaking for callers.
+    """
+
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class Raw:
+    """Fallthrough: any line that did not match a more specific kind."""
+
+    message: str
+
+
+ParsedDceLine = PerChannel | Phase | Success | Banner | StatusDot | Error | Raw
+
+
+def parse_dce_line(line: str) -> ParsedDceLine:
+    """Map one DCE stdout line to a typed ParsedDceLine.
+
+    Total function: every input maps to some result; never raises.
+    """
+    return Raw(message=line)

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -88,6 +88,11 @@ class Raw:
 ParsedDceLine = PerChannel | Phase | Success | Banner | StatusDot | Error | Raw
 
 
+# GREEDY (.+, not .+?) + anchored: backtracking lets the channel match the
+# largest substring that still leaves ': <digits>%$' at the end. This is what
+# makes `category: subname / channel: 50%` parse correctly.
+_PER_CHANNEL_RE = re.compile(r"^(?P<channel>.+):\s(?P<pct>\d+)%$")
+
 _PHASE_PATTERNS: tuple[tuple[PhaseKind, re.Pattern[str]], ...] = (
     ("fetching_channels", re.compile(r"^Fetching channels\.\.\.$")),
     ("fetching_threads", re.compile(r"^Fetching threads\.\.\.$")),
@@ -103,7 +108,20 @@ def parse_dce_line(line: str) -> ParsedDceLine:
     """Map one DCE stdout line to a typed ParsedDceLine.
 
     Total function: every input maps to some result; never raises.
+
+    Patterns tried in order:
+      1. PerChannel -- most common at runtime
+      2. Phase headlines
+      3. Success final line
+      4. Raw fallthrough
     """
+    pc_match = _PER_CHANNEL_RE.match(line)
+    if pc_match:
+        return PerChannel(
+            channel=pc_match.group("channel"),
+            pct=int(pc_match.group("pct")),
+        )
+
     for kind, pattern in _PHASE_PATTERNS:
         match = pattern.match(line)
         if match:

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -105,7 +105,7 @@ def parse_dce_line(line: str) -> ParsedDceLine:
     for kind, pattern in _PHASE_PATTERNS:
         match = pattern.match(line)
         if match:
-            count = int(match.group("n")) if "n" in match.groupdict() and match.group("n") else None
+            count = int(match.group("n")) if "n" in match.groupdict() else None
             return Phase(kind=kind, count=count, message=line)
 
     return Raw(message=line)

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -103,6 +103,12 @@ _PHASE_PATTERNS: tuple[tuple[PhaseKind, re.Pattern[str]], ...] = (
 
 _SUCCESS_RE = re.compile(r"^Successfully exported (?P<n>\d+) channel\(s\)\.$")
 
+_STATUS_DOT_RE = re.compile(r"^\.{3,}$")
+
+# Ukraine banner box-drawing characters: corners, edges, vertical bar.
+# Box edges and content rows all start with one of these.
+_BANNER_RE = re.compile(r"^[┌┐└┘─│]")
+
 
 def parse_dce_line(line: str) -> ParsedDceLine:
     """Map one DCE stdout line to a typed ParsedDceLine.
@@ -110,10 +116,12 @@ def parse_dce_line(line: str) -> ParsedDceLine:
     Total function: every input maps to some result; never raises.
 
     Patterns tried in order:
-      1. PerChannel -- most common at runtime
-      2. Phase headlines
-      3. Success final line
-      4. Raw fallthrough
+      1. PerChannel  -- most common at runtime
+      2. Phase       -- headline lines
+      3. Success     -- final line
+      4. StatusDot   -- Spectre fallback `...`
+      5. Banner      -- Ukraine banner box-drawing
+      6. Raw         -- fallthrough
     """
     pc_match = _PER_CHANNEL_RE.match(line)
     if pc_match:
@@ -131,5 +139,11 @@ def parse_dce_line(line: str) -> ParsedDceLine:
     success_match = _SUCCESS_RE.match(line)
     if success_match:
         return Success(count=int(success_match.group("n")), message=line)
+
+    if _STATUS_DOT_RE.match(line):
+        return StatusDot(message=line)
+
+    if _BANNER_RE.match(line):
+        return Banner(message=line)
 
     return Raw(message=line)

--- a/src/discord_ferry/exporter/dce_output.py
+++ b/src/discord_ferry/exporter/dce_output.py
@@ -96,6 +96,8 @@ _PHASE_PATTERNS: tuple[tuple[PhaseKind, re.Pattern[str]], ...] = (
     ("exporting_header", re.compile(r"^Exporting (?P<n>\d+) channel\(s\)\.\.\.$")),
 )
 
+_SUCCESS_RE = re.compile(r"^Successfully exported (?P<n>\d+) channel\(s\)\.$")
+
 
 def parse_dce_line(line: str) -> ParsedDceLine:
     """Map one DCE stdout line to a typed ParsedDceLine.
@@ -107,5 +109,9 @@ def parse_dce_line(line: str) -> ParsedDceLine:
         if match:
             count = int(match.group("n")) if "n" in match.groupdict() else None
             return Phase(kind=kind, count=count, message=line)
+
+    success_match = _SUCCESS_RE.match(line)
+    if success_match:
+        return Success(count=int(success_match.group("n")), message=line)
 
     return Raw(message=line)

--- a/src/discord_ferry/exporter/manager.py
+++ b/src/discord_ferry/exporter/manager.py
@@ -103,12 +103,15 @@ def detect_dotnet() -> bool:
     """Check if .NET 8+ runtime is available. Always True on Windows (self-contained)."""
     if platform.system() == "Windows":
         return True
+    # On non-Windows the Windows-only flag does not exist -- pass 0 (no-op).
+    creationflags = 0
     try:
         result = subprocess.run(
             ["dotnet", "--version"],
             capture_output=True,
             text=True,
             timeout=10,
+            creationflags=creationflags,
         )
         if result.returncode != 0:
             return False

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -6,12 +6,23 @@ import asyncio
 import logging
 import re
 import shutil
+import subprocess
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.errors import DiscordAuthError, ExportError
+from discord_ferry.exporter.dce_output import (
+    Banner,
+    ParsedDceLine,
+    PerChannel,
+    Phase,
+    Raw,
+    StatusDot,
+    Success,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,6 +39,14 @@ _DCE_PROGRESS_RE = re.compile(
 )
 
 _DISK_WARN_BYTES = 5_000_000_000  # 5 GB
+
+# Windows console + signal flags. On non-Windows these are 0 (no-op).
+_CREATE_NEW_PROCESS_GROUP: int = (
+    getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+)
+_CREATE_NO_WINDOW: int = (
+    getattr(subprocess, "CREATE_NO_WINDOW", 0)
+)
 
 
 def _build_dce_command(config: FerryConfig, dce_path: Path) -> list[str]:
@@ -71,6 +90,126 @@ def _check_disk_space(export_dir: Path, on_event: EventCallback) -> None:
             )
     except OSError:
         pass  # Can't check disk space -- not critical
+
+
+@dataclass
+class _RunState:
+    """Per-export mutable state for tracking overall progress.
+
+    `total_channels` is set once when the `Exporting N channel(s)...` headline
+    arrives; subsequent headers are ignored to defend against DCE retries
+    re-emitting the header.
+
+    `channels_completed` is a SET (not a counter) for structural defense
+    against DCE's per-channel retry behavior: a channel that hits 100%, fails
+    transiently, retries from 25%, and hits 100% again would otherwise
+    double-count and overshoot total_channels.
+    """
+
+    total_channels: int | None = None
+    channels_completed: set[str] = field(default_factory=set)
+
+
+def _emit_for_parsed(
+    parsed: ParsedDceLine,
+    on_event: EventCallback,
+    state: _RunState,
+) -> None:
+    """Translate a ParsedDceLine into one or more MigrationEvents.
+
+    PerChannel:
+      - Updates state on pct==100 (adds channel to channels_completed set).
+      - Emits with current=len(channels_completed), total=total_channels.
+      - Label format: `Finished <ch>` for 100%, `<ch> (<pct>%)` otherwise.
+
+    Phase(exporting_header):
+      - Sets state.total_channels (set-once); emits a progress event.
+
+    Phase(other):
+      - Emits the headline message verbatim.
+
+    Success:
+      - If count < state.total_channels, emits a warning about silent failures
+        BEFORE emitting the success message itself.
+
+    Banner / StatusDot / Raw:
+      - Emit prefixed with `[dce] ` to make their provenance clear in the log.
+    """
+    match parsed:
+        case PerChannel(channel=ch, pct=p):
+            if p == 100:
+                state.channels_completed.add(ch)
+            current = len(state.channels_completed)
+            total = state.total_channels or 0
+            label = f"Finished {ch}" if p == 100 else f"{ch} ({p}%)"
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message=label,
+                    channel_name=ch,
+                    current=current,
+                    total=total,
+                )
+            )
+        case Phase(kind="exporting_header", count=n, message=msg):
+            if state.total_channels is None and n is not None:
+                state.total_channels = n
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message=msg,
+                    current=len(state.channels_completed),
+                    total=state.total_channels or 0,
+                )
+            )
+        case Phase(message=msg):
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message=msg,
+                )
+            )
+        case Success(count=s, message=msg):
+            if state.total_channels is not None and s < state.total_channels:
+                missing = state.total_channels - s
+                on_event(
+                    MigrationEvent(
+                        phase="export",
+                        status="warning",
+                        message=(
+                            f"DCE reports {s} of {state.total_channels} channels "
+                            f"exported successfully. {missing} channel(s) appear "
+                            "to have failed silently."
+                        ),
+                    )
+                )
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message=msg,
+                )
+            )
+        case Banner(message=msg) | StatusDot(message=msg) | Raw(message=msg):
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="progress",
+                    message=f"[dce] {msg}",
+                )
+            )
+        case _:
+            # Future variants (Error, etc.) -- emit as warning so never silent.
+            on_event(
+                MigrationEvent(
+                    phase="export",
+                    status="warning",
+                    message=f"[dce] {parsed.message}",
+                )
+            )
 
 
 async def validate_discord_token(token: str) -> None:

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -6,7 +6,9 @@ import asyncio
 import logging
 import re
 import shutil
+import signal
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -210,6 +212,58 @@ def _emit_for_parsed(
                     message=f"[dce] {parsed.message}",
                 )
             )
+
+
+async def _terminate_process(process: asyncio.subprocess.Process) -> None:
+    """Platform-aware subprocess termination.
+
+    POSIX: SIGTERM (process.terminate()) -- DCE has a chance to flush partial
+    JSON before exit.
+
+    Windows: CTRL_BREAK_EVENT to the child's process group (safe because we
+    spawned with CREATE_NEW_PROCESS_GROUP -- the signal targets only the child,
+    not Ferry). DCE's .NET CancelKeyPress handler runs a graceful shutdown.
+    Falls back to hard kill after 3s if the child does not exit.
+    """
+    if sys.platform == "win32":
+        try:
+            process.send_signal(signal.CTRL_BREAK_EVENT)
+        except (ValueError, OSError):
+            process.terminate()  # fallback: hard kill
+        try:
+            await asyncio.wait_for(process.wait(), timeout=3.0)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+    else:
+        process.terminate()
+        await process.wait()
+
+
+async def _drain_overlong_line(reader: asyncio.StreamReader) -> int:
+    r"""Consume bytes from `reader` until we reach `\n` (or EOF).
+
+    Used after `readuntil(b"\n")` raised LimitOverrunError to ensure the
+    remainder of the over-long line does not end up returned by the next
+    `readuntil` call as if it were its own line. Returns total bytes consumed.
+
+    Loops until either:
+      - `readuntil` finds the next `\n` (returns tail, total + len(tail))
+      - EOF is hit (IncompleteReadError, total + len(exc.partial))
+      - Another LimitOverrunError fires (consume that 64KiB chunk and keep going)
+    """
+    total = 0
+    while True:
+        try:
+            tail = await reader.readuntil(b"\n")
+            total += len(tail)
+            return total
+        except asyncio.LimitOverrunError as exc:
+            chunk = await reader.readexactly(exc.consumed)
+            total += len(chunk)
+        except asyncio.IncompleteReadError as exc:
+            total += len(exc.partial)
+            return total
 
 
 async def validate_discord_token(token: str) -> None:

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -38,12 +38,8 @@ logger = logging.getLogger(__name__)
 _DISK_WARN_BYTES = 5_000_000_000  # 5 GB
 
 # Windows console + signal flags. On non-Windows these are 0 (no-op).
-_CREATE_NEW_PROCESS_GROUP: int = (
-    getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-)
-_CREATE_NO_WINDOW: int = (
-    getattr(subprocess, "CREATE_NO_WINDOW", 0)
-)
+_CREATE_NEW_PROCESS_GROUP: int = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+_CREATE_NO_WINDOW: int = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
 
 def _build_dce_command(config: FerryConfig, dce_path: Path) -> list[str]:
@@ -360,10 +356,7 @@ async def run_dce_export(
                     MigrationEvent(
                         phase="export",
                         status="progress",
-                        message=(
-                            f"[dce] <truncated {consumed} bytes; "
-                            "line exceeded 64 KiB>"
-                        ),
+                        message=(f"[dce] <truncated {consumed} bytes; line exceeded 64 KiB>"),
                     )
                 )
                 continue

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-import re
 import shutil
 import signal
 import subprocess
@@ -24,6 +24,7 @@ from discord_ferry.exporter.dce_output import (
     Raw,
     StatusDot,
     Success,
+    parse_dce_line,
 )
 
 if TYPE_CHECKING:
@@ -33,12 +34,6 @@ if TYPE_CHECKING:
     from discord_ferry.core.events import EventCallback
 
 logger = logging.getLogger(__name__)
-
-# Regex to parse DCE stdout progress lines.
-# Matches: "[1/15] Exporting #general... 50.0%" or "[1/15] Exporting #general..."
-_DCE_PROGRESS_RE = re.compile(
-    r"\[\d+/\d+\] Exporting #(?P<channel>[^\s.]+)\.{3}\s*(?:(?P<pct>[\d.]+)%)?"
-)
 
 _DISK_WARN_BYTES = 5_000_000_000  # 5 GB
 
@@ -317,6 +312,7 @@ async def run_dce_export(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        creationflags=_CREATE_NO_WINDOW | _CREATE_NEW_PROCESS_GROUP,
     )
 
     # DCE prints nothing while it enumerates the guild's channels — on large
@@ -333,26 +329,47 @@ async def run_dce_export(
         )
     )
 
+    state = _RunState()
     stderr_lines: list[str] = []
 
-    try:
-        assert process.stdout is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    async def _read_stderr() -> None:
         assert process.stderr is not None
+        async for raw_line in process.stderr:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if line:
+                stderr_lines.append(line)
 
-        async def _read_stderr() -> None:
-            assert process.stderr is not None
-            async for raw_line in process.stderr:
-                line = raw_line.decode("utf-8", errors="replace").strip()
-                if line:
-                    stderr_lines.append(line)
+    stderr_task = asyncio.create_task(_read_stderr())
 
-        stderr_task = asyncio.create_task(_read_stderr())
+    try:
+        while True:
+            try:
+                raw_line = await process.stdout.readuntil(b"\n")
+            except asyncio.IncompleteReadError as exc:
+                raw_line = exc.partial
+                if not raw_line:
+                    break  # clean EOF
+            except asyncio.LimitOverrunError:
+                # Line longer than 64 KiB -- drain to next \n entirely so the
+                # remainder does not get parsed as a separate "line".
+                consumed = await _drain_overlong_line(process.stdout)
+                on_event(
+                    MigrationEvent(
+                        phase="export",
+                        status="progress",
+                        message=(
+                            f"[dce] <truncated {consumed} bytes; "
+                            "line exceeded 64 KiB>"
+                        ),
+                    )
+                )
+                continue
 
-        async for raw_line in process.stdout:
-            # Check cancel event.
             if config.cancel_event and config.cancel_event.is_set():
-                process.terminate()
-                await process.wait()
+                await _terminate_process(process)
                 raise asyncio.CancelledError("Export cancelled by user")
 
             line = raw_line.decode("utf-8", errors="replace").strip()
@@ -360,30 +377,22 @@ async def run_dce_export(
                 continue
 
             logger.debug("DCE: %s", line)
+            parsed = parse_dce_line(line)
+            _emit_for_parsed(parsed, on_event, state)
 
-            match = _DCE_PROGRESS_RE.search(line)
-            if match:
-                channel = match.group("channel")
-                pct_str = match.group("pct")
-                pct = int(float(pct_str)) if pct_str else 0
-                on_event(
-                    MigrationEvent(
-                        phase="export",
-                        status="progress",
-                        message=f"Exporting #{channel}...",
-                        channel_name=channel,
-                        current=pct,
-                        total=100,
-                    )
-                )
-
-        await stderr_task
         await process.wait()
 
     except asyncio.CancelledError:
-        process.terminate()
-        await process.wait()
+        await _terminate_process(process)
         raise
+    finally:
+        # IMPORTANT: cancel stderr_task BEFORE awaiting it so a hung _read_stderr
+        # does not deadlock the cleanup. Heartbeat-style tasks (#39) follow this
+        # same pattern.
+        if not stderr_task.done():
+            stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stderr_task
 
     if process.returncode != 0:
         last_err = stderr_lines[-1] if stderr_lines else "Unknown error"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -621,11 +621,21 @@ def export_page() -> None:
             if event.status == "progress":
                 if event.total > 0:
                     progress_bar.set_value(event.current / event.total)
-                if event.channel_name:
-                    channel_label.set_text(f"Exporting #{event.channel_name}...")
+                # The parser controls the label format. event.message is set
+                # for PerChannel ("<ch> (<pct>%)" or "Finished <ch>") and Phase
+                # ("Fetching channels...", etc.) events. Fall back to channel_name
+                # only if message is somehow empty.
+                if event.message:
+                    channel_label.set_text(event.message)
+                elif event.channel_name:
+                    channel_label.set_text(event.channel_name)
             elif event.status == "completed":
                 channel_label.set_text("Export complete!")
                 progress_bar.set_value(1.0)
+            elif event.status == "warning":
+                # Warnings (e.g. "DCE reports N of M channels...") deserve label
+                # surface time, not just the log panel.
+                channel_label.set_text(event.message)
             elif event.status == "error":
                 channel_label.set_text(f"Error: {event.message}")
 

--- a/tests/fixtures/dce_stdout_sample.txt
+++ b/tests/fixtures/dce_stdout_sample.txt
@@ -1,12 +1,47 @@
-Starting export of guild 123456789...
-[1/15] Exporting #general...
-[1/15] Exporting #general... 25.0%
-[1/15] Exporting #general... 50.0%
-[1/15] Exporting #general... 100.0%
-[2/15] Exporting #announcements...
-[2/15] Exporting #announcements... 100.0%
-[3/15] Exporting #memes...
-[3/15] Exporting #memes... 33.3%
-[3/15] Exporting #memes... 66.7%
-[3/15] Exporting #memes... 100.0%
-Export complete.
+# Hybrid DCE 2.47.1 stdout fixture for Ferry parser tests.
+#
+# Lines 1-13 (before the [HYBRID BOUNDARY] comment): captured 2026-05-15
+# from real DCE 2.47.1 invocation (macOS-arm64, stdout piped, intentionally
+# invalid token to keep the capture short). Original at /tmp/dce-stdout-piped.log.
+#
+# Lines after the boundary: derived from DCE source at tag 2.47.1 --
+# specifically ExportGuildCommand.cs, ExportCommandBase.cs, and Spectre's
+# FallbackProgressRenderer.cs. The post-auth path is not yet captured because
+# we don't have a test Discord server. See #35 for the plan to replace the
+# suffix with a real capture.
+#
+# Comment lines (this header) start with '#' and are stripped by tests that
+# read this file; the parser itself never sees them.
+┌────────────────────────────────────────────────────────────────────┐
+│   Thank you for supporting Ukraine <3                              │
+│                                                                    │
+│   As Russia wages a genocidal war against my country,              │
+│   I'm grateful to everyone who continues to                        │
+│   stand with Ukraine in our fight for freedom.                     │
+│                                                                    │
+│   Learn more: https://tyrrrz.me/ukraine                            │
+└────────────────────────────────────────────────────────────────────┘
+
+Fetching channels...
+...
+# [HYBRID BOUNDARY] -- below this point: source-derived
+Fetched 3 channel(s).
+Fetching threads...
+Fetched 0 thread(s).
+Exporting 3 channel(s)...
+general: 25%
+general: 50%
+general: 75%
+general: 95%
+general: 100%
+announcements: 25%
+announcements: 50%
+announcements: 75%
+announcements: 95%
+announcements: 100%
+memes: 25%
+memes: 50%
+memes: 75%
+memes: 95%
+memes: 100%
+Successfully exported 3 channel(s).

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -7,9 +7,11 @@ import dataclasses
 import pytest
 
 from discord_ferry.exporter.dce_output import (
+    Banner,
     PerChannel,
     Phase,
     Raw,
+    StatusDot,
     Success,
     parse_dce_line,
 )
@@ -128,4 +130,41 @@ class TestPerChannelParsing:
     def test_per_channel_decimal_pct_falls_through(self) -> None:
         # DCE per-source emits integer-only milestone percents. Reject decimals.
         result = parse_dce_line("general: 25.5%")
+        assert isinstance(result, Raw)
+
+
+class TestStatusDotParsing:
+    def test_status_dot_three(self) -> None:
+        result = parse_dce_line("...")
+        assert isinstance(result, StatusDot)
+        assert result.message == "..."
+
+    def test_status_dot_more(self) -> None:
+        # Spectre may emit longer dot runs.
+        result = parse_dce_line("......")
+        assert isinstance(result, StatusDot)
+
+
+class TestBannerParsing:
+    def test_banner_top_edge(self) -> None:
+        # Box-drawing top edge of Ukraine banner.
+        line = "┌" + "─" * 68 + "┐"
+        result = parse_dce_line(line)
+        assert isinstance(result, Banner)
+
+    def test_banner_text_inside(self) -> None:
+        # Vertical bar + text + vertical bar = Banner content row.
+        line = "│   Thank you for supporting Ukraine <3" + " " * 30 + "│"
+        result = parse_dce_line(line)
+        assert isinstance(result, Banner)
+
+
+class TestRawFallthrough:
+    def test_raw_unknown_text(self) -> None:
+        result = parse_dce_line("Some unknown DCE line we have not seen before")
+        assert isinstance(result, Raw)
+        assert result.message == "Some unknown DCE line we have not seen before"
+
+    def test_raw_empty_string(self) -> None:
+        result = parse_dce_line("")
         assert isinstance(result, Raw)

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -10,6 +10,7 @@ from discord_ferry.exporter.dce_output import (
     PerChannel,
     Phase,
     Raw,
+    Success,
     parse_dce_line,
 )
 
@@ -62,3 +63,17 @@ class TestPhaseParsing:
         assert result.kind == "exporting_header"
         assert result.count == 229
         assert result.message == "Exporting 229 channel(s)..."
+
+
+class TestSuccessParsing:
+    def test_success_typical(self) -> None:
+        result = parse_dce_line("Successfully exported 229 channel(s).")
+        assert isinstance(result, Success)
+        assert result.count == 229
+        assert result.message == "Successfully exported 229 channel(s)."
+
+    def test_success_count_zero(self) -> None:
+        # Edge case: empty server or all channels filtered out.
+        result = parse_dce_line("Successfully exported 0 channel(s).")
+        assert isinstance(result, Success)
+        assert result.count == 0

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -7,29 +7,23 @@ import dataclasses
 import pytest
 
 from discord_ferry.exporter.dce_output import (
-    Banner,
-    Error,
-    ParsedDceLine,
     PerChannel,
-    Phase,
     Raw,
-    StatusDot,
-    Success,
     parse_dce_line,
 )
 
 
 class TestModuleShape:
-    def test_dataclasses_are_frozen(self):
+    def test_dataclasses_are_frozen(self) -> None:
         pc = PerChannel(channel="general", pct=50)
         with pytest.raises(dataclasses.FrozenInstanceError):
             pc.pct = 99  # type: ignore[misc]
 
-    def test_parse_dce_line_returns_raw_for_unknown(self):
+    def test_parse_dce_line_returns_raw_for_unknown(self) -> None:
         result = parse_dce_line("totally unrecognized line")
         assert isinstance(result, Raw)
         assert result.message == "totally unrecognized line"
 
-    def test_parse_dce_line_is_total_on_empty_string(self):
+    def test_parse_dce_line_is_total_on_empty_string(self) -> None:
         result = parse_dce_line("")
         assert isinstance(result, Raw)

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -8,6 +8,7 @@ import pytest
 
 from discord_ferry.exporter.dce_output import (
     PerChannel,
+    Phase,
     Raw,
     parse_dce_line,
 )
@@ -27,3 +28,37 @@ class TestModuleShape:
     def test_parse_dce_line_is_total_on_empty_string(self) -> None:
         result = parse_dce_line("")
         assert isinstance(result, Raw)
+
+
+class TestPhaseParsing:
+    def test_phase_fetching_channels(self) -> None:
+        result = parse_dce_line("Fetching channels...")
+        assert isinstance(result, Phase)
+        assert result.kind == "fetching_channels"
+        assert result.count is None
+        assert result.message == "Fetching channels..."
+
+    def test_phase_fetched_channels(self) -> None:
+        result = parse_dce_line("Fetched 142 channel(s).")
+        assert isinstance(result, Phase)
+        assert result.kind == "fetched_channels"
+        assert result.count == 142
+
+    def test_phase_fetching_threads(self) -> None:
+        result = parse_dce_line("Fetching threads...")
+        assert isinstance(result, Phase)
+        assert result.kind == "fetching_threads"
+        assert result.count is None
+
+    def test_phase_fetched_threads(self) -> None:
+        result = parse_dce_line("Fetched 87 thread(s).")
+        assert isinstance(result, Phase)
+        assert result.kind == "fetched_threads"
+        assert result.count == 87
+
+    def test_phase_exporting_header(self) -> None:
+        result = parse_dce_line("Exporting 229 channel(s)...")
+        assert isinstance(result, Phase)
+        assert result.kind == "exporting_header"
+        assert result.count == 229
+        assert result.message == "Exporting 229 channel(s)..."

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -77,3 +77,55 @@ class TestSuccessParsing:
         result = parse_dce_line("Successfully exported 0 channel(s).")
         assert isinstance(result, Success)
         assert result.count == 0
+
+
+class TestPerChannelParsing:
+    """Per-channel `<name>: NN%` lines from DCE's Spectre fallback renderer.
+
+    The regex is intentionally greedy + anchored: ^(?P<channel>.+):\\s(?P<pct>\\d+)%$.
+    A non-greedy .+? would match only the prefix up to the first `:` and orphan
+    the rest of channels named like `category: subname / channel: 50%`. Backtracking
+    on greedy match resolves to the largest channel that still leaves : <digits>%$.
+    """
+
+    def test_per_channel_25(self) -> None:
+        result = parse_dce_line("general: 25%")
+        assert isinstance(result, PerChannel)
+        assert result.channel == "general"
+        assert result.pct == 25
+
+    def test_per_channel_hierarchical(self) -> None:
+        # DCE joins forum/thread hierarchy with " / ", NOT Discord's "#" prefix.
+        result = parse_dce_line("Information / general / my-thread: 50%")
+        assert isinstance(result, PerChannel)
+        assert result.channel == "Information / general / my-thread"
+        assert result.pct == 50
+
+    def test_per_channel_100(self) -> None:
+        result = parse_dce_line("announcements: 100%")
+        assert isinstance(result, PerChannel)
+        assert result.channel == "announcements"
+        assert result.pct == 100
+
+    def test_per_channel_with_colon_in_name(self) -> None:
+        # Adversarial: channel name itself contains ': '. Greedy match required.
+        # Non-greedy would yield channel="category" and orphan the rest.
+        result = parse_dce_line("category: subname / channel: 50%")
+        assert isinstance(result, PerChannel)
+        assert result.channel == "category: subname / channel"
+        assert result.pct == 50
+
+    def test_per_channel_no_percent_falls_through(self) -> None:
+        # Bare "25" might be a count or part of a name -- require the % suffix.
+        result = parse_dce_line("general: 25")
+        assert isinstance(result, Raw)
+
+    def test_per_channel_no_space_falls_through(self) -> None:
+        # Spectre always emits ": " (colon-space). Be strict about the separator.
+        result = parse_dce_line("general:25%")
+        assert isinstance(result, Raw)
+
+    def test_per_channel_decimal_pct_falls_through(self) -> None:
+        # DCE per-source emits integer-only milestone percents. Reject decimals.
+        result = parse_dce_line("general: 25.5%")
+        assert isinstance(result, Raw)

--- a/tests/test_dce_output.py
+++ b/tests/test_dce_output.py
@@ -1,0 +1,35 @@
+"""Tests for DCE stdout parser."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from discord_ferry.exporter.dce_output import (
+    Banner,
+    Error,
+    ParsedDceLine,
+    PerChannel,
+    Phase,
+    Raw,
+    StatusDot,
+    Success,
+    parse_dce_line,
+)
+
+
+class TestModuleShape:
+    def test_dataclasses_are_frozen(self):
+        pc = PerChannel(channel="general", pct=50)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            pc.pct = 99  # type: ignore[misc]
+
+    def test_parse_dce_line_returns_raw_for_unknown(self):
+        result = parse_dce_line("totally unrecognized line")
+        assert isinstance(result, Raw)
+        assert result.message == "totally unrecognized line"
+
+    def test_parse_dce_line_is_total_on_empty_string(self):
+        result = parse_dce_line("")
+        assert isinstance(result, Raw)

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -286,10 +286,13 @@ class TestStderrTaskDrainedOnCancel:
             if len(events) == 2:
                 cfg.cancel_event.set()
 
-        with patch(
-            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
-            new=AsyncMock(return_value=process),
-        ), pytest.raises(asyncio.CancelledError):
+        with (
+            patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
             await run_dce_export(cfg, tmp_path / "dce", cancel_after_first)
 
         if sys.platform != "win32":
@@ -310,13 +313,15 @@ class TestWindowsCreationFlags:
             captured_kwargs.update(kwargs)
             return process
 
-        with patch("discord_ferry.exporter.runner.sys.platform", "win32"), \
-             patch("discord_ferry.exporter.runner._CREATE_NO_WINDOW", 0x08000000), \
-             patch("discord_ferry.exporter.runner._CREATE_NEW_PROCESS_GROUP", 0x00000200), \
-             patch(
-                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
-                 new=_capture,
-             ):
+        with (
+            patch("discord_ferry.exporter.runner.sys.platform", "win32"),
+            patch("discord_ferry.exporter.runner._CREATE_NO_WINDOW", 0x08000000),
+            patch("discord_ferry.exporter.runner._CREATE_NEW_PROCESS_GROUP", 0x00000200),
+            patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                new=_capture,
+            ),
+        ):
             await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         flags = captured_kwargs.get("creationflags", 0)
@@ -347,13 +352,15 @@ class TestCancelSendsCtrlBreakOnWindows:
         # CTRL_BREAK_EVENT only exists on Windows; patch it in for POSIX runs.
         ctrl_break = getattr(_signal, "CTRL_BREAK_EVENT", 1)  # Windows value is 1
 
-        with patch("discord_ferry.exporter.runner.sys.platform", "win32"), \
-             patch.object(_signal, "CTRL_BREAK_EVENT", ctrl_break, create=True), \
-             patch(
-                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
-                 new=AsyncMock(return_value=process),
-             ), \
-             pytest.raises(asyncio.CancelledError):
+        with (
+            patch("discord_ferry.exporter.runner.sys.platform", "win32"),
+            patch.object(_signal, "CTRL_BREAK_EVENT", ctrl_break, create=True),
+            patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
             await run_dce_export(cfg, tmp_path / "dce", cancel_immediately)
 
         assert process.send_signal.called or process.terminate.called

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,56 +12,67 @@ from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.exporter.runner import (
-    _DCE_PROGRESS_RE,
     _build_dce_command,
     _check_disk_space,
+    _drain_overlong_line,
     run_dce_export,
     validate_discord_token,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
     from pathlib import Path
 
     from discord_ferry.core.events import MigrationEvent
 
 
-class TestProgressRegex:
-    def test_channel_with_percentage(self):
-        line = "[1/15] Exporting #general... 50.0%"
-        match = _DCE_PROGRESS_RE.search(line)
-        assert match is not None
-        assert match.group("channel") == "general"
-        assert match.group("pct") == "50.0"
+# ---------- Helpers ----------
 
-    def test_channel_start_no_percentage(self):
-        line = "[2/15] Exporting #announcements..."
-        match = _DCE_PROGRESS_RE.search(line)
-        assert match is not None
-        assert match.group("channel") == "announcements"
-        assert match.group("pct") is None
 
-    def test_no_match_for_other_lines(self):
-        line = "Starting export of guild 123..."
-        assert _DCE_PROGRESS_RE.search(line) is None
+def _make_config(tmp_path: Path) -> FerryConfig:
+    return FerryConfig(
+        export_dir=tmp_path / "exports",
+        stoat_url="https://stoat.example",
+        token="st",
+        discord_token="dt",
+        discord_server_id="12345",
+    )
 
-    def test_channel_100_percent(self):
-        line = "[3/15] Exporting #memes... 100.0%"
-        match = _DCE_PROGRESS_RE.search(line)
-        assert match is not None
-        assert match.group("channel") == "memes"
-        assert match.group("pct") == "100.0"
+
+async def _empty_stderr_iter() -> AsyncGenerator[bytes, None]:
+    for _ in ():
+        yield b""
+
+
+def _make_process(stdout_lines: list[bytes], returncode: int = 0) -> MagicMock:
+    """Build a MagicMock subprocess that yields stdout_lines via readuntil()."""
+    process = MagicMock()
+    queue: list[bytes] = list(stdout_lines)
+
+    async def _readuntil(_sep: bytes) -> bytes:
+        if not queue:
+            raise asyncio.IncompleteReadError(partial=b"", expected=None)
+        return queue.pop(0)
+
+    stdout = MagicMock()
+    stdout.readuntil = _readuntil
+    process.stdout = stdout
+    process.stderr = _empty_stderr_iter()
+    process.wait = AsyncMock(return_value=returncode)
+    process.returncode = returncode
+    process.terminate = MagicMock()
+    process.kill = MagicMock()
+    process.send_signal = MagicMock()
+    return process
+
+
+# ---------- Existing tests (preserved) ----------
 
 
 class TestBuildCommand:
-    def test_command_construction(self, tmp_path: Path):
+    def test_command_construction(self, tmp_path: Path) -> None:
         dce_path = tmp_path / "dce"
-        cfg = FerryConfig(
-            export_dir=tmp_path / "exports",
-            stoat_url="https://stoat.example",
-            token="st",
-            discord_token="dt",
-            discord_server_id="12345",
-        )
+        cfg = _make_config(tmp_path)
         cmd = _build_dce_command(cfg, dce_path)
         assert cmd[0] == str(dce_path)
         assert "exportguild" in cmd
@@ -80,35 +93,35 @@ class TestBuildCommand:
 
 
 class TestDiskSpaceCheck:
-    def test_warns_when_low(self, tmp_path: Path):
+    def test_warns_when_low(self, tmp_path: Path) -> None:
         events: list[MigrationEvent] = []
         with patch("discord_ferry.exporter.runner.shutil.disk_usage") as mock_du:
-            mock_du.return_value = MagicMock(free=1_000_000_000)  # 1 GB
+            mock_du.return_value = MagicMock(free=1_000_000_000)
             _check_disk_space(tmp_path, events.append)
         assert len(events) == 1
         assert "Low disk space" in events[0].message
 
-    def test_no_warning_when_plenty(self, tmp_path: Path):
+    def test_no_warning_when_plenty(self, tmp_path: Path) -> None:
         events: list[MigrationEvent] = []
         with patch("discord_ferry.exporter.runner.shutil.disk_usage") as mock_du:
-            mock_du.return_value = MagicMock(free=20_000_000_000)  # 20 GB
+            mock_du.return_value = MagicMock(free=20_000_000_000)
             _check_disk_space(tmp_path, events.append)
         assert len(events) == 0
 
 
 class TestValidateDiscordToken:
     @pytest.mark.asyncio
-    async def test_valid_token(self):
+    async def test_valid_token(self) -> None:
         with aioresponses() as m:
             m.get(
                 "https://discord.com/api/v10/users/@me",
                 status=200,
                 payload={"id": "1"},
             )
-            await validate_discord_token("valid-token")  # should not raise
+            await validate_discord_token("valid-token")
 
     @pytest.mark.asyncio
-    async def test_invalid_token(self):
+    async def test_invalid_token(self) -> None:
         from discord_ferry.errors import DiscordAuthError
 
         with aioresponses() as m:
@@ -117,7 +130,7 @@ class TestValidateDiscordToken:
                 await validate_discord_token("bad-token")
 
     @pytest.mark.asyncio
-    async def test_unexpected_status(self):
+    async def test_unexpected_status(self) -> None:
         from discord_ferry.errors import DiscordAuthError
 
         with aioresponses() as m:
@@ -126,36 +139,19 @@ class TestValidateDiscordToken:
                 await validate_discord_token("some-token")
 
 
-class TestRunDceExportProgressEmits:
-    """Lock in the progress-emit contract that closes the silent-window UX gap.
+# ---------- New tests for the v2.2.0 parser-based runner ----------
 
-    Without an emit between subprocess spawn and the first stdout regex match,
-    the GUI used to freeze on the last status for the entire DCE enumeration
-    phase (minutes on large servers — see issue #23).
+
+class TestRunDceExportProgressEmits:
+    """Lock in the early-emit contract: GUI must see something before stdout flows.
+
+    Added in v2.1.0 (#23 stopgap); remains required behavior.
     """
 
     @pytest.mark.asyncio
     async def test_enumerating_emit_fires_before_stdout_progress(self, tmp_path: Path) -> None:
-        async def _empty_iter():
-            for _ in ():
-                yield b""
-
-        async def _stdout_iter():
-            yield b"[1/3] Exporting #general... 50.0%\n"
-
-        process = MagicMock()
-        process.stdout = _stdout_iter()
-        process.stderr = _empty_iter()
-        process.wait = AsyncMock(return_value=0)
-        process.returncode = 0
-
-        cfg = FerryConfig(
-            export_dir=tmp_path / "exports",
-            stoat_url="https://stoat.example",
-            token="st",
-            discord_token="dt",
-            discord_server_id="12345",
-        )
+        process = _make_process([b"general: 25%\n"])
+        cfg = _make_config(tmp_path)
 
         events: list[MigrationEvent] = []
         with patch(
@@ -168,11 +164,228 @@ class TestRunDceExportProgressEmits:
         enumerating_idx = next(
             (i for i, m in enumerate(messages) if "enumerating channels" in m), None
         )
-        exporting_idx = next(
-            (i for i, m in enumerate(messages) if m.startswith("Exporting #")), None
+        per_channel_idx = next(
+            (i for i, m in enumerate(messages) if "general" in m and "25" in m), None
         )
-        assert enumerating_idx is not None, f"missing 'enumerating channels' emit; got {messages!r}"
-        assert exporting_idx is not None, f"missing per-channel emit; got {messages!r}"
-        assert enumerating_idx < exporting_idx, (
-            "enumeration emit must precede the first per-channel progress emit"
+        assert enumerating_idx is not None, f"missing enumerating emit; got {messages!r}"
+        assert per_channel_idx is not None, f"missing per-channel emit; got {messages!r}"
+        assert enumerating_idx < per_channel_idx
+
+
+class TestPerChannelEmitsOverallProgress:
+    @pytest.mark.asyncio
+    async def test_overall_progress_monotonic(self, tmp_path: Path) -> None:
+        lines = [
+            b"Exporting 3 channel(s)...\n",
+            b"general: 25%\n",
+            b"general: 50%\n",
+            b"general: 75%\n",
+            b"general: 95%\n",
+            b"general: 100%\n",
+            b"announcements: 25%\n",
+            b"announcements: 100%\n",
+            b"memes: 100%\n",
+            b"Successfully exported 3 channel(s).\n",
+        ]
+        process = _make_process(lines)
+        cfg = _make_config(tmp_path)
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        progress_currents = [e.current for e in events if e.total > 0]
+        for prev, nxt in zip(progress_currents, progress_currents[1:], strict=False):
+            assert prev <= nxt, f"progress went backward: {progress_currents!r}"
+        assert max(progress_currents) == 3
+        assert {e.total for e in events if e.total > 0} == {3}
+
+
+class TestPhaseLinesEmitProgressEvents:
+    @pytest.mark.asyncio
+    async def test_phase_lines_visible_to_gui(self, tmp_path: Path) -> None:
+        lines = [
+            b"Fetching channels...\n",
+            b"Fetched 5 channel(s).\n",
+            b"Fetching threads...\n",
+            b"Fetched 2 thread(s).\n",
+        ]
+        process = _make_process(lines)
+        cfg = _make_config(tmp_path)
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        messages = [e.message for e in events]
+        assert any("Fetching channels..." in m for m in messages)
+        assert any("Fetched 5 channel(s)." in m for m in messages)
+        assert any("Fetching threads..." in m for m in messages)
+        assert any("Fetched 2 thread(s)." in m for m in messages)
+
+
+class TestRawLinesRoutedToGui:
+    @pytest.mark.asyncio
+    async def test_unknown_line_emitted_to_gui_with_prefix(self, tmp_path: Path) -> None:
+        lines = [b"Some unknown DCE diagnostic line\n"]
+        process = _make_process(lines)
+        cfg = _make_config(tmp_path)
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        assert any("[dce] Some unknown DCE diagnostic line" in e.message for e in events)
+
+
+class TestSuccessCountWarning:
+    @pytest.mark.asyncio
+    async def test_success_less_than_total_emits_warning(self, tmp_path: Path) -> None:
+        lines = [
+            b"Exporting 10 channel(s)...\n",
+            b"Successfully exported 7 channel(s).\n",
+        ]
+        process = _make_process(lines)
+        cfg = _make_config(tmp_path)
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        warnings = [e for e in events if e.status == "warning"]
+        assert any(
+            "7 of 10" in w.message and "3 channel(s) appear to have failed silently" in w.message
+            for w in warnings
         )
+
+
+class TestStderrTaskDrainedOnCancel:
+    @pytest.mark.asyncio
+    async def test_stderr_task_done_after_cancel(self, tmp_path: Path) -> None:
+        lines = [b"general: 25%\n"] * 100
+        process = _make_process(lines)
+        cfg = _make_config(tmp_path)
+        cfg.cancel_event = asyncio.Event()
+
+        events: list[MigrationEvent] = []
+
+        def cancel_after_first(ev: MigrationEvent) -> None:
+            events.append(ev)
+            if len(events) == 2:
+                cfg.cancel_event.set()
+
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ), pytest.raises(asyncio.CancelledError):
+            await run_dce_export(cfg, tmp_path / "dce", cancel_after_first)
+
+        if sys.platform != "win32":
+            assert process.terminate.called
+
+
+class TestWindowsCreationFlags:
+    @pytest.mark.asyncio
+    async def test_creation_flags_include_no_window_and_new_process_group_on_windows(
+        self, tmp_path: Path
+    ) -> None:
+        process = _make_process([])
+        cfg = _make_config(tmp_path)
+
+        captured_kwargs: dict[str, int] = {}
+
+        async def _capture(*args: object, **kwargs: int) -> MagicMock:
+            captured_kwargs.update(kwargs)
+            return process
+
+        with patch("discord_ferry.exporter.runner.sys.platform", "win32"), \
+             patch("discord_ferry.exporter.runner._CREATE_NO_WINDOW", 0x08000000), \
+             patch("discord_ferry.exporter.runner._CREATE_NEW_PROCESS_GROUP", 0x00000200), \
+             patch(
+                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                 new=_capture,
+             ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+        flags = captured_kwargs.get("creationflags", 0)
+        assert flags & 0x08000000, "CREATE_NO_WINDOW bit not set"
+        assert flags & 0x00000200, "CREATE_NEW_PROCESS_GROUP bit not set"
+
+
+class TestCancelSendsCtrlBreakOnWindows:
+    @pytest.mark.asyncio
+    async def test_cancel_uses_ctrl_break_on_windows(self, tmp_path: Path) -> None:
+        import signal as _signal
+
+        lines = [b"general: 25%\n"] * 5
+        process = _make_process(lines)
+        process.wait = AsyncMock(return_value=0)
+
+        cfg = _make_config(tmp_path)
+        cfg.cancel_event = asyncio.Event()
+
+        events_seen = 0
+
+        def cancel_immediately(_ev: MigrationEvent) -> None:
+            nonlocal events_seen
+            events_seen += 1
+            if events_seen == 2:
+                cfg.cancel_event.set()
+
+        # CTRL_BREAK_EVENT only exists on Windows; patch it in for POSIX runs.
+        ctrl_break = getattr(_signal, "CTRL_BREAK_EVENT", 1)  # Windows value is 1
+
+        with patch("discord_ferry.exporter.runner.sys.platform", "win32"), \
+             patch.object(_signal, "CTRL_BREAK_EVENT", ctrl_break, create=True), \
+             patch(
+                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                 new=AsyncMock(return_value=process),
+             ), \
+             pytest.raises(asyncio.CancelledError):
+            await run_dce_export(cfg, tmp_path / "dce", cancel_immediately)
+
+        assert process.send_signal.called or process.terminate.called
+        if process.send_signal.called:
+            (sig_arg,), _ = process.send_signal.call_args
+            assert sig_arg == ctrl_break
+
+
+class TestLongLineHandling:
+    @pytest.mark.asyncio
+    async def test_drain_overlong_line_consumes_to_newline(self) -> None:
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"x" * 200 + b"\n" + b"next\n")
+        reader.feed_eof()
+
+        with pytest.raises(asyncio.LimitOverrunError):
+            await reader.readuntil(b"\n")
+
+        consumed = await _drain_overlong_line(reader)
+        assert consumed > 0
+
+        next_line = await reader.readuntil(b"\n")
+        assert next_line == b"next\n"
+
+    @pytest.mark.asyncio
+    async def test_drain_overlong_line_handles_eof(self) -> None:
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"x" * 200)
+        reader.feed_eof()
+
+        with pytest.raises(asyncio.LimitOverrunError):
+            await reader.readuntil(b"\n")
+
+        consumed = await _drain_overlong_line(reader)
+        assert consumed > 0

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.6"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #23. Replaces the per-channel progress regex in `runner.py` that never matched any line DCE 2.47.1 actually emits (latent since 2026-02-28). User-visible symptom from @The-Red-Priest: GUI sat on `"Discord Chat Exporter — Started"` for 5–30 minutes on large servers with zero progress feedback.

The fix:

- **New pure-function parser** at `src/discord_ferry/exporter/dce_output.py` that returns a typed union (`PerChannel | Phase | Success | Banner | StatusDot | Error | Raw`). Verified against real DCE 2.47.1 source (Spectre.Console `FallbackProgressRenderer` emits `<name>: NN%` when stdout is piped — never the bracketed `[N/M] Exporting #...` the broken regex expected).
- **Rewritten runner stdout loop** using explicit `readuntil(b"\n")` with `LimitOverrunError` + `IncompleteReadError` handling, `try/finally` stderr task cleanup, and platform-aware termination (`CTRL_BREAK_EVENT` via `CREATE_NEW_PROCESS_GROUP` on Windows; SIGTERM on POSIX).
- **GUI consumer fix** at `gui.py:on_export_event`: drops the hard-coded `f"Exporting #{event.channel_name}..."` (wrong for hierarchical names like `Information / general / my-thread`) and surfaces parser-set labels instead.
- **Hybrid fixture** at `tests/fixtures/dce_stdout_sample.txt` (captured prefix + source-derived suffix; full-capture replacement tracked under #35).
- **Version bump** 2.1.3 → 2.2.0 (minor — the `MigrationEvent.current/total` semantics flip described under `### Changed` is the breaking part).

## Breaking change

Per `CHANGELOG.md ## [2.2.0] ### Changed`: `MigrationEvent.current` and `MigrationEvent.total` semantics flip for export-phase events. They now hold `channels_done / total_channels` instead of `per_channel_pct / 100`. Any external consumer of `MigrationEvent` needs to know.

## Test plan

- [x] 792 tests pass on this branch (was 764 on origin/main + 28 new parser/runner tests)
- [x] mypy strict clean across `src/discord_ferry`
- [x] ruff lint + format clean across `src/` and `tests/`
- [x] Smoke test: invoked the real DCE 2.47.1 binary with an intentionally invalid token; parser correctly classified the banner box (8 lines with `[dce]` prefix), the `Fetching channels...` Phase line, and the `...` StatusDot; no leftover `Exporting #` output anywhere; exited gracefully with ExportError on auth failure
- [ ] Reviewer to confirm: regression-test the Windows console-flash + cancel paths on a Windows machine if possible (the integration tests patch `sys.platform = "win32"` but don't actually run on a Windows runner in this repo's CI matrix)

## Trap-points caught by spec critique passes (worth re-verifying)

The spec for this work went through two critique passes; three implementation-blocking bugs were caught in the first revision and fixed in the third revision. They are present and correct in this PR:

1. **Greedy regex** — `dce_output._PER_CHANNEL_RE` uses `.+` (greedy) not `.+?` (non-greedy). The trailing `: <digits>%$` anchor + backtracking lets channels with embedded colons (e.g. `category: subname / channel: 50%`) parse correctly. The canary test is `test_per_channel_with_colon_in_name` in `tests/test_dce_output.py`.
2. **Set-based dedup** — `runner._RunState.channels_completed` is `set[str]`, not a counter. DCE retries on transient channel failures and re-emits `name: 25%`; counter-based tracking would double-count when a retried channel hits 100% twice.
3. **Full-drain `readuntil` loop** — `runner._drain_overlong_line` keeps consuming until it actually finds a `\n` (or EOF). The first-revision version returned after `exc.consumed`, leaving the line's tail in the buffer for the next `readuntil` to return as a phantom "line".

## Follow-ups (separate issues)

This PR ships only the fix for #23. The investigation surfaced six related issues that are tracked separately and will land in their own PRs:

- #34 — DCE contract test in CI (uses `parse_dce_line` from this PR)
- #35 — captured-real fixtures (replaces the hybrid suffix with a real Discord-server capture)
- #36 — `isInline` embed-field parser fix
- #37 — ARM DCE checksum pinning (v2.1.5 additive, v2.2.0 fail-loud — to follow this PR)
- #38 — Windows compat audit + `xdg-open` → `os.startfile`
- #39 — adaptive backoff heartbeat / silence-breaker

## References

- Spec: `docs/superpowers/specs/2026-05-15-issue-23-dce-parser-rewrite-design.md` (third revision)
- Critique pass docs: `docs/superpowers/specs/2026-05-15-critique-pass.md`, `docs/superpowers/specs/2026-05-16-second-critique-pass.md`
- Implementation plan: `docs/superpowers/plans/2026-05-16-issue-23-dce-parser-rewrite.md`
- Original reporter: @The-Red-Priest
