### PR TITLE
security(state-errors): sanitize state.errors.append messages through token store (v2.2.10) (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.10] - 2026-05-19
+
+### Security
+
+- **`state.errors.append` callsites now sanitize messages through the token store (closes #47)**. v2.0.1 wired `SecureTokenStore` and added `_safe_error` / `sanitize_for_display` helpers, but a coverage audit during v2.2.0's ship review found five `state.errors.append` callsites that interpolated raw exception `repr()`s without going through any sanitizer: `migrator/emoji.py:296`, `migrator/reactions.py:112`, `migrator/pins.py:83`, `migrator/messages.py:382`, and `core/engine.py:599`. If a Stoat/Discord/Autumn aiohttp exception's `repr()` ever contained a token value (token-in-URL leak from a misconfigured HTTP library, 401 body echo, etc.) it landed in `state.json` unredacted — visible via `cat state.json`, `ferry stats`'s `last_error` 80-char preview (added in v2.2.3), and `reporter.generate_markdown_report`'s `### Errors` section. The exposure pre-dated `ferry stats`; that command surfaced it more discoverably without creating new ingress. Project rule `.claude/rules/security.md` ("Never log tokens... in log output, error messages, or state files") was violated by construction at all five sites.
+- **Fix**: promoted `_safe_error` from `migrator/messages.py` (private, used at one site) to `core/security.py:safe_sanitize(token_store, text)` — a `None`-tolerant wrapper around `SecureTokenStore.sanitize` so test paths without a registered store don't have to thread a fake one through. All five callsites now wrap their `"message"` (or `"error"`) field through `safe_sanitize(config.token_store, ...)`. The `core/engine.py` site is the trickiest: the same `str(e)` interpolation also flowed into the wrapped `MigrationError`, the `MigrationEvent.message`, and the event `detail`'s `error` — all four are now sanitized via a single `safe_exc` local, since partial sanitization would still leak via the event log panel or the propagated exception.
+- **Locked by** three regression tests in `tests/test_security.py`: `test_safe_sanitize_returns_text_unchanged_when_store_is_none` (no-op without store, so test paths keep working), `test_safe_sanitize_masks_registered_tokens` (multi-token replacement), and `test_safe_sanitize_at_state_errors_call_site` (end-to-end: synthetic token in a `RuntimeError`'s URL → masked in the resulting `state.errors[-1]["message"]`).
+- **Acceptance**: `grep -n "state.errors.append" src/` shows all five sites; manual audit confirms each goes through `safe_sanitize` (4 migrator sites directly in the `"message"` value, 1 engine site via the shared `safe_exc` local). *Note: v2.2.3's CHANGELOG cross-referenced this fix as "#46" — the actual issue number is #47; #46 was the unrelated reporter fidelity bug fixed in v2.2.9.*
+
 ## [2.2.9] - 2026-05-19
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.2.9"
+version = "2.2.10"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.2.9"
+__version__ = "2.2.10"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.events import EventCallback, MigrationEvent
+from discord_ferry.core.security import safe_sanitize
 from discord_ferry.discord import (
     fetch_and_translate_guild_metadata,
     load_discord_metadata,
@@ -596,17 +597,18 @@ async def _run_phases(
             )
             return
         except Exception as e:
-            state.errors.append({"phase": phase_name, "type": "phase_failed", "error": str(e)})
+            safe_exc = safe_sanitize(config.token_store, str(e))
+            state.errors.append({"phase": phase_name, "type": "phase_failed", "error": safe_exc})
             save_state(state, config.output_dir)
             on_event(
                 MigrationEvent(
                     phase=phase_name,
                     status="error",
-                    message=f"Error in {phase_name}: {e}",
-                    detail={"error": str(e)},
+                    message=f"Error in {phase_name}: {safe_exc}",
+                    detail={"error": safe_exc},
                 )
             )
-            raise MigrationError(f"Phase {phase_name} failed: {e}") from e
+            raise MigrationError(f"Phase {phase_name} failed: {safe_exc}") from e
 
         on_event(
             MigrationEvent(phase=phase_name, status="completed", message=f"Completed {phase_name}")

--- a/src/discord_ferry/core/security.py
+++ b/src/discord_ferry/core/security.py
@@ -60,3 +60,16 @@ class SecureTokenStore:
 def sanitize_for_display(text: str, token_store: SecureTokenStore) -> str:
     """Convenience wrapper around :meth:`SecureTokenStore.sanitize`."""
     return token_store.sanitize(text)
+
+
+def safe_sanitize(token_store: SecureTokenStore | None, text: str) -> str:
+    """Sanitize *text*, returning it unchanged when *token_store* is ``None``.
+
+    Use at every point where an error/warning message containing a raw
+    exception ``repr()`` may be persisted (``state.errors``, event payloads,
+    on-disk logs). The ``None`` branch keeps test paths working without
+    requiring every test to construct a SecureTokenStore.
+    """
+    if token_store is None:
+        return text
+    return token_store.sanitize(text)

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -8,6 +8,7 @@ import re
 from typing import TYPE_CHECKING
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_create_emoji, get_session
 from discord_ferry.migrator.sanitize import sanitize_emoji_name
 from discord_ferry.parser.dce_parser import stream_messages
@@ -297,7 +298,10 @@ async def run_emoji(
                     {
                         "phase": "emoji",
                         "type": "emoji_create_failed",
-                        "message": f"Failed to create emoji :{name}: — {exc}",
+                        "message": safe_sanitize(
+                            config.token_store,
+                            f"Failed to create emoji :{name}: — {exc}",
+                        ),
                     }
                 )
                 on_event(

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_send_message, get_rate_multiplier, get_session
 from discord_ferry.migrator.sanitize import truncate_name
 from discord_ferry.parser.dce_parser import check_cdn_url_expiry, stream_messages
@@ -37,13 +38,6 @@ if TYPE_CHECKING:
     from discord_ferry.state import MigrationState
 
 _THREAD_STRATEGIES = frozenset({"flatten", "merge", "archive"})
-
-
-def _safe_error(config: FerryConfig, text: str) -> str:
-    """Sanitize an error/warning string, stripping any token values."""
-    if config.token_store is not None:
-        return config.token_store.sanitize(text)
-    return text
 
 
 logger = logging.getLogger(__name__)
@@ -383,7 +377,10 @@ async def run_messages(
                     {
                         "phase": "messages",
                         "type": "channel_worker_failed",
-                        "message": (f"Channel {export.channel.name!r} worker failed: {result}"),
+                        "message": safe_sanitize(
+                            config.token_store,
+                            f"Channel {export.channel.name!r} worker failed: {result}",
+                        ),
                     }
                 )
                 on_event(
@@ -1092,7 +1089,7 @@ async def _process_message(
                     )
 
     except Exception as exc:  # noqa: BLE001
-        safe_exc = _safe_error(config, str(exc))
+        safe_exc = safe_sanitize(config.token_store, str(exc))
         acc_errors.append(
             {
                 "phase": "messages",

--- a/src/discord_ferry/migrator/pins.py
+++ b/src/discord_ferry/migrator/pins.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_pin_message, get_session
 
 if TYPE_CHECKING:
@@ -84,8 +85,9 @@ async def run_pins(
                     {
                         "phase": "pins",
                         "type": "pin_failed",
-                        "message": (
-                            f"Failed to pin message {message_id} in channel {channel_id}: {exc}"
+                        "message": safe_sanitize(
+                            config.token_store,
+                            f"Failed to pin message {message_id} in channel {channel_id}: {exc}",
                         ),
                     }
                 )

--- a/src/discord_ferry/migrator/reactions.py
+++ b/src/discord_ferry/migrator/reactions.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_add_reaction, get_session
 
 if TYPE_CHECKING:
@@ -113,8 +114,9 @@ async def run_reactions(
                     {
                         "phase": "reactions",
                         "type": "reaction_add_failed",
-                        "message": (
-                            f"Failed to add reaction {emoji} to message {message_id}: {exc}"
+                        "message": safe_sanitize(
+                            config.token_store,
+                            f"Failed to add reaction {emoji} to message {message_id}: {exc}",
                         ),
                     }
                 )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from discord_ferry.core.security import SecureTokenStore, sanitize_for_display
+from discord_ferry.core.security import SecureTokenStore, safe_sanitize, sanitize_for_display
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -152,3 +152,48 @@ def test_sanitize_for_display_delegates_to_store() -> None:
     result = sanitize_for_display(text, store)
     assert "mytoken12345" not in result
     assert "****2345" in result
+
+
+# ---------------------------------------------------------------------------
+# safe_sanitize None-tolerant wrapper (used by state.errors.append callsites)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_sanitize_returns_text_unchanged_when_store_is_none() -> None:
+    """Test paths construct FerryConfig without a token_store; helper must no-op."""
+    assert safe_sanitize(None, "anything goes here") == "anything goes here"
+
+
+def test_safe_sanitize_masks_registered_tokens() -> None:
+    store = make_store(stoat="stoat_abc12345", discord="disc_xyz98765")
+    text = "stoat_abc12345 leaked alongside disc_xyz98765"
+    result = safe_sanitize(store, text)
+    assert "stoat_abc12345" not in result
+    assert "disc_xyz98765" not in result
+    assert "****2345" in result
+    assert "****8765" in result
+
+
+def test_safe_sanitize_at_state_errors_call_site() -> None:
+    """Regression for #47: a sanitized exception repr does not leak the raw token.
+
+    Mirrors the wrapping pattern used in migrator/{emoji,reactions,pins,messages}.py
+    and core/engine.py. If a Stoat/Discord/Autumn aiohttp exception's repr() ever
+    contains a token (e.g. token-in-URL leak from a misconfigured HTTP library),
+    the helper masks it before it lands in state.errors.
+    """
+    store = make_store(stoat="stoat_secret_token_value")
+    state_errors: list[dict[str, str]] = []
+    try:
+        raise RuntimeError("401 at https://api.test/?token=stoat_secret_token_value")
+    except Exception as exc:  # noqa: BLE001
+        state_errors.append(
+            {
+                "phase": "messages",
+                "type": "phase_failed",
+                "message": safe_sanitize(store, str(exc)),
+            }
+        )
+    last = state_errors[-1]["message"]
+    assert "stoat_secret_token_value" not in last
+    assert "****alue" in last

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.2.9"
+version = "2.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes the token-leak gap identified during the v2.2.0 ship-review audit. Five `state.errors.append` callsites in `src/` interpolated raw exception `repr()`s into the persisted `"message"`/`"error"` field without going through any sanitizer — even though `SecureTokenStore` and helpers have existed since v2.0.1. All five now wrap through a promoted `safe_sanitize` helper.

## Changes

| File | Before | After |
|---|---|---|
| `core/security.py` | `sanitize_for_display` (raises on `None` store) | + `safe_sanitize(token_store, text)` — `None`-tolerant for test paths |
| `migrator/messages.py` | private `_safe_error`, single caller | removed; uses shared `safe_sanitize`; line 382 `channel_worker_failed` now sanitized |
| `migrator/emoji.py` | line 296 raw `{exc}` | wrapped |
| `migrator/reactions.py` | line 112 raw `{exc}` | wrapped |
| `migrator/pins.py` | line 83 raw `{exc}` | wrapped |
| `core/engine.py` | line 599 raw `str(e)` × 4 (state, event message, event detail, wrapped `MigrationError`) | single `safe_exc` local, all 4 sanitized |

## Why fix all 4 uses at engine.py:599 (not just `state.errors`)

The issue scoped to `state.errors.append`, but the same `str(e)` interpolation at the same call path also flowed into the `MigrationEvent` (displayed in GUI log panel & CLI Rich console) and the wrapped `MigrationError` (propagated to shells that log it). Sanitizing only the `state.errors` write would leave the leak open via the event log and the raised exception — same bug at the same site, not scope creep.

## Acceptance (from issue #47)

- [x] All 5 `state.errors.append` callsites wrap their `message` field via token-store sanitization
- [x] Regression test: synthetic token in exception → masked in `state.errors[-1]["message"]`
- [x] `grep -n "state.errors.append" src/` reveals no callsite that interpolates a raw exception without sanitization (verified — all 5 visible sites use `safe_sanitize`)
- [ ] Manual smoke (suggest running before merge): cause a known exception path (e.g. wrong Stoat URL) and verify `state.json` contains no plaintext token-shaped strings

## Test plan

- [x] `uv run pytest tests/test_security.py` — 20 passed (17 prior + 3 new)
- [x] Full verify: `uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` — 925 passed, all green
- [ ] Manual: run a real migration with an invalid `STOAT_TOKEN` and inspect `state.json` for the literal token string
- [ ] Manual: run `ferry stats <output-dir>` on a failed migration and confirm the `last_error` preview shows the masked form

## Notes

- v2.2.3's CHANGELOG cross-referenced this fix as `#46`; the actual issue number is `#47` (the swap is documented in both this and the v2.2.9 CHANGELOG entries to keep the historical record self-correcting).
- `.claude/rules/security.md` doesn't need updating: the rule was already correct ("Never log tokens... in error messages, or state files") — this PR closes the gap, not changes the rule.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)