### PR TITLE
feat: tests/provisioning/ test-server provisioning CLI (v2.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Added `tests/provisioning/` script** for Discord test-server provisioning
   (issue #35 enabler). Standalone CLI with `provision` / `teardown` / `verify`
   subcommands using a Discord bot token. Human-run only; never executed in CI.
+  The diff comparator normalizes channel names (lowercase + spaces→hyphens +
+  strip non-`[a-z0-9_-]`) to match Discord's server-side rule — verified by
+  live smoke test against a test guild (provision → verify → idempotent
+  re-provision → teardown → verify-drift, all six steps pass).
 
 ## [2.2.4] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Tooling
+
+- **Added `tests/provisioning/` script** for Discord test-server provisioning
+  (issue #35 enabler). Standalone CLI with `provision` / `teardown` / `verify`
+  subcommands using a Discord bot token. Human-run only; never executed in CI.
+
 ## [2.2.4] - 2026-05-17
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.5] - 2026-05-18
+
 ### Tooling
 
-- **Added `tests/provisioning/` script** for Discord test-server provisioning
-  (issue #35 enabler). Standalone CLI with `provision` / `teardown` / `verify`
-  subcommands using a Discord bot token. Human-run only; never executed in CI.
-  The diff comparator normalizes channel names (lowercase + spaces→hyphens +
-  strip non-`[a-z0-9_-]`) to match Discord's server-side rule — verified by
-  live smoke test against a test guild (provision → verify → idempotent
-  re-provision → teardown → verify-drift, all six steps pass).
+- **`tests/provisioning/` test-server provisioning CLI shipped (issue #35 enabler)**. Standalone Click-based tool with `provision` / `teardown` / `verify` subcommands that hits Discord's REST API using a Bot token from `DISCORD_TEST_BOT_TOKEN`. Human-run only; the import firewall (`[tool.hatch.build.targets.wheel] packages = ["src/discord_ferry"]`) ensures the bot-auth write paths never ship in installable wheels. Architecture: three-layer (transport `_bot_api.py` → logic `_applier.py` → CLI `provision_test_server.py`). Reconciler uses a sealed `DiffOpT` discriminated union with `assert_never` exhaustiveness; per-op priority ordering ensures channels are created before messages/threads/posts depend on them. Verified end-to-end against a live Discord guild — the full six-step smoke test (dry-run → provision → verify-match → idempotent re-provision → teardown → verify-drift) passes cleanly. 61 hermetic unit tests run alongside the rest of the suite (mocked via aioresponses).
+
+### Bug Fixes
+
+- **`diff()` channel-name normalization** (caught by the live smoke test, not the mock-based unit tests). Discord lowercases and hyphenates channel names server-side, so a manifest entry `"Feedback Forum"` is stored as `"feedback-forum"`. The diff comparator previously matched by exact name and falsely reported the forum channel as missing. Fixed with `_normalize_channel_name` (lowercase + spaces→hyphens + strip non-`[a-z0-9_-]`) applied symmetrically on both sides of the lookup. Locked in by `test_diff_matches_discord_normalized_channel_names`.
+- **403 error message no longer leaks guild IDs**. The previous `url.split('/')[-2]` returned the guild snowflake for nested endpoints like `/api/v10/guilds/{id}/channels`, exposing a guild ID in the exception text. Now uses `url.removeprefix(DISCORD_API_BASE)` to keep only the relative path.
+- **`ProvisioningPermissionError` exits 2 across all CLI subcommands**. Previously a 403 fell through to the bare `ProvisioningError` handler and exited 1 (drift) instead of 2 (couldn't-determine), violating the documented 3-way exit-code contract in `tests/provisioning/README.md`. Permission errors are now handled explicitly alongside auth errors.
+- **`reconcile_teardown` no longer swallows auth/permission failures into `skipped_count`**. Previously a token revocation mid-teardown reported "deleted 0, skipped N" with exit 0, masking the failure. The function now re-raises `ProvisioningAuthError` and `ProvisioningPermissionError` so the CLI can surface them as exit 2. Other `ProvisioningError`s (5xx, network) are still treated as transient and counted in `skipped_count`. The CLI now also prints a warning when `skipped_count > 0` so operators have a clear retry hint.
 
 ## [2.2.4] - 2026-05-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.2.4"
+version = "2.2.5"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/tests/provisioning/README.md
+++ b/tests/provisioning/README.md
@@ -1,0 +1,92 @@
+# Discord Test Server Provisioning
+
+Standalone CLI for provisioning a Discord test server matching the fixture
+spec for issue #35's "captured-real fixtures" work. **Human-run only —
+never in CI**, per issue #35 design.
+
+## Prerequisites
+
+1. **Discord bot** registered in the [Discord Developer Portal][1]:
+   - Create a new application, then add a bot to it
+   - Reset & copy the bot token (it appears once)
+   - Store the token in shared 1Password vault under "Discord Ferry test bot"
+   - Bot needs `MANAGE_CHANNELS`, `SEND_MESSAGES`, and `MANAGE_THREADS` scopes
+   - Either invite the bot to an existing guild (use the OAuth URL generator)
+     OR plan to use `--create-guild` (requires bot in <10 guilds total)
+
+2. **Environment variable**:
+   ```bash
+   export DISCORD_TEST_BOT_TOKEN="MTM0NTY3..."
+   ```
+
+3. **Python deps** (already in the repo's `uv sync`):
+   - aiohttp, Click, dataclasses, pytest, pytest-asyncio, aioresponses
+
+[1]: https://discord.com/developers/applications
+
+## Subcommands
+
+### `provision` — apply manifest to a guild
+
+```bash
+# Use an existing guild:
+uv run python -m tests.provisioning.provision_test_server provision --guild-id 123456789
+
+# Bootstrap a new guild (unverified bot must be in <10 guilds):
+uv run python -m tests.provisioning.provision_test_server provision --create-guild "Test Server"
+
+# Plan only, no writes:
+uv run python -m tests.provisioning.provision_test_server provision --guild-id 123456789 --dry-run
+```
+
+Idempotent — re-running on the same guild creates only missing entities.
+
+### `teardown` — delete marker-carrying entities
+
+```bash
+uv run python -m tests.provisioning.provision_test_server teardown --guild-id 123456789
+# Prompts for confirmation; use --yes to skip:
+uv run python -m tests.provisioning.provision_test_server teardown --guild-id 123456789 --yes
+```
+
+Deletes ONLY channels carrying the `[ferry-fixture]` marker in their topic.
+Manually-created channels in the test guild are untouched. Does NOT delete
+the guild itself.
+
+### `verify` — read-only state check
+
+```bash
+uv run python -m tests.provisioning.provision_test_server verify --guild-id 123456789
+```
+
+Exit codes (grep-style):
+- `0` — manifest matches live state exactly
+- `1` — drift detected (diff printed to stderr)
+- `2` — couldn't determine (auth, network, malformed manifest)
+
+## Marker conventions
+
+To enable idempotent re-runs, every entity this script creates is tagged:
+
+- **Channel topics**: prefixed with `[ferry-fixture]`
+- **Message content**: suffixed with `[ferry:<manifest-id>]`
+
+These markers are intentionally visible — they survive every renderer (Discord
+client, DCE export, fixture-file JSON). **Do NOT hand-edit these markers** in
+the Discord UI; doing so will cause `provision` re-runs to create duplicates
+(and `verify` will catch this as `extra_marker_entity` drift).
+
+## The "no CI" rule
+
+This script must NEVER run in CI per issue #35's deferred design. Reason:
+the DCE capture step that follows provisioning is fundamentally human-run
+(DCE requires interactive authentication). Automating provisioning without
+automating capture would be misleading — the captured fixtures could drift
+from what we expect to capture.
+
+## Manifest
+
+The committed `fixture-spec.json` IS the fixture specification. To change
+what gets provisioned, edit the JSON; the loader enforces invariants
+(exactly 3 inline + 2 non-inline embed fields, etc.) so malformed edits
+fail fast.

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 
 from tests.provisioning._bot_api import BotApi, ProvisioningError
 
@@ -645,3 +645,172 @@ def _channel_has_first_message_marker(ch: ActualChannel, actual: ActualState) ->
     if not msgs:
         return False
     return "[ferry:" in msgs[0].content
+
+
+# ---- Reconciler: apply_op + reconcile_provision ----
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    created_count: int
+    created_summary: tuple[str, ...]
+    skipped_count: int
+    failed_op_index: int | None
+
+
+class _ProvisionState:
+    """Mutable scratch-state threaded through apply_op as ops complete."""
+
+    def __init__(self, guild_id: str) -> None:
+        self.guild_id = guild_id
+        self.text_channel_discord_id: dict[str, str] = {}
+        self.forum_channel_discord_id: dict[str, str] = {}
+        self.message_discord_id: dict[str, str] = {}
+
+
+async def reconcile_provision(
+    d: Diff,
+    api: BotApi,
+    *,
+    guild_id: str,
+    audit_reason: str,
+) -> ProvisionResult:
+    """Apply create-ops in dependency order. Skips delete ops entirely.
+
+    On op failure: stops, returns partial result with failed_op_index set.
+    """
+    state = _ProvisionState(guild_id=guild_id)
+    created_lines: list[str] = []
+
+    sorted_ops = sorted(d.ops, key=_op_priority)
+
+    for idx, op in enumerate(sorted_ops):
+        try:
+            await apply_op(op, api, state, audit_reason=audit_reason)
+            created_lines.append(_op_summary(op, state))
+        except ProvisioningError:
+            return ProvisionResult(
+                created_count=len(created_lines),
+                created_summary=tuple(created_lines),
+                skipped_count=0,
+                failed_op_index=idx,
+            )
+
+    return ProvisionResult(
+        created_count=len(created_lines),
+        created_summary=tuple(created_lines),
+        skipped_count=0,
+        failed_op_index=None,
+    )
+
+
+def _op_priority(op: DiffOpT) -> int:
+    """Sort ops so parents come before children."""
+    match op:
+        case CreateTextChannelOp():
+            return 0
+        case CreateForumChannelOp():
+            return 1
+        case CreateMessageOp():
+            return 2
+        case CreateThreadOp():
+            return 3
+        case CreateForumPostOp():
+            return 4
+        case DeleteChannelOp():
+            return 100
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _op_summary(op: DiffOpT, state: _ProvisionState) -> str:
+    match op:
+        case CreateTextChannelOp(target=t):
+            sid = state.text_channel_discord_id.get(t.id, "?")
+            return f"created text channel #{t.name} ({sid})"
+        case CreateForumChannelOp(target=t):
+            sid = state.forum_channel_discord_id.get(t.id, "?")
+            return f"created forum channel #{t.name} ({sid})"
+        case CreateMessageOp(target=t):
+            return f"created message {t.id}"
+        case CreateThreadOp(target=t):
+            return f"created thread {t.name}"
+        case CreateForumPostOp(target=t):
+            return f"created forum post {t.name}"
+        case DeleteChannelOp(target=t):
+            return f"deleted channel #{t.name}"
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+async def apply_op(
+    op: DiffOpT,
+    api: BotApi,
+    state: _ProvisionState,
+    *,
+    audit_reason: str,
+) -> None:
+    """Execute one diff operation against Discord. Updates state with new IDs."""
+    match op:
+        case CreateTextChannelOp(target=t):
+            result = await api.create_channel(
+                state.guild_id,
+                name=t.name,
+                channel_type=0,
+                topic=f"[ferry-fixture] {t.topic_suffix}",
+                audit_reason=audit_reason,
+            )
+            state.text_channel_discord_id[t.id] = str(result["id"])
+        case CreateForumChannelOp(target=t):
+            result = await api.create_channel(
+                state.guild_id,
+                name=t.name,
+                channel_type=15,
+                topic=f"[ferry-fixture] {t.topic_suffix}",
+                audit_reason=audit_reason,
+            )
+            state.forum_channel_discord_id[t.id] = str(result["id"])
+        case CreateMessageOp(target=t, parent_manifest_channel_id=pmc, parent_discord_id=p):
+            parent_id = p if p is not None else state.text_channel_discord_id[pmc]
+            embed_dict = None
+            if t.embed is not None:
+                embed_dict = {
+                    "title": t.embed.title,
+                    "description": t.embed.description,
+                    "color": t.embed.color,
+                    "fields": [
+                        {"name": f.name, "value": f.value, "inline": f.inline}
+                        for f in t.embed.fields
+                    ],
+                }
+            result = await api.send_message(
+                parent_id,
+                content=f"{t.content} [ferry:{t.id}]",
+                embed=embed_dict,
+                audit_reason=audit_reason,
+            )
+            state.message_discord_id[t.id] = str(result["id"])
+        case CreateThreadOp(target=t, parent_discord_id=p, anchor_message_discord_id=a):
+            parent_id = p if p is not None else state.text_channel_discord_id[t.parent_channel_id]
+            anchor_id = a if a is not None else state.message_discord_id[t.anchor_message_id]
+            thread_result = await api.create_thread_from_message(
+                parent_id, anchor_id, name=t.name, audit_reason=audit_reason
+            )
+            await api.send_message(
+                str(thread_result["id"]),
+                content=f"{t.first_message_content} [ferry:{t.id}]",
+                embed=None,
+                audit_reason=audit_reason,
+            )
+        case CreateForumPostOp(target=t, parent_manifest_forum_id=pmf, parent_discord_id=p):
+            parent_id = p if p is not None else state.forum_channel_discord_id[pmf]
+            await api.create_forum_post(
+                parent_id,
+                name=t.name,
+                first_message_content=f"{t.first_message_content} [ferry:{t.id}]",
+                audit_reason=audit_reason,
+            )
+        case DeleteChannelOp(target=t):
+            await api.delete_channel(t.discord_id, audit_reason=audit_reason)
+        case _ as unreachable:
+            assert_never(unreachable)

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -1,0 +1,243 @@
+"""Manifest schema, state fetcher, diff engine, and reconciler for provisioning.
+
+This module is the logic layer between the CLI and the _bot_api transport.
+It knows about manifest invariants, marker conventions, and the reconciler
+modes; it does not know about Click, env vars, or exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from tests.provisioning._bot_api import ProvisioningError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MARKER_SAFE_REGEX = re.compile(r"^[a-zA-Z0-9 \-\[\]:]+$")
+
+
+@dataclass(frozen=True)
+class ManifestEmbedField:
+    name: str
+    value: str
+    inline: bool
+
+
+@dataclass(frozen=True)
+class ManifestEmbed:
+    title: str
+    description: str
+    color: int
+    fields: tuple[ManifestEmbedField, ...]
+
+
+@dataclass(frozen=True)
+class ManifestMessage:
+    id: str
+    content: str
+    embed: ManifestEmbed | None = None
+
+
+@dataclass(frozen=True)
+class ManifestTextChannel:
+    id: str
+    name: str
+    topic_suffix: str
+    messages: tuple[ManifestMessage, ...]
+
+
+@dataclass(frozen=True)
+class ManifestThread:
+    id: str
+    name: str
+    parent_channel_id: str
+    anchor_message_id: str
+    first_message_content: str
+
+
+@dataclass(frozen=True)
+class ManifestForumPost:
+    id: str
+    name: str
+    first_message_content: str
+
+
+@dataclass(frozen=True)
+class ManifestForumChannel:
+    id: str
+    name: str
+    topic_suffix: str
+    posts: tuple[ManifestForumPost, ...]
+
+
+@dataclass(frozen=True)
+class Manifest:
+    version: int
+    marker: str
+    guild_name_for_bootstrap: str
+    text_channels: tuple[ManifestTextChannel, ...]
+    threads: tuple[ManifestThread, ...]
+    forum_channels: tuple[ManifestForumChannel, ...]
+
+
+def load_manifest(path: Path) -> Manifest:
+    """Parse manifest JSON and enforce all load-time invariants.
+
+    Enforces:
+    - version == 1
+    - marker matches MARKER_SAFE_REGEX (no HTML / shell-metachar attacks)
+    - all IDs unique across the entire manifest
+    - every thread.anchor_message_id references a real message in its
+      parent_channel_id text channel
+    - every text channel has exactly 1 message with an embed, and that
+      embed has exactly 3 inline + 2 non-inline fields
+
+    Raises ProvisioningError with a field-path pointer on any violation.
+    """
+    raw = json.loads(path.read_text())
+    if raw.get("version") != 1:
+        raise ProvisioningError(
+            f"manifest version mismatch: expected 1, got {raw.get('version')!r}"
+        )
+    marker = raw.get("marker", "")
+    if not marker or not MARKER_SAFE_REGEX.match(marker):
+        raise ProvisioningError(
+            f"manifest marker must match {MARKER_SAFE_REGEX.pattern!r}; got {marker!r}"
+        )
+
+    text_channels = tuple(_parse_text_channel(tc) for tc in raw["text_channels"])
+    threads = tuple(_parse_thread(t) for t in raw["threads"])
+    forum_channels = tuple(_parse_forum_channel(fc) for fc in raw["forum_channels"])
+    manifest = Manifest(
+        version=raw["version"],
+        marker=marker,
+        guild_name_for_bootstrap=raw["guild_name_for_bootstrap"],
+        text_channels=text_channels,
+        threads=threads,
+        forum_channels=forum_channels,
+    )
+
+    _validate_unique_ids(manifest)
+    _validate_anchor_message_refs(manifest)
+    _validate_embed_inline_ratios(manifest)
+    return manifest
+
+
+def _parse_text_channel(data: dict[str, Any]) -> ManifestTextChannel:
+    return ManifestTextChannel(
+        id=data["id"],
+        name=data["name"],
+        topic_suffix=data["topic_suffix"],
+        messages=tuple(_parse_message(m) for m in data["messages"]),
+    )
+
+
+def _parse_message(data: dict[str, Any]) -> ManifestMessage:
+    embed = data.get("embed")
+    return ManifestMessage(
+        id=data["id"],
+        content=data["content"],
+        embed=_parse_embed(embed) if embed is not None else None,
+    )
+
+
+def _parse_embed(data: dict[str, Any]) -> ManifestEmbed:
+    return ManifestEmbed(
+        title=data["title"],
+        description=data["description"],
+        color=data["color"],
+        fields=tuple(_parse_embed_field(f) for f in data["fields"]),
+    )
+
+
+def _parse_embed_field(data: dict[str, Any]) -> ManifestEmbedField:
+    return ManifestEmbedField(name=data["name"], value=data["value"], inline=data["inline"])
+
+
+def _parse_thread(data: dict[str, Any]) -> ManifestThread:
+    return ManifestThread(
+        id=data["id"],
+        name=data["name"],
+        parent_channel_id=data["parent_channel_id"],
+        anchor_message_id=data["anchor_message_id"],
+        first_message_content=data["first_message_content"],
+    )
+
+
+def _parse_forum_channel(data: dict[str, Any]) -> ManifestForumChannel:
+    return ManifestForumChannel(
+        id=data["id"],
+        name=data["name"],
+        topic_suffix=data["topic_suffix"],
+        posts=tuple(_parse_forum_post(p) for p in data["posts"]),
+    )
+
+
+def _parse_forum_post(data: dict[str, Any]) -> ManifestForumPost:
+    return ManifestForumPost(
+        id=data["id"],
+        name=data["name"],
+        first_message_content=data["first_message_content"],
+    )
+
+
+def _validate_unique_ids(m: Manifest) -> None:
+    seen: set[str] = set()
+    for tc in m.text_channels:
+        _check_id(tc.id, seen, f"text_channels[id={tc.id}]")
+        for msg in tc.messages:
+            _check_id(msg.id, seen, f"text_channels[{tc.id}].messages[id={msg.id}]")
+    for t in m.threads:
+        _check_id(t.id, seen, f"threads[id={t.id}]")
+    for fc in m.forum_channels:
+        _check_id(fc.id, seen, f"forum_channels[id={fc.id}]")
+        for post in fc.posts:
+            _check_id(post.id, seen, f"forum_channels[{fc.id}].posts[id={post.id}]")
+
+
+def _check_id(id_: str, seen: set[str], path: str) -> None:
+    if id_ in seen:
+        raise ProvisioningError(f"duplicate id {id_!r} at {path}")
+    seen.add(id_)
+
+
+def _validate_anchor_message_refs(m: Manifest) -> None:
+    msg_ids_by_channel: dict[str, set[str]] = {
+        tc.id: {msg.id for msg in tc.messages} for tc in m.text_channels
+    }
+    tc_ids = set(msg_ids_by_channel.keys())
+    for t in m.threads:
+        if t.parent_channel_id not in tc_ids:
+            raise ProvisioningError(
+                f"thread {t.id!r}: parent_channel_id {t.parent_channel_id!r} "
+                f"does not reference an existing text channel"
+            )
+        if t.anchor_message_id not in msg_ids_by_channel[t.parent_channel_id]:
+            raise ProvisioningError(
+                f"thread {t.id!r}: anchor_message_id {t.anchor_message_id!r} "
+                f"not found in parent channel {t.parent_channel_id!r}"
+            )
+
+
+def _validate_embed_inline_ratios(m: Manifest) -> None:
+    for tc in m.text_channels:
+        embed_messages = [msg for msg in tc.messages if msg.embed is not None]
+        if len(embed_messages) != 1:
+            raise ProvisioningError(
+                f"text_channel {tc.id!r}: expected exactly 1 message with an "
+                f"embed; got {len(embed_messages)}"
+            )
+        embed = embed_messages[0].embed
+        assert embed is not None  # narrowed by filter above
+        inline_count = sum(1 for f in embed.fields if f.inline)
+        non_inline_count = sum(1 for f in embed.fields if not f.inline)
+        if inline_count != 3 or non_inline_count != 2:
+            raise ProvisioningError(
+                f"text_channel {tc.id!r} embed at message {embed_messages[0].id!r}: "
+                f"expected 3 inline / 2 non-inline fields; got "
+                f"{inline_count} inline / {non_inline_count} non-inline"
+            )

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -814,3 +814,75 @@ async def apply_op(
             await api.delete_channel(t.discord_id, audit_reason=audit_reason)
         case _ as unreachable:
             assert_never(unreachable)
+
+
+# ---- Reconciler: teardown + verify ----
+
+
+@dataclass(frozen=True)
+class TeardownResult:
+    deleted_count: int
+    deleted_ids: tuple[str, ...]
+    skipped_count: int
+
+
+async def reconcile_teardown(
+    actual: ActualState,
+    api: BotApi,
+    *,
+    marker: str,
+    audit_reason: str,
+) -> TeardownResult:
+    """Delete only marker-carrying entities; ignore the manifest entirely.
+
+    Channels are matched by topic prefix. Threads/forum-posts get deleted
+    automatically when their parent channel is deleted (Discord cascade),
+    so we only iterate top-level channels (type 0 = text, type 15 = forum).
+    """
+    to_delete = [
+        ch
+        for ch in actual.channels
+        if ch.type in (0, 15) and ch.topic and ch.topic.startswith(marker)
+    ]
+    deleted_ids: list[str] = []
+    skipped = 0
+    for ch in to_delete:
+        try:
+            await api.delete_channel(ch.discord_id, audit_reason=audit_reason)
+            deleted_ids.append(ch.discord_id)
+        except ProvisioningError:
+            skipped += 1
+    return TeardownResult(
+        deleted_count=len(deleted_ids),
+        deleted_ids=tuple(deleted_ids),
+        skipped_count=skipped,
+    )
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    exit_code: int  # 0=match, 1=drift, 2=error
+    diff_lines: tuple[str, ...]
+
+
+def reconcile_verify(d: Diff) -> VerifyResult:
+    """Pure-read verification: classify the diff into a 3-way exit code."""
+    if (
+        not d.ops
+        and not d.missing_entities
+        and not d.extra_marker_entities
+        and not d.mismatched_embeds
+    ):
+        return VerifyResult(exit_code=0, diff_lines=())
+
+    lines: list[str] = []
+    for mid in d.missing_entities:
+        lines.append(f"missing: {mid}")
+    for ch in d.extra_marker_entities:
+        lines.append(f"extra marker entity: #{ch.name} ({ch.discord_id})")
+    for ch in d.extra_foreign_entities:
+        lines.append(f"foreign entity (informational): #{ch.name}")
+    for em in d.mismatched_embeds:
+        lines.append(f"embed mismatch on {em.manifest_message_id}: {em.reason}")
+
+    return VerifyResult(exit_code=1, diff_lines=tuple(lines))

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -12,7 +12,12 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, assert_never
 
-from tests.provisioning._bot_api import BotApi, ProvisioningError
+from tests.provisioning._bot_api import (
+    BotApi,
+    ProvisioningAuthError,
+    ProvisioningError,
+    ProvisioningPermissionError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -864,6 +869,10 @@ async def reconcile_teardown(
         try:
             await api.delete_channel(ch.discord_id, audit_reason=audit_reason)
             deleted_ids.append(ch.discord_id)
+        except (ProvisioningAuthError, ProvisioningPermissionError):
+            # Auth/permission failures cannot be salvaged by retrying with the
+            # next channel — re-raise so the CLI can surface them as exit 2.
+            raise
         except ProvisioningError:
             skipped += 1
     return TeardownResult(

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from tests.provisioning._bot_api import ProvisioningError
+from tests.provisioning._bot_api import BotApi, ProvisioningError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -364,3 +364,80 @@ class Diff:
     extra_marker_entities: tuple[ActualChannel, ...]  # actual+marker+not-in-manifest
     extra_foreign_entities: tuple[ActualChannel, ...]  # actual+no-marker (informational)
     mismatched_embeds: tuple[EmbedMismatch, ...]
+
+
+# ---- State fetcher ----
+
+
+async def fetch_actual_state(api: BotApi, guild_id: str) -> ActualState:
+    """Fetch the live guild state for diffing against the manifest.
+
+    Fans out:
+      - GET /guilds/{id}/channels (text + forum, NOT threads)
+      - GET /guilds/{id}/threads/active (guild-wide active threads)
+      - GET /channels/{parent}/threads/archived/public per text channel
+      - GET /channels/{id}/messages?limit=100 for each channel and thread
+
+    The merged channels tuple includes archived threads so that `verify`
+    works after the 24h auto-archive boundary.
+    """
+    raw_channels = await api.list_channels(guild_id)
+    raw_active_threads = await api.list_active_threads(guild_id)
+
+    # Archived public threads — per parent text channel only
+    text_channel_ids = [str(ch["id"]) for ch in raw_channels if ch["type"] == 0]
+    raw_archived: list[dict[str, Any]] = []
+    for parent_id in text_channel_ids:
+        raw_archived.extend(await api.list_archived_public_threads(parent_id))
+
+    # Build ActualChannel tuple
+    all_raw = raw_channels + raw_active_threads + raw_archived
+    channels = tuple(
+        ActualChannel(
+            discord_id=str(c["id"]),
+            name=c["name"],
+            type=c["type"],
+            topic=c.get("topic"),
+            parent_id=str(c["parent_id"]) if c.get("parent_id") else None,
+        )
+        for c in all_raw
+    )
+
+    # Fetch messages for every channel (text + threads — but NOT forum channels;
+    # forum channels reject /messages by design)
+    messages_by_channel: dict[str, tuple[ActualMessage, ...]] = {}
+    for ch in channels:
+        if ch.type == 15:  # forum channels: no direct messages
+            continue
+        raw_msgs = await api.list_messages(ch.discord_id)
+        messages_by_channel[ch.discord_id] = tuple(
+            _parse_actual_message(m, ch.discord_id) for m in raw_msgs
+        )
+
+    return ActualState(
+        guild_id=guild_id,
+        channels=channels,
+        messages_by_channel=messages_by_channel,
+    )
+
+
+def _parse_actual_message(raw: dict[str, Any], channel_id: str) -> ActualMessage:
+    embed = None
+    embeds = raw.get("embeds") or []
+    if embeds:
+        e = embeds[0]
+        embed = ActualEmbed(
+            title=e.get("title", ""),
+            description=e.get("description", ""),
+            color=e.get("color", 0),
+            fields=tuple(
+                ActualEmbedField(name=f["name"], value=f["value"], inline=f.get("inline", False))
+                for f in (e.get("fields") or [])
+            ),
+        )
+    return ActualMessage(
+        discord_id=str(raw["id"]),
+        channel_discord_id=channel_id,
+        content=raw.get("content", ""),
+        embed=embed,
+    )

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -441,3 +441,207 @@ def _parse_actual_message(raw: dict[str, Any], channel_id: str) -> ActualMessage
         content=raw.get("content", ""),
         embed=embed,
     )
+
+
+# ---- Reconciler diff ----
+
+
+def diff(manifest: Manifest, actual: ActualState) -> Diff:
+    """Compute the reconciler diff between desired manifest and actual state."""
+    ops: list[DiffOpT] = []
+    missing: list[str] = []
+    extra_marker: list[ActualChannel] = []
+    extra_foreign: list[ActualChannel] = []
+    mismatched_embeds: list[EmbedMismatch] = []
+
+    marker = manifest.marker
+
+    actual_text_channels = {
+        ch.name: ch
+        for ch in actual.channels
+        if ch.type == 0 and ch.topic and ch.topic.startswith(marker)
+    }
+    actual_forum_channels = {
+        ch.name: ch
+        for ch in actual.channels
+        if ch.type == 15 and ch.topic and ch.topic.startswith(marker)
+    }
+    actual_threads = {ch.name: ch for ch in actual.channels if ch.type == 11}
+
+    matched_actual_ids: set[str] = set()
+
+    # Text channels and their messages
+    for tc in manifest.text_channels:
+        actual_ch = actual_text_channels.get(tc.name)
+        if actual_ch is None:
+            missing.append(tc.id)
+            ops.append(CreateTextChannelOp(target=tc, reason="missing from guild"))
+            for msg in tc.messages:
+                ops.append(
+                    CreateMessageOp(
+                        target=msg,
+                        parent_manifest_channel_id=tc.id,
+                        reason="parent channel missing",
+                    )
+                )
+        else:
+            matched_actual_ids.add(actual_ch.discord_id)
+            actual_msgs = actual.messages_by_channel.get(actual_ch.discord_id, ())
+            actual_msg_by_marker_id: dict[str, ActualMessage] = {}
+            for am in actual_msgs:
+                for manifest_id in _extract_marker_ids(am.content):
+                    actual_msg_by_marker_id[manifest_id] = am
+            for msg in tc.messages:
+                if msg.id not in actual_msg_by_marker_id:
+                    missing.append(msg.id)
+                    ops.append(
+                        CreateMessageOp(
+                            target=msg,
+                            parent_manifest_channel_id=tc.id,
+                            parent_discord_id=actual_ch.discord_id,
+                            reason="missing marker in channel",
+                        )
+                    )
+                else:
+                    am = actual_msg_by_marker_id[msg.id]
+                    mismatch = _diff_embed(msg, am)
+                    if mismatch is not None:
+                        mismatched_embeds.append(mismatch)
+
+    # Threads
+    for thread in manifest.threads:
+        actual_t = actual_threads.get(thread.name)
+        if actual_t is None or not _thread_has_marker(actual_t, thread, actual):
+            missing.append(thread.id)
+            ops.append(CreateThreadOp(target=thread, reason="thread missing or no marker"))
+        else:
+            matched_actual_ids.add(actual_t.discord_id)
+
+    # Forum channels and posts
+    for fc in manifest.forum_channels:
+        actual_fc = actual_forum_channels.get(fc.name)
+        if actual_fc is None:
+            missing.append(fc.id)
+            ops.append(CreateForumChannelOp(target=fc, reason="missing from guild"))
+            for post in fc.posts:
+                ops.append(
+                    CreateForumPostOp(
+                        target=post,
+                        parent_manifest_forum_id=fc.id,
+                        reason="parent forum missing",
+                    )
+                )
+        else:
+            matched_actual_ids.add(actual_fc.discord_id)
+            for post in fc.posts:
+                actual_post = next(
+                    (
+                        c
+                        for c in actual.channels
+                        if c.parent_id == actual_fc.discord_id
+                        and c.name == post.name
+                        and _post_has_marker(c, post, actual)
+                    ),
+                    None,
+                )
+                if actual_post is None:
+                    missing.append(post.id)
+                    ops.append(
+                        CreateForumPostOp(
+                            target=post,
+                            parent_manifest_forum_id=fc.id,
+                            parent_discord_id=actual_fc.discord_id,
+                            reason="post missing or no marker",
+                        )
+                    )
+                else:
+                    matched_actual_ids.add(actual_post.discord_id)
+
+    # Extras
+    for ch in actual.channels:
+        if ch.discord_id in matched_actual_ids:
+            continue
+        is_marker = (ch.topic and ch.topic.startswith(marker)) or _channel_has_first_message_marker(
+            ch, actual
+        )
+        if is_marker:
+            extra_marker.append(ch)
+        elif ch.type != 11:
+            extra_foreign.append(ch)
+
+    return Diff(
+        ops=tuple(ops),
+        missing_entities=tuple(missing),
+        extra_marker_entities=tuple(extra_marker),
+        extra_foreign_entities=tuple(extra_foreign),
+        mismatched_embeds=tuple(mismatched_embeds),
+    )
+
+
+_MARKER_PATTERN = re.compile(r"\[ferry:([a-zA-Z0-9_-]+)\]")
+
+
+def _extract_marker_ids(content: str) -> list[str]:
+    """Pull out all `[ferry:msg-id-XXX]` manifest IDs from message content."""
+    return _MARKER_PATTERN.findall(content)
+
+
+def _diff_embed(manifest_msg: ManifestMessage, actual_msg: ActualMessage) -> EmbedMismatch | None:
+    if manifest_msg.embed is None and actual_msg.embed is None:
+        return None
+    if manifest_msg.embed is None or actual_msg.embed is None:
+        return EmbedMismatch(
+            manifest_message_id=manifest_msg.id,
+            reason="embed presence differs between manifest and actual",
+        )
+    me, ae = manifest_msg.embed, actual_msg.embed
+    if me.title != ae.title:
+        return EmbedMismatch(manifest_msg.id, f"title differs: {me.title!r} vs {ae.title!r}")
+    if me.description != ae.description:
+        return EmbedMismatch(manifest_msg.id, "description differs")
+    if me.color != ae.color:
+        return EmbedMismatch(manifest_msg.id, f"color differs: {me.color} vs {ae.color}")
+    if len(me.fields) != len(ae.fields):
+        return EmbedMismatch(
+            manifest_msg.id,
+            f"field count differs: expected {len(me.fields)}, got {len(ae.fields)}",
+        )
+    for i, (mf, af) in enumerate(zip(me.fields, ae.fields, strict=False)):
+        if mf.name != af.name:
+            return EmbedMismatch(
+                manifest_msg.id, f"field {i} name differs: {mf.name!r} vs {af.name!r}"
+            )
+        if mf.value != af.value:
+            return EmbedMismatch(manifest_msg.id, f"field {i} value differs")
+        if mf.inline != af.inline:
+            return EmbedMismatch(
+                manifest_msg.id,
+                f"field {i} inline differs: expected {mf.inline}, got {af.inline}",
+            )
+    return None
+
+
+def _thread_has_marker(
+    actual_t: ActualChannel, thread: ManifestThread, actual: ActualState
+) -> bool:
+    msgs = actual.messages_by_channel.get(actual_t.discord_id, ())
+    if not msgs:
+        return False
+    return f"[ferry:{thread.id}]" in msgs[0].content
+
+
+def _post_has_marker(
+    actual_post: ActualChannel, post: ManifestForumPost, actual: ActualState
+) -> bool:
+    msgs = actual.messages_by_channel.get(actual_post.discord_id, ())
+    if not msgs:
+        return False
+    return f"[ferry:{post.id}]" in msgs[0].content
+
+
+def _channel_has_first_message_marker(ch: ActualChannel, actual: ActualState) -> bool:
+    """Used to identify orphan threads/posts created by past provisions."""
+    msgs = actual.messages_by_channel.get(ch.discord_id, ())
+    if not msgs:
+        return False
+    return "[ferry:" in msgs[0].content

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -457,12 +457,12 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
     marker = manifest.marker
 
     actual_text_channels = {
-        ch.name: ch
+        _normalize_channel_name(ch.name): ch
         for ch in actual.channels
         if ch.type == 0 and ch.topic and ch.topic.startswith(marker)
     }
     actual_forum_channels = {
-        ch.name: ch
+        _normalize_channel_name(ch.name): ch
         for ch in actual.channels
         if ch.type == 15 and ch.topic and ch.topic.startswith(marker)
     }
@@ -472,7 +472,7 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
 
     # Text channels and their messages
     for tc in manifest.text_channels:
-        actual_ch = actual_text_channels.get(tc.name)
+        actual_ch = actual_text_channels.get(_normalize_channel_name(tc.name))
         if actual_ch is None:
             missing.append(tc.id)
             ops.append(CreateTextChannelOp(target=tc, reason="missing from guild"))
@@ -519,7 +519,7 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
 
     # Forum channels and posts
     for fc in manifest.forum_channels:
-        actual_fc = actual_forum_channels.get(fc.name)
+        actual_fc = actual_forum_channels.get(_normalize_channel_name(fc.name))
         if actual_fc is None:
             missing.append(fc.id)
             ops.append(CreateForumChannelOp(target=fc, reason="missing from guild"))
@@ -579,6 +579,20 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
 
 
 _MARKER_PATTERN = re.compile(r"\[ferry:([a-zA-Z0-9_-]+)\]")
+
+_CHANNEL_NAME_STRIP = re.compile(r"[^a-z0-9_-]")
+
+
+def _normalize_channel_name(name: str) -> str:
+    """Apply Discord's server-side normalization rule to a channel name.
+
+    Discord lowercases the name, replaces internal whitespace with hyphens,
+    and strips characters outside `[a-z0-9_-]`. Use this on both sides of
+    channel matching so manifest names like 'Feedback Forum' match actual
+    channels stored as 'feedback-forum'. Threads and forum posts are NOT
+    normalized — their names preserve case and spaces.
+    """
+    return _CHANNEL_NAME_STRIP.sub("", name.strip().lower().replace(" ", "-"))
 
 
 def _extract_marker_ids(content: str) -> list[str]:

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from tests.provisioning._bot_api import ProvisioningError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 MARKER_SAFE_REGEX = re.compile(r"^[a-zA-Z0-9 \-\[\]:]+$")
@@ -241,3 +242,125 @@ def _validate_embed_inline_ratios(m: Manifest) -> None:
                 f"expected 3 inline / 2 non-inline fields; got "
                 f"{inline_count} inline / {non_inline_count} non-inline"
             )
+
+
+# ---- Actual state (fetched from Discord) ----
+
+
+@dataclass(frozen=True)
+class ActualEmbedField:
+    name: str
+    value: str
+    inline: bool
+
+
+@dataclass(frozen=True)
+class ActualEmbed:
+    title: str
+    description: str
+    color: int
+    fields: tuple[ActualEmbedField, ...]
+
+
+@dataclass(frozen=True)
+class ActualMessage:
+    discord_id: str
+    channel_discord_id: str
+    content: str
+    embed: ActualEmbed | None
+
+
+@dataclass(frozen=True)
+class ActualChannel:
+    discord_id: str
+    name: str
+    type: int  # 0=text, 15=forum, 11=public thread
+    topic: str | None
+    parent_id: str | None  # for threads: the parent text channel's snowflake
+
+
+@dataclass(frozen=True)
+class ActualState:
+    guild_id: str
+    channels: tuple[ActualChannel, ...]
+    messages_by_channel: Mapping[str, tuple[ActualMessage, ...]]
+
+
+# ---- Diff types: sealed discriminated union for mypy --strict ----
+# Note: no shared base/Protocol. The reconciler relies on the union type alias
+# `DiffOpT` for type narrowing via `match`. A Protocol with named fields would
+# be inert here — `match` dispatch doesn't trigger structural checks, and the
+# union alias is what apply_op annotates against. Each per-kind dataclass
+# carries `parent_discord_id` and `reason` as its own fields (consistency by
+# convention, enforced by code review rather than the type system).
+
+
+@dataclass(frozen=True)
+class CreateTextChannelOp:
+    target: ManifestTextChannel
+    parent_discord_id: str | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CreateForumChannelOp:
+    target: ManifestForumChannel
+    parent_discord_id: str | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CreateMessageOp:
+    target: ManifestMessage
+    parent_manifest_channel_id: str  # which manifest text channel (for state lookup)
+    parent_discord_id: str | None = None  # resolved by apply_op via state if None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CreateThreadOp:
+    target: ManifestThread
+    parent_discord_id: str | None = None  # text channel's Discord ID
+    anchor_message_discord_id: str | None = None  # resolved after messages created
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CreateForumPostOp:
+    target: ManifestForumPost
+    parent_manifest_forum_id: str  # which manifest forum channel (for state lookup)
+    parent_discord_id: str | None = None  # resolved by apply_op via state if None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class DeleteChannelOp:
+    target: ActualChannel
+    parent_discord_id: str | None = None  # always None
+    reason: str = ""
+
+
+# Type alias for any op (used in Diff.ops and apply_op):
+DiffOpT = (
+    CreateTextChannelOp
+    | CreateForumChannelOp
+    | CreateMessageOp
+    | CreateThreadOp
+    | CreateForumPostOp
+    | DeleteChannelOp
+)
+
+
+@dataclass(frozen=True)
+class EmbedMismatch:
+    manifest_message_id: str
+    reason: str  # e.g. "field 2 inline flag differs: expected False, got True"
+
+
+@dataclass(frozen=True)
+class Diff:
+    ops: tuple[DiffOpT, ...]
+    missing_entities: tuple[str, ...]  # manifest ids not present in actual
+    extra_marker_entities: tuple[ActualChannel, ...]  # actual+marker+not-in-manifest
+    extra_foreign_entities: tuple[ActualChannel, ...]  # actual+no-marker (informational)
+    mismatched_embeds: tuple[EmbedMismatch, ...]

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -91,8 +91,9 @@ async def _request_with_retry(
                 if resp.status == 401:
                     raise ProvisioningAuthError("bot token rejected by Discord (401 Unauthorized)")
                 if resp.status == 403:
+                    endpoint = url.removeprefix(DISCORD_API_BASE) or url
                     raise ProvisioningPermissionError(
-                        f"missing permission for {method} {url.split('/')[-2]} (403 Forbidden)"
+                        f"missing permission for {method} {endpoint} (403 Forbidden)"
                     )
                 if resp.status == 429:
                     body = await resp.json()

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -14,6 +14,11 @@ from typing import Any
 
 import aiohttp
 
+DISCORD_API_BASE = "https://discord.com/api/v10"
+USER_AGENT = (
+    "DiscordFerry-TestProvisioner (https://github.com/nordscope-fi/Discord-stoat-ferry, v0.0.0)"
+)
+
 
 class ProvisioningError(Exception):
     """Base for all provisioning failures."""
@@ -114,3 +119,40 @@ async def _request_with_retry(
     if isinstance(last_exception, ProvisioningError):
         raise last_exception
     raise ProvisioningRateLimitError("rate limited after 3 retries")
+
+
+class BotApi:
+    """Authenticated async client for Discord REST API v10 using Bot tokens.
+
+    The Authorization HEADER DICT is built ad-hoc inside each method;
+    the token VALUE is stored once as self._token and never exposed via
+    introspection (overridden __repr__ redacts it).
+    """
+
+    def __init__(self, session: aiohttp.ClientSession, token: str) -> None:
+        self._session = session
+        self._token = token
+
+    def __repr__(self) -> str:
+        return "BotApi(token=<redacted>)"
+
+    def _headers(self, audit_reason: str | None = None) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bot {self._token}",
+            "User-Agent": USER_AGENT,
+            "Content-Type": "application/json",
+        }
+        if audit_reason is not None:
+            headers["X-Audit-Log-Reason"] = audit_reason
+        return headers
+
+    async def list_my_guilds(self) -> list[dict[str, Any]]:
+        """GET /users/@me/guilds — for --create-guild preflight."""
+        result = await _request_with_retry(
+            self._session,
+            "GET",
+            f"{DISCORD_API_BASE}/users/@me/guilds",
+            self._headers(),
+            None,
+        )
+        return result  # type: ignore[return-value]

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -315,3 +315,16 @@ class BotApi:
             self._headers(audit_reason),
             None,
         )
+
+
+def configure_aiohttp_logging(*, verbose: bool) -> None:
+    """In non-verbose mode, force aiohttp's internal loggers to WARNING.
+
+    Prevents accidental token surface in DEBUG output from aiohttp.client,
+    aiohttp.connector, etc. In verbose mode this is a no-op — caller has
+    opted in to seeing internal traces.
+    """
+    if verbose:
+        return
+    for name in ("aiohttp", "aiohttp.client", "aiohttp.connector", "aiohttp.access"):
+        logging.getLogger(name).setLevel(logging.WARNING)

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -293,3 +293,25 @@ class BotApi:
             body,
         )
         return result  # type: ignore[return-value]
+
+    async def create_guild(self, *, name: str, audit_reason: str) -> dict[str, Any]:
+        """POST /guilds — bootstrap a new guild (bot must be in <10 guilds)."""
+        body = {"name": name}
+        result = await _request_with_retry(
+            self._session,
+            "POST",
+            f"{DISCORD_API_BASE}/guilds",
+            self._headers(audit_reason),
+            body,
+        )
+        return result  # type: ignore[return-value]
+
+    async def delete_channel(self, channel_id: str, *, audit_reason: str) -> None:
+        """DELETE /channels/{id}."""
+        await _request_with_retry(
+            self._session,
+            "DELETE",
+            f"{DISCORD_API_BASE}/channels/{channel_id}",
+            self._headers(audit_reason),
+            None,
+        )

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -8,7 +8,11 @@ exception hierarchy reinforces that isolation in the type system.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Any
+
+import aiohttp
 
 
 class ProvisioningError(Exception):
@@ -49,3 +53,64 @@ class TokenRedactingFilter(logging.Filter):
             record.msg = message.replace(self._token, self.REDACTED)
             record.args = None
         return True
+
+
+_MAX_RETRIES = 3
+_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+_JITTER_SECONDS = 0.05
+
+
+async def _request_with_retry(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_body: dict[str, Any] | None,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Perform an HTTP request with 429/5xx/network retry.
+
+    On 429: sleep retry_after + jitter, retry up to 3 times total.
+    On 5xx or aiohttp.ClientError: exp backoff 1/2/4s, retry up to 3 times.
+    On 401: ProvisioningAuthError (no retry).
+    On 403: ProvisioningPermissionError (no retry).
+    On 4xx (other): ProvisioningError with Discord's code + message (never errors).
+    """
+    last_exception: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            async with session.request(method, url, headers=headers, json=json_body) as resp:
+                if resp.status in (200, 201, 204):
+                    if resp.status == 204:
+                        return {}
+                    return await resp.json()  # type: ignore[no-any-return]
+                if resp.status == 401:
+                    raise ProvisioningAuthError("bot token rejected by Discord (401 Unauthorized)")
+                if resp.status == 403:
+                    raise ProvisioningPermissionError(
+                        f"missing permission for {method} {url.split('/')[-2]} (403 Forbidden)"
+                    )
+                if resp.status == 429:
+                    body = await resp.json()
+                    retry_after = float(body.get("retry_after", 1))
+                    await asyncio.sleep(retry_after + _JITTER_SECONDS)
+                    continue
+                if 500 <= resp.status < 600:
+                    last_exception = ProvisioningError(f"Discord server error ({resp.status})")
+                    await asyncio.sleep(_BACKOFF_SECONDS[attempt])
+                    continue
+                # 4xx (other): surface code + message ONLY
+                body = await resp.json()
+                code = body.get("code", "unknown")
+                message = body.get("message", "no message")
+                raise ProvisioningError(f"Discord {resp.status} (code {code}): {message}")
+        except (ProvisioningAuthError, ProvisioningPermissionError, ProvisioningError):
+            raise
+        except aiohttp.ClientError as exc:
+            last_exception = ProvisioningError(f"network error: {type(exc).__name__}")
+            await asyncio.sleep(_BACKOFF_SECONDS[attempt])
+            continue
+
+    # Loop exhausted
+    if isinstance(last_exception, ProvisioningError):
+        raise last_exception
+    raise ProvisioningRateLimitError("rate limited after 3 retries")

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -247,3 +247,49 @@ class BotApi:
             body,
         )
         return result  # type: ignore[return-value]
+
+    async def create_thread_from_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        *,
+        name: str,
+        audit_reason: str,
+    ) -> dict[str, Any]:
+        """POST /channels/{ch}/messages/{msg}/threads — thread from text-channel message."""
+        body = {"name": name, "auto_archive_duration": 1440}
+        result = await _request_with_retry(
+            self._session,
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/threads",
+            self._headers(audit_reason),
+            body,
+        )
+        return result  # type: ignore[return-value]
+
+    async def create_forum_post(
+        self,
+        forum_channel_id: str,
+        *,
+        name: str,
+        first_message_content: str,
+        audit_reason: str,
+    ) -> dict[str, Any]:
+        """POST /channels/{forum}/threads — creates forum post (thread+nested first message).
+
+        Forum channels REJECT POST /messages. Posts go through this endpoint
+        which returns a channel object with the nested first message.
+        """
+        body = {
+            "name": name,
+            "auto_archive_duration": 1440,
+            "message": {"content": first_message_content},
+        }
+        result = await _request_with_retry(
+            self._session,
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{forum_channel_id}/threads",
+            self._headers(audit_reason),
+            body,
+        )
+        return result  # type: ignore[return-value]

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -156,3 +156,25 @@ class BotApi:
             None,
         )
         return result  # type: ignore[return-value]
+
+    async def list_channels(self, guild_id: str) -> list[dict[str, Any]]:
+        """GET /guilds/{id}/channels — returns text+forum channels, NOT threads."""
+        result = await _request_with_retry(
+            self._session,
+            "GET",
+            f"{DISCORD_API_BASE}/guilds/{guild_id}/channels",
+            self._headers(),
+            None,
+        )
+        return result  # type: ignore[return-value]
+
+    async def list_messages(self, channel_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """GET /channels/{id}/messages?limit=N — paginated reads not modelled."""
+        result = await _request_with_retry(
+            self._session,
+            "GET",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages?limit={limit}",
+            self._headers(),
+            None,
+        )
+        return result  # type: ignore[return-value]

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -178,3 +178,31 @@ class BotApi:
             None,
         )
         return result  # type: ignore[return-value]
+
+    async def list_active_threads(self, guild_id: str) -> list[dict[str, Any]]:
+        """GET /guilds/{id}/threads/active — guild-wide active threads."""
+        result = await _request_with_retry(
+            self._session,
+            "GET",
+            f"{DISCORD_API_BASE}/guilds/{guild_id}/threads/active",
+            self._headers(),
+            None,
+        )
+        # API returns {"threads": [...], "members": [...]} — extract threads.
+        return result["threads"]  # type: ignore[call-overload,no-any-return]
+
+    async def list_archived_public_threads(self, parent_channel_id: str) -> list[dict[str, Any]]:
+        """GET /channels/{parent}/threads/archived/public — per-parent.
+
+        Pagination NOT implemented; test server is bounded to <100 threads
+        per parent by spec. If has_more becomes true at scale, paginate via
+        the `before` cursor.
+        """
+        result = await _request_with_retry(
+            self._session,
+            "GET",
+            f"{DISCORD_API_BASE}/channels/{parent_channel_id}/threads/archived/public",
+            self._headers(),
+            None,
+        )
+        return result["threads"]  # type: ignore[call-overload,no-any-return]

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -8,6 +8,8 @@ exception hierarchy reinforces that isolation in the type system.
 
 from __future__ import annotations
 
+import logging
+
 
 class ProvisioningError(Exception):
     """Base for all provisioning failures."""
@@ -23,3 +25,27 @@ class ProvisioningPermissionError(ProvisioningError):
 
 class ProvisioningRateLimitError(ProvisioningError):
     """Rate limited after exhausting retries (429)."""
+
+
+class TokenRedactingFilter(logging.Filter):
+    """Scrubs the bot token from every log record's resolved message.
+
+    Operates on record.getMessage() (which uniformly handles %-style, {}-style,
+    and Mapping-args formatting) rather than scanning record.msg and record.args
+    separately. If the token is found, replaces record.msg with the redacted
+    version and clears record.args so re-formatting doesn't reintroduce the
+    token.
+    """
+
+    REDACTED = "<TOKEN>"
+
+    def __init__(self, token: str) -> None:
+        super().__init__()
+        self._token = token
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if self._token in message:
+            record.msg = message.replace(self._token, self.REDACTED)
+            record.args = None
+        return True

--- a/tests/provisioning/_bot_api.py
+++ b/tests/provisioning/_bot_api.py
@@ -206,3 +206,44 @@ class BotApi:
             None,
         )
         return result["threads"]  # type: ignore[call-overload,no-any-return]
+
+    async def send_message(
+        self,
+        channel_id: str,
+        *,
+        content: str,
+        embed: dict[str, Any] | None,
+        audit_reason: str,
+    ) -> dict[str, Any]:
+        """POST /channels/{id}/messages — supports text + optional embed."""
+        body: dict[str, Any] = {"content": content}
+        if embed is not None:
+            body["embeds"] = [embed]
+        result = await _request_with_retry(
+            self._session,
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+            self._headers(audit_reason),
+            body,
+        )
+        return result  # type: ignore[return-value]
+
+    async def create_channel(
+        self,
+        guild_id: str,
+        *,
+        name: str,
+        channel_type: int,
+        topic: str,
+        audit_reason: str,
+    ) -> dict[str, Any]:
+        """POST /guilds/{id}/channels — text (type=0) or forum (type=15)."""
+        body = {"name": name, "type": channel_type, "topic": topic}
+        result = await _request_with_retry(
+            self._session,
+            "POST",
+            f"{DISCORD_API_BASE}/guilds/{guild_id}/channels",
+            self._headers(audit_reason),
+            body,
+        )
+        return result  # type: ignore[return-value]

--- a/tests/provisioning/fixture-spec.json
+++ b/tests/provisioning/fixture-spec.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "marker": "[ferry-fixture]",
+  "guild_name_for_bootstrap": "Discord Ferry Test Fixture",
+  "text_channels": [
+    {
+      "id": "ch-general",
+      "name": "general",
+      "topic_suffix": "primary test channel for DCE fixture capture",
+      "messages": [
+        {"id": "msg-001", "content": "Hello, this is message 1 of the test fixture."},
+        {"id": "msg-002", "content": "Plain text message 2 — used for parser baseline."},
+        {"id": "msg-thread-anchor", "content": "Message anchoring the thread reply chain."},
+        {"id": "msg-004", "content": "Message 4 — plain text continuation."},
+        {"id": "msg-005", "content": "Message 5 — plain text continuation."},
+        {"id": "msg-006", "content": "Message 6 — plain text continuation."},
+        {"id": "msg-007", "content": "Message 7 — plain text continuation."},
+        {"id": "msg-008", "content": "Message 8 — plain text continuation."},
+        {"id": "msg-009", "content": "Message 9 — plain text continuation."},
+        {
+          "id": "msg-embed",
+          "content": "Message with rich embed (inline+non-inline field mix).",
+          "embed": {
+            "title": "Embed title",
+            "description": "Embed description testing mixed inline fields.",
+            "color": 5814783,
+            "fields": [
+              {"name": "Inline 1", "value": "Value 1", "inline": true},
+              {"name": "Inline 2", "value": "Value 2", "inline": true},
+              {"name": "Inline 3", "value": "Value 3", "inline": true},
+              {"name": "Full-width 1", "value": "Value 4", "inline": false},
+              {"name": "Full-width 2", "value": "Value 5", "inline": false}
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "threads": [
+    {
+      "id": "thread-cool",
+      "name": "Cool Thread",
+      "parent_channel_id": "ch-general",
+      "anchor_message_id": "msg-thread-anchor",
+      "first_message_content": "First reply in the thread."
+    }
+  ],
+  "forum_channels": [
+    {
+      "id": "fch-feedback",
+      "name": "Feedback Forum",
+      "topic_suffix": "forum channel for DCE fixture capture",
+      "posts": [
+        {
+          "id": "post-bug",
+          "name": "Bug Report",
+          "first_message_content": "Bug report post body — initial forum-post message."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/provisioning/provision_test_server.py
+++ b/tests/provisioning/provision_test_server.py
@@ -1,0 +1,166 @@
+"""Click CLI for Discord test-server provisioning.
+
+Three subcommands: provision, teardown, verify. Reads bot token from the
+DISCORD_TEST_BOT_TOKEN env var. Three-way exit codes per subcommand:
+  0 = success / match
+  1 = drift (verify) or partial failure (provision)
+  2 = setup error (missing env var, malformed manifest, auth failure)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+import aiohttp
+import click
+
+from tests.provisioning._applier import (
+    Manifest,
+    diff,
+    fetch_actual_state,
+    load_manifest,
+    reconcile_provision,
+)
+from tests.provisioning._bot_api import (
+    BotApi,
+    ProvisioningAuthError,
+    ProvisioningError,
+    TokenRedactingFilter,
+    configure_aiohttp_logging,
+)
+
+DEFAULT_MANIFEST = Path(__file__).parent / "fixture-spec.json"
+
+
+@click.group()
+def cli() -> None:
+    """Discord test-server provisioning. Human-run only, never in CI."""
+
+
+def _setup_logging(token: str, *, verbose: bool) -> None:
+    """Install token-redacting filter on root and quiet aiohttp by default."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    fltr = TokenRedactingFilter(token)
+    logging.getLogger().addFilter(fltr)
+    configure_aiohttp_logging(verbose=verbose)
+
+
+def _require_token() -> str:
+    token = os.environ.get("DISCORD_TEST_BOT_TOKEN")
+    if not token:
+        click.echo("error: DISCORD_TEST_BOT_TOKEN env var not set", err=True)
+        sys.exit(2)
+    return token
+
+
+@cli.command()
+@click.option("--guild-id", help="Existing guild ID to provision into.")
+@click.option(
+    "--create-guild",
+    "create_guild_name",
+    help="Bootstrap a new guild with the given name (unverified bot must be in <10 guilds).",
+)
+@click.option(
+    "--manifest",
+    "manifest_path",
+    default=None,
+    help="Path to fixture-spec.json (defaults to bundled manifest).",
+)
+@click.option("--dry-run", is_flag=True, help="Plan only; no writes.")
+@click.option("--verbose", "-v", is_flag=True, help="DEBUG-level logging.")
+def provision(
+    guild_id: str | None,
+    create_guild_name: str | None,
+    manifest_path: str | None,
+    dry_run: bool,
+    verbose: bool,
+) -> None:
+    """Apply manifest to a guild, creating any missing entities idempotently."""
+    if not guild_id and not create_guild_name:
+        click.echo("error: must specify --guild-id or --create-guild", err=True)
+        sys.exit(2)
+    if guild_id and create_guild_name:
+        click.echo("error: --guild-id and --create-guild are mutually exclusive", err=True)
+        sys.exit(2)
+
+    token = _require_token()
+    _setup_logging(token, verbose=verbose)
+    manifest = _load_manifest_or_exit(manifest_path)
+    asyncio.run(_run_provision(token, guild_id, create_guild_name, manifest, dry_run))
+
+
+def _load_manifest_or_exit(manifest_path: str | None) -> Manifest:
+    path = Path(manifest_path) if manifest_path else DEFAULT_MANIFEST
+    try:
+        return load_manifest(path)
+    except ProvisioningError as exc:
+        click.echo(f"error: invalid manifest: {exc}", err=True)
+        sys.exit(2)
+
+
+async def _run_provision(
+    token: str,
+    guild_id: str | None,
+    create_guild_name: str | None,
+    manifest: Manifest,
+    dry_run: bool,
+) -> None:
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, token)
+        try:
+            target_guild_id = guild_id
+            if create_guild_name:
+                # Preflight: unverified bots can be in at most 10 guilds
+                my_guilds = await api.list_my_guilds()
+                if len(my_guilds) >= 10:
+                    raise ProvisioningError(
+                        f"bot is already in {len(my_guilds)} guilds; "
+                        f"unverified bots are limited to 10. Remove the bot from "
+                        f"one before retrying --create-guild."
+                    )
+                new_guild = await api.create_guild(
+                    name=create_guild_name, audit_reason="bootstrap (issue #35)"
+                )
+                target_guild_id = str(new_guild["id"])
+                click.echo(f"created guild {create_guild_name!r} ({target_guild_id})")
+
+            assert target_guild_id is not None  # narrowed above
+            actual = await fetch_actual_state(api, target_guild_id)
+            d = diff(manifest, actual)
+
+            if dry_run:
+                click.echo("=== DRY RUN PLAN ===")
+                for op in d.ops:
+                    click.echo(f"  would: {type(op).__name__} → {getattr(op.target, 'name', '?')}")
+                click.echo(f"=== END DRY RUN ({len(d.ops)} ops would execute) ===")
+                return
+
+            result = await reconcile_provision(
+                d, api, guild_id=target_guild_id, audit_reason="provision (issue #35)"
+            )
+            click.echo(f"created {result.created_count} entities:")
+            for line in result.created_summary:
+                click.echo(f"  {line}")
+            if result.failed_op_index is not None:
+                click.echo(
+                    f"\nFAILED at op {result.failed_op_index}. "
+                    f"Re-run `provision` with the same --guild-id to resume; "
+                    f"idempotency will skip already-created entities.",
+                    err=True,
+                )
+                sys.exit(1)
+        except ProvisioningAuthError as exc:
+            click.echo(f"auth error: {exc}", err=True)
+            sys.exit(2)
+        except ProvisioningError as exc:
+            click.echo(f"provisioning error: {exc}", err=True)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/provisioning/provision_test_server.py
+++ b/tests/provisioning/provision_test_server.py
@@ -24,6 +24,8 @@ from tests.provisioning._applier import (
     fetch_actual_state,
     load_manifest,
     reconcile_provision,
+    reconcile_teardown,
+    reconcile_verify,
 )
 from tests.provisioning._bot_api import (
     BotApi,
@@ -160,6 +162,85 @@ async def _run_provision(
         except ProvisioningError as exc:
             click.echo(f"provisioning error: {exc}", err=True)
             sys.exit(1)
+
+
+@cli.command()
+@click.option("--guild-id", required=True, help="Guild to teardown.")
+@click.option("--manifest", "manifest_path", default=None)
+@click.option("--yes", is_flag=True, help="Skip interactive confirmation.")
+@click.option("--verbose", "-v", is_flag=True)
+def teardown(guild_id: str, manifest_path: str | None, yes: bool, verbose: bool) -> None:
+    """Delete every marker-carrying entity. Does NOT delete the guild itself."""
+    token = _require_token()
+    _setup_logging(token, verbose=verbose)
+    manifest = _load_manifest_or_exit(manifest_path)
+    asyncio.run(_run_teardown(token, guild_id, manifest, yes))
+
+
+async def _run_teardown(token: str, guild_id: str, manifest: Manifest, yes: bool) -> None:
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, token)
+        try:
+            actual = await fetch_actual_state(api, guild_id)
+            to_delete = [
+                ch
+                for ch in actual.channels
+                if ch.type in (0, 15) and ch.topic and ch.topic.startswith(manifest.marker)
+            ]
+            if not to_delete:
+                click.echo("nothing to delete — guild is clean of marker entities")
+                return
+            click.echo("the following channels will be deleted:")
+            for ch in to_delete:
+                click.echo(f"  #{ch.name} ({ch.discord_id})")
+            if not yes and not click.confirm("\nproceed?", default=False):
+                click.echo("aborted")
+                return
+            result = await reconcile_teardown(
+                actual, api, marker=manifest.marker, audit_reason="teardown (issue #35)"
+            )
+            click.echo(f"deleted {result.deleted_count} entities")
+        except ProvisioningAuthError as exc:
+            click.echo(f"auth error: {exc}", err=True)
+            sys.exit(2)
+        except ProvisioningError as exc:
+            click.echo(f"teardown error: {exc}", err=True)
+            sys.exit(1)
+
+
+@cli.command()
+@click.option("--guild-id", required=True)
+@click.option("--manifest", "manifest_path", default=None)
+@click.option("--verbose", "-v", is_flag=True)
+def verify(guild_id: str, manifest_path: str | None, verbose: bool) -> None:
+    """Compare manifest to live guild state; exit 0=match, 1=drift, 2=error."""
+    token = _require_token()
+    _setup_logging(token, verbose=verbose)
+    manifest = _load_manifest_or_exit(manifest_path)
+    asyncio.run(_run_verify(token, guild_id, manifest))
+
+
+async def _run_verify(token: str, guild_id: str, manifest: Manifest) -> None:
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, token)
+        try:
+            actual = await fetch_actual_state(api, guild_id)
+            d = diff(manifest, actual)
+            result = reconcile_verify(d)
+            if result.exit_code == 0:
+                click.echo("VERIFIED: manifest matches actual state")
+                sys.exit(0)
+            else:
+                click.echo("DRIFT DETECTED:", err=True)
+                for line in result.diff_lines:
+                    click.echo(f"  {line}", err=True)
+                sys.exit(1)
+        except ProvisioningAuthError as exc:
+            click.echo(f"auth error: {exc}", err=True)
+            sys.exit(2)
+        except ProvisioningError as exc:
+            click.echo(f"verify error: {exc}", err=True)
+            sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/tests/provisioning/provision_test_server.py
+++ b/tests/provisioning/provision_test_server.py
@@ -12,11 +12,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import aiohttp
 import click
+
+if TYPE_CHECKING:
+    from types import FrameType
 
 from tests.provisioning._applier import (
     Manifest,
@@ -36,6 +41,35 @@ from tests.provisioning._bot_api import (
 )
 
 DEFAULT_MANIFEST = Path(__file__).parent / "fixture-spec.json"
+
+_sigint_count = 0
+
+
+def _install_sigint_handler() -> None:
+    """Install a SIGINT handler that escalates on the second Ctrl-C.
+
+    First SIGINT: print interrupt message + raise KeyboardInterrupt so the
+    async stack unwinds through the existing exception handlers. Second
+    SIGINT: hard exit with code 130 (128 + SIGINT). Reset per subcommand
+    so each invocation starts with a clean count.
+    """
+    global _sigint_count
+    _sigint_count = 0
+
+    def handler(signum: int, frame: FrameType | None) -> None:
+        global _sigint_count
+        _sigint_count += 1
+        if _sigint_count == 1:
+            click.echo(
+                "\nInterrupted. Re-run with same --guild-id to resume; "
+                "idempotency will skip already-created entities.",
+                err=True,
+            )
+            raise KeyboardInterrupt
+        click.echo("\nHard exit.", err=True)
+        os._exit(130)
+
+    signal.signal(signal.SIGINT, handler)
 
 
 @click.group()
@@ -91,6 +125,7 @@ def provision(
         sys.exit(2)
 
     token = _require_token()
+    _install_sigint_handler()
     _setup_logging(token, verbose=verbose)
     manifest = _load_manifest_or_exit(manifest_path)
     asyncio.run(_run_provision(token, guild_id, create_guild_name, manifest, dry_run))
@@ -172,6 +207,7 @@ async def _run_provision(
 def teardown(guild_id: str, manifest_path: str | None, yes: bool, verbose: bool) -> None:
     """Delete every marker-carrying entity. Does NOT delete the guild itself."""
     token = _require_token()
+    _install_sigint_handler()
     _setup_logging(token, verbose=verbose)
     manifest = _load_manifest_or_exit(manifest_path)
     asyncio.run(_run_teardown(token, guild_id, manifest, yes))
@@ -215,6 +251,7 @@ async def _run_teardown(token: str, guild_id: str, manifest: Manifest, yes: bool
 def verify(guild_id: str, manifest_path: str | None, verbose: bool) -> None:
     """Compare manifest to live guild state; exit 0=match, 1=drift, 2=error."""
     token = _require_token()
+    _install_sigint_handler()
     _setup_logging(token, verbose=verbose)
     manifest = _load_manifest_or_exit(manifest_path)
     asyncio.run(_run_verify(token, guild_id, manifest))

--- a/tests/provisioning/provision_test_server.py
+++ b/tests/provisioning/provision_test_server.py
@@ -36,6 +36,7 @@ from tests.provisioning._bot_api import (
     BotApi,
     ProvisioningAuthError,
     ProvisioningError,
+    ProvisioningPermissionError,
     TokenRedactingFilter,
     configure_aiohttp_logging,
 )
@@ -194,6 +195,9 @@ async def _run_provision(
         except ProvisioningAuthError as exc:
             click.echo(f"auth error: {exc}", err=True)
             sys.exit(2)
+        except ProvisioningPermissionError as exc:
+            click.echo(f"permission error: {exc}", err=True)
+            sys.exit(2)
         except ProvisioningError as exc:
             click.echo(f"provisioning error: {exc}", err=True)
             sys.exit(1)
@@ -236,8 +240,17 @@ async def _run_teardown(token: str, guild_id: str, manifest: Manifest, yes: bool
                 actual, api, marker=manifest.marker, audit_reason="teardown (issue #35)"
             )
             click.echo(f"deleted {result.deleted_count} entities")
+            if result.skipped_count > 0:
+                click.echo(
+                    f"WARNING: {result.skipped_count} entities skipped due to errors; "
+                    f"re-run teardown to retry",
+                    err=True,
+                )
         except ProvisioningAuthError as exc:
             click.echo(f"auth error: {exc}", err=True)
+            sys.exit(2)
+        except ProvisioningPermissionError as exc:
+            click.echo(f"permission error: {exc}", err=True)
             sys.exit(2)
         except ProvisioningError as exc:
             click.echo(f"teardown error: {exc}", err=True)
@@ -274,6 +287,9 @@ async def _run_verify(token: str, guild_id: str, manifest: Manifest) -> None:
                 sys.exit(1)
         except ProvisioningAuthError as exc:
             click.echo(f"auth error: {exc}", err=True)
+            sys.exit(2)
+        except ProvisioningPermissionError as exc:
+            click.echo(f"permission error: {exc}", err=True)
             sys.exit(2)
         except ProvisioningError as exc:
             click.echo(f"verify error: {exc}", err=True)

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -1,0 +1,190 @@
+"""Tests for tests/provisioning/_applier.py."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tests.provisioning._applier import (
+    Manifest,
+    ManifestEmbed,
+    ManifestEmbedField,
+    ManifestForumChannel,
+    ManifestForumPost,
+    ManifestMessage,
+    ManifestTextChannel,
+    ManifestThread,
+    load_manifest,
+)
+from tests.provisioning._bot_api import ProvisioningError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_public_dataclass_surface_is_importable() -> None:
+    """Smoke-test that all public manifest dataclasses are importable.
+
+    Downstream tasks (12-16) import these names; this test gives a clear
+    failure signal if a rename or removal breaks the public surface.
+    """
+    for cls in (
+        Manifest,
+        ManifestEmbed,
+        ManifestEmbedField,
+        ManifestForumChannel,
+        ManifestForumPost,
+        ManifestMessage,
+        ManifestTextChannel,
+        ManifestThread,
+    ):
+        assert isinstance(cls, type)
+
+
+def _valid_manifest_dict() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "marker": "[ferry-fixture]",
+        "guild_name_for_bootstrap": "Discord Ferry Test Fixture",
+        "text_channels": [
+            {
+                "id": "ch-general",
+                "name": "general",
+                "topic_suffix": "primary",
+                "messages": [
+                    {"id": f"msg-{i:03d}", "content": f"Message {i}."} for i in range(1, 10)
+                ]
+                + [
+                    {
+                        "id": "msg-embed",
+                        "content": "Embed message.",
+                        "embed": {
+                            "title": "T",
+                            "description": "D",
+                            "color": 5814783,
+                            "fields": [
+                                {"name": "i1", "value": "v1", "inline": True},
+                                {"name": "i2", "value": "v2", "inline": True},
+                                {"name": "i3", "value": "v3", "inline": True},
+                                {"name": "n1", "value": "v4", "inline": False},
+                                {"name": "n2", "value": "v5", "inline": False},
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+        "threads": [
+            {
+                "id": "thread-cool",
+                "name": "Cool Thread",
+                "parent_channel_id": "ch-general",
+                "anchor_message_id": "msg-003",
+                "first_message_content": "First reply.",
+            }
+        ],
+        "forum_channels": [
+            {
+                "id": "fch-feedback",
+                "name": "Feedback Forum",
+                "topic_suffix": "forum",
+                "posts": [
+                    {
+                        "id": "post-bug",
+                        "name": "Bug Report",
+                        "first_message_content": "Bug body.",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_load_manifest_happy_path(tmp_path: Path) -> None:
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(_valid_manifest_dict()))
+    manifest = load_manifest(path)
+    assert isinstance(manifest, Manifest)
+    assert manifest.version == 1
+    assert len(manifest.text_channels[0].messages) == 10
+
+
+def test_load_manifest_rejects_duplicate_ids(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    data["text_channels"][0]["messages"][1]["id"] = "msg-001"  # dup
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="duplicate.*msg-001"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_dangling_anchor_message_id(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    data["threads"][0]["anchor_message_id"] = "msg-nonexistent"
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="anchor_message_id.*msg-nonexistent"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_wrong_inline_ratio(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    # Flip one inline field to non-inline → 2 inline / 3 non-inline
+    data["text_channels"][0]["messages"][9]["embed"]["fields"][0]["inline"] = False
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="inline"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_unsafe_marker(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    data["marker"] = "<script>alert(1)</script>"
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="marker"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_wrong_version(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    data["version"] = 2
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="version"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_zero_embed_messages(tmp_path: Path) -> None:
+    """Spec invariant: exactly 1 message per text channel must have an embed."""
+    data = _valid_manifest_dict()
+    # Remove the embed from the only embed-carrying message
+    del data["text_channels"][0]["messages"][9]["embed"]
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="embed"):
+        load_manifest(path)
+
+
+def test_load_manifest_rejects_two_embed_messages(tmp_path: Path) -> None:
+    """Spec invariant: exactly 1 (not 2+) message per text channel has an embed."""
+    data = _valid_manifest_dict()
+    # Add an embed to a second message
+    data["text_channels"][0]["messages"][0]["embed"] = {
+        "title": "T2",
+        "description": "D2",
+        "color": 0,
+        "fields": [
+            {"name": "i1", "value": "v1", "inline": True},
+            {"name": "i2", "value": "v2", "inline": True},
+            {"name": "i3", "value": "v3", "inline": True},
+            {"name": "n1", "value": "v4", "inline": False},
+            {"name": "n2", "value": "v5", "inline": False},
+        ],
+    }
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ProvisioningError, match="embed"):
+        load_manifest(path)

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -9,6 +9,19 @@ from typing import Any
 import pytest
 
 from tests.provisioning._applier import (
+    ActualChannel,
+    ActualEmbed,
+    ActualEmbedField,
+    ActualMessage,
+    ActualState,
+    CreateForumChannelOp,
+    CreateForumPostOp,
+    CreateMessageOp,
+    CreateTextChannelOp,
+    CreateThreadOp,
+    DeleteChannelOp,
+    Diff,
+    EmbedMismatch,
     Manifest,
     ManifestEmbed,
     ManifestEmbedField,
@@ -37,6 +50,20 @@ def test_public_dataclass_surface_is_importable() -> None:
         ManifestMessage,
         ManifestTextChannel,
         ManifestThread,
+        # ActualState + diff types (Task 12)
+        ActualChannel,
+        ActualEmbed,
+        ActualEmbedField,
+        ActualMessage,
+        ActualState,
+        CreateForumChannelOp,
+        CreateForumPostOp,
+        CreateMessageOp,
+        CreateTextChannelOp,
+        CreateThreadOp,
+        DeleteChannelOp,
+        Diff,
+        EmbedMismatch,
     ):
         assert isinstance(cls, type)
 
@@ -202,3 +229,38 @@ def test_committed_fixture_spec_loads() -> None:
     assert embed_msg.embed is not None
     inline = sum(1 for f in embed_msg.embed.fields if f.inline)
     assert inline == 3
+
+
+def test_actual_state_is_frozen_and_uses_mapping() -> None:
+    state = ActualState(
+        guild_id="111",
+        channels=(),
+        messages_by_channel={},
+    )
+    with pytest.raises(AttributeError):
+        state.guild_id = "222"  # type: ignore[misc]
+
+
+def test_diff_op_dataclasses_are_constructible() -> None:
+    """Per-kind dataclasses replace the single DiffOp for mypy --strict."""
+    msg = ManifestMessage(id="x", content="y")
+    op = CreateMessageOp(
+        target=msg,
+        parent_manifest_channel_id="ch-1",
+        parent_discord_id="100",
+        reason="missing",
+    )
+    assert op.target is msg
+    assert op.reason == "missing"
+    assert op.parent_manifest_channel_id == "ch-1"
+
+
+def test_empty_diff_is_no_op() -> None:
+    diff = Diff(
+        ops=(),
+        missing_entities=(),
+        extra_marker_entities=(),
+        extra_foreign_entities=(),
+        mismatched_embeds=(),
+    )
+    assert len(diff.ops) == 0

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -639,3 +639,56 @@ async def test_reconcile_provision_on_empty_guild(
         )
 
     assert result.created_count >= 14  # 1 text + 10 msgs + 1 thread + 1 forum + 1 post
+
+
+from tests.provisioning._applier import (  # noqa: E402
+    TeardownResult,
+    VerifyResult,
+    reconcile_teardown,
+    reconcile_verify,
+)
+
+
+async def test_reconcile_teardown_deletes_marker_channels(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    actual = ActualState(
+        guild_id="111",
+        channels=(
+            ActualChannel("100", "general", 0, "[ferry-fixture] x", None),
+            ActualChannel("101", "Feedback Forum", 15, "[ferry-fixture] y", None),
+            ActualChannel("200", "user-channel", 0, None, None),
+        ),
+        messages_by_channel={},
+    )
+    mock_discord_for_state.delete(f"{DISCORD_API}/channels/100", status=200, payload={})
+    mock_discord_for_state.delete(f"{DISCORD_API}/channels/101", status=200, payload={})
+
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await reconcile_teardown(
+            actual, api, marker="[ferry-fixture]", audit_reason="teardown (issue #35)"
+        )
+    assert isinstance(result, TeardownResult)
+    assert result.deleted_count == 2
+    assert "200" not in result.deleted_ids
+
+
+def test_reconcile_verify_returns_exit_zero_on_match() -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    d = diff(manifest, actual)
+    result = reconcile_verify(d)
+    assert isinstance(result, VerifyResult)
+    assert result.exit_code == 0
+
+
+def test_reconcile_verify_returns_exit_one_on_drift() -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = ActualState(guild_id="111", channels=(), messages_by_channel={})
+    d = diff(manifest, actual)
+    result = reconcile_verify(d)
+    assert result.exit_code == 1
+    assert len(result.diff_lines) > 0

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import aiohttp
 import pytest
+from aioresponses import aioresponses
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 from tests.provisioning._applier import (
     ActualChannel,
@@ -30,9 +35,13 @@ from tests.provisioning._applier import (
     ManifestMessage,
     ManifestTextChannel,
     ManifestThread,
+    fetch_actual_state,
     load_manifest,
 )
-from tests.provisioning._bot_api import ProvisioningError
+from tests.provisioning._bot_api import BotApi, ProvisioningError
+
+DISCORD_API = "https://discord.com/api/v10"
+TOKEN = "test-bot-token"
 
 
 def test_public_dataclass_surface_is_importable() -> None:
@@ -264,3 +273,92 @@ def test_empty_diff_is_no_op() -> None:
         mismatched_embeds=(),
     )
     assert len(diff.ops) == 0
+
+
+@pytest.fixture
+def mock_discord_for_state() -> Generator[aioresponses, None, None]:
+    with aioresponses() as m:
+        yield m
+
+
+async def test_fetch_actual_state_merges_active_and_archived_threads(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    guild = "111"
+    # Channels: one text + one forum
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[
+            {
+                "id": "100",
+                "name": "general",
+                "type": 0,
+                "topic": "[ferry-fixture] x",
+                "parent_id": None,
+            },
+            {
+                "id": "101",
+                "name": "Feedback Forum",
+                "type": 15,
+                "topic": "[ferry-fixture] y",
+                "parent_id": None,
+            },
+        ],
+    )
+    # Active threads: one in text channel
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={
+            "threads": [
+                {"id": "t1", "name": "Active Thread", "type": 11, "topic": None, "parent_id": "100"}
+            ],
+            "members": [],
+        },
+    )
+    # Archived public threads per parent channel
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/100/threads/archived/public",
+        payload={
+            "threads": [
+                {
+                    "id": "t2",
+                    "name": "Archived Thread",
+                    "type": 11,
+                    "topic": None,
+                    "parent_id": "100",
+                }
+            ],
+            "members": [],
+            "has_more": False,
+        },
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/101/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    # Messages in each channel (empty for this test)
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/100/messages?limit=100",
+        payload=[],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/101/messages?limit=100",
+        payload=[],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/t1/messages?limit=100",
+        payload=[],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/t2/messages?limit=100",
+        payload=[],
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        state = await fetch_actual_state(api, guild)
+
+    # 4 channels total: 1 text + 1 forum + 1 active thread + 1 archived thread
+    assert len(state.channels) == 4
+    thread_ids = {ch.discord_id for ch in state.channels if ch.type == 11}
+    assert thread_ids == {"t1", "t2"}

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -362,3 +362,220 @@ async def test_fetch_actual_state_merges_active_and_archived_threads(
     assert len(state.channels) == 4
     thread_ids = {ch.discord_id for ch in state.channels if ch.type == 11}
     assert thread_ids == {"t1", "t2"}
+
+
+from tests.provisioning._applier import diff  # noqa: E402
+
+
+def test_diff_empty_actual_yields_create_ops_for_every_manifest_entity() -> None:
+    """Empty guild + manifest → ops to create everything."""
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = ActualState(guild_id="111", channels=(), messages_by_channel={})
+    d = diff(manifest, actual)
+    # Should have: 1 text channel + 10 messages + 1 thread + 1 forum channel + 1 forum post
+    create_ops = [o for o in d.ops if not isinstance(o, DeleteChannelOp)]
+    assert len(create_ops) == 14  # 1 + 10 + 1 + 1 + 1 = 14
+    text_ops = [o for o in d.ops if isinstance(o, CreateTextChannelOp)]
+    assert len(text_ops) == 1
+
+
+def test_diff_matching_state_yields_zero_ops() -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    d = diff(manifest, actual)
+    assert d.ops == ()
+    assert d.missing_entities == ()
+    assert d.extra_marker_entities == ()
+    assert d.mismatched_embeds == ()
+
+
+def test_diff_extra_marker_channel_reported(tmp_path: Path) -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    # Add an extra marker-carrying channel that isn't in the manifest:
+    extra = ActualChannel(
+        discord_id="999",
+        name="orphan",
+        type=0,
+        topic="[ferry-fixture] leftover",
+        parent_id=None,
+    )
+    actual = ActualState(
+        guild_id=actual.guild_id,
+        channels=actual.channels + (extra,),
+        messages_by_channel=actual.messages_by_channel,
+    )
+    d = diff(manifest, actual)
+    assert any(ch.discord_id == "999" for ch in d.extra_marker_entities)
+
+
+def test_diff_extra_foreign_channel_ignored() -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    foreign = ActualChannel(
+        discord_id="888",
+        name="dev-chat",
+        type=0,
+        topic=None,  # no marker
+        parent_id=None,
+    )
+    actual = ActualState(
+        guild_id=actual.guild_id,
+        channels=actual.channels + (foreign,),
+        messages_by_channel=actual.messages_by_channel,
+    )
+    d = diff(manifest, actual)
+    assert d.extra_marker_entities == ()
+    assert any(ch.discord_id == "888" for ch in d.extra_foreign_entities)
+    assert d.ops == ()
+
+
+def test_diff_embed_field_text_drift_detected() -> None:
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    # Find the embed message and corrupt its first field name
+    text_ch = next(c for c in actual.channels if c.name == "general")
+    msgs = list(actual.messages_by_channel[text_ch.discord_id])
+    embed_msg_idx = next(i for i, m in enumerate(msgs) if m.embed is not None)
+    bad = msgs[embed_msg_idx]
+    assert bad.embed is not None
+    new_fields = (ActualEmbedField(name="DRIFT", value="Value 1", inline=True),) + bad.embed.fields[
+        1:
+    ]
+    msgs[embed_msg_idx] = ActualMessage(
+        discord_id=bad.discord_id,
+        channel_discord_id=bad.channel_discord_id,
+        content=bad.content,
+        embed=ActualEmbed(
+            title=bad.embed.title,
+            description=bad.embed.description,
+            color=bad.embed.color,
+            fields=new_fields,
+        ),
+    )
+    new_msg_map = dict(actual.messages_by_channel)
+    new_msg_map[text_ch.discord_id] = tuple(msgs)
+    actual = ActualState(
+        guild_id=actual.guild_id,
+        channels=actual.channels,
+        messages_by_channel=new_msg_map,
+    )
+    d = diff(manifest, actual)
+    assert len(d.mismatched_embeds) == 1
+    assert (
+        "DRIFT" in d.mismatched_embeds[0].reason or "field" in d.mismatched_embeds[0].reason.lower()
+    )
+
+
+def _build_fully_matching_state(manifest: Manifest) -> ActualState:
+    """Construct an ActualState that perfectly mirrors the manifest."""
+    channels: list[ActualChannel] = []
+    messages_by_channel: dict[str, tuple[ActualMessage, ...]] = {}
+    snowflake = 1000
+    for tc in manifest.text_channels:
+        ch_id = str(snowflake)
+        snowflake += 1
+        channels.append(
+            ActualChannel(
+                discord_id=ch_id,
+                name=tc.name,
+                type=0,
+                topic=f"{manifest.marker} {tc.topic_suffix}",
+                parent_id=None,
+            )
+        )
+        msgs: list[ActualMessage] = []
+        for m in tc.messages:
+            embed: ActualEmbed | None = None
+            if m.embed is not None:
+                embed = ActualEmbed(
+                    title=m.embed.title,
+                    description=m.embed.description,
+                    color=m.embed.color,
+                    fields=tuple(
+                        ActualEmbedField(name=f.name, value=f.value, inline=f.inline)
+                        for f in m.embed.fields
+                    ),
+                )
+            msg_id = str(snowflake)
+            snowflake += 1
+            msgs.append(
+                ActualMessage(
+                    discord_id=msg_id,
+                    channel_discord_id=ch_id,
+                    content=f"{m.content} [ferry:{m.id}]",
+                    embed=embed,
+                )
+            )
+        messages_by_channel[ch_id] = tuple(msgs)
+    for t in manifest.threads:
+        parent_ch = next(c for c in channels if c.name == _channel_name_for_thread(manifest, t))
+        thread_id = str(snowflake)
+        snowflake += 1
+        channels.append(
+            ActualChannel(
+                discord_id=thread_id,
+                name=t.name,
+                type=11,
+                topic=None,
+                parent_id=parent_ch.discord_id,
+            )
+        )
+        first_id = str(snowflake)
+        snowflake += 1
+        messages_by_channel[thread_id] = (
+            ActualMessage(
+                discord_id=first_id,
+                channel_discord_id=thread_id,
+                content=f"{t.first_message_content} [ferry:{t.id}]",
+                embed=None,
+            ),
+        )
+    for fc in manifest.forum_channels:
+        forum_id = str(snowflake)
+        snowflake += 1
+        channels.append(
+            ActualChannel(
+                discord_id=forum_id,
+                name=fc.name,
+                type=15,
+                topic=f"{manifest.marker} {fc.topic_suffix}",
+                parent_id=None,
+            )
+        )
+        for post in fc.posts:
+            post_id = str(snowflake)
+            snowflake += 1
+            channels.append(
+                ActualChannel(
+                    discord_id=post_id,
+                    name=post.name,
+                    type=11,
+                    topic=None,
+                    parent_id=forum_id,
+                )
+            )
+            first_post_msg_id = str(snowflake)
+            snowflake += 1
+            messages_by_channel[post_id] = (
+                ActualMessage(
+                    discord_id=first_post_msg_id,
+                    channel_discord_id=post_id,
+                    content=f"{post.first_message_content} [ferry:{post.id}]",
+                    embed=None,
+                ),
+            )
+    return ActualState(
+        guild_id="111",
+        channels=tuple(channels),
+        messages_by_channel=messages_by_channel,
+    )
+
+
+def _channel_name_for_thread(manifest: Manifest, thread: ManifestThread) -> str:
+    return next(c.name for c in manifest.text_channels if c.id == thread.parent_channel_id)

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -579,3 +579,63 @@ def _build_fully_matching_state(manifest: Manifest) -> ActualState:
 
 def _channel_name_for_thread(manifest: Manifest, thread: ManifestThread) -> str:
     return next(c.name for c in manifest.text_channels if c.id == thread.parent_channel_id)
+
+
+import re as re_  # noqa: E402
+
+from tests.provisioning._applier import reconcile_provision  # noqa: E402
+
+
+async def test_reconcile_provision_on_empty_guild(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """provision on empty guild → 1 text ch + 10 messages + 1 thread + 1 forum + 1 post."""
+    guild = "111"
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual_empty = ActualState(guild_id=guild, channels=(), messages_by_channel={})
+
+    # Mock the text channel creation:
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload={"id": "ch_text_id", "name": "general", "type": 0},
+    )
+    # 10 messages in text channel
+    for i in range(10):
+        mock_discord_for_state.post(
+            f"{DISCORD_API}/channels/ch_text_id/messages",
+            payload={"id": f"msg_id_{i}", "channel_id": "ch_text_id"},
+        )
+    # Thread creation off some message (use regex match for which message)
+    mock_discord_for_state.post(
+        re_.compile(r".*/channels/ch_text_id/messages/.+/threads$"),
+        payload={"id": "thread_id", "name": "Cool Thread", "type": 11, "parent_id": "ch_text_id"},
+    )
+    # First message in the thread
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/channels/thread_id/messages",
+        payload={"id": "thread_first_msg_id", "channel_id": "thread_id"},
+    )
+    # Forum channel creation (separate POST to same endpoint as text channel)
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload={"id": "forum_id", "name": "Feedback Forum", "type": 15},
+    )
+    # Forum post
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/channels/forum_id/threads",
+        payload={
+            "id": "post_id",
+            "name": "Bug Report",
+            "message": {"id": "post_first_msg_id"},
+        },
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        d = diff(manifest, actual_empty)
+        result = await reconcile_provision(
+            d, api, guild_id=guild, audit_reason="provision (issue #35)"
+        )
+
+    assert result.created_count >= 14  # 1 text + 10 msgs + 1 thread + 1 forum + 1 post

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -19,9 +20,6 @@ from tests.provisioning._applier import (
     load_manifest,
 )
 from tests.provisioning._bot_api import ProvisioningError
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_public_dataclass_surface_is_importable() -> None:
@@ -188,3 +186,19 @@ def test_load_manifest_rejects_two_embed_messages(tmp_path: Path) -> None:
     path.write_text(json.dumps(data))
     with pytest.raises(ProvisioningError, match="embed"):
         load_manifest(path)
+
+
+def test_committed_fixture_spec_loads() -> None:
+    """The committed fixture-spec.json must pass load_manifest invariants."""
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    assert len(manifest.text_channels) == 1
+    assert len(manifest.text_channels[0].messages) == 10
+    assert len(manifest.threads) == 1
+    assert len(manifest.forum_channels) == 1
+    assert len(manifest.forum_channels[0].posts) == 1
+    # Verify the embed has exactly 3 inline + 2 non-inline:
+    embed_msg = next(m for m in manifest.text_channels[0].messages if m.embed)
+    assert embed_msg.embed is not None
+    inline = sum(1 for f in embed_msg.embed.fields if f.inline)
+    assert inline == 3

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -472,6 +472,40 @@ def test_diff_embed_field_text_drift_detected() -> None:
     )
 
 
+def test_diff_matches_discord_normalized_channel_names() -> None:
+    """Discord lowercases + hyphenates channel names server-side.
+
+    Manifest says 'Feedback Forum'; Discord stores 'feedback-forum'. The diff
+    comparator must normalize both sides so the names match. Without this fix,
+    verify against a real guild reports the forum channel as missing and the
+    Discord-normalized name as an extra marker entity.
+    """
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+    # Rewrite the forum channel's name to Discord's normalized form
+    new_channels = tuple(
+        ActualChannel(
+            discord_id=ch.discord_id,
+            name="feedback-forum" if ch.name == "Feedback Forum" else ch.name,
+            type=ch.type,
+            topic=ch.topic,
+            parent_id=ch.parent_id,
+        )
+        for ch in actual.channels
+    )
+    actual = ActualState(
+        guild_id=actual.guild_id,
+        channels=new_channels,
+        messages_by_channel=actual.messages_by_channel,
+    )
+    d = diff(manifest, actual)
+    assert d.ops == ()
+    assert d.missing_entities == ()
+    assert d.extra_marker_entities == ()
+    assert d.mismatched_embeds == ()
+
+
 def _build_fully_matching_state(manifest: Manifest) -> ActualState:
     """Construct an ActualState that perfectly mirrors the manifest."""
     channels: list[ActualChannel] = []

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -10,6 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 from tests.provisioning._bot_api import (
+    BotApi,
     ProvisioningAuthError,
     ProvisioningError,
     ProvisioningPermissionError,
@@ -162,3 +163,33 @@ async def test_request_with_retry_400_includes_code_and_message_not_errors(
     assert "50035" in msg
     assert "Invalid Form Body" in msg
     assert "leak me" not in msg
+
+
+async def test_botapi_repr_redacts_token(mock_discord: aioresponses) -> None:
+    real_looking_token = "MTM0NTY3ODkwMTIz.ABCdef.real-looking-token-xyz"
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, real_looking_token)
+        rendered = repr(api)
+    assert "MTM0NTY3" not in rendered
+    assert "<redacted>" in rendered
+
+
+async def test_botapi_sends_bot_prefixed_authorization(
+    mock_discord: aioresponses,
+) -> None:
+    """Every request must carry Authorization: Bot <token> and a User-Agent."""
+    mock_discord.get(
+        f"{DISCORD_API}/users/@me/guilds",
+        payload=[],
+        status=200,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        await api.list_my_guilds()
+
+    # aioresponses stores requests in .requests; verify headers
+    requests = mock_discord.requests
+    key = list(requests.keys())[0]
+    call = requests[key][0]
+    assert call.kwargs["headers"]["Authorization"] == f"Bot {TOKEN}"
+    assert "DiscordFerry-TestProvisioner" in call.kwargs["headers"]["User-Agent"]

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -402,3 +402,18 @@ async def test_delete_channel(mock_discord: aioresponses) -> None:
         api = BotApi(session, TOKEN)
         await api.delete_channel("100", audit_reason="teardown (issue #35)")
     # No assertion needed — successful return is the test
+
+
+from tests.provisioning._bot_api import configure_aiohttp_logging  # noqa: E402
+
+
+def test_configure_aiohttp_logging_sets_warning_in_default() -> None:
+    configure_aiohttp_logging(verbose=False)
+    for name in ("aiohttp", "aiohttp.client", "aiohttp.connector", "aiohttp.access"):
+        assert logging.getLogger(name).level >= logging.WARNING
+
+
+def test_configure_aiohttp_logging_allows_debug_in_verbose() -> None:
+    configure_aiohttp_logging(verbose=True)
+    # In verbose mode, we don't enforce a floor — caller's root level is used.
+    # No assertion needed; just confirm it doesn't raise.

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -240,3 +240,40 @@ async def test_list_messages_uses_limit_query(mock_discord: aioresponses) -> Non
         result = await api.list_messages("100")
     assert len(result) == 1
     assert result[0]["id"] == "m1"
+
+
+async def test_list_active_threads_returns_threads(mock_discord: aioresponses) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/guilds/{GUILD_ID}/threads/active",
+        payload={
+            "threads": [
+                {"id": "t1", "name": "Cool Thread", "type": 11, "parent_id": "100"},
+            ],
+            "members": [],
+        },
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.list_active_threads(GUILD_ID)
+    assert len(result) == 1
+    assert result[0]["name"] == "Cool Thread"
+
+
+async def test_list_archived_public_threads_returns_threads(
+    mock_discord: aioresponses,
+) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/channels/100/threads/archived/public",
+        payload={
+            "threads": [
+                {"id": "t2", "name": "Archived Thread", "type": 11, "parent_id": "100"},
+            ],
+            "members": [],
+            "has_more": False,
+        },
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.list_archived_public_threads("100")
+    assert len(result) == 1
+    assert result[0]["id"] == "t2"

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -277,3 +277,59 @@ async def test_list_archived_public_threads_returns_threads(
         result = await api.list_archived_public_threads("100")
     assert len(result) == 1
     assert result[0]["id"] == "t2"
+
+
+async def test_send_message_posts_content_and_embed(mock_discord: aioresponses) -> None:
+    mock_discord.post(
+        f"{DISCORD_API}/channels/100/messages",
+        payload={"id": "m99", "channel_id": "100", "content": "hi"},
+        status=200,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.send_message(
+            "100",
+            content="hi [ferry:msg-001]",
+            embed=None,
+            audit_reason="provision (issue #35)",
+        )
+    assert result["id"] == "m99"
+    # Audit reason header was sent:
+    call = list(mock_discord.requests.values())[0][0]
+    assert call.kwargs["headers"]["X-Audit-Log-Reason"] == "provision (issue #35)"
+
+
+async def test_create_channel_text_type_zero(mock_discord: aioresponses) -> None:
+    mock_discord.post(
+        f"{DISCORD_API}/guilds/{GUILD_ID}/channels",
+        payload={"id": "100", "name": "general", "type": 0},
+        status=201,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.create_channel(
+            GUILD_ID,
+            name="general",
+            channel_type=0,
+            topic="[ferry-fixture] primary test channel",
+            audit_reason="provision (issue #35)",
+        )
+    assert result["id"] == "100"
+
+
+async def test_create_channel_forum_type_fifteen(mock_discord: aioresponses) -> None:
+    mock_discord.post(
+        f"{DISCORD_API}/guilds/{GUILD_ID}/channels",
+        payload={"id": "101", "name": "Feedback Forum", "type": 15},
+        status=201,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.create_channel(
+            GUILD_ID,
+            name="Feedback Forum",
+            channel_type=15,
+            topic="[ferry-fixture] forum channel",
+            audit_reason="provision (issue #35)",
+        )
+    assert result["type"] == 15

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 DISCORD_API = "https://discord.com/api/v10"
 TOKEN = "test-bot-token"
+GUILD_ID = "987654321"
 
 
 def test_exception_hierarchy_is_self_contained() -> None:
@@ -208,3 +209,34 @@ def test_botapi_token_only_stored_in_underscore_token() -> None:
     """Regression guard: token must never be cached on any other attribute."""
     api = BotApi(session=None, token="abc123")  # type: ignore[arg-type]
     assert set(api.__dict__.keys()) == {"_session", "_token"}
+
+
+async def test_list_channels_returns_channel_objects(
+    mock_discord: aioresponses,
+) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/guilds/{GUILD_ID}/channels",
+        payload=[
+            {"id": "100", "name": "general", "type": 0, "topic": "[ferry-fixture] x"},
+            {"id": "101", "name": "Feedback Forum", "type": 15, "topic": "[ferry-fixture] y"},
+        ],
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.list_channels(GUILD_ID)
+    assert len(result) == 2
+    assert result[0]["name"] == "general"
+
+
+async def test_list_messages_uses_limit_query(mock_discord: aioresponses) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/channels/100/messages?limit=100",
+        payload=[
+            {"id": "m1", "content": "hello", "channel_id": "100"},
+        ],
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.list_messages("100")
+    assert len(result) == 1
+    assert result[0]["id"] == "m1"

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -375,3 +375,30 @@ async def test_create_forum_post_uses_threads_endpoint(
         )
     assert result["id"] == "t20"
     assert result["message"]["id"] == "msg-in-post"
+
+
+async def test_create_guild_returns_new_guild(mock_discord: aioresponses) -> None:
+    mock_discord.post(
+        f"{DISCORD_API}/guilds",
+        payload={"id": "999", "name": "Discord Ferry Test Fixture"},
+        status=201,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.create_guild(
+            name="Discord Ferry Test Fixture",
+            audit_reason="bootstrap (issue #35)",
+        )
+    assert result["id"] == "999"
+
+
+async def test_delete_channel(mock_discord: aioresponses) -> None:
+    mock_discord.delete(
+        f"{DISCORD_API}/channels/100",
+        payload={},
+        status=200,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        await api.delete_channel("100", audit_reason="teardown (issue #35)")
+    # No assertion needed — successful return is the test

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 from tests.provisioning._bot_api import (
     ProvisioningAuthError,
     ProvisioningError,
     ProvisioningPermissionError,
     ProvisioningRateLimitError,
+    TokenRedactingFilter,
 )
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_exception_hierarchy_is_self_contained() -> None:
@@ -25,3 +32,36 @@ def test_exception_hierarchy_is_self_contained() -> None:
     from discord_ferry.errors import FerryError
 
     assert not issubclass(ProvisioningError, FerryError)
+
+
+def test_token_redacting_filter_scrubs_token_from_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Filter must replace literal token with <TOKEN> in record.getMessage()."""
+    token = "secret-token-MTM0NTY3.ABCdef"
+    fltr = TokenRedactingFilter(token)
+    logger = logging.getLogger("test_token_filter")
+    logger.addFilter(fltr)
+    logger.setLevel(logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG, logger="test_token_filter"):
+        logger.info("about to call: token=%s", token)
+
+    assert token not in caplog.text
+    assert "<TOKEN>" in caplog.text
+
+
+def test_token_redacting_filter_handles_no_token_in_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Filter must not modify records that don't contain the token."""
+    token = "secret-token-xyz"
+    fltr = TokenRedactingFilter(token)
+    logger = logging.getLogger("test_token_filter_clean")
+    logger.addFilter(fltr)
+    logger.setLevel(logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG, logger="test_token_filter_clean"):
+        logger.info("normal log line with no secrets")
+
+    assert "normal log line with no secrets" in caplog.text

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -5,16 +5,24 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
 from tests.provisioning._bot_api import (
     ProvisioningAuthError,
     ProvisioningError,
     ProvisioningPermissionError,
     ProvisioningRateLimitError,
     TokenRedactingFilter,
+    _request_with_retry,
 )
 
 if TYPE_CHECKING:
-    import pytest
+    from collections.abc import Generator
+
+DISCORD_API = "https://discord.com/api/v10"
+TOKEN = "test-bot-token"
 
 
 def test_exception_hierarchy_is_self_contained() -> None:
@@ -65,3 +73,92 @@ def test_token_redacting_filter_handles_no_token_in_message(
         logger.info("normal log line with no secrets")
 
     assert "normal log line with no secrets" in caplog.text
+
+
+@pytest.fixture
+def mock_discord() -> Generator[aioresponses, None, None]:
+    with aioresponses() as m:
+        yield m
+
+
+async def test_request_with_retry_succeeds_first_try(mock_discord: aioresponses) -> None:
+    mock_discord.get(f"{DISCORD_API}/test", payload={"ok": True}, status=200)
+    async with aiohttp.ClientSession() as session:
+        result = await _request_with_retry(
+            session, "GET", f"{DISCORD_API}/test", headers={}, json_body=None
+        )
+    assert result == {"ok": True}
+
+
+async def test_request_with_retry_429_then_success(mock_discord: aioresponses) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/test",
+        status=429,
+        payload={"retry_after": 0.01},
+    )
+    mock_discord.get(f"{DISCORD_API}/test", payload={"ok": True}, status=200)
+    async with aiohttp.ClientSession() as session:
+        result = await _request_with_retry(
+            session, "GET", f"{DISCORD_API}/test", headers={}, json_body=None
+        )
+    assert result == {"ok": True}
+
+
+async def test_request_with_retry_429_exhausted_raises(mock_discord: aioresponses) -> None:
+    mock_discord.get(
+        f"{DISCORD_API}/test",
+        status=429,
+        payload={"retry_after": 0.01},
+        repeat=True,
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ProvisioningRateLimitError):
+            await _request_with_retry(
+                session, "GET", f"{DISCORD_API}/test", headers={}, json_body=None
+            )
+
+
+async def test_request_with_retry_401_raises_auth_error(mock_discord: aioresponses) -> None:
+    mock_discord.get(f"{DISCORD_API}/test", status=401, payload={})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ProvisioningAuthError) as exc:
+            await _request_with_retry(
+                session, "GET", f"{DISCORD_API}/test", headers={}, json_body=None
+            )
+    # Token never in message:
+    assert TOKEN not in str(exc.value)
+
+
+async def test_request_with_retry_403_raises_permission_error(
+    mock_discord: aioresponses,
+) -> None:
+    mock_discord.get(f"{DISCORD_API}/test", status=403, payload={})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ProvisioningPermissionError):
+            await _request_with_retry(
+                session, "GET", f"{DISCORD_API}/test", headers={}, json_body=None
+            )
+
+
+async def test_request_with_retry_400_includes_code_and_message_not_errors(
+    mock_discord: aioresponses,
+) -> None:
+    """400 error must surface code+message but never the errors object."""
+    mock_discord.post(
+        f"{DISCORD_API}/test",
+        status=400,
+        payload={
+            "code": 50035,
+            "message": "Invalid Form Body",
+            "errors": {"name": {"_errors": [{"message": "leak me"}]}},
+        },
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ProvisioningError) as exc:
+            await _request_with_retry(
+                session, "POST", f"{DISCORD_API}/test", headers={}, json_body={"x": 1}
+            )
+    msg = str(exc.value)
+    assert "50035" in msg
+    assert "Invalid Form Body" in msg
+    assert "leak me" not in msg

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -193,3 +193,18 @@ async def test_botapi_sends_bot_prefixed_authorization(
     call = requests[key][0]
     assert call.kwargs["headers"]["Authorization"] == f"Bot {TOKEN}"
     assert "DiscordFerry-TestProvisioner" in call.kwargs["headers"]["User-Agent"]
+
+
+def test_botapi_headers_includes_audit_reason_when_provided() -> None:
+    """X-Audit-Log-Reason is set only when audit_reason is provided."""
+    api = BotApi(session=None, token=TOKEN)  # type: ignore[arg-type]
+    with_reason = api._headers(audit_reason="cleanup test")
+    without_reason = api._headers()
+    assert with_reason["X-Audit-Log-Reason"] == "cleanup test"
+    assert "X-Audit-Log-Reason" not in without_reason
+
+
+def test_botapi_token_only_stored_in_underscore_token() -> None:
+    """Regression guard: token must never be cached on any other attribute."""
+    api = BotApi(session=None, token="abc123")  # type: ignore[arg-type]
+    assert set(api.__dict__.keys()) == {"_session", "_token"}

--- a/tests/provisioning/test_bot_api.py
+++ b/tests/provisioning/test_bot_api.py
@@ -333,3 +333,45 @@ async def test_create_channel_forum_type_fifteen(mock_discord: aioresponses) -> 
             audit_reason="provision (issue #35)",
         )
     assert result["type"] == 15
+
+
+async def test_create_thread_from_message(mock_discord: aioresponses) -> None:
+    mock_discord.post(
+        f"{DISCORD_API}/channels/100/messages/m1/threads",
+        payload={"id": "t10", "name": "Cool Thread", "type": 11, "parent_id": "100"},
+        status=201,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.create_thread_from_message(
+            "100", "m1", name="Cool Thread", audit_reason="provision (issue #35)"
+        )
+    assert result["id"] == "t10"
+    # auto_archive_duration must be 1440:
+    call = list(mock_discord.requests.values())[0][0]
+    assert call.kwargs["json"]["auto_archive_duration"] == 1440
+
+
+async def test_create_forum_post_uses_threads_endpoint(
+    mock_discord: aioresponses,
+) -> None:
+    """Forum posts MUST use /channels/{forum}/threads, NOT /messages."""
+    mock_discord.post(
+        f"{DISCORD_API}/channels/101/threads",
+        payload={
+            "id": "t20",
+            "name": "Bug Report",
+            "message": {"id": "msg-in-post", "content": "Bug report body."},
+        },
+        status=201,
+    )
+    async with aiohttp.ClientSession() as session:
+        api = BotApi(session, TOKEN)
+        result = await api.create_forum_post(
+            "101",
+            name="Bug Report",
+            first_message_content="Bug report body. [ferry:post-bug]",
+            audit_reason="provision (issue #35)",
+        )
+    assert result["id"] == "t20"
+    assert result["message"]["id"] == "msg-in-post"

--- a/tests/provisioning/test_cli.py
+++ b/tests/provisioning/test_cli.py
@@ -1,0 +1,31 @@
+"""Tests for tests/provisioning/provision_test_server.py CLI."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from tests.provisioning.provision_test_server import cli
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_cli_missing_env_var_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISCORD_TEST_BOT_TOKEN", raising=False)
+    # Click 8.2+ separates stderr from stdout by default; result.stderr is available.
+    runner = CliRunner()
+    result = runner.invoke(cli, ["provision", "--guild-id", "111"])
+    assert result.exit_code == 2
+    assert "DISCORD_TEST_BOT_TOKEN" in result.stderr
+
+
+def test_cli_provision_requires_guild_id_or_create_guild() -> None:
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["provision"])
+        # Click should error on missing --guild-id and --create-guild
+        assert result.exit_code != 0

--- a/tests/provisioning/test_cli.py
+++ b/tests/provisioning/test_cli.py
@@ -3,15 +3,27 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
+import pytest
+from aioresponses import aioresponses
 from click.testing import CliRunner
 
 from tests.provisioning.provision_test_server import cli
 
 if TYPE_CHECKING:
-    import pytest
+    from collections.abc import Generator
+
+
+DISCORD_API = "https://discord.com/api/v10"
+
+
+@pytest.fixture
+def mock_discord_for_state() -> Generator[aioresponses, None, None]:
+    with aioresponses() as m:
+        yield m
 
 
 def test_cli_missing_env_var_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -29,3 +41,310 @@ def test_cli_provision_requires_guild_id_or_create_guild() -> None:
         result = runner.invoke(cli, ["provision"])
         # Click should error on missing --guild-id and --create-guild
         assert result.exit_code != 0
+
+
+def test_cli_teardown_requires_guild_id() -> None:
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["teardown"])
+        assert result.exit_code != 0
+
+
+def test_cli_verify_requires_guild_id() -> None:
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify"])
+        assert result.exit_code != 0
+
+
+def test_cli_teardown_deletes_marker_channels_with_yes_flag(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S4-HP1: teardown deletes only marker-carrying entities."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[
+            {"id": "100", "name": "general", "type": 0, "topic": "[ferry-fixture] x"},
+            {"id": "101", "name": "Feedback Forum", "type": 15, "topic": "[ferry-fixture] y"},
+            {"id": "200", "name": "user-channel", "type": 0, "topic": None},
+        ],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={"threads": [], "members": []},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/100/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/200/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    for ch_id in ("100", "101", "200"):
+        mock_discord_for_state.get(
+            f"{DISCORD_API}/channels/{ch_id}/messages?limit=100",
+            payload=[],
+        )
+    mock_discord_for_state.delete(f"{DISCORD_API}/channels/100", status=200, payload={})
+    mock_discord_for_state.delete(f"{DISCORD_API}/channels/101", status=200, payload={})
+
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["teardown", "--guild-id", guild, "--yes"])
+
+    assert result.exit_code == 0
+    delete_calls = [k for k in mock_discord_for_state.requests if k[0] == "DELETE"]
+    assert len(delete_calls) == 2
+
+
+def test_cli_teardown_without_yes_prompts_and_aborts_on_no(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S4-ER1: teardown without --yes prompts; user typing 'n' aborts."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[
+            {"id": "100", "name": "general", "type": 0, "topic": "[ferry-fixture] x"},
+        ],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={"threads": [], "members": []},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/100/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/100/messages?limit=100",
+        payload=[],
+    )
+
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["teardown", "--guild-id", guild], input="n\n")
+
+    delete_calls = [k for k in mock_discord_for_state.requests if k[0] == "DELETE"]
+    assert len(delete_calls) == 0
+    assert "aborted" in result.output.lower() or "abort" in result.output.lower()
+
+
+def test_cli_verify_perfect_match_exits_zero(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S5-HP1: verify on a perfect-match guild exits 0."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[
+            {
+                "id": "ch_text",
+                "name": "general",
+                "type": 0,
+                "topic": "[ferry-fixture] primary test channel for DCE fixture capture",
+            },
+            {
+                "id": "ch_forum",
+                "name": "Feedback Forum",
+                "type": 15,
+                "topic": "[ferry-fixture] forum channel for DCE fixture capture",
+            },
+        ],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={
+            "threads": [
+                {
+                    "id": "thread_cool",
+                    "name": "Cool Thread",
+                    "type": 11,
+                    "parent_id": "ch_text",
+                    "topic": None,
+                },
+                {
+                    "id": "post_bug",
+                    "name": "Bug Report",
+                    "type": 11,
+                    "parent_id": "ch_forum",
+                    "topic": None,
+                },
+            ],
+            "members": [],
+        },
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/ch_text/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    # Messages must match manifest content + [ferry:msg-NNN] markers
+    from tests.provisioning._applier import load_manifest
+
+    manifest = load_manifest(Path(__file__).parent / "fixture-spec.json")
+    text_ch = manifest.text_channels[0]
+    text_msgs = []
+    for i, m in enumerate(text_ch.messages):
+        msg_payload: dict[str, Any] = {
+            "id": f"msg_{i}",
+            "channel_id": "ch_text",
+            "content": f"{m.content} [ferry:{m.id}]",
+            "embeds": [],
+        }
+        if m.embed is not None:
+            msg_payload["embeds"] = [
+                {
+                    "title": m.embed.title,
+                    "description": m.embed.description,
+                    "color": m.embed.color,
+                    "fields": [
+                        {"name": f.name, "value": f.value, "inline": f.inline}
+                        for f in m.embed.fields
+                    ],
+                }
+            ]
+        text_msgs.append(msg_payload)
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/ch_text/messages?limit=100",
+        payload=text_msgs,
+    )
+    thread_spec = manifest.threads[0]
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/thread_cool/messages?limit=100",
+        payload=[
+            {
+                "id": "thread_first_msg",
+                "channel_id": "thread_cool",
+                "content": f"{thread_spec.first_message_content} [ferry:{thread_spec.id}]",
+                "embeds": [],
+            }
+        ],
+    )
+    post_spec = manifest.forum_channels[0].posts[0]
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/post_bug/messages?limit=100",
+        payload=[
+            {
+                "id": "post_first_msg",
+                "channel_id": "post_bug",
+                "content": f"{post_spec.first_message_content} [ferry:{post_spec.id}]",
+                "embeds": [],
+            }
+        ],
+    )
+
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify", "--guild-id", guild])
+
+    assert result.exit_code == 0, f"verify failed: stderr={result.stderr}, stdout={result.output}"
+
+
+def test_cli_verify_missing_thread_exits_one(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S5-EC1 variant: missing thread → exit 1 with drift report."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[
+            {
+                "id": "ch_text",
+                "name": "general",
+                "type": 0,
+                "topic": "[ferry-fixture] primary test channel for DCE fixture capture",
+            },
+        ],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={"threads": [], "members": []},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/ch_text/threads/archived/public",
+        payload={"threads": [], "members": [], "has_more": False},
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/channels/ch_text/messages?limit=100",
+        payload=[],
+    )
+
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify", "--guild-id", guild])
+
+    assert result.exit_code == 1
+    assert "missing" in result.stderr.lower() or "missing" in result.output.lower()
+
+
+def test_cli_verify_401_exits_two(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S5-ER1: verify with 401 exits 2 (couldn't determine), NOT 1 (drift)."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        status=401,
+        payload={},
+    )
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify", "--guild-id", guild])
+    assert result.exit_code == 2
+
+
+def test_cli_provision_partial_failure_prints_resume_hint(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S3-ER3: partial failure mid-provision exits 1 with resume hint."""
+    guild = "111"
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload=[],
+    )
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/guilds/{guild}/threads/active",
+        payload={"threads": [], "members": []},
+    )
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/guilds/{guild}/channels",
+        payload={"id": "ch_text", "name": "general", "type": 0},
+        status=201,
+    )
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/channels/ch_text/messages",
+        payload={"id": "msg_1", "channel_id": "ch_text"},
+        status=200,
+    )
+    mock_discord_for_state.post(
+        f"{DISCORD_API}/channels/ch_text/messages",
+        status=500,
+        payload={},
+        repeat=4,
+    )
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["provision", "--guild-id", guild])
+    assert result.exit_code == 1
+    assert (
+        "re-run" in (result.output + result.stderr).lower()
+        or "resume" in (result.output + result.stderr).lower()
+    )
+
+
+def test_cli_create_guild_preflight_fails_at_ten_guilds(
+    mock_discord_for_state: aioresponses,
+) -> None:
+    """SC-S3-ER1: --create-guild aborts if bot is in >=10 guilds."""
+    mock_discord_for_state.get(
+        f"{DISCORD_API}/users/@me/guilds",
+        payload=[{"id": str(i), "name": f"Guild {i}"} for i in range(10)],
+    )
+    with patch.dict(os.environ, {"DISCORD_TEST_BOT_TOKEN": "test-token"}):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["provision", "--create-guild", "Test"])
+    assert result.exit_code != 0
+    combined = result.output + (result.stderr or "")
+    assert "10" in combined or "guilds" in combined.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.2.4"
+version = "2.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Discord test-server provisioning CLI for issue #35's "captured-real fixtures" work. Standalone `provision` / `teardown` / `verify` subcommands that hit Discord's REST API using a Bot token from `DISCORD_TEST_BOT_TOKEN`. Architecture: three layers under `tests/provisioning/` — `_bot_api.py` (transport) → `_applier.py` (manifest schema + reconciler with sealed `DiffOpT` union and `assert_never` exhaustiveness) → `provision_test_server.py` (Click CLI with 3-way exit codes).

The import firewall (`[tool.hatch.build.targets.wheel] packages = ["src/discord_ferry"]`, established in v2.2.4) ensures bot-auth write paths never ship in installable wheels. Reinforced in types: `ProvisioningError` deliberately does NOT inherit from `FerryError`.

Caught by the live smoke test (not by 60 mock-based unit tests): Discord normalizes channel names server-side (`Feedback Forum` stored as `feedback-forum`). Fixed in `f808d45` with `_normalize_channel_name` applied symmetrically on both sides of the diff lookup. Three additional operator-safety fixes from the final code review (`cacc06e`): 403 error message no longer leaks guild IDs; `ProvisioningPermissionError` exits 2 per the documented contract; `reconcile_teardown` re-raises auth/permission errors instead of silently incrementing `skipped_count`.

## Test plan

- [x] 910 tests pass (61 hermetic tests in `tests/provisioning/` via aioresponses)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `mypy --strict` clean on `src/` and `tests/provisioning/` (48 files)
- [x] Live smoke test against guild \`1505988963628879902\` — all 6 steps pass:
  - dry-run plan (14 ops)
  - provision (14 entities created, visual check confirmed: 10 messages incl. embed with 3 inline + 2 non-inline fields, thread on `msg-thread-anchor`, forum post)
  - verify match → exit 0
  - idempotent re-provision → 0 entities created
  - teardown → 2 channels deleted, cascade cleaned up
  - verify drift → exit 1
- [x] Code review (`superpowers:code-reviewer`) — verdict: ready to merge
- [x] Second Opinion (Mistral `mistral-large-latest`) — 0 actionable issues

## Known follow-ups (deferred, non-blocking)

- **Thread-name collision**: if a manifest ever has a thread and forum-post with the same name, the `actual_threads` dict in `diff()` could clobber. Fix: key by `(parent_id, name)` tuple. Current fixture doesn't trigger it (\`Cool Thread\` vs \`Bug Report\`).
- **README CI clarification**: the "never in CI" rule applies to the CLI tool (\`provision_test_server.py\`), not the hermetic unit tests in \`tests/provisioning/test_*.py\` (which DO run in CI). README line 80 could be more explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)