### PR TITLE
chore(tests): remove dead _patch_checksums helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Internal
+
+- **Removed dead `_patch_checksums` test helper** (`tests/test_exporter_manager.py`). It was defined but never called (every `TestVerifyDceChecksum` test inlines its own `patch("importlib.resources.files")`), and was broken anyway — it built a `_Ctx` context manager then ignored it and returned a fresh, unconfigured patcher, papered over with `# type: ignore[return]`. No behavior change; suite stays at 926 passed.
+
 ## [2.2.12] - 2026-06-07
 
 ### Security

--- a/tests/test_exporter_manager.py
+++ b/tests/test_exporter_manager.py
@@ -293,22 +293,6 @@ def _checksums_json(version: str, platform_key: str, sha256: str) -> str:
     return json.dumps({version: {platform_key: sha256}})
 
 
-def _patch_checksums(checksums_json: str):  # type: ignore[return]
-    """Context manager: patch importlib.resources.files to return checksums_json."""
-    mock_files = patch("importlib.resources.files")
-
-    class _Ctx:
-        def __enter__(self) -> None:
-            self._patcher = mock_files.__enter__()
-            mock_ref = self._patcher.return_value.joinpath.return_value
-            mock_ref.read_text.return_value = checksums_json
-
-        def __exit__(self, *args: object) -> None:
-            mock_files.__exit__(*args)
-
-    return patch("importlib.resources.files")
-
-
 class TestVerifyDceChecksum:
     def test_dce_checksum_verification_passes(self) -> None:
         """Matching hash produces no error."""


### PR DESCRIPTION
Removes the dead `_patch_checksums` helper in `tests/test_exporter_manager.py`, flagged during the #59 code review.

## Why
- **Unused:** referenced nowhere — every `TestVerifyDceChecksum` test inlines its own `patch("importlib.resources.files")`.
- **Broken:** it constructed a `_Ctx` context manager, then ignored it and `return`ed a fresh, unconfigured patcher — so it never actually did what its docstring claimed. Masked by an undocumented `# type: ignore[return]`.

## Scope
Pure dead-code removal. No `src/` change, no behavior change, no version bump (test-internal hygiene). Full suite stays at **926 passed**; ruff / ruff-format / mypy clean. `patch` import is retained (used 37× elsewhere in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)