### PR TITLE
fix: high-severity bug-hunt quick wins (v2.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.4.2] - 2026-06-23
+
+### Fixed
+
+- **Resume no longer crashes after a validated migration** (`core/engine.py`). When `validate_after` is enabled, `run_migration` persists `current_phase="validate_migration"` — a terminal phase that is not in `PHASE_ORDER`. A subsequent `--resume` called `PHASE_ORDER.index(state.current_phase)` in `_run_phases` with no membership check, raising `ValueError: 'validate_migration' is not in list` before any phase ran, aborting the resume entirely. The resume guard now treats any `current_phase` outside `PHASE_ORDER` as "all runnable phases complete" (`current_idx = len(PHASE_ORDER)`), so resume correctly skips the finished pipeline instead of crashing. Locked by `test_run_migration_resume_after_validate_does_not_crash`.
+- **GUI progress bar no longer crashes on the post-migration validation event** (`gui.py`). The migration progress handler called `PHASE_ORDER.index(event.phase)` on every non-`report` `completed` event, but the engine emits a `phase="validate_migration"` completed event when post-migration validation passes — a value not in `PHASE_ORDER`, raising `ValueError` inside the event handler. Extracted a `_phase_progress(phase)` helper that returns `None` for post-pipeline phases; the handler skips the progress-bar update for them. Locked by `test_phase_progress_pipeline_phases` and `test_phase_progress_post_pipeline_phase_is_none`.
+
+### Security
+
+- **`dce_checksums.json` is now bundled into the frozen binary** (`ferry.spec`). The PyInstaller spec bundled only `templates/*.json`, so the shipped binary lacked the pinned DCE hashes. `exporter/manager._verify_dce_checksum` reads them via `importlib.resources`, and its `except (FileNotFoundError, ModuleNotFoundError): return` clause then **silently skipped** checksum verification — defeating the supply-chain hard-fail gate from v2.2.12, but only in the packaged app (source-run tests always had the file, so the suite never caught it). Added `("src/discord_ferry/dce_checksums.json", "discord_ferry")` to `all_datas`. Locked by `test_ferry_spec_bundles_dce_checksums`.
+
 ## [2.4.1] - 2026-06-23
 
 ### Security

--- a/ferry.spec
+++ b/ferry.spec
@@ -40,6 +40,10 @@ ferry_imports = collect_submodules("discord_ferry")
 
 all_datas = nicegui_datas + aiohttp_datas + webview_datas + [
     ("src/discord_ferry/templates/*.json", "discord_ferry/templates"),
+    # Pinned DCE SHA-256 hashes — MUST be bundled, otherwise exporter/manager.py
+    # silently skips checksum verification in the frozen binary (the supply-chain
+    # security gate from v2.2.12 would be defeated only in the shipped app).
+    ("src/discord_ferry/dce_checksums.json", "discord_ferry"),
 ]
 all_binaries = nicegui_bins + aiohttp_bins + webview_bins
 all_hiddenimports = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.4.1"
+version = "2.4.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -568,7 +568,15 @@ async def _run_phases(
         # Check resume: skip phases that precede current_phase
         if config.resume and state.current_phase:
             phase_idx = PHASE_ORDER.index(phase_name)
-            current_idx = PHASE_ORDER.index(state.current_phase)
+            # current_phase may hold a terminal/post-pipeline value (e.g.
+            # "validate_migration") that is not in PHASE_ORDER; treat any such
+            # value as "all runnable phases complete" instead of crashing with
+            # ValueError from .index().
+            current_idx = (
+                PHASE_ORDER.index(state.current_phase)
+                if state.current_phase in PHASE_ORDER
+                else len(PHASE_ORDER)
+            )
             if phase_idx < current_idx:
                 on_event(
                     MigrationEvent(

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -126,6 +126,18 @@ def _msgs_per_hour(rate_limit: float) -> int:
     return int(3600 / rate_limit)
 
 
+def _phase_progress(phase: str) -> float | None:
+    """Progress-bar fraction in (0, 1] for a pipeline phase, or None if it has no slot.
+
+    Post-pipeline phases such as "validate_migration" are not in PHASE_ORDER and must
+    not be passed to PHASE_ORDER.index() (which raises ValueError); callers skip the
+    progress update when this returns None.
+    """
+    if phase not in PHASE_ORDER:
+        return None
+    return (PHASE_ORDER.index(phase) + 1) / len(PHASE_ORDER)
+
+
 def _compute_summary(exports: list[DCEExport]) -> dict[str, int | str]:
     """Compute summary counts from a list of exports."""
     total_messages = sum(e.message_count for e in exports)
@@ -1263,7 +1275,12 @@ def migrate_page() -> None:
                     # Final completion — switch UI
                     _on_migration_complete()
                 else:
-                    progress_bar.set_value((PHASE_ORDER.index(event.phase) + 1) / len(PHASE_ORDER))
+                    # Post-pipeline phases (e.g. "validate_migration") have no
+                    # progress slot; _phase_progress returns None for them rather
+                    # than crashing on PHASE_ORDER.index().
+                    frac = _phase_progress(event.phase)
+                    if frac is not None:
+                        progress_bar.set_value(frac)
             case "confirm":
                 if event.detail:
                     _show_review_dialog(event.detail)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -165,6 +165,33 @@ async def test_run_migration_resume_skips_completed(tmp_path: Path) -> None:
         assert any(e.status == "skipped" for e in phase_events), f"{phase} should be skipped"
 
 
+async def test_run_migration_resume_after_validate_does_not_crash(tmp_path: Path) -> None:
+    """Resume must not crash when current_phase is a terminal value outside PHASE_ORDER.
+
+    Regression: run_migration persists current_phase="validate_migration" when
+    validate_after is set and a stoat_server_id exists. A later --resume then called
+    PHASE_ORDER.index("validate_migration") -> ValueError before any phase ran. A
+    terminal phase means the whole pipeline already completed, so every runnable phase
+    should be skipped rather than crashing.
+    """
+    from discord_ferry.state import save_state
+
+    prior_state = MigrationState(
+        current_phase="validate_migration", started_at="2024-01-01T00:00:00+00:00"
+    )
+    save_state(prior_state, tmp_path)
+
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, resume=True)
+    # Must not raise ValueError("'validate_migration' is not in list").
+    await run_migration(config, events.append, phase_overrides=_NOOP_OVERRIDES)
+
+    # Terminal current_phase => all runnable pipeline phases are already complete.
+    for phase in ["connect", "server", "roles", "categories", "channels", "messages"]:
+        phase_events = [e for e in events if e.phase == phase]
+        assert any(e.status == "skipped" for e in phase_events), f"{phase} should be skipped"
+
+
 async def test_run_migration_phase_error(tmp_path: Path) -> None:
     """Engine catches phase exceptions and raises MigrationError."""
     from discord_ferry.errors import MigrationError

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -56,6 +56,26 @@ def test_msgs_per_hour_zero() -> None:
     assert _msgs_per_hour(0) == 0
 
 
+def test_phase_progress_pipeline_phases() -> None:
+    """Pipeline phases map to a fraction in (0, 1]."""
+    from discord_ferry.core.engine import PHASE_ORDER
+    from discord_ferry.gui import _phase_progress
+
+    assert _phase_progress("export") == pytest.approx(1 / len(PHASE_ORDER))
+    assert _phase_progress("report") == pytest.approx(1.0)
+
+
+def test_phase_progress_post_pipeline_phase_is_none() -> None:
+    """Terminal phases outside PHASE_ORDER must return None, not crash .index().
+
+    Regression: the engine emits phase="validate_migration" events, and the GUI's
+    progress handler called PHASE_ORDER.index(event.phase) -> ValueError.
+    """
+    from discord_ferry.gui import _phase_progress
+
+    assert _phase_progress("validate_migration") is None
+
+
 def test_step_labels_include_export() -> None:
     """Step labels include the Export step."""
     from discord_ferry.gui import _STEP_LABELS

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,35 @@
+"""Packaging invariants — guards for defects invisible to the normal test run.
+
+The frozen PyInstaller binary is never exercised by pytest (tests run from source),
+so a data-file omission in ferry.spec passes every test yet breaks the shipped app.
+These lightweight existence/text checks are the cheap first line of defense until a
+full build-and-inspect smoke test exists.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ferry_spec_bundles_dce_checksums() -> None:
+    """ferry.spec must bundle dce_checksums.json into the frozen binary.
+
+    Regression: the spec only bundled templates/*.json, so the frozen binary shipped
+    without dce_checksums.json. exporter/manager._verify_dce_checksum then hits
+    FileNotFoundError and silently returns, skipping the supply-chain checksum gate
+    added in v2.2.12 — but only in the shipped app, so source-run tests never saw it.
+    """
+    checksums = _REPO_ROOT / "src" / "discord_ferry" / "dce_checksums.json"
+    assert checksums.is_file(), f"missing source data file: {checksums}"
+
+    spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")
+    # Must map into the "discord_ferry" package dir so manager.py's
+    # importlib.resources.files("discord_ferry").joinpath("dce_checksums.json") resolves it.
+    # A wrong dest dir would silently reintroduce the skipped-verification bug.
+    assert re.search(r'dce_checksums\.json"\s*,\s*"discord_ferry"', spec_text), (
+        "ferry.spec must map dce_checksums.json -> the 'discord_ferry' package dir in "
+        "all_datas, else the frozen binary skips DCE checksum verification."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.4.1"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Three high-severity bug fixes from the first whole-codebase adversarial bug-hunt (2026-06-23), each with a regression test. Patch release **v2.4.2**.

- **Resume crash** (`core/engine.py`) — `--resume` after a `validate_after` migration crashed with `ValueError` because `current_phase` was persisted as `"validate_migration"`, which is not in `PHASE_ORDER`, and the resume guard called `PHASE_ORDER.index()` with no membership check. The guard now treats any terminal `current_phase` as "all runnable phases complete", so resume skips the finished pipeline.
- **Frozen-binary checksum gap** (`ferry.spec`) — `dce_checksums.json` was not bundled into the PyInstaller binary, so `exporter/manager._verify_dce_checksum` hit `FileNotFoundError` and **silently skipped** DCE checksum verification (the v2.2.12 supply-chain hard-fail gate) — in the shipped app only. pytest never caught it because tests run from source where the file exists.
- **GUI progress crash** (`gui.py`) — the migration progress handler called `PHASE_ORDER.index(event.phase)` and crashed on the emitted `validate_migration` completed event. Same root class as the engine fix; surfaced by the ship-time audit grep, not the original hunt. Extracted a testable `_phase_progress()` helper.

## Tests (all fail on pre-fix code)

- `tests/test_engine.py::test_run_migration_resume_after_validate_does_not_crash`
- `tests/test_packaging.py::test_ferry_spec_bundles_dce_checksums` (new file)
- `tests/test_gui.py::test_phase_progress_pipeline_phases`, `test_phase_progress_post_pipeline_phase_is_none`

## Verification

- `ruff check` + `ruff format --check` + `mypy` clean
- **970 tests pass**
- Fresh-context code review + Mistral second opinion — both clean, no residual issues

## Context

Part of a larger triage. The bug hunt surfaced **23 confirmed findings** (7 high, 12 medium, 4 low); these are the two trivial-tier quick wins plus the audit-discovered GUI sibling. The remaining high/medium findings go through the `/df` design pipeline next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
