### PR TITLE
fix(gui): use os.startfile on Windows for Open Report (issue #38, ships v2.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.6] - 2026-05-16
+
+### Fixed
+
+- **Open Report button now works on Windows** (#38). Previously, the GUI's "Open report" action tried to invoke `xdg-open` on Windows (`sys.platform == "win32"` falls into the non-darwin branch), which doesn't exist — the click silently failed with a `ui.notify` toast. Replaced with a three-branch platform check using `os.startfile(path)` on Windows. Bundled audit confirmed `xdg-open` was the only Windows-incompat bug in `src/` (full grep results in `docs/superpowers/specs/2026-05-15-issue-38-windows-compat-audit-design.md`); no other code paths needed changes.
+
 ## [2.1.5] - 2026-05-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.1.5"
+version = "2.1.6"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -83,6 +83,22 @@ _STEP_LABELS: list[str] = ["Configure", "Export", "Validate", "Migrate", "Done"]
 # ---------------------------------------------------------------------------
 
 
+def _open_path(path: Path) -> None:
+    """Open a file in the OS default handler.
+
+    Path-with-spaces invariant: all three branches handle paths containing
+    spaces correctly because none invoke a shell. Do NOT "simplify" any branch
+    into a string command (e.g. shell=True, or `cmd /c start ...` as a single
+    string) — that re-introduces shell-parsing bugs for paths with spaces.
+    """
+    if sys.platform == "win32":
+        os.startfile(path)  # Python 3.8+ accepts Path objects
+    elif sys.platform == "darwin":
+        subprocess.Popen(["open", path])
+    else:
+        subprocess.Popen(["xdg-open", path])
+
+
 def _format_bytes(n: int | float) -> str:
     """Format a byte count as a human-readable string."""
     value = float(n)
@@ -1017,8 +1033,7 @@ def migrate_page() -> None:
     def _open_report() -> None:
         if report_path:
             try:
-                opener = "open" if sys.platform == "darwin" else "xdg-open"
-                subprocess.Popen([opener, str(report_path[0])])
+                _open_path(report_path[0])  # report_path[0] is already a Path
             except Exception as exc:
                 ui.notify(f"Could not open report: {exc}", type="negative")
 

--- a/tests/test_gui_open_path.py
+++ b/tests/test_gui_open_path.py
@@ -1,0 +1,39 @@
+"""Tests for src/discord_ferry/gui._open_path platform dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    import pytest
+
+from discord_ferry.gui import _open_path
+
+
+class TestOpenPathPlatformDispatch:
+    def test_open_path_uses_startfile_on_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.platform", "win32")
+        mock_startfile = MagicMock()
+        # raising=False: os.startfile doesn't exist on macOS/Linux test hosts
+        monkeypatch.setattr("os.startfile", mock_startfile, raising=False)
+        p = Path("C:/Users/Pete/report.html")
+        _open_path(p)
+        mock_startfile.assert_called_once_with(p)  # Path object, not str
+
+    def test_open_path_uses_open_on_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.platform", "darwin")
+        mock_popen = MagicMock()
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+        p = Path("/Users/Pete/report.html")
+        _open_path(p)
+        mock_popen.assert_called_once_with(["open", p])  # Path, not str
+
+    def test_open_path_uses_xdg_open_on_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.platform", "linux")
+        mock_popen = MagicMock()
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+        p = Path("/home/pete/report.html")
+        _open_path(p)
+        mock_popen.assert_called_once_with(["xdg-open", p])

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.1.5"
+version = "2.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #38. Discord Ferry's GUI "Open report" button was dead on Windows: `gui.py:_open_report` chose `"open"` on macOS and `"xdg-open"` everywhere else — but on Windows, `xdg-open` doesn't exist, so the click silently failed with a `ui.notify(..., type="negative")` toast.

This PR rewrites `_open_report` to dispatch on `sys.platform` to one of three correct openers: `os.startfile(path)` on Windows, `open` on macOS, `xdg-open` on Linux. The body is extracted to a module-level `_open_path(path: Path) -> None` helper so it can be unit-tested per-platform.

## Audit summary (full table in spec)

The original brainstorming hypothesized "this is one instance of a pattern; audit src/ for similar Windows-incompat code paths." The audit ran 8 grep patterns against `src/discord_ferry/` and found exactly 1 finding — the xdg-open bug being fixed here:

- `subprocess.Popen / subprocess.run / asyncio.create_subprocess_exec`: 5 sites; `runner.py` and `manager.py` are owned by #23 (which adds `CREATE_NO_WINDOW`); `gui.py:1021` is the bug.
- `os.fork / os.execv`: 0 hits.
- `signal.SIG*`: 0 hits.
- `os.sep` / hardcoded path separators: 0 hits.
- `shell=True`: 0 hits.
- `chmod` / `0o7*`: 1 hit, already gated by `if platform.system() != "Windows":`.
- `read_text`/`write_text` without `encoding=`: 0 actionable (14 calls, all explicit `encoding="utf-8"`).
- `open()` without `encoding=`: 2 hits, both binary mode (`"rb"`) — safe.

Codebase is otherwise Windows-clean. Full audit table preserved in the spec for future readers.

## Path-with-spaces invariant

All three branches pass the `Path` object directly without shell quoting:
- `os.startfile(path)` calls `ShellExecuteW` directly with the path as a parameter — no shell parsing.
- `subprocess.Popen(["open", path])` and `subprocess.Popen(["xdg-open", path])` use list-form argv (no `shell=True`) — paths pass verbatim to `execve`.

Future refactors must NOT collapse any branch into a shell string command — that re-introduces spaces-in-path bugs. The invariant is documented in the helper's docstring.

## Test plan

- [x] 3 new tests in `tests/test_gui_open_path.py` cover all three platform branches
- [x] Tests use `monkeypatch.setattr("os.startfile", ..., raising=False)` so they work on macOS/Linux hosts where `os.startfile` doesn't exist
- [x] Tests assert on `Path` objects directly (not `str(path)`) for platform-stable equality
- [x] Full test suite + mypy + ruff lint + format all clean
- [ ] Deferred verification: first user-report on Windows post-merge confirms `os.startfile` actually opens the file. No maintainer currently has a Windows machine for manual smoke-test. The unit tests prove the dispatch is correct; the actual `os.startfile` call cannot be unit-tested off-Windows.

## Coordination with #23

#23 modifies subprocess invocations in `runner.py` and `manager.py` (adds `creationflags=CREATE_NO_WINDOW` on Windows). This PR touches only `gui.py` — fully orthogonal. The audit table above explicitly defers those sites to #23's scope. Whoever lands second rebases; no logical conflict expected.

## References

- Spec: `docs/superpowers/specs/2026-05-15-issue-38-windows-compat-audit-design.md` (revised after critique pass)
- Coordination note re #23: spec's "Coordination protocol with #23" section