### PR TITLE
fix(provisioning): thread/forum-post key disambiguation + README CI scope (v2.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.8] - 2026-05-18
+
+### Bug Fixes
+
+- **`diff()` thread-keying disambiguates threads from forum posts** (`tests/provisioning/_applier.py`). Both Discord threads and forum posts use channel type `11`, so the previous `actual_threads = {ch.name: ch for ch in actual.channels if ch.type == 11}` would silently collide if a manifest grew to include a thread and a forum post with the same name — only one would survive in the dict and the other manifest entity would be spuriously reported as missing/needing creation. Re-keyed to `(parent_id, name)` tuples and threaded a `manifest_tc_id_to_discord_id` map through the diff so the lookup targets the correct text-channel parent. Current fixture (`Cool Thread` vs `Bug Report`) doesn't trigger the collision; the new `test_diff_distinguishes_thread_from_forum_post_with_same_name` regression test injects a colliding foreign forum post named "Cool Thread" inside `feedback-forum` and asserts the manifest's `Cool Thread` thread under `general` is still matched without drift.
+
+### Docs
+
+- **`tests/provisioning/README.md` "no CI" rule scoped explicitly**. The previous wording ("this script must NEVER run in CI") was ambiguous about whether the rule covered `provision_test_server.py` (yes — that's the human-only CLI) or `tests/provisioning/test_*.py` (no — those are hermetic via `aioresponses` and run alongside the rest of the suite in CI). Clarified that the rule applies to the CLI only.
+
 ## [2.2.7] - 2026-05-18
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.2.7"
+version = "2.2.8"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.2.7"
+__version__ = "2.2.8"

--- a/tests/provisioning/README.md
+++ b/tests/provisioning/README.md
@@ -78,11 +78,17 @@ the Discord UI; doing so will cause `provision` re-runs to create duplicates
 
 ## The "no CI" rule
 
-This script must NEVER run in CI per issue #35's deferred design. Reason:
-the DCE capture step that follows provisioning is fundamentally human-run
-(DCE requires interactive authentication). Automating provisioning without
-automating capture would be misleading — the captured fixtures could drift
-from what we expect to capture.
+The `provision_test_server.py` CLI (the `provision` / `teardown` / `verify`
+subcommands documented above) must NEVER run in CI per issue #35's design.
+Reason: the DCE capture step that follows provisioning is fundamentally
+human-run (DCE requires interactive authentication). Automating provisioning
+without automating capture would be misleading — the captured fixtures could
+drift from what we expect to capture.
+
+This rule applies ONLY to the CLI; the unit tests in `tests/provisioning/
+test_*.py` (`test_applier.py`, `test_bot_api.py`, `test_cli.py`) are
+hermetic — they mock the Discord REST API via `aioresponses` and run in CI
+alongside the rest of the suite without contacting any real guild.
 
 ## Manifest
 

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -475,9 +475,7 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
     # would collide if the manifest grew to include a thread + forum post with
     # the same name. Disambiguate by `(parent_id, name)` so the lookup in the
     # threads loop below targets the thread under its text-channel parent.
-    actual_threads = {
-        (ch.parent_id or "", ch.name): ch for ch in actual.channels if ch.type == 11
-    }
+    actual_threads = {(ch.parent_id or "", ch.name): ch for ch in actual.channels if ch.type == 11}
     # manifest text-channel ID → Discord channel snowflake; populated as we
     # match text channels so the threads loop can resolve parents by Discord ID.
     manifest_tc_id_to_discord_id: dict[str, str] = {}

--- a/tests/provisioning/_applier.py
+++ b/tests/provisioning/_applier.py
@@ -471,7 +471,16 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
         for ch in actual.channels
         if ch.type == 15 and ch.topic and ch.topic.startswith(marker)
     }
-    actual_threads = {ch.name: ch for ch in actual.channels if ch.type == 11}
+    # Threads and forum posts both have Discord type 11. Keying by name alone
+    # would collide if the manifest grew to include a thread + forum post with
+    # the same name. Disambiguate by `(parent_id, name)` so the lookup in the
+    # threads loop below targets the thread under its text-channel parent.
+    actual_threads = {
+        (ch.parent_id or "", ch.name): ch for ch in actual.channels if ch.type == 11
+    }
+    # manifest text-channel ID → Discord channel snowflake; populated as we
+    # match text channels so the threads loop can resolve parents by Discord ID.
+    manifest_tc_id_to_discord_id: dict[str, str] = {}
 
     matched_actual_ids: set[str] = set()
 
@@ -491,6 +500,7 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
                 )
         else:
             matched_actual_ids.add(actual_ch.discord_id)
+            manifest_tc_id_to_discord_id[tc.id] = actual_ch.discord_id
             actual_msgs = actual.messages_by_channel.get(actual_ch.discord_id, ())
             actual_msg_by_marker_id: dict[str, ActualMessage] = {}
             for am in actual_msgs:
@@ -515,7 +525,8 @@ def diff(manifest: Manifest, actual: ActualState) -> Diff:
 
     # Threads
     for thread in manifest.threads:
-        actual_t = actual_threads.get(thread.name)
+        parent_discord_id = manifest_tc_id_to_discord_id.get(thread.parent_channel_id, "")
+        actual_t = actual_threads.get((parent_discord_id, thread.name))
         if actual_t is None or not _thread_has_marker(actual_t, thread, actual):
             missing.append(thread.id)
             ops.append(CreateThreadOp(target=thread, reason="thread missing or no marker"))

--- a/tests/provisioning/test_applier.py
+++ b/tests/provisioning/test_applier.py
@@ -506,6 +506,52 @@ def test_diff_matches_discord_normalized_channel_names() -> None:
     assert d.mismatched_embeds == ()
 
 
+def test_diff_distinguishes_thread_from_forum_post_with_same_name() -> None:
+    """Forum posts and threads both have Discord type 11. If a forum post
+    shares its name with a manifest thread, the previous `{ch.name: ch}` key
+    would arbitrarily keep only one of them and the manifest thread would be
+    spuriously reported as missing. The fix keys by `(parent_id, name)` so
+    threads-under-text-channel and posts-under-forum are disambiguated.
+    """
+    path = Path(__file__).parent / "fixture-spec.json"
+    manifest = load_manifest(path)
+    actual = _build_fully_matching_state(manifest)
+
+    # Add a foreign forum post inside the feedback-forum that collides on name
+    # with the manifest's "Cool Thread" (which lives under the general text
+    # channel). Without the (parent_id, name) keying fix, the dict lookup
+    # would resolve "Cool Thread" to whichever channel iterated last, causing
+    # spurious drift in `diff()`.
+    feedback_forum = next(
+        ch for ch in actual.channels if ch.name == "Feedback Forum" and ch.type == 15
+    )
+    # Note: deliberately no entry for "9999" in messages_by_channel. On the
+    # old code (name-only key), the dict lookup would resolve to this foreign
+    # post and `_thread_has_marker` would return False (no messages → no
+    # marker), spuriously triggering CreateThreadOp. The tuple-keyed fix
+    # avoids the lookup entirely.
+    colliding_post = ActualChannel(
+        discord_id="9999",
+        name="Cool Thread",
+        type=11,
+        topic=None,
+        parent_id=feedback_forum.discord_id,
+    )
+    actual = ActualState(
+        guild_id=actual.guild_id,
+        channels=actual.channels + (colliding_post,),
+        messages_by_channel=actual.messages_by_channel,
+    )
+
+    d = diff(manifest, actual)
+    # The manifest thread is still matched under its real parent text channel.
+    assert d.missing_entities == ()
+    assert d.ops == ()
+    # The colliding foreign post is type 11 and therefore not reported as
+    # extra_foreign (type-11 entities are excluded from foreign-drift). The
+    # important property is the manifest thread isn't shadowed.
+
+
 def _build_fully_matching_state(manifest: Manifest) -> ActualState:
     """Construct an ActualState that perfectly mirrors the manifest."""
     channels: list[ActualChannel] = []

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.2.7"
+version = "2.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes the two v2.2.5 follow-up items from the previous handoff.

1. **`diff()` thread keying** (`tests/provisioning/_applier.py`). Both Discord threads and forum posts use channel type `11`. The previous `actual_threads = {ch.name: ch for ch in actual.channels if ch.type == 11}` silently collided if a manifest grew to include a thread + forum post with the same name — only one survived in the dict, and the other manifest entity was spuriously reported as missing. Re-keyed to `(parent_id, name)` tuples and threaded a `manifest_tc_id_to_discord_id: dict[str, str]` map through the diff pass so thread lookups resolve to the correct text-channel parent's Discord snowflake. Forum-post matching (lines 542-551) already filtered by `c.parent_id == actual_fc.discord_id`, so it was already disambiguated — only the thread side needed fixing.

2. **README "no CI" wording** (`tests/provisioning/README.md`). The previous "this script must NEVER run in CI" was ambiguous about whether the rule covered the CLI or the unit tests. Now explicitly scoped: the rule applies to `provision_test_server.py` only; the hermetic `tests/provisioning/test_*.py` units (mocked via `aioresponses`) are CI-safe and run alongside the rest of the suite.

## How the bug was caught

The v2.2.5 handoff (PR #50) flagged this collision as an open follow-up but classified it as non-blocking because the current `fixture-spec.json` (`Cool Thread` thread vs `Bug Report` forum post) avoids the collision by giving the entities distinct names. The new regression test `test_diff_distinguishes_thread_from_forum_post_with_same_name` injects a colliding foreign forum post inside `feedback-forum` to lock the disambiguation behavior independent of the manifest's current naming choices.

## Stacked PR base

Base must be `fix/parser-null-field-sweep-v2.2.7` (PR #52) until #51 and #52 merge. After both land on `main`, GitHub will auto-rebase this PR's visible diff against `main`.

## Test plan

- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`
- [x] `uv run mypy src/` (strict)
- [x] `uv run pytest` — **920 passed** (was 919; +1 collision test)
- [x] All 5 audit targets from `.claude/change-manifest.md` pass: tuple-keyed `actual_threads`, tuple lookup in threads loop, `manifest_tc_id_to_discord_id` appears 3x, collision regression test passes, README still flags the rule but now scoped
- [x] `feature-dev:code-reviewer` agent: clean (one Important note: implicit empty-messages dependency in the regression test — addressed with an explanatory comment)
- [x] Mistral `mistral-large-latest` (honest, 0.3 temp): "No critical or important issues. Merge confidently."

## Out of scope

- `_normalize_channel_name` leading/trailing hyphen edge case + `DISCORD_API_BASE` startswith validation — both were Mistral hypotheticals from the v2.2.5 review, neither real bugs. Deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)