### PR TITLE
fix: parser reads DCE's 'isInline' key, not 'inline' (issue #36, ships v2.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.4] - 2026-05-16
+
+### Fixed
+
+- **Embed fields with `isInline: true` now correctly render as pipe-separated rows in migrated messages** (#36). The parser previously read the wrong key (`inline`), causing every multi-field Discord embed to render as a stacked list since v1. Verified against DCE 2.47.1 source (`JsonMessageWriter.cs:259` writes `isInline`). Re-running migration on a server with bot-posted embeds will produce visibly cleaner output. The accompanying parser-audit appendix (see spec `docs/superpowers/specs/2026-05-15-issue-36-isinline-and-parser-audit-design.md`) confirmed this was the only key-typo in `transforms.py` and `dce_parser.py`.
+
 ## [2.1.3] - 2026-05-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.3"
+version = "2.1.4"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"

--- a/src/discord_ferry/parser/transforms.py
+++ b/src/discord_ferry/parser/transforms.py
@@ -207,7 +207,7 @@ def flatten_embed(
             fvalue = str(field_obj.get("value", ""))
             if not fname and not fvalue:
                 continue
-            is_inline = bool(field_obj.get("inline", False))
+            is_inline = bool(field_obj.get("isInline", False))
             if is_inline:
                 inline_row.append((fname, fvalue))
                 if len(inline_row) >= 3:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -307,9 +307,9 @@ def test_all_inline_fields_in_rows() -> None:
     """3 inline fields render as a pipe-separated row."""
     embed: dict[str, object] = {
         "fields": [
-            {"name": "HP", "value": "100", "inline": True},
-            {"name": "MP", "value": "50", "inline": True},
-            {"name": "ATK", "value": "25", "inline": True},
+            {"name": "HP", "value": "100", "isInline": True},
+            {"name": "MP", "value": "50", "isInline": True},
+            {"name": "ATK", "value": "25", "isInline": True},
         ],
     }
     result, _ = flatten_embed(embed)
@@ -318,11 +318,33 @@ def test_all_inline_fields_in_rows() -> None:
     assert "100 | 50 | 25" in desc
 
 
+def test_embed_field_inline_grouping_uses_dce_key() -> None:
+    """Regression for #36: parser must read DCE's `isInline`, not `inline`.
+
+    Before the fix, the parser read `inline` and silently ignored the real
+    `isInline` key, so every multi-field embed rendered as a stacked list
+    instead of a pipe-separated row.
+    """
+    # DCE 2.47.1 writes `isInline` (JsonMessageWriter.cs:259).
+    embed: dict[str, object] = {
+        "fields": [
+            {"name": "A", "value": "1", "isInline": True},
+            {"name": "B", "value": "2", "isInline": True},
+        ],
+    }
+    result, _ = flatten_embed(embed)
+    desc = str(result["description"])
+    # If the parser reads the wrong key, both fields collapse to non-inline blocks
+    # (`**A**\n1\n\n**B**\n2`), and `**A** | **B**` is absent.
+    assert "**A** | **B**" in desc
+    assert "1 | 2" in desc
+
+
 def test_non_inline_field_own_line() -> None:
     """Non-inline field renders as bold name on its own line, value below."""
     embed: dict[str, object] = {
         "fields": [
-            {"name": "Description", "value": "Long text", "inline": False},
+            {"name": "Description", "value": "Long text", "isInline": False},
         ],
     }
     result, _ = flatten_embed(embed)
@@ -335,11 +357,11 @@ def test_mixed_inline_breaks_rows() -> None:
     """[inline, inline, non-inline, inline, inline] produces 2 rows + 1 block."""
     embed: dict[str, object] = {
         "fields": [
-            {"name": "A", "value": "1", "inline": True},
-            {"name": "B", "value": "2", "inline": True},
-            {"name": "C", "value": "3", "inline": False},
-            {"name": "D", "value": "4", "inline": True},
-            {"name": "E", "value": "5", "inline": True},
+            {"name": "A", "value": "1", "isInline": True},
+            {"name": "B", "value": "2", "isInline": True},
+            {"name": "C", "value": "3", "isInline": False},
+            {"name": "D", "value": "4", "isInline": True},
+            {"name": "E", "value": "5", "isInline": True},
         ],
     }
     result, _ = flatten_embed(embed)
@@ -358,12 +380,12 @@ def test_max_three_inline_per_row() -> None:
     """6 inline fields produce exactly 2 rows of 3."""
     embed: dict[str, object] = {
         "fields": [
-            {"name": "A", "value": "1", "inline": True},
-            {"name": "B", "value": "2", "inline": True},
-            {"name": "C", "value": "3", "inline": True},
-            {"name": "D", "value": "4", "inline": True},
-            {"name": "E", "value": "5", "inline": True},
-            {"name": "F", "value": "6", "inline": True},
+            {"name": "A", "value": "1", "isInline": True},
+            {"name": "B", "value": "2", "isInline": True},
+            {"name": "C", "value": "3", "isInline": True},
+            {"name": "D", "value": "4", "isInline": True},
+            {"name": "E", "value": "5", "isInline": True},
+            {"name": "F", "value": "6", "isInline": True},
         ],
     }
     result, _ = flatten_embed(embed)
@@ -419,8 +441,8 @@ def test_unicode_field_names_preserved() -> None:
     """Unicode characters in field names and values are preserved."""
     embed: dict[str, object] = {
         "fields": [
-            {"name": "\u2764\ufe0f Health", "value": "\u2b50 100", "inline": True},
-            {"name": "\u2694\ufe0f Attack", "value": "\u2b50 50", "inline": True},
+            {"name": "\u2764\ufe0f Health", "value": "\u2b50 100", "isInline": True},
+            {"name": "\u2694\ufe0f Attack", "value": "\u2b50 50", "isInline": True},
         ],
     }
     result, _ = flatten_embed(embed)

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #36. Discord Ferry's embed-field parser read the wrong key — `inline` instead of DCE 2.47.1's actual `isInline` (per `JsonMessageWriter.cs:259`). Result: every multi-field embed in every export since v1 has rendered as a stacked list instead of a pipe-separated row.

This PR is a one-line production change (`transforms.py:210`), six mechanical test updates (the tests used the same wrong key), and one new regression test that uses the DCE-correct key.

The spec's audit appendix confirmed this is the only key-typo of its kind in `transforms.py` and `dce_parser.py` — the hypothesis "the parser is riddled with similar typos" was falsified by cross-referencing every Ferry `obj.get(...)` against every DCE `_writer.WriteX("...", ...)` call (full cross-reference table in the spec).

## Test plan

- [x] Existing inline-related tests in `tests/test_transforms.py` updated to use `isInline` (still pass)
- [x] New `test_embed_field_inline_grouping_uses_dce_key` regression test passes
- [x] Full test suite passes (no regressions elsewhere)
- [x] mypy strict + ruff lint + format all clean
- [ ] Reviewer to confirm: visually inspect one re-migrated multi-field embed on a Stoat target server to confirm pipe-separated rendering

## References

- Spec: `docs/superpowers/specs/2026-05-15-issue-36-isinline-and-parser-audit-design.md` (revised after critique pass)
- Audit appendix (in spec) confirming n=1 typo
- DCE source: `Tyrrrz/DiscordChatExporter@2.47.1/JsonMessageWriter.cs:259`
