### PR TITLE
feat: live-instance probe + post-migration invite generation (v2.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.4.0] - 2026-06-23
+
+### Added
+
+- **`probe` CLI subcommand — live-instance diagnostics**. `discord-ferry probe --test-server-id <id>` runs four read-mostly checks against a live Stoat instance and renders a Rich table (or `--json`): Autumn per-tag size limits vs. our assumptions, voice Bug #194 detection (this Revolt fork has no VoiceChannel variant — judged on the presence of a `voice` field, not the discriminator), webhook availability (judged on EXECUTE, which is mounted only when `features.webhooks_enabled` is true — default off), and rate-limit header capture. Every entity created under the throwaway test server is torn down in a `finally` block (capture-id-before-raise), and the probe never constructs or writes a `MigrationState`. New module `migrator/probe.py` (`run_probe`, `ProbeReport`).
+- **Post-migration invite generation (S4)**. The migration now mints an invite to the new Stoat server during the REPORT phase and surfaces it in the CLI summary, `migration_report.json` (`invite` block), the markdown report (`## Invite`), and the post-migration checklist. Controlled by `--create-invite/--no-create-invite` (default on) and `--invite-channel-id`. `_select_invite_channel` picks a Text channel, excluding voice (Discord type 2), threads, and synthetic forum-index channels; forums (15/16 → Stoat Text) are eligible. The invite URL is built best-effort from the instance root's `app` field (bare code otherwise). Non-fatal on error (migration is already complete → warning, never raises), idempotent via an `invite_code` guard in both the engine caller and `_generate_invite`, and carried forward on incremental re-runs so resumes never re-mint. New `MigrationState.invite_code`/`invite_url` (serialised, forward-compatible). Failure warnings are sanitised through the token store before reaching `state.json`.
+
+### Internal
+
+- **Four probe-support API wrappers + `_headers(token: str | None)` widening** (`migrator/api.py`): `api_create_invite`, `api_create_webhook`, `api_fetch_channel`, `api_delete_webhook`, and an auth-leak-safe `api_execute_webhook` that passes `token=None` so the user's `x-session-token` is never sent to the URL-token-authenticated webhook-execute endpoint. Webhook wrappers are **probe-only** — webhook-based message posting is deliberately out of scope.
+
+### Fixed
+
+- **`icons` Autumn size limit corrected to 2_500_000** (`uploader/autumn.py`). Source check against stoatchat `Revolt.toml` (`features.limits.default.file_upload_size_limit`) shows a flat 2.5 MB, not the `2560 * 1024 = 2_621_440` we previously enforced — an icon between those sizes would pass our pre-check then be rejected by Autumn.
+
 ## [2.3.0] - 2026-06-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.3.0"
+version = "2.4.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import textwrap
 from collections.abc import Callable
@@ -21,7 +22,7 @@ from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.errors import MigrationError, StateError
 from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
-from discord_ferry.state import load_state
+from discord_ferry.state import MigrationState, load_state
 from discord_ferry.stats import summarize_state
 
 if TYPE_CHECKING:
@@ -382,6 +383,12 @@ _common_options = [
     ),
     click.option("--server-id", default=None, help="Use existing Stoat server"),
     click.option("--server-name", default=None, help="Name for new server"),
+    click.option(
+        "--create-invite/--no-create-invite",
+        default=True,
+        help="Generate an invite to the migrated server (default on)",
+    ),
+    click.option("--invite-channel-id", default=None, help="Discord channel id to invite to"),
     click.option("--skip-messages", is_flag=True, help="Structure only"),
     click.option("--skip-emoji", is_flag=True, help="Skip emoji upload"),
     click.option("--skip-reactions", is_flag=True, help="Skip reactions"),
@@ -508,6 +515,8 @@ def _build_config(kwargs: dict[str, Any]) -> FerryConfig:
         thread_strategy=kwargs.get("thread_strategy", "flatten"),
         cleanup_orphans=kwargs.get("cleanup_orphans", False),
         force_unlock=kwargs.get("force_unlock", False),
+        create_invite=kwargs.get("create_invite", True),
+        invite_channel_id=kwargs.get("invite_channel_id"),
     )
 
 
@@ -553,9 +562,10 @@ def migrate(**kwargs: Any) -> None:
 
     console.print("[bold]Discord Ferry[/] — starting migration\n")
 
+    final_state: MigrationState | None = None
     try:
         with tracker.start_live():
-            asyncio.run(run_migration(config, on_event=tracker.on_event))
+            final_state = asyncio.run(run_migration(config, on_event=tracker.on_event))
     except MigrationError as exc:
         console.print(f"\n[bold red]Migration failed:[/] {exc}")
         sys.exit(1)
@@ -567,6 +577,10 @@ def migrate(**kwargs: Any) -> None:
     if not config.verbose and tracker.warning_count > 0:
         console.print(
             f"[dim]{tracker.warning_count} warning(s) suppressed — run with -v to see details[/]"
+        )
+    if final_state and (final_state.invite_url or final_state.invite_code):
+        console.print(
+            f"\n[bold green]Invite:[/] {final_state.invite_url or final_state.invite_code}"
         )
 
 
@@ -1103,6 +1117,49 @@ def rollback_cmd(
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/] State saved — re-run to resume.")
         sys.exit(130)
+
+
+@main.command(name="probe")
+@click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
+@click.option("--token", envvar="STOAT_TOKEN", default=None, help="Stoat user token")
+@click.option("--test-server-id", required=True, help="Throwaway server for probe entities")
+@click.option("--deep", is_flag=True, default=False, help="Probe Autumn size boundaries by upload")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+def probe_cmd(
+    stoat_url: str | None,
+    token: str | None,
+    test_server_id: str,
+    deep: bool,
+    as_json: bool,
+    verbose: bool,
+) -> None:
+    """Probe a live Stoat instance for Autumn limits, rate window, voice Bug #194, webhooks."""
+    load_dotenv()
+    if not stoat_url:
+        console.print("[bold red]Error:[/] --stoat-url is required (or set STOAT_URL)")
+        sys.exit(1)
+    if not token:
+        console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
+        sys.exit(1)
+
+    from discord_ferry.migrator.probe import run_probe
+
+    report = asyncio.run(run_probe(stoat_url, token, test_server_id, lambda _e: None, deep=deep))
+
+    if as_json:
+        payload = {c.name: {"status": c.status, "detail": c.detail} for c in report.checks}
+        console.print(json.dumps(payload))
+        return
+
+    table = Table(title="Stoat Probe Results")
+    table.add_column("Check")
+    table.add_column("Status")
+    table.add_column("Detail")
+    for c in report.checks:
+        colour = {"ok": "green", "warn": "yellow", "fail": "red"}.get(c.status, "white")
+        table.add_row(c.name, f"[{colour}]{c.status}[/]", c.detail)
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/src/discord_ferry/config.py
+++ b/src/discord_ferry/config.py
@@ -43,6 +43,9 @@ class FerryConfig:
     min_thread_messages: int = 0
     validate_after: bool = False
     force: bool = False
+    # Post-migration invite generation (S4).
+    create_invite: bool = True
+    invite_channel_id: str | None = None
     max_concurrent_requests: int = 5
     max_concurrent_channels: int = 3
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import re
 import socket
 from collections.abc import Callable, Coroutine
@@ -28,6 +29,7 @@ from discord_ferry.exporter import (
     validate_discord_token,
 )
 from discord_ferry.migrator.api import (
+    api_create_invite,
     api_delete_channel,
     api_delete_emoji,
     api_delete_role,
@@ -168,6 +170,8 @@ async def run_migration(
             state.message_map = dict(prior.message_map)
             state.stoat_server_id = prior.stoat_server_id
             state.autumn_url = prior.autumn_url
+            state.invite_code = prior.invite_code
+            state.invite_url = prior.invite_url
             # Carry over cumulative counters
             state.attachments_uploaded = prior.attachments_uploaded
             state.attachments_skipped = prior.attachments_skipped
@@ -457,6 +461,15 @@ async def run_migration(
                 message=f"Found {len(orphans)} orphaned uploads",
             )
         )
+
+    # S4: Post-migration invite (folds into REPORT; non-idempotent → guard on invite_code).
+    if (
+        config.create_invite
+        and not config.dry_run
+        and state.stoat_server_id
+        and not state.invite_code
+    ):
+        await _generate_invite(config, state, exports, on_event)
 
     generate_report(config, state, exports)
     generate_markdown_report(config, state, exports)
@@ -969,6 +982,87 @@ async def run_retry_failed(
 # ---------------------------------------------------------------------------
 # Rollback engine (issue #10)
 # ---------------------------------------------------------------------------
+
+
+def _select_invite_channel(
+    config: FerryConfig,
+    state: MigrationState,
+    exports: list[DCEExport],
+) -> str | None:
+    """Pick a Stoat Text channel to invite to.
+
+    Excludes voice (Discord type 2), threads, and synthetic forum-index channels.
+    Forums (15/16 → Stoat Text) are valid. Prefers ``config.invite_channel_id``
+    when it maps to an eligible channel. Returns a Stoat channel id, or None.
+    """
+
+    def _eligible(discord_id: str, ch_type: int, is_thread: bool) -> str | None:
+        if ch_type == 2 or is_thread or discord_id.startswith("forum-index-"):
+            return None
+        return state.channel_map.get(discord_id)
+
+    # Preferred override.
+    if config.invite_channel_id:
+        for export in exports:
+            if export.channel.id == config.invite_channel_id:
+                chosen = _eligible(export.channel.id, export.channel.type, export.is_thread)
+                if chosen:
+                    return chosen
+
+    # First eligible by deterministic channel.id order.
+    for export in sorted(exports, key=lambda e: e.channel.id):
+        chosen = _eligible(export.channel.id, export.channel.type, export.is_thread)
+        if chosen:
+            return chosen
+    return None
+
+
+async def _generate_invite(
+    config: FerryConfig,
+    state: MigrationState,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> None:
+    """Mint a post-migration invite and store it on state (non-fatal on error).
+
+    The engine caller also guards on ``not state.invite_code``; this internal
+    guard makes the helper idempotent on its own (non-idempotent API).
+    """
+    if state.invite_code:
+        return
+    channel_id = _select_invite_channel(config, state, exports)
+    if channel_id is None:
+        state.warnings.append(
+            {
+                "phase": "report",
+                "type": "invite_no_channel",
+                "message": "No eligible text channel for invite",
+            }
+        )
+        return
+    try:
+        async with get_session(config) as session:
+            result = await api_create_invite(session, config.stoat_url, config.token, channel_id)
+            code = result.get("_id") or result.get("code") or ""
+            state.invite_code = code
+            # Best-effort URL: our own root GET (connect's discover parses only autumn).
+            if code:
+                with contextlib.suppress(Exception):
+                    async with session.get(f"{config.stoat_url.rstrip('/')}/") as resp:
+                        root = await resp.json() if resp.status == 200 else {}
+                    app = root.get("app")
+                    if isinstance(app, str) and app:
+                        state.invite_url = f"{app.rstrip('/')}/invite/{code}"
+    except Exception as exc:  # noqa: BLE001 — invite is non-fatal
+        # Sanitize through the token store before persisting to state.json (security.md).
+        message = safe_sanitize(config.token_store, f"Invite generation failed: {exc}")
+        state.warnings.append(
+            {
+                "phase": "report",
+                "type": "invite_failed",
+                "message": message,
+            }
+        )
 
 
 _HTTP_STATUS_RE = re.compile(r"(?:API error|after \d+ retries:)\s*(\d{3})")

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -76,15 +76,18 @@ async def get_session(config: FerryConfig) -> AsyncIterator[aiohttp.ClientSessio
             yield session
 
 
-def _headers(token: str) -> dict[str, str]:
-    return {"x-session-token": token, "Content-Type": "application/json"}
+def _headers(token: str | None) -> dict[str, str]:
+    h: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        h["x-session-token"] = token
+    return h
 
 
 async def _api_request(
     session: aiohttp.ClientSession,
     method: str,
     url: str,
-    token: str,
+    token: str | None,
     json_data: dict[str, Any] | None = None,
     *,
     extra_headers: dict[str, str] | None = None,
@@ -100,7 +103,8 @@ async def _api_request(
         session: An active aiohttp ClientSession.
         method: HTTP method string (GET, POST, PATCH, etc.).
         url: Full URL for the request.
-        token: Stoat session token for the x-session-token header.
+        token: Stoat session token for the x-session-token header, or None to
+            omit it entirely (auth-less webhook-execute path).
         json_data: Optional JSON body. Not sent for GET requests.
         extra_headers: Additional HTTP headers to merge into the request.
         expected_404_ok: When True, a 404 response is treated as functional
@@ -141,7 +145,7 @@ async def _api_request_inner(
     session: aiohttp.ClientSession,
     method: str,
     url: str,
-    token: str,
+    token: str | None,
     json_data: dict[str, Any] | None = None,
     *,
     extra_headers: dict[str, str] | None = None,
@@ -293,6 +297,112 @@ async def api_edit_server(
     """
     url = f"{stoat_url.rstrip('/')}/servers/{server_id}"
     return await _api_request(session, "PATCH", url, token, kwargs)
+
+
+async def api_create_invite(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    channel_id: str,
+) -> dict[str, Any]:
+    """Create an invite to a channel.
+
+    Uses ``POST /channels/{channel_id}/invites``. Backend requires a TextChannel,
+    a non-bot caller, and the ``InviteOthers`` permission. The invite code is
+    returned as the ``_id`` field (read ``result.get("_id") or result.get("code")``).
+    Not idempotent — each call mints a new invite.
+    """
+    url = f"{stoat_url.rstrip('/')}/channels/{channel_id}/invites"
+    return await _api_request(session, "POST", url, token, {})
+
+
+# ---------------------------------------------------------------------------
+# Webhook wrappers — PROBE-ONLY. Never called from the message-send path
+# (feature C / webhook message-posting is OUT of scope). See migrator/probe.py.
+# ---------------------------------------------------------------------------
+
+
+async def api_create_webhook(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    channel_id: str,
+    *,
+    name: str,
+    avatar: str | None = None,
+) -> dict[str, Any]:
+    """Create a channel webhook (probe-only).
+
+    ``POST /channels/{channel_id}/webhooks``. Requires ``ManageWebhooks`` on a
+    TextChannel/Group. Response ``id`` is the webhook id (Ulid, NOT ``_id``);
+    ``token`` is the execute secret.
+    """
+    url = f"{stoat_url.rstrip('/')}/channels/{channel_id}/webhooks"
+    data: dict[str, Any] = {"name": name}
+    if avatar is not None:
+        data["avatar"] = avatar
+    return await _api_request(session, "POST", url, token, data)
+
+
+async def api_fetch_channel(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    channel_id: str,
+) -> dict[str, Any]:
+    """Fetch a channel object by id (GET /channels/{id}).
+
+    Used by the probe to read back the actual ``channel_type`` / ``voice`` field
+    after a create (voice Bug #194 detection).
+    """
+    url = f"{stoat_url.rstrip('/')}/channels/{channel_id}"
+    return await _api_request(session, "GET", url, token)
+
+
+async def api_delete_webhook(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    webhook_id: str,
+) -> None:
+    """Delete a webhook (DELETE /webhooks/{id}); 404 treated as success."""
+    url = f"{stoat_url.rstrip('/')}/webhooks/{webhook_id}"
+    await _api_request(session, "DELETE", url, token, expected_404_ok=True)
+
+
+async def api_execute_webhook(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    webhook_id: str,
+    webhook_token: str,
+    *,
+    content: str | None = None,
+    attachments: list[str] | None = None,
+    embeds: list[dict[str, Any]] | None = None,
+    masquerade: dict[str, str | None] | None = None,
+    replies: list[dict[str, Any]] | None = None,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """Execute a webhook (probe-only): POST /webhooks/{id}/{token}.
+
+    The URL token authenticates — the request MUST NOT carry ``x-session-token``
+    (passed via ``token=None`` to ``_api_request``). Body mirrors
+    ``api_send_message``'s ``DataMessageSend`` shape.
+    """
+    url = f"{stoat_url.rstrip('/')}/webhooks/{webhook_id}/{webhook_token}"
+    data: dict[str, Any] = {}
+    if content is not None:
+        data["content"] = content
+    if attachments is not None:
+        data["attachments"] = attachments
+    if embeds is not None:
+        data["embeds"] = embeds
+    if masquerade is not None:
+        data["masquerade"] = masquerade
+    if replies is not None:
+        data["replies"] = replies
+    extra = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+    return await _api_request(session, "POST", url, token=None, json_data=data, extra_headers=extra)
 
 
 async def api_create_role(

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -1,0 +1,193 @@
+"""Live validation probe for a Stoat instance (read-mostly diagnostics)."""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from discord_ferry.migrator.api import (
+    api_create_channel,
+    api_create_webhook,
+    api_delete_channel,
+    api_delete_webhook,
+    api_execute_webhook,
+    api_fetch_channel,
+)
+from discord_ferry.migrator.connect import _discover_autumn_url
+from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass
+class ProbeCheck:
+    name: str
+    status: str  # "ok" | "warn" | "fail"
+    detail: str
+
+
+@dataclass
+class ProbeReport:
+    checks: list[ProbeCheck] = field(default_factory=list)
+
+    def add(self, name: str, status: str, detail: str) -> None:
+        self.checks.append(ProbeCheck(name=name, status=status, detail=detail))
+
+
+async def run_probe(
+    stoat_url: str,
+    token: str,
+    test_server_id: str,
+    on_event: Callable[[object], None],
+    *,
+    deep: bool = False,
+    session: aiohttp.ClientSession | None = None,
+) -> ProbeReport:
+    """Run four independent read-mostly checks against a live Stoat instance.
+
+    Never constructs or writes a MigrationState/state.json. Every entity created
+    under ``test_server_id`` is torn down in a ``finally`` block.
+    """
+    report = ProbeReport()
+    own_session = session is None
+    sess = session or aiohttp.ClientSession()
+    try:
+        await _check_autumn(sess, stoat_url, report)
+        await _check_voice_bug(sess, stoat_url, token, test_server_id, report)
+        await _check_webhook(sess, stoat_url, token, test_server_id, report)
+        await _check_rate_limit(sess, stoat_url, token, test_server_id, report)
+        if deep:
+            report.add("deep_probe", "warn", "deep boundary-upload probe not yet implemented")
+    finally:
+        if own_session:
+            await sess.close()
+    return report
+
+
+async def _check_autumn(sess: aiohttp.ClientSession, stoat_url: str, report: ProbeReport) -> None:
+    try:
+        autumn_url = await _discover_autumn_url(sess, stoat_url)
+        # Best-effort: GET the autumn root for advertised per-tag limits.
+        async with sess.get(f"{autumn_url.rstrip('/')}/") as resp:
+            data: dict[str, Any] = await resp.json() if resp.status == 200 else {}
+        advertised = data.get("tags") or {}
+        diffs = [
+            f"{tag}: advertised {advertised.get(tag)} vs assumed {assumed}"
+            for tag, assumed in TAG_SIZE_LIMITS.items()
+            if tag in advertised and advertised.get(tag) != assumed
+        ]
+        report.add(
+            "autumn_limits",
+            "warn" if diffs else "ok",
+            "; ".join(diffs) or "matches assumptions",
+        )
+    except Exception as exc:  # noqa: BLE001 — probe must continue
+        report.add("autumn_limits", "fail", f"{type(exc).__name__}: {exc}")
+
+
+async def _check_voice_bug(
+    sess: aiohttp.ClientSession, stoat_url: str, token: str, server_id: str, report: ProbeReport
+) -> None:
+    # SOURCE-VERIFIED (stoatchat/stoatchat core/models/v0/channels.rs): this fork has
+    # NO VoiceChannel variant — every server channel serializes as
+    # "channel_type":"TextChannel". A Voice request maps to TextChannel{ voice: Some(..) }.
+    # So the real signal for "voice works on this instance" is the PRESENCE of a non-null
+    # `voice` field on the returned channel — NOT the discriminator. On stock self-hosted,
+    # voice is unsupported (#194/#176) and `voice` comes back absent (plain text).
+    channel_id: str | None = None
+    try:
+        created = await api_create_channel(
+            sess, stoat_url, token, server_id, name="ferry-probe-voice", channel_type="Voice"
+        )
+        channel_id = created.get("_id")
+        fetched = await api_fetch_channel(sess, stoat_url, token, channel_id) if channel_id else {}
+        discriminator = fetched.get("channel_type", "?")
+        has_voice = fetched.get("voice") is not None
+        if has_voice:
+            report.add(
+                "voice_channel",
+                "ok",
+                f"voice supported (channel_type={discriminator}, voice present)",
+            )
+        else:
+            report.add(
+                "voice_channel",
+                "warn",
+                f"requested Voice but `voice` field absent (channel_type={discriminator}) — "
+                "voice unsupported on this instance / Bug #194; Discord voice channels become text",
+            )
+    except Exception as exc:  # noqa: BLE001
+        report.add("voice_channel", "fail", f"{type(exc).__name__}: {exc}")
+    finally:
+        if channel_id:
+            # best-effort teardown
+            with contextlib.suppress(Exception):
+                await api_delete_channel(sess, stoat_url, token, channel_id)
+
+
+async def _check_webhook(
+    sess: aiohttp.ClientSession, stoat_url: str, token: str, server_id: str, report: ProbeReport
+) -> None:
+    channel_id: str | None = None
+    webhook_id: str | None = None
+    try:
+        created = await api_create_channel(
+            sess, stoat_url, token, server_id, name="ferry-probe-webhook", channel_type="Text"
+        )
+        channel_id = created.get("_id")
+        if not channel_id:
+            report.add("webhook", "fail", "could not create probe channel")
+            return
+        # SOURCE-VERIFIED (stoatchat routes/mod.rs): `POST /channels/{id}/webhooks` (create) is
+        # ALWAYS mounted, but the `/webhooks/*` EXECUTE group is mounted only when
+        # `features.webhooks_enabled` is true — default FALSE in stock Revolt.toml. So create may
+        # 2xx while execute 404s. Judge availability on EXECUTE, not create.
+        wh = await api_create_webhook(
+            sess, stoat_url, token, channel_id, name="Discord Ferry Probe"
+        )
+        webhook_id = wh.get("id")  # webhook id is `id`, not `_id` (verified)
+        if not webhook_id:
+            # Malformed create response — don't execute against /webhooks//{token}
+            # (which would mis-report as "webhooks DISABLED").
+            report.add("webhook", "fail", "webhook create returned no id")
+            return
+        await api_execute_webhook(sess, stoat_url, webhook_id, wh.get("token", ""), content="probe")
+        report.add(
+            "webhook",
+            "ok",
+            "webhooks ENABLED on this instance (execute succeeded). "
+            "NOTE: default webhook perms lack UploadFiles, so attachment "
+            "sends would fail.",
+        )
+    except Exception as exc:  # noqa: BLE001
+        report.add(
+            "webhook",
+            "warn",
+            "webhooks DISABLED on this instance (features.webhooks_enabled=false by default) — "
+            f"execute unavailable: {type(exc).__name__}: {exc}. This is config, not a bug.",
+        )
+    finally:
+        if webhook_id:
+            with contextlib.suppress(Exception):
+                await api_delete_webhook(sess, stoat_url, token, webhook_id)
+        if channel_id:
+            with contextlib.suppress(Exception):
+                await api_delete_channel(sess, stoat_url, token, channel_id)
+
+
+async def _check_rate_limit(
+    sess: aiohttp.ClientSession, stoat_url: str, token: str, server_id: str, report: ProbeReport
+) -> None:
+    try:
+        from discord_ferry.migrator.api import _headers
+
+        url = f"{stoat_url.rstrip('/')}/servers/{server_id}"
+        async with sess.get(url, headers=_headers(token)) as resp:
+            rl = {k: v for k, v in resp.headers.items() if k.lower().startswith("x-ratelimit")}
+        report.add("rate_limit", "ok", f"headers={rl or 'none observed'}")
+    except Exception as exc:  # noqa: BLE001
+        report.add("rate_limit", "fail", f"{type(exc).__name__}: {exc}")

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -182,6 +182,7 @@ def generate_report(
         discord_meta=discord_meta,
     )
     report["checklist"] = checklist
+    report["invite"] = {"code": state.invite_code, "url": state.invite_url}
 
     _write_report(config.output_dir, report)
 
@@ -285,12 +286,16 @@ def _build_checklist(
         )
 
     # Final items
-    items.append(
-        {
-            "task": "Invite members to the new Stoat server",
-            "status": "todo",
-        }
-    )
+    if state.invite_code:
+        invite_target = state.invite_url or state.invite_code
+        items.append({"task": f"Invite members using: {invite_target}", "status": "todo"})
+    else:
+        items.append(
+            {
+                "task": "Invite members to the new Stoat server",
+                "status": "todo",
+            }
+        )
 
     return items
 
@@ -371,6 +376,10 @@ def generate_markdown_report(
     lines.append(f"| Reactions applied | {state.reactions_applied} |")
     lines.append(f"| Pins restored | {state.pins_applied} |")
     lines.append("")
+
+    if state.invite_code:
+        lines.append("\n## Invite\n")
+        lines.append(f"- {state.invite_url or state.invite_code}\n")
 
     lines.append("## Errors\n")
     if state.failed_messages:

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -144,6 +144,11 @@ class MigrationState:
     # the entity maps above are never mutated by rollback.
     rollback_progress: RollbackProgress | None = None
 
+    # Post-migration invite (S4). invite_code is the bare code; invite_url is the
+    # best-effort full link ("" when the frontend base couldn't be discovered).
+    invite_code: str = ""
+    invite_url: str = ""
+
 
 def save_state(state: MigrationState, output_dir: Path) -> None:
     """Save migration state to state.json using atomic write.
@@ -257,6 +262,8 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "replies_linked": state.replies_linked,
         "replies_total": state.replies_total,
         "rollback_progress": rp_data,
+        "invite_code": state.invite_code,
+        "invite_url": state.invite_url,
     }
 
 
@@ -320,6 +327,8 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             replies_linked=data.get("replies_linked", 0),
             replies_total=data.get("replies_total", 0),
             rollback_progress=rollback_progress,
+            invite_code=data.get("invite_code", ""),
+            invite_url=data.get("invite_url", ""),
         )
     except (TypeError, ValueError) as e:
         raise StateError(f"Invalid state data: {e}") from e

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -22,7 +22,7 @@ TAG_SIZE_LIMITS: dict[str, int] = {
     "attachments": 20 * 1024 * 1024,
     "avatars": 4 * 1024 * 1024,
     "backgrounds": 6 * 1024 * 1024,
-    "icons": 2560 * 1024,
+    "icons": 2_500_000,  # Autumn enforces a flat 2.5MB (stoatchat Revolt.toml), not 2560*1024
     "banners": 6 * 1024 * 1024,
     "emojis": 500 * 1024,
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,18 +13,24 @@ from discord_ferry.errors import MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
     _circuit_state,
+    _headers,
     _reset_circuit_state,
     _reset_rate_state,
     api_add_reaction,
     api_create_channel,
     api_create_emoji,
+    api_create_invite,
     api_create_role,
     api_create_server,
+    api_create_webhook,
     api_delete_channel,
     api_delete_emoji,
     api_delete_role,
+    api_delete_webhook,
     api_edit_role,
     api_edit_server,
+    api_execute_webhook,
+    api_fetch_channel,
     api_fetch_server,
     api_pin_message,
     api_send_message,
@@ -58,6 +64,125 @@ def _clean_circuit() -> None:  # type: ignore[misc]
     _reset_circuit_state()
     _reset_rate_state()
     _api_mod._request_semaphore = None
+
+
+# ---------------------------------------------------------------------------
+# _headers — auth header construction (Task 1)
+# ---------------------------------------------------------------------------
+
+
+def test_headers_with_token_includes_session_token() -> None:
+    """A real token yields the x-session-token header (regression guard)."""
+    h = _headers(TOKEN)
+    assert h["x-session-token"] == TOKEN
+    assert h["Content-Type"] == "application/json"
+
+
+def test_headers_none_omits_session_token() -> None:
+    """token=None produces headers WITHOUT x-session-token (auth-less webhook path)."""
+    h = _headers(None)
+    assert "x-session-token" not in h
+    assert h["Content-Type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# api_create_invite (Task 2)
+# ---------------------------------------------------------------------------
+
+
+async def test_api_create_invite_reads_id(mock_aiohttp: aioresponses) -> None:
+    """POST /channels/{id}/invites returns the invite; code read from _id."""
+    mock_aiohttp.post(
+        f"{BASE_URL}/channels/ch1/invites", payload={"_id": "inv_AB", "type": "Server"}
+    )
+    async with aiohttp.ClientSession() as session:
+        result = await api_create_invite(session, BASE_URL, TOKEN, "ch1")
+    assert result["_id"] == "inv_AB"
+
+
+async def test_api_create_invite_reads_code_fallback(mock_aiohttp: aioresponses) -> None:
+    """Some responses carry `code` instead of `_id`; both must be accessible."""
+    mock_aiohttp.post(f"{BASE_URL}/channels/ch1/invites", payload={"code": "inv_CD"})
+    async with aiohttp.ClientSession() as session:
+        result = await api_create_invite(session, BASE_URL, TOKEN, "ch1")
+    assert result.get("_id", result.get("code")) == "inv_CD"
+
+
+# ---------------------------------------------------------------------------
+# Webhook + channel-fetch wrappers (Task 3, probe-support)
+# ---------------------------------------------------------------------------
+
+
+async def test_api_create_webhook_reads_id_and_token(mock_aiohttp: aioresponses) -> None:
+    """Webhook id comes from `id` (NOT _id); token from `token`."""
+    mock_aiohttp.post(
+        f"{BASE_URL}/channels/ch1/webhooks",
+        payload={"id": "wh1", "token": "tok_w", "name": "Discord Ferry"},
+    )
+    async with aiohttp.ClientSession() as session:
+        result = await api_create_webhook(session, BASE_URL, TOKEN, "ch1", name="Discord Ferry")
+    assert result["id"] == "wh1"
+    assert result["token"] == "tok_w"
+
+
+async def test_api_fetch_channel_returns_type(mock_aiohttp: aioresponses) -> None:
+    """GET /channels/{id} returns the channel object (used for Bug #194 check)."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/ch_tmp", payload={"_id": "ch_tmp", "channel_type": "Text"}
+    )
+    async with aiohttp.ClientSession() as session:
+        result = await api_fetch_channel(session, BASE_URL, TOKEN, "ch_tmp")
+    assert result["channel_type"] == "Text"
+
+
+async def test_api_delete_webhook_404_ok(mock_aiohttp: aioresponses) -> None:
+    """DELETE /webhooks/{id} treats 404 as success (idempotent teardown)."""
+    mock_aiohttp.delete(f"{BASE_URL}/webhooks/wh1", status=404)
+    async with aiohttp.ClientSession() as session:
+        await api_delete_webhook(session, BASE_URL, TOKEN, "wh1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# api_execute_webhook — auth-leak-safe (Task 4)
+# ---------------------------------------------------------------------------
+
+
+async def test_api_execute_webhook_sends_no_session_token(mock_aiohttp: aioresponses) -> None:
+    """Execute auths via the URL token only — NO x-session-token; Idempotency-Key passes through."""
+    captured: dict[str, str] = {}
+
+    def cap(url: object, **kwargs: object) -> None:
+        captured.update(kwargs.get("headers") or {})  # type: ignore[arg-type]
+
+    mock_aiohttp.post(f"{BASE_URL}/webhooks/wh1/tok_w", payload={"_id": "m1"}, callback=cap)
+    async with aiohttp.ClientSession() as session:
+        await api_execute_webhook(
+            session, BASE_URL, "wh1", "tok_w", content="hi", idempotency_key="k1"
+        )
+    assert "x-session-token" not in captured
+    assert captured.get("Idempotency-Key") == "k1"
+
+
+async def test_api_send_message_still_authenticated(mock_aiohttp: aioresponses) -> None:
+    """Auth regression: ordinary sends MUST still carry x-session-token."""
+    captured: dict[str, str] = {}
+
+    def cap(url: object, **kwargs: object) -> None:
+        captured.update(kwargs.get("headers") or {})  # type: ignore[arg-type]
+
+    mock_aiohttp.post(f"{BASE_URL}/channels/ch1/messages", payload={"_id": "m1"}, callback=cap)
+    async with aiohttp.ClientSession() as session:
+        await api_send_message(session, BASE_URL, TOKEN, "ch1", content="hi")
+    assert captured.get("x-session-token") == TOKEN
+
+
+async def test_api_execute_webhook_retries_429(mock_aiohttp: aioresponses) -> None:
+    """A 429 (retry_after in ms) is retried; the second attempt succeeds."""
+    mock_aiohttp.post(f"{BASE_URL}/webhooks/wh1/tok_w", status=429, payload={"retry_after": 50})
+    mock_aiohttp.post(f"{BASE_URL}/webhooks/wh1/tok_w", payload={"_id": "m9"})
+    async with aiohttp.ClientSession() as session:
+        result = await api_execute_webhook(session, BASE_URL, "wh1", "tok_w", content="hi")
+    assert result["_id"] == "m9"
 
 
 @pytest.fixture

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -174,3 +174,10 @@ async def test_upload_with_cache_miss(tmp_path: Path, mock_aiohttp: aioresponses
 
     assert result == "new_file_id"
     assert cache[str(file)] == "new_file_id"
+
+
+def test_icons_limit_matches_stoat_autumn_config() -> None:
+    """Autumn enforces a flat 2_500_000 for icons (Revolt.toml), not 2560*1024."""
+    from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
+
+    assert TAG_SIZE_LIMITS["icons"] == 2_500_000

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -693,3 +693,56 @@ def test_rollback_tracker_renders_suspect_columns() -> None:
     assert "not-a-ulid-id-here" in out
     # --yes mode releases the gate.
     assert pause.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Probe subcommand (T6) + create-invite flag wiring (T9)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_requires_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["probe", "--test-server-id", "srv1"], catch_exceptions=False)
+    assert result.exit_code == 1
+    assert "--stoat-url is required" in result.output
+
+
+def test_probe_requires_test_server_id(runner: CliRunner) -> None:
+    result = runner.invoke(
+        main, ["probe", "--stoat-url", "https://api.test", "--token", "t"], catch_exceptions=False
+    )
+    assert result.exit_code != 0  # Click flags the missing required option
+
+
+def test_no_create_invite_flag_threads_to_config(runner: CliRunner) -> None:
+    mock_engine = _make_mock_engine()
+    with patch("discord_ferry.cli.run_migration", mock_engine):
+        result = runner.invoke(
+            main,
+            [
+                "migrate",
+                "--export-dir",
+                FIXTURES_DIR,
+                "--stoat-url",
+                "u",
+                "--token",
+                "t",
+                "--no-create-invite",
+                "--yes",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    config: FerryConfig = mock_engine.call_args[0][0]
+    assert config.create_invite is False
+
+
+def test_create_invite_default_true(runner: CliRunner) -> None:
+    mock_engine = _make_mock_engine()
+    with patch("discord_ferry.cli.run_migration", mock_engine):
+        runner.invoke(
+            main,
+            ["migrate", "--export-dir", FIXTURES_DIR, "--stoat-url", "u", "--token", "t", "--yes"],
+            catch_exceptions=False,
+        )
+    config: FerryConfig = mock_engine.call_args[0][0]
+    assert config.create_invite is True

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,7 +11,7 @@ from aioresponses import aioresponses
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, PhaseFunction, run_migration, run_retry_failed
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.parser.models import DCEExport
+from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
 from discord_ferry.state import FailedMessage, MigrationState
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -1525,3 +1525,99 @@ async def test_migration_lock_overrides_expired_lock(tmp_path: Path) -> None:
     assert result is True
     lock_warnings = [w for w in state.warnings if w.get("type") == "lock_expired"]
     assert len(lock_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Post-migration invite generation (T8)
+# ---------------------------------------------------------------------------
+
+from discord_ferry.core.engine import _generate_invite, _select_invite_channel  # noqa: E402
+
+
+def _text_channel_export(channel_id: str, ch_type: int = 0, is_thread: bool = False) -> DCEExport:
+    return DCEExport(
+        guild=DCEGuild(id="g", name="G"),
+        channel=DCEChannel(id=channel_id, type=ch_type, name=f"c-{channel_id}"),
+        messages=[],
+        message_count=0,
+        is_thread=is_thread,
+    )
+
+
+def _exports_with_text_channel(channel_id: str) -> list[DCEExport]:
+    return [_text_channel_export(channel_id, ch_type=0)]
+
+
+def _exports_voice_and_forum(voice_id: str, forum_id: str) -> list[DCEExport]:
+    return [
+        _text_channel_export(voice_id, ch_type=2),
+        _text_channel_export(forum_id, ch_type=15),
+    ]
+
+
+def _exports_voice_only(voice_id: str) -> list[DCEExport]:
+    return [_text_channel_export(voice_id, ch_type=2)]
+
+
+async def test_generate_invite_happy(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, create_invite=True)
+    state = MigrationState(stoat_server_id="srv1", channel_map={"d_ch": "s_ch"})
+    exports = _exports_with_text_channel("d_ch")
+    with aioresponses() as m:
+        m.get("https://api.test/", payload={"app": "https://app.test", "features": {}})
+        m.post("https://api.test/channels/s_ch/invites", payload={"_id": "inv_X"})
+        await _generate_invite(config, state, exports, lambda _e: None)
+    assert state.invite_code == "inv_X"
+    assert state.invite_url == "https://app.test/invite/inv_X"
+
+
+async def test_generate_invite_bare_code_when_no_app(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, create_invite=True)
+    state = MigrationState(stoat_server_id="srv1", channel_map={"d_ch": "s_ch"})
+    exports = _exports_with_text_channel("d_ch")
+    with aioresponses() as m:
+        m.get("https://api.test/", payload={"features": {}})  # no "app"
+        m.post("https://api.test/channels/s_ch/invites", payload={"_id": "inv_Y"})
+        await _generate_invite(config, state, exports, lambda _e: None)
+    assert state.invite_code == "inv_Y"
+    assert state.invite_url == ""
+
+
+async def test_generate_invite_idempotent(tmp_path: Path) -> None:
+    """An already-populated invite_code → no POST (SC-15). The internal guard
+    short-circuits, so no aioresponses mock is registered (a POST would raise)."""
+    config = _make_config(tmp_path, create_invite=True)
+    state = MigrationState(
+        stoat_server_id="srv1", channel_map={"d_ch": "s_ch"}, invite_code="inv_done"
+    )
+    exports = _exports_with_text_channel("d_ch")
+    with aioresponses():
+        # No invite mock registered — if a POST fires, aioresponses raises.
+        await _generate_invite(config, state, exports, lambda _e: None)
+    assert state.invite_code == "inv_done"
+
+
+async def test_generate_invite_failure_non_fatal(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, create_invite=True)
+    state = MigrationState(stoat_server_id="srv1", channel_map={"d_ch": "s_ch"})
+    exports = _exports_with_text_channel("d_ch")
+    with aioresponses() as m:
+        m.get("https://api.test/", payload={"app": "https://app.test"})
+        m.post("https://api.test/channels/s_ch/invites", status=500, repeat=True)
+        await _generate_invite(config, state, exports, lambda _e: None)  # must not raise
+    assert state.invite_code == ""
+    assert any(w.get("type") == "invite_failed" for w in state.warnings)
+
+
+def test_select_invite_channel_prefers_forum_over_voice(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    state = MigrationState(channel_map={"d_voice": "s_voice", "d_forum": "s_forum"})
+    exports = _exports_voice_and_forum("d_voice", "d_forum")
+    assert _select_invite_channel(config, state, exports) == "s_forum"
+
+
+def test_select_invite_channel_none_when_only_voice(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    state = MigrationState(channel_map={"d_voice": "s_voice"})
+    exports = _exports_voice_only("d_voice")
+    assert _select_invite_channel(config, state, exports) is None

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from discord_ferry.migrator.probe import ProbeReport, run_probe
+
+BASE_URL = "https://api.test"
+TOKEN = "test-token"
+
+
+def _noop_event(_evt: object) -> None:
+    pass
+
+
+@pytest.fixture
+def mock_aiohttp() -> aioresponses:
+    with aioresponses() as m:
+        yield m
+
+
+async def test_probe_voice_teardown_fires_on_getback_failure(mock_aiohttp: aioresponses) -> None:
+    """If the GET-back fails, the created channel is still deleted (I2)."""
+    # Root (autumn discovery) — minimal.
+    mock_aiohttp.get(
+        f"{BASE_URL}/", payload={"features": {"autumn": {"url": f"{BASE_URL}/autumn"}}}
+    )
+    # Voice check: create succeeds (returns TextChannel — this fork has no VoiceChannel variant),
+    # GET-back 500s on every retry, DELETE must still fire.
+    mock_aiohttp.post(
+        f"{BASE_URL}/servers/srv1/channels",
+        payload={"_id": "ch_tmp", "channel_type": "TextChannel"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/channels/ch_tmp", status=500, repeat=True)
+    delete_called = {"n": 0}
+    mock_aiohttp.delete(
+        f"{BASE_URL}/channels/ch_tmp",
+        callback=lambda u, **k: delete_called.__setitem__("n", 1),
+        status=204,
+    )
+    # Webhook check: create 4xx (disabled) — keep it simple.
+    mock_aiohttp.post(f"{BASE_URL}/channels/ch_tmp/webhooks", status=403, repeat=True)
+
+    async with aiohttp.ClientSession() as session:
+        report = await run_probe(BASE_URL, TOKEN, "srv1", _noop_event, session=session)
+
+    assert delete_called["n"] == 1  # teardown fired despite GET-back failure
+    assert isinstance(report, ProbeReport)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -789,3 +789,18 @@ def test_fidelity_rounding() -> None:
     #         = (2/3)*0.65 + 0.35 ≈ 0.7833 → 78.3
     assert score["overall"] == 78.3
     assert score["messages"] == round((2 / 3) * 100, 1)
+
+
+def test_report_includes_invite_block(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    state = MigrationState(invite_code="inv_X", invite_url="https://app.test/invite/inv_X")
+    report = generate_report(config, state, exports=[])
+    assert report["invite"]["code"] == "inv_X"
+    assert report["invite"]["url"] == "https://app.test/invite/inv_X"
+
+
+def test_report_omits_invite_when_absent(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    state = MigrationState()
+    report = generate_report(config, state, exports=[])
+    assert not report.get("invite", {}).get("code")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,6 @@
 """Tests for migration state persistence."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -507,3 +508,21 @@ def test_rollback_progress_none_serializes_as_null(tmp_path: Path) -> None:
 
     assert "rollback_progress" in raw
     assert raw["rollback_progress"] is None
+
+
+def test_invite_fields_roundtrip(tmp_path: Path) -> None:
+    """invite_code/invite_url survive save/load."""
+    state = MigrationState(invite_code="inv_R", invite_url="https://app/invite/inv_R")
+    save_state(state, tmp_path)
+    loaded = load_state(tmp_path)
+    assert loaded.invite_code == "inv_R"
+    assert loaded.invite_url == "https://app/invite/inv_R"
+
+
+def test_invite_fields_default_when_absent(tmp_path: Path) -> None:
+    """Old state.json without invite fields loads with empty defaults."""
+    minimal = {"stoat_server_id": "s", "current_phase": "report"}
+    (tmp_path / "state.json").write_text(json.dumps(minimal), encoding="utf-8")
+    loaded = load_state(tmp_path)
+    assert loaded.invite_code == ""
+    assert loaded.invite_url == ""

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Two operator-facing capabilities for Discord Ferry, plus an Autumn size-limit fix.

### `discord-ferry probe` — live-instance diagnostics
Runs four read-mostly checks against a live Stoat instance and renders a Rich table (or `--json`):
- **Autumn limits** — advertised per-tag size limits vs. our assumptions.
- **Voice Bug #194** — this Revolt fork has no VoiceChannel variant, so the check judges voice support on the *presence of a `voice` field*, not the channel-type discriminator.
- **Webhooks** — judged on EXECUTE (mounted only when `features.webhooks_enabled` is true, default off), not create.
- **Rate-limit headers** — raw `x-ratelimit-*` capture.

Every entity created under the throwaway test server is torn down in a `finally` block (capture-id-before-raise). The probe never constructs or writes a `MigrationState`.

### Post-migration invite generation (S4)
The migration mints an invite to the new server during the REPORT phase and surfaces it in the CLI summary, `migration_report.json`, the markdown report, and the post-migration checklist. Gated by `--create-invite/--no-create-invite` (default on) + `--invite-channel-id`. `_select_invite_channel` excludes voice/threads/forum-index channels (forums are eligible). Non-fatal on error, idempotent (double-guarded on `invite_code`), carried forward on incremental re-runs so resumes never re-mint. Failure warnings are sanitised through the token store before reaching `state.json`.

### Fix
- `icons` Autumn size limit corrected `2560*1024` → `2_500_000` (flat 2.5 MB per stoatchat `Revolt.toml`).

## Security notes
- **`api_execute_webhook` passes `token=None`** so the user's `x-session-token` is never sent to the URL-token-authenticated webhook-execute endpoint (verified).
- Webhook wrappers are **probe-only** — webhook-based message posting is deliberately out of scope.

## Verification
- `ruff` + `ruff format --check` + `mypy --strict` (42 files) clean; **pytest: 966 passed**.
- Reviewed via a fresh-context code review (Spec ✅, Quality Approved, 0 critical; 9 security checks CLEAN) and a Mistral security second opinion (0 critical). Both flagged a warning-sanitisation gap + a webhook-id guard, both fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)