### PR TITLE
fix(parser): null-field sweep across remaining call sites (v2.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.7] - 2026-05-18
+
+### Bug Fixes
+
+- **Null-field collapse extended across the remaining parser call sites.** v2.2.6 (PR #51) fixed the `str(raw.get(K, default))` → `"None"` pattern in `_parse_channel` and `_parse_message`'s reference block — the four fields exposed by the new captured fixtures. The same pattern remained in seven other parsing sites (`_parse_export` `exportedAt`, `_parse_guild` `iconUrl`, `_parse_author` `discriminator`/`nickname`/`avatarUrl`, the inline `DCEEmoji` construction in `_parse_reaction` for `id`/`name`/`imageUrl`). Each of those produced the truthy 4-char string `"None"` when DCE serialized a present-but-null value — Pomelo-era users with no discriminator/nickname/avatar, guilds with no icon, and unicode emojis with no ID or image URL. Fixed by switching every site to the `str(raw.get(K) or default)` pattern, preserving the existing defaults (`""` everywhere except `discriminator`'s `"0000"`). Locked by three new unit tests against the private parse functions: `test_parse_guild_null_icon_url_collapses`, `test_parse_author_null_fields_collapse_to_defaults`, `test_parse_reaction_unicode_emoji_null_id` (the last verifies the unicode-emoji case end-to-end since unicode emojis natively emit `null` for both `id` and `imageUrl`).
+
 ## [2.2.6] - 2026-05-18
 
 ### Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.2.6"
+version = "2.2.7"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.2.6"
+__version__ = "2.2.7"

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -112,7 +112,7 @@ def parse_single_export(json_path: Path, *, metadata_only: bool = False) -> DCEE
         channel=channel,
         messages=messages,
         message_count=int(raw["messageCount"]),
-        exported_at=str(raw.get("exportedAt", "")),
+        exported_at=str(raw.get("exportedAt") or ""),
         is_thread=is_thread,
         parent_channel_name=parent_channel_name,
         json_path=json_path,
@@ -326,7 +326,7 @@ def _parse_guild(raw: Any) -> DCEGuild:
     return DCEGuild(
         id=str(raw["id"]),
         name=str(raw["name"]),
-        icon_url=str(raw.get("iconUrl", "")),
+        icon_url=str(raw.get("iconUrl") or ""),
     )
 
 
@@ -414,11 +414,14 @@ def _parse_author(raw: Any) -> DCEAuthor:
     return DCEAuthor(
         id=str(raw["id"]),
         name=str(raw["name"]),
-        discriminator=str(raw.get("discriminator", "0000")),
-        nickname=str(raw.get("nickname", "")),
+        # `raw.get(K, default)` returns the default only when K is missing; if
+        # K is present-but-null, `.get` returns None and `str(None) == "None"`.
+        # Collapse via `or` to preserve the intended default for both shapes.
+        discriminator=str(raw.get("discriminator") or "0000"),
+        nickname=str(raw.get("nickname") or ""),
         color=str(raw["color"]) if raw.get("color") else None,
         is_bot=bool(raw.get("isBot", False)),
-        avatar_url=str(raw.get("avatarUrl", "")),
+        avatar_url=str(raw.get("avatarUrl") or ""),
         roles=roles,
     )
 
@@ -434,11 +437,13 @@ def _parse_attachment(raw: Any) -> DCEAttachment:
 
 def _parse_reaction(raw: Any) -> DCEReaction:
     emoji_raw = raw["emoji"]
+    # Unicode emojis emit `"id": null` in DCE output; without `or ""` we'd
+    # produce the truthy 4-char string "None" instead of an empty ID.
     emoji = DCEEmoji(
-        id=str(emoji_raw.get("id", "")),
-        name=str(emoji_raw.get("name", "")),
+        id=str(emoji_raw.get("id") or ""),
+        name=str(emoji_raw.get("name") or ""),
         is_animated=bool(emoji_raw.get("isAnimated", False)),
-        image_url=str(emoji_raw.get("imageUrl", "")),
+        image_url=str(emoji_raw.get("imageUrl") or ""),
     )
     return DCEReaction(
         emoji=emoji,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,9 @@ import pytest
 from discord_ferry.parser.dce_parser import (
     _coerce_channel_type,
     _infer_thread_info,
+    _parse_author,
+    _parse_guild,
+    _parse_reaction,
     check_cdn_url_expiry,
     parse_export_directory,
     parse_single_export,
@@ -322,6 +325,54 @@ def test_null_json_fields_collapse_to_empty_string(fixtures_dir: Path) -> None:
         fixtures_dir / "Discord Ferry Test - general - Cool Thread [1506019505778987190].json"
     )
     assert cool_thread.channel.topic == ""
+
+
+def test_parse_guild_null_icon_url_collapses() -> None:
+    """A guild without a custom icon emits `"iconUrl": null` — must not stringify to `"None"`."""
+    guild = _parse_guild({"id": "1", "name": "Iconless Guild", "iconUrl": None})
+    assert guild.icon_url == ""
+
+
+def test_parse_author_null_fields_collapse_to_defaults() -> None:
+    """Author fields default to their intended values when JSON-null.
+
+    Pomelo-era users have no discriminator and may have neither a server-specific
+    nickname nor a custom avatar; DCE serializes those as `null`, not as missing
+    keys. The defaults must hold whether the key is missing or present-but-null.
+    """
+    author = _parse_author(
+        {
+            "id": "100",
+            "name": "pomelo_user",
+            "discriminator": None,
+            "nickname": None,
+            "color": None,
+            "isBot": False,
+            "avatarUrl": None,
+            "roles": [],
+        }
+    )
+    assert author.discriminator == "0000"
+    assert author.nickname == ""
+    assert author.avatar_url == ""
+
+
+def test_parse_reaction_unicode_emoji_null_id() -> None:
+    """Unicode emojis emit `"id": null` and `"imageUrl": null` — must collapse to ``\"\"``."""
+    reaction_raw = {
+        "emoji": {
+            "id": None,
+            "name": "\N{THUMBS UP SIGN}",
+            "isAnimated": False,
+            "imageUrl": None,
+        },
+        "count": 1,
+        "users": [],
+    }
+    reaction = _parse_reaction(reaction_raw)
+    assert reaction.emoji.id == ""
+    assert reaction.emoji.image_url == ""
+    assert reaction.emoji.name == "\N{THUMBS UP SIGN}"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.2.6"
+version = "2.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Mechanical follow-up to #51 (now merged as `ee311e3`). #51 fixed the `str(raw.get(K, default))` → `"None"` bug for the 4 fields exposed by the real captured fixtures (`categoryId`/`category`/`topic` in `_parse_channel`, `messageId` in `_parse_message` reference). This PR extends the same `str(raw.get(K) or default)` pattern to the remaining 7 latent sites:

- `_parse_export`: `exportedAt`
- `_parse_guild`: `iconUrl`
- `_parse_author`: `discriminator` (preserves `"0000"` default), `nickname`, `avatarUrl`
- `_parse_reaction` / inline `DCEEmoji`: `id`, `name`, `imageUrl`

## Production cases that would have hit the latent bug

- **Pomelo-era users** (Discord's username migration, completed 2023): no discriminator, often no server nickname, often no custom avatar. DCE serializes those as `null`.
- **Iconless guilds**: `null` for `iconUrl`.
- **Unicode emojis**: natively emit `null` for both `id` and `imageUrl` (only custom emojis have those).

Each would have produced the truthy 4-char string `"None"` instead of the intended `""`, slipping past downstream truthy guards in `migrator/`, `review.py`, and the shells.

## What's deliberately not touched

- `int(raw.get(K, default))` patterns — `int(None)` crashes loudly (safer than silent wrong value).
- `bool(raw.get(K, default))` patterns — `bool(None)` is `False`, which is the correct default.
- The Pomelo `"0000"` vs `"0"` discriminator default question — separate scope from null-handling. Kept `"0000"` matching `DCEAuthor` dataclass default at `parser/models.py:24`.
- `color` and `timestamp_edited` fields — already null-safe via `if raw.get(K) else None` pattern.

## Replacement context

This PR replaces the original PR #52, which was auto-closed by GitHub when its base branch (`fix/parser-null-collapse-v2.2.6`) was deleted after #51's squash-merge. The branch was rebased clean onto the new `main` (git detected #51's content already applied and skipped re-application). Content is identical to the original #52; only the PR number changes.

## Test plan

- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`
- [x] `uv run mypy src/` (strict)
- [x] `uv run pytest` — **919 passed** (was 916 before this PR; +3 sweep tests)
- [x] Audit greps: zero remaining `str(...get(K, default))` survivors; all 14 sites use `or default` form; smoke against 3 helpers confirms null-collapse
- [x] `feature-dev:code-reviewer` agent: clean, no critical or important findings
- [x] Mistral `mistral-large-latest` (honest, 0.3 temp): confirms the four scoping decisions (Pomelo default, no missing sites, int/bool exclusions, defensive `exportedAt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)