### PR TITLE
fix(reporter): correct reactions_total denominator in fidelity score (v2.2.9) (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.9] - 2026-05-19
+
+### Bug Fixes
+
+- **`reporter` fidelity score: reactions sub-score no longer inflates in partial state (closes #46)**. `generate_report` (`reporter.py:120`) and `generate_markdown_report` (`reporter.py:351`) both passed `reactions_total=len(state.pending_reactions)` to `compute_fidelity_score` — a denominator that's wrong in both terminal states. **Completed migration**: `pending_reactions` is drained → denominator is 0 → the function's `if reactions_total else 1.0` short-circuit silently returns 100%, hiding any reactions that failed. **Partial migration** (e.g. `reactions_applied=10`, `pending_reactions=[5 items]`): denominator is 5 → ratio is `10/5 = 200%`, inflating the overall score by up to 10 percentage points (the reactions weight). Both callsites now use the formula `state.reactions_applied + len(state.pending_reactions)`, matching what `stats.summarize_state` (added in v2.2.3) already does — so `ferry stats` and `migration_report.json`/`.md` agree on the reactions sub-score for the same state. Locked by `test_fidelity_reactions_partial_state_not_inflated` (asserts 60-70% for the 10/15 case) and `test_fidelity_reactions_completed_state_is_100_percent` (asserts the completed case now reaches 100% via the corrected formula, not the zero-denominator short-circuit). *Note: v2.2.3's CHANGELOG cross-referenced this fix as "#47" — the actual issue number is #46; #47 tracks the unrelated `state.errors` sanitization gap.*
+
 ## [2.2.8] - 2026-05-18
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.2.8"
+version = "2.2.9"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.2.8"
+__version__ = "2.2.9"

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -117,7 +117,7 @@ def generate_report(
         replies_linked=state.replies_linked,
         replies_total=state.replies_total,
         reactions_applied=state.reactions_applied,
-        reactions_total=len(state.pending_reactions),
+        reactions_total=state.reactions_applied + len(state.pending_reactions),
     )
 
     # Delta stats: messages migrated in this run vs cumulatively
@@ -348,7 +348,7 @@ def generate_markdown_report(
         replies_linked=state.replies_linked,
         replies_total=state.replies_total,
         reactions_applied=state.reactions_applied,
-        reactions_total=len(state.pending_reactions),
+        reactions_total=state.reactions_applied + len(state.pending_reactions),
     )
     lines.append("## Fidelity Score\n")
     lines.append(f"**Overall:** {fidelity['overall']}%  ")

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -738,6 +738,44 @@ def test_fidelity_included_in_markdown_report(tmp_path: Path) -> None:
     assert "Attachments:" in content
 
 
+def test_fidelity_reactions_partial_state_not_inflated(tmp_path: Path) -> None:
+    """Partial migration: reactions sub-score reflects applied/(applied+pending), not >100%.
+
+    Regression for #46: previously reactions_total was len(pending_reactions) alone,
+    giving 10/5 = 200% for this state. Correct formula yields 10/15 ≈ 66.7%.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        reactions_applied=10,
+        pending_reactions=[{"channel_id": "c", "message_id": str(i)} for i in range(5)],
+    )
+    exports = [_make_export(message_count=0)]
+
+    report = generate_report(config, state, exports)
+    fidelity = report["fidelity"]
+    assert isinstance(fidelity, dict)
+    reactions = fidelity["reactions"]
+    assert isinstance(reactions, float)
+    assert 60.0 <= reactions <= 70.0, f"expected 60-70%, got {reactions}"
+
+
+def test_fidelity_reactions_completed_state_is_100_percent(tmp_path: Path) -> None:
+    """Completed migration: pending_reactions drained, reactions sub-score is 100%.
+
+    Regression for #46: previously this case relied on the zero-denominator
+    short-circuit (reactions_total=0 → ratio=1.0). Now it computes 200/200=1.0
+    via the corrected formula.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(reactions_applied=200, pending_reactions=[])
+    exports = [_make_export(message_count=0)]
+
+    report = generate_report(config, state, exports)
+    fidelity = report["fidelity"]
+    assert isinstance(fidelity, dict)
+    assert fidelity["reactions"] == 100.0
+
+
 def test_fidelity_rounding() -> None:
     """Fidelity scores are rounded to one decimal place."""
     score = compute_fidelity_score(

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.2.8"
+version = "2.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Fix `compute_fidelity_score` denominator at both call sites in `reporter.py` (lines 120 & 351). The issue identified line 120 only, but the same broken denominator existed in `generate_markdown_report` — fixing one would leave the JSON↔markdown reports re-divergent.
- Formula changes from `len(state.pending_reactions)` to `state.reactions_applied + len(state.pending_reactions)`, matching what `stats.summarize_state` (v2.2.3) already does.
- Two new regression tests in `tests/test_reporter.py` covering partial and completed states per the issue's acceptance criteria.
- Version bump 2.2.8 → 2.2.9 (patch, bug fix only).

## Why it matters

- **Completed migration**: `pending_reactions` is drained → denominator 0 → the function's `if reactions_total else 1.0` short-circuit silently returns 100%, hiding any reactions that failed.
- **Partial migration** (`reactions_applied=10`, `pending_reactions=[5 items]`): denominator 5 → ratio `10/5 = 200%`, inflating the overall score by up to 10 percentage points (the reactions weight).
- After fix: completed = `200/200 = 100%` (now derived, not short-circuited); partial = `10/15 ≈ 66.7%`.

## Acceptance (from issue #46)

- [x] `reporter.py:120` uses the derived formula.
- [x] *(scope-expanded)* `reporter.py:351` uses the same formula — same bug at the markdown surface.
- [x] Regression: `reactions_applied=10, pending_reactions=[5]` → sub-score in 60–70% range.
- [x] Regression: `reactions_applied=200, pending_reactions=[]` → sub-score = 100% (now via correct formula, not zero-denominator short-circuit).
- [x] CHANGELOG entry under v2.2.9 `Bug Fixes`.
- [ ] *Out of scope here*: the v2.2.0 "Known Issues" line referenced in the issue body lives in the v2.2.3 entry (line 65) and a separate Known Issues block (line 73). The v2.2.3 entry cross-referenced the issue numbers swapped (`#46` ↔ `#47`); rather than rewrite historical changelog content, the new v2.2.9 entry includes a corrective note. Left to your discretion whether to amend v2.2.3 historically.

## Test plan

- [x] `uv run pytest tests/test_reporter.py` — 42 passed (40 prior + 2 new)
- [x] Full verify suite: `uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` — 922 passed, all green
- [ ] Manual: render a real migration with both partial and completed reactions to confirm the JSON and markdown reports now agree

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)