### PR TITLE
feat: native-fidelity batch 2 — slowmode, voice user_limit, role icons (v2.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.5.0] - 2026-06-24
+
+### Added
+
+- **Native-fidelity batch 2: per-channel slowmode, voice user-limit, and image role icons.** Successor to the v2.3.0 batch (#62). Three more native Discord properties now migrate when a `discord_token` is supplied, all source-verified against `stoatchat/stoatchat` @ a15a542:
+  - **Per-channel slowmode** (`migrator/structure.py`, `migrator/api.py`). Discord `rate_limit_per_user` is captured into `ChannelMeta.slowmode` and applied via a new `api_edit_channel` PATCH wrapper (routes through the existing rate-limited `_api_request`). Applied only when `> 0`, clamped to Stoat's `0..=21600` range with a `slowmode_clamped` warning. Slowmode is a flat top-level PATCH field.
+  - **Voice channel user-limit** (`migrator/structure.py`). Discord voice `user_limit` is captured into `ChannelMeta.user_limit` and applied as `voice={"max_users": N}` (nested). Discord's `0` (unlimited) maps to an omitted `max_users` (Stoat rejects `0`). The voice PATCH is gated by a `created_as_voice` flag so it never fires on a channel that fell back to Text via the Bug #194 retry; slowmode still applies to such fallbacks.
+  - **Image role icons** (`migrator/structure.py`, `discord/client.py`). A role's image icon is downloaded from the Discord CDN (`download_role_icon`, capped at the Autumn 2.5 MB icons limit), uploaded to Autumn under the `icons` tag, and folded into the existing role attributes pass as `DataEditRole.icon`. Unicode-emoji-only role icons are not migratable and are skipped with a warning. The Autumn upload failure is caught as `AutumnUploadError` and reported with a fixed, role-name-only message — never the raw exception body, which can echo the session token (`security.md`).
+  - **Reporter credit + shell surfacing** (`reporter.py`, `cli.py`, `gui.py`, `state.py`). Applied counts accumulate in `MigrationState.native_fidelity_counts` (serialized for resume) and surface as `report["native_fidelity"]`, a `## Native Fidelity` markdown section, a CLI summary line, and a GUI completion-card label (hidden when empty).
+  - **Graceful degradation.** With no `discord_token`, all three fields skip and emit distinct one-time `slowmode_skipped` / `user_limit_skipped` / `role_icon_skipped` warnings; migration completes and v2.3.0 fields are unaffected.
+
 ## [2.4.2] - 2026-06-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.4.2"
+version = "2.5.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.4.2"
+__version__ = "2.5.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -582,6 +582,14 @@ def migrate(**kwargs: Any) -> None:
         console.print(
             f"\n[bold green]Invite:[/] {final_state.invite_url or final_state.invite_code}"
         )
+    if final_state and final_state.native_fidelity_counts:
+        nf = final_state.native_fidelity_counts
+        console.print(
+            f"[green]Native fidelity:[/] "
+            f"slowmode={nf.get('slowmode', 0)}, "
+            f"user_limit={nf.get('user_limit', 0)}, "
+            f"role_icons={nf.get('role_icons', 0)}"
+        )
 
 
 @main.command()

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -585,7 +585,7 @@ def migrate(**kwargs: Any) -> None:
     if final_state and final_state.native_fidelity_counts:
         nf = final_state.native_fidelity_counts
         console.print(
-            f"[green]Native fidelity:[/] "
+            f"\n[green]Native fidelity:[/] "
             f"slowmode={nf.get('slowmode', 0)}, "
             f"user_limit={nf.get('user_limit', 0)}, "
             f"role_icons={nf.get('role_icons', 0)}"

--- a/src/discord_ferry/discord/__init__.py
+++ b/src/discord_ferry/discord/__init__.py
@@ -64,7 +64,12 @@ async def fetch_and_translate_guild_metadata(
             continue
         translated = translate_permissions(role.permissions)
         role_permissions[role.id] = PermissionPair(allow=translated, deny=0)
-        role_metadata[role.id] = RoleMeta(hoist=role.hoist, position=role.position)
+        role_metadata[role.id] = RoleMeta(
+            hoist=role.hoist,
+            position=role.position,
+            icon_hash=role.icon,
+            unicode_emoji=role.unicode_emoji,
+        )
 
     # Build channel metadata (filter user overrides, translate permissions)
     channel_metadata: dict[str, ChannelMeta] = {}
@@ -105,6 +110,8 @@ async def fetch_and_translate_guild_metadata(
             nsfw=channel.nsfw,
             default_override=default_override,
             role_overrides=role_overrides,
+            slowmode=channel.rate_limit_per_user,
+            user_limit=channel.user_limit,
         )
 
     return DiscordMetadata(

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -146,6 +146,31 @@ async def _discord_get_object(
     raise MigrationError(f"Discord API request failed after {_MAX_RETRIES} retries")
 
 
+_ROLE_ICON_MAX_BYTES = 2_500_000  # Autumn "icons" tag limit (stoatchat Revolt.toml)
+
+
+async def download_role_icon(
+    session: aiohttp.ClientSession, role_id: str, icon_hash: str
+) -> bytes | None:
+    """Download a Discord role icon PNG from the CDN.
+
+    Returns the image bytes, or ``None`` on any non-200 status, network error,
+    or when the image exceeds the Autumn icons limit. The CDN URL is public
+    (no token) — safe to log.
+    """
+    url = f"https://cdn.discordapp.com/role-icons/{role_id}/{icon_hash}.png"
+    try:
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                return None
+            data = await resp.read()
+            if len(data) > _ROLE_ICON_MAX_BYTES:
+                return None
+            return data
+    except aiohttp.ClientError:
+        return None
+
+
 def _parse_role(data: dict[str, Any]) -> DiscordRole:
     return DiscordRole(
         id=str(data["id"]),

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -155,6 +155,8 @@ def _parse_role(data: dict[str, Any]) -> DiscordRole:
         color=data.get("color", 0),
         hoist=data.get("hoist", False),
         managed=data.get("managed", False),
+        icon=str(data.get("icon") or ""),
+        unicode_emoji=str(data.get("unicode_emoji") or ""),
     )
 
 

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -174,5 +174,7 @@ def _parse_channel(data: dict[str, Any]) -> DiscordChannel:
         type=data["type"],
         nsfw=data.get("nsfw", False),
         position=data.get("position", 0),
+        rate_limit_per_user=data.get("rate_limit_per_user", 0),
+        user_limit=data.get("user_limit", 0),
         permission_overwrites=overwrites,
     )

--- a/src/discord_ferry/discord/metadata.py
+++ b/src/discord_ferry/discord/metadata.py
@@ -29,6 +29,8 @@ class RoleMeta:
 
     hoist: bool = False
     position: int = 0
+    icon_hash: str = ""
+    unicode_emoji: str = ""
 
 
 @dataclass
@@ -38,6 +40,8 @@ class ChannelMeta:
     nsfw: bool
     default_override: PermissionPair | None = None
     role_overrides: list[RoleOverride] = field(default_factory=list)
+    slowmode: int = 0
+    user_limit: int = 0
 
 
 @dataclass
@@ -88,7 +92,13 @@ def _meta_to_dict(meta: DiscordMetadata) -> dict[str, Any]:
         "user_override_channels": meta.user_override_channels,
         "banner_hash": meta.banner_hash,
         "role_metadata": {
-            k: {"hoist": v.hoist, "position": v.position} for k, v in meta.role_metadata.items()
+            k: {
+                "hoist": v.hoist,
+                "position": v.position,
+                "icon_hash": v.icon_hash,
+                "unicode_emoji": v.unicode_emoji,
+            }
+            for k, v in meta.role_metadata.items()
         },
         "category_positions": meta.category_positions,
         "guild_description": meta.guild_description,
@@ -111,6 +121,8 @@ def _channel_meta_to_dict(cm: ChannelMeta) -> dict[str, Any]:
         }
         for ro in cm.role_overrides
     ]
+    d["slowmode"] = cm.slowmode
+    d["user_limit"] = cm.user_limit
     return d
 
 
@@ -129,7 +141,12 @@ def _dict_to_meta(data: dict[str, Any]) -> DiscordMetadata:
         user_override_channels=data.get("user_override_channels", []),
         banner_hash=data.get("banner_hash", ""),
         role_metadata={
-            k: RoleMeta(hoist=v.get("hoist", False), position=v.get("position", 0))
+            k: RoleMeta(
+                hoist=v.get("hoist", False),
+                position=v.get("position", 0),
+                icon_hash=v.get("icon_hash", ""),
+                unicode_emoji=v.get("unicode_emoji", ""),
+            )
             for k, v in data.get("role_metadata", {}).items()
         },
         category_positions=data.get("category_positions", {}),
@@ -154,4 +171,6 @@ def _dict_to_channel_meta(data: dict[str, Any]) -> ChannelMeta:
             )
             for ro in data.get("role_overrides", [])
         ],
+        slowmode=data.get("slowmode", 0),
+        user_limit=data.get("user_limit", 0),
     )

--- a/src/discord_ferry/discord/models.py
+++ b/src/discord_ferry/discord/models.py
@@ -24,6 +24,8 @@ class DiscordRole:
     color: int = 0
     hoist: bool = False
     managed: bool = False
+    icon: str = ""
+    unicode_emoji: str = ""
 
 
 @dataclass

--- a/src/discord_ferry/discord/models.py
+++ b/src/discord_ferry/discord/models.py
@@ -35,4 +35,6 @@ class DiscordChannel:
     type: int
     nsfw: bool = False
     position: int = 0
+    rate_limit_per_user: int = 0  # slowmode seconds (text channels)
+    user_limit: int = 0  # voice channel capacity cap (0 = unlimited)
     permission_overwrites: list[PermissionOverwrite] = field(default_factory=list)

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1008,6 +1008,7 @@ def migrate_page() -> None:
                 ui.label("Migration Complete").classes("text-xl font-bold text-green-600")
                 ui.label("").classes("text-sm text-gray-500").bind_text_from(errors_label, "text")
                 native_fidelity_label = ui.label("").classes("text-sm text-gray-500")
+                native_fidelity_label.set_visibility(False)
                 with ui.row().classes("gap-2 mt-2"):
                     open_report_btn = ui.button(
                         "Open Report", on_click=lambda: _open_report()
@@ -1307,6 +1308,7 @@ def migrate_page() -> None:
                 report = json.loads(report_file.read_text(encoding="utf-8"))
                 nf = report.get("native_fidelity") or {}
                 if nf:
+                    native_fidelity_label.set_visibility(True)
                     native_fidelity_label.set_text(
                         f"Native fidelity: slowmode={nf.get('slowmode', 0)}, "
                         f"user_limit={nf.get('user_limit', 0)}, "

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
 import secrets
 import subprocess
@@ -1006,6 +1007,7 @@ def migrate_page() -> None:
             with ui.card().classes("w-full mt-4 hidden") as completion_card:
                 ui.label("Migration Complete").classes("text-xl font-bold text-green-600")
                 ui.label("").classes("text-sm text-gray-500").bind_text_from(errors_label, "text")
+                native_fidelity_label = ui.label("").classes("text-sm text-gray-500")
                 with ui.row().classes("gap-2 mt-2"):
                     open_report_btn = ui.button(
                         "Open Report", on_click=lambda: _open_report()
@@ -1301,6 +1303,17 @@ def migrate_page() -> None:
         if report_file.exists():
             report_path.append(report_file)
             open_report_btn.enable()
+            try:
+                report = json.loads(report_file.read_text(encoding="utf-8"))
+                nf = report.get("native_fidelity") or {}
+                if nf:
+                    native_fidelity_label.set_text(
+                        f"Native fidelity: slowmode={nf.get('slowmode', 0)}, "
+                        f"user_limit={nf.get('user_limit', 0)}, "
+                        f"role_icons={nf.get('role_icons', 0)}"
+                    )
+            except (OSError, ValueError):
+                pass
         else:
             open_report_btn.disable()
         progress_bar.set_value(1.0)

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -453,6 +453,29 @@ async def api_edit_role(
     return await _api_request(session, "PATCH", url, token, kwargs)
 
 
+async def api_edit_channel(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    channel_id: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Edit a channel's properties (slowmode, voice info, etc.).
+
+    Args:
+        session: An active aiohttp ClientSession.
+        stoat_url: Stoat API base URL.
+        token: Stoat session token.
+        channel_id: Target channel ID.
+        **kwargs: Fields to update (e.g. ``slowmode=30``, ``voice={"max_users": 5}``).
+
+    Returns:
+        Updated channel object dict.
+    """
+    url = f"{stoat_url.rstrip('/')}/channels/{channel_id}"
+    return await _api_request(session, "PATCH", url, token, kwargs)
+
+
 async def api_upsert_categories(
     session: aiohttp.ClientSession,
     stoat_url: str,

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -15,6 +15,7 @@ from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_role,
     api_create_server,
+    api_edit_channel,
     api_edit_role,
     api_edit_server,
     api_fetch_server,
@@ -788,6 +789,7 @@ async def run_channels(
             nsfw = ch_meta.nsfw if ch_meta else False
 
             stoat_channel_id: str
+            created_as_voice = stoat_type == "Voice"
             try:
                 result = await api_create_channel(
                     session,
@@ -802,6 +804,7 @@ async def run_channels(
                 stoat_channel_id = result["_id"]
             except MigrationError as exc:
                 if stoat_type == "Voice":
+                    created_as_voice = False
                     # Voice channels may fail (Bug #194) — retry as text.
                     state.warnings.append(
                         {
@@ -834,6 +837,52 @@ async def run_channels(
                     raise
 
             state.channel_map[ch.id] = stoat_channel_id
+
+            # S1/S2 (native-fidelity batch 2): apply slowmode + voice user_limit.
+            if ch_meta is not None:
+                edit_kwargs: dict[str, Any] = {}
+                if ch_meta.slowmode > 0:
+                    if ch_meta.slowmode > 21600:
+                        state.warnings.append(
+                            {
+                                "phase": "channels",
+                                "type": "slowmode_clamped",
+                                "message": (
+                                    f"Slowmode for '{unique_name}' clamped to 21600s "
+                                    f"(was {ch_meta.slowmode})."
+                                ),
+                            }
+                        )
+                    edit_kwargs["slowmode"] = min(ch_meta.slowmode, 21600)
+                if created_as_voice and ch_meta.user_limit >= 1:
+                    edit_kwargs["voice"] = {"max_users": ch_meta.user_limit}
+                if edit_kwargs:
+                    try:
+                        await api_edit_channel(
+                            session,
+                            config.stoat_url,
+                            config.token,
+                            stoat_channel_id,
+                            **edit_kwargs,
+                        )
+                        if "slowmode" in edit_kwargs:
+                            state.native_fidelity_counts["slowmode"] = (
+                                state.native_fidelity_counts.get("slowmode", 0) + 1
+                            )
+                        if "voice" in edit_kwargs:
+                            state.native_fidelity_counts["user_limit"] = (
+                                state.native_fidelity_counts.get("user_limit", 0) + 1
+                            )
+                    except Exception as exc:  # noqa: BLE001
+                        state.warnings.append(
+                            {
+                                "phase": "channels",
+                                "type": "channel_attributes_failed",
+                                "message": (
+                                    f"Failed to set attributes for channel '{unique_name}': {exc}"
+                                ),
+                            }
+                        )
 
             # Track forum post info for index channel generation.
             if discord_cat_id.startswith("forum-"):

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -553,6 +553,13 @@ async def run_roles(
                 "message": "Role hoist skipped: Discord metadata unavailable.",
             }
         )
+        state.warnings.append(
+            {
+                "phase": "roles",
+                "type": "role_icon_skipped",
+                "message": "Role icons skipped: Discord metadata unavailable.",
+            }
+        )
 
     # Third pass: apply translated permissions from Discord metadata (reuse the load).
     if discord_metadata and not config.dry_run:
@@ -1152,6 +1159,33 @@ async def run_channels(
                 state.stoat_server_id,
                 all_categories,
             )
+
+    # S5: graceful-degrade — slowmode/user_limit need Discord metadata.
+    if discord_metadata is None:
+        on_event(
+            MigrationEvent(
+                phase="channels",
+                status="warning",
+                message=(
+                    "Slowmode / voice user-limit not migrated "
+                    "(no Discord metadata — discord_token required)."
+                ),
+            )
+        )
+        state.warnings.append(
+            {
+                "phase": "channels",
+                "type": "slowmode_skipped",
+                "message": "Slowmode skipped: Discord metadata unavailable.",
+            }
+        )
+        state.warnings.append(
+            {
+                "phase": "channels",
+                "type": "user_limit_skipped",
+                "message": "Voice user-limit skipped: Discord metadata unavailable.",
+            }
+        )
 
     on_event(
         MigrationEvent(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.discord.client import download_role_icon
 from discord_ferry.discord.metadata import load_discord_metadata
-from discord_ferry.errors import MigrationError
+from discord_ferry.errors import AutumnUploadError, MigrationError
 from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_role,
@@ -30,9 +31,11 @@ from discord_ferry.migrator.api import (
 )
 from discord_ferry.migrator.sanitize import truncate_name
 from discord_ferry.parser.dce_parser import stream_messages
-from discord_ferry.uploader.autumn import upload_with_cache
+from discord_ferry.uploader.autumn import upload_to_autumn, upload_with_cache
 
 if TYPE_CHECKING:
+    import aiohttp
+
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
     from discord_ferry.parser.models import DCEChannel, DCEExport, DCERole
@@ -341,6 +344,55 @@ async def run_server(
             )
 
 
+async def _resolve_role_icon(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    role_name: str,
+    role_id: str,
+    icon_hash: str,
+) -> str | None:
+    """Download a role icon, upload to Autumn, return the attachment id or None.
+
+    Token-safe: an AutumnUploadError (which may carry the HTTP body) is never
+    interpolated into a warning. The temp file is always cleaned up.
+    """
+    icon_bytes = await download_role_icon(session, role_id, icon_hash)
+    if icon_bytes is None:
+        state.warnings.append(
+            {
+                "phase": "roles",
+                "type": "role_icon_download_failed",
+                "message": f"Role icon download failed for role '{role_name}'.",
+            }
+        )
+        return None
+    icon_dir = config.output_dir / "role-icons"
+    icon_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = icon_dir / f"{role_id}.png"
+    try:
+        temp_path.write_bytes(icon_bytes)
+        icon_id = await upload_to_autumn(
+            session, state.autumn_url, "icons", temp_path, config.token
+        )
+        state.native_fidelity_counts["role_icons"] = (
+            state.native_fidelity_counts.get("role_icons", 0) + 1
+        )
+        return icon_id
+    except AutumnUploadError:
+        # Fixed template — never str(exc); the body may echo x-session-token.
+        state.warnings.append(
+            {
+                "phase": "roles",
+                "type": "role_icon_upload_failed",
+                "message": f"Role icon upload failed for role '{role_name}'.",
+            }
+        )
+        return None
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 async def run_roles(
     config: FerryConfig,
     state: MigrationState,
@@ -451,6 +503,22 @@ async def run_roles(
             rm = role_meta.get(role.id)
             if rm is not None:
                 edit_kwargs["hoist"] = rm.hoist
+                if rm.icon_hash:
+                    icon_id = await _resolve_role_icon(
+                        session, config, state, role.name, role.id, rm.icon_hash
+                    )
+                    if icon_id is not None:
+                        edit_kwargs["icon"] = icon_id
+                elif rm.unicode_emoji:
+                    state.warnings.append(
+                        {
+                            "phase": "roles",
+                            "type": "role_icon_skipped",
+                            "message": (
+                                f"Role '{role.name}' has an emoji icon (not migratable to Stoat)."
+                            ),
+                        }
+                    )
             if not edit_kwargs:
                 continue
             try:

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -183,6 +183,7 @@ def generate_report(
     )
     report["checklist"] = checklist
     report["invite"] = {"code": state.invite_code, "url": state.invite_url}
+    report["native_fidelity"] = dict(state.native_fidelity_counts)
 
     _write_report(config.output_dir, report)
 
@@ -394,6 +395,16 @@ def generate_markdown_report(
             lines.append(f"- [{w.get('type', 'unknown')}] {w.get('message', '')}")
     else:
         lines.append("No warnings.\n")
+
+    nf = state.native_fidelity_counts
+    if nf:
+        lines.append("\n## Native Fidelity\n")
+        if nf.get("slowmode"):
+            lines.append(f"- Slowmode set on {nf['slowmode']} channel(s)\n")
+        if nf.get("user_limit"):
+            lines.append(f"- Voice user-limit set on {nf['user_limit']} channel(s)\n")
+        if nf.get("role_icons"):
+            lines.append(f"- Icons set on {nf['role_icons']} role(s)\n")
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
     output_path = config.output_dir / "migration_report.md"

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -81,6 +81,9 @@ class MigrationState:
     errors: list[dict[str, str]] = field(default_factory=list)
     warnings: list[dict[str, str]] = field(default_factory=list)
 
+    # Native-fidelity attribute application counts (slowmode, user_limit, ...)
+    native_fidelity_counts: dict[str, int] = field(default_factory=dict)
+
     # Stoat server ID and Autumn URL (discovered during CONNECT phase)
     stoat_server_id: str = ""
     autumn_url: str = ""

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -267,6 +267,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "rollback_progress": rp_data,
         "invite_code": state.invite_code,
         "invite_url": state.invite_url,
+        "native_fidelity_counts": state.native_fidelity_counts,
     }
 
 
@@ -332,6 +333,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             rollback_progress=rollback_progress,
             invite_code=data.get("invite_code", ""),
             invite_url=data.get("invite_url", ""),
+            native_fidelity_counts=data.get("native_fidelity_counts", {}),
         )
     except (TypeError, ValueError) as e:
         raise StateError(f"Invalid state data: {e}") from e

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1024,3 +1024,21 @@ async def test_expected_404_ok_with_204_unchanged_behaviour(
         )
     assert result == {}
     assert _circuit_state.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_api_edit_channel_patches_body():
+    with aioresponses() as m:
+        m.patch("https://stoat.test/channels/ch1", payload={"_id": "ch1"})
+        async with aiohttp.ClientSession() as s:
+            from discord_ferry.migrator.api import api_edit_channel
+
+            result = await api_edit_channel(
+                s,
+                "https://stoat.test",
+                "tok",
+                "ch1",
+                slowmode=30,
+                voice={"max_users": 5},
+            )
+    assert result["_id"] == "ch1"

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -346,3 +346,26 @@ async def test_capture_batch2_fields(mock_discord: aioresponses) -> None:
     assert meta.channel_metadata["301"].user_limit == 5
     assert meta.role_metadata["200"].icon_hash == "iconhash123"
     assert meta.role_metadata["200"].unicode_emoji == ""
+
+
+@pytest.mark.asyncio
+async def test_download_role_icon_returns_bytes():
+    url = "https://cdn.discordapp.com/role-icons/r1/hash.png"
+    with aioresponses() as m:
+        m.get(url, body=b"\x89PNG-data", status=200)
+        async with aiohttp.ClientSession() as s:
+            from discord_ferry.discord.client import download_role_icon
+
+            data = await download_role_icon(s, "r1", "hash")
+    assert data == b"\x89PNG-data"
+
+
+@pytest.mark.asyncio
+async def test_download_role_icon_none_on_404():
+    url = "https://cdn.discordapp.com/role-icons/r1/hash.png"
+    with aioresponses() as m:
+        m.get(url, status=404)
+        async with aiohttp.ClientSession() as s:
+            from discord_ferry.discord.client import download_role_icon
+
+            assert await download_role_icon(s, "r1", "hash") is None

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -292,3 +292,57 @@ async def test_fetch_guild_nsfw_level_mapping(
     async with aiohttp.ClientSession() as session:
         meta = await fetch_and_translate_guild_metadata(session, TOKEN, guild_id)
     assert meta.guild_nsfw is expected
+
+
+async def test_capture_batch2_fields(mock_discord: aioresponses) -> None:
+    """Capture slowmode/user_limit/role-icon/unicode_emoji into metadata."""
+    guild_id = "100"
+    mock_discord.get(
+        f"{DISCORD_API}/guilds/{guild_id}",
+        payload={"description": "", "nsfw_level": 0, "banner": None},
+    )
+    mock_discord.get(
+        f"{DISCORD_API}/guilds/{guild_id}/roles",
+        payload=[
+            {
+                "id": "200",
+                "name": "Mod",
+                "permissions": "0",
+                "position": 2,
+                "color": 0,
+                "hoist": True,
+                "managed": False,
+                "icon": "iconhash123",
+                "unicode_emoji": None,
+            }
+        ],
+    )
+    mock_discord.get(
+        f"{DISCORD_API}/guilds/{guild_id}/channels",
+        payload=[
+            {
+                "id": "300",
+                "name": "gen",
+                "type": 0,
+                "nsfw": False,
+                "position": 0,
+                "rate_limit_per_user": 30,
+                "permission_overwrites": [],
+            },
+            {
+                "id": "301",
+                "name": "vc",
+                "type": 2,
+                "nsfw": False,
+                "position": 1,
+                "user_limit": 5,
+                "permission_overwrites": [],
+            },
+        ],
+    )
+    async with aiohttp.ClientSession() as session:
+        meta = await fetch_and_translate_guild_metadata(session, TOKEN, guild_id)
+    assert meta.channel_metadata["300"].slowmode == 30
+    assert meta.channel_metadata["301"].user_limit == 5
+    assert meta.role_metadata["200"].icon_hash == "iconhash123"
+    assert meta.role_metadata["200"].unicode_emoji == ""

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -369,3 +369,29 @@ async def test_download_role_icon_none_on_404():
             from discord_ferry.discord.client import download_role_icon
 
             assert await download_role_icon(s, "r1", "hash") is None
+
+
+@pytest.mark.asyncio
+async def test_download_role_icon_none_when_oversize(monkeypatch):
+    # Patch the limit down so a small body exercises the oversize branch without
+    # streaming a multi-MB body through aioresponses (which trips an internal
+    # parser assertion on aiohttp 3.14).
+    from discord_ferry.discord import client as discord_client
+
+    monkeypatch.setattr(discord_client, "_ROLE_ICON_MAX_BYTES", 4)
+    url = "https://cdn.discordapp.com/role-icons/r1/hash.png"
+    with aioresponses() as m:
+        m.get(url, body=b"toobig", status=200)
+        async with aiohttp.ClientSession() as s:
+            assert await discord_client.download_role_icon(s, "r1", "hash") is None
+
+
+@pytest.mark.asyncio
+async def test_download_role_icon_none_on_client_error():
+    url = "https://cdn.discordapp.com/role-icons/r1/hash.png"
+    with aioresponses() as m:
+        m.get(url, exception=aiohttp.ClientError())
+        async with aiohttp.ClientSession() as s:
+            from discord_ferry.discord.client import download_role_icon
+
+            assert await download_role_icon(s, "r1", "hash") is None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -12,6 +12,8 @@ from discord_ferry.discord.metadata import (
     PermissionPair,
     RoleMeta,
     RoleOverride,
+    _dict_to_meta,
+    _meta_to_dict,
     load_discord_metadata,
     save_discord_metadata,
 )
@@ -384,12 +386,6 @@ async def test_no_banner_hash() -> None:
             meta = await fetch_and_translate_guild_metadata(session, "test-token", guild_id)
 
     assert meta.banner_hash == ""
-
-
-from discord_ferry.discord.metadata import (  # noqa: E402
-    _dict_to_meta,
-    _meta_to_dict,
-)
 
 
 def test_batch2_fields_round_trip():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -384,3 +384,43 @@ async def test_no_banner_hash() -> None:
             meta = await fetch_and_translate_guild_metadata(session, "test-token", guild_id)
 
     assert meta.banner_hash == ""
+
+
+from discord_ferry.discord.metadata import (  # noqa: E402
+    _dict_to_meta,
+    _meta_to_dict,
+)
+
+
+def test_batch2_fields_round_trip():
+    meta = DiscordMetadata(
+        guild_id="g1",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={
+            "c1": ChannelMeta(nsfw=False, slowmode=30, user_limit=5),
+        },
+        role_metadata={"r1": RoleMeta(hoist=True, position=3, icon_hash="abc", unicode_emoji="")},
+    )
+    restored = _dict_to_meta(_meta_to_dict(meta))
+    assert restored.channel_metadata["c1"].slowmode == 30
+    assert restored.channel_metadata["c1"].user_limit == 5
+    assert restored.role_metadata["r1"].icon_hash == "abc"
+    assert restored.role_metadata["r1"].unicode_emoji == ""
+
+
+def test_batch2_fields_default_on_legacy_json():
+    # Legacy metadata without the new keys loads with zero/empty defaults.
+    legacy = {
+        "guild_id": "g",
+        "fetched_at": "t",
+        "server_default_permissions": 0,
+        "role_permissions": {},
+        "channel_metadata": {"c1": {"nsfw": False}},
+        "role_metadata": {"r1": {"hoist": False, "position": 0}},
+    }
+    restored = _dict_to_meta(legacy)
+    assert restored.channel_metadata["c1"].slowmode == 0
+    assert restored.channel_metadata["c1"].user_limit == 0
+    assert restored.role_metadata["r1"].icon_hash == ""

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -74,6 +74,12 @@ def test_report_includes_native_fidelity(tmp_path: Path) -> None:
     assert isinstance(native_fidelity, dict)
     assert native_fidelity["slowmode"] == 1
 
+    # The markdown report carries a matching ## Native Fidelity section.
+    generate_markdown_report(config, state, exports)
+    md = (tmp_path / "migration_report.md").read_text()
+    assert "## Native Fidelity" in md
+    assert "Slowmode set on 1 channel(s)" in md
+
 
 def test_generate_report_summary_keys(tmp_path: Path) -> None:
     """Summary dict contains all required keys."""

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -61,6 +61,20 @@ def test_generate_report_structure(tmp_path: Path) -> None:
     assert "maps" in report
 
 
+def test_report_includes_native_fidelity(tmp_path: Path) -> None:
+    """generate_report surfaces native_fidelity_counts under report['native_fidelity']."""
+    config = _make_config(tmp_path)
+    state = MigrationState()
+    state.native_fidelity_counts = {"slowmode": 1}
+    exports = [_make_export()]
+
+    report = generate_report(config, state, exports)
+
+    native_fidelity = report["native_fidelity"]
+    assert isinstance(native_fidelity, dict)
+    assert native_fidelity["slowmode"] == 1
+
+
 def test_generate_report_summary_keys(tmp_path: Path) -> None:
     """Summary dict contains all required keys."""
     config = _make_config(tmp_path)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -252,6 +252,25 @@ def test_completed_channel_ids_roundtrip(tmp_path: Path) -> None:
     assert loaded.completed_channel_ids == {"ch_a", "ch_b", "ch_c"}
 
 
+def test_native_fidelity_counts_round_trip() -> None:
+    """native_fidelity_counts dict survives _state_to_dict -> _dict_to_state."""
+    from discord_ferry.state import _dict_to_state, _state_to_dict
+
+    s = MigrationState()
+    s.native_fidelity_counts = {"slowmode": 2, "user_limit": 1, "role_icons": 3}
+    restored = _dict_to_state(_state_to_dict(s))
+    assert restored.native_fidelity_counts == {"slowmode": 2, "user_limit": 1, "role_icons": 3}
+
+
+def test_native_fidelity_counts_save_load_roundtrip(tmp_path: Path) -> None:
+    """native_fidelity_counts survives a JSON save/load round-trip."""
+    state = MigrationState()
+    state.native_fidelity_counts = {"slowmode": 4}
+    save_state(state, tmp_path)
+    loaded = load_state(tmp_path)
+    assert loaded.native_fidelity_counts == {"slowmode": 4}
+
+
 def test_channel_message_offsets_roundtrip(tmp_path: Path) -> None:
     """channel_message_offsets dict survives JSON serialization."""
     state = MigrationState(channel_message_offsets={"ch1": "msg_123", "ch2": "msg_456"})

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1124,6 +1124,46 @@ async def test_channel_slowmode_and_user_limit_applied(tmp_path: Path) -> None:
     assert state.native_fidelity_counts == {"slowmode": 1, "user_limit": 1}
 
 
+async def test_channel_slowmode_clamped_above_max(tmp_path: Path) -> None:
+    """Slowmode > 21600 is clamped to 21600 and a slowmode_clamped warning is logged."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={
+            "txt1": ChannelMeta(nsfw=False, slowmode=30000),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    exports = [_make_export(channel_id="txt1", channel_name="slow-chat", category_id="")]
+
+    edit_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-txt1", "name": "slow-chat"},
+        )
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-txt1",
+            payload={"_id": "stoat-txt1"},
+            callback=lambda url, **kwargs: edit_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        await run_channels(config, state, exports, events.append)
+
+    assert len(edit_bodies) == 1
+    assert edit_bodies[0].get("slowmode") == 21600
+    assert any(w.get("type") == "slowmode_clamped" for w in state.warnings)
+
+
 async def test_voice_fallback_skips_voice_patch(tmp_path: Path) -> None:
     """A voice channel that falls back to text (Bug #194) skips the voice PATCH.
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -868,6 +868,113 @@ async def test_run_channels_passes_nsfw_flag(tmp_path: Path) -> None:
     assert created_bodies[0].get("nsfw") is True
 
 
+async def test_channel_slowmode_and_user_limit_applied(tmp_path: Path) -> None:
+    """CHANNELS phase PATCHes slowmode (text) and voice.max_users (voice)."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={
+            "txt1": ChannelMeta(nsfw=False, slowmode=30),
+            "vc1": ChannelMeta(nsfw=False, user_limit=5),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    exports = [
+        _make_export(channel_id="txt1", channel_name="slow-chat", category_id=""),
+        _make_export(channel_id="vc1", channel_name="voice-chat", channel_type=2, category_id=""),
+    ]
+
+    edit_bodies: dict[str, dict[str, object]] = {}
+
+    def _capture(url: object, **kwargs: object) -> None:
+        channel_id = str(url).rsplit("/", 1)[-1]
+        edit_bodies[channel_id] = kwargs.get("json", {})  # type: ignore[assignment]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-txt1", "name": "slow-chat"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-vc1", "name": "voice-chat"},
+        )
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-txt1",
+            payload={"_id": "stoat-txt1"},
+            callback=_capture,  # type: ignore[arg-type]
+        )
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-vc1",
+            payload={"_id": "stoat-vc1"},
+            callback=_capture,  # type: ignore[arg-type]
+        )
+        await run_channels(config, state, exports, events.append)
+
+    assert edit_bodies["stoat-txt1"].get("slowmode") == 30
+    assert "voice" not in edit_bodies["stoat-txt1"]
+    assert edit_bodies["stoat-vc1"].get("voice") == {"max_users": 5}
+    assert "slowmode" not in edit_bodies["stoat-vc1"]
+    assert state.native_fidelity_counts == {"slowmode": 1, "user_limit": 1}
+
+
+async def test_voice_fallback_skips_voice_patch(tmp_path: Path) -> None:
+    """A voice channel that falls back to text (Bug #194) skips the voice PATCH.
+
+    slowmode is still applied to the text-fallback channel.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={
+            "vc1": ChannelMeta(nsfw=False, slowmode=15, user_limit=8),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    exports = [
+        _make_export(channel_id="vc1", channel_name="voice-chat", channel_type=2, category_id="")
+    ]
+
+    edit_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        # First call (Voice) fails -> Bug #194 fallback to Text.
+        m.post(f"{STOAT_URL}/servers/srv1/channels", status=400)
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-vc1", "name": "voice-chat"},
+        )
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-vc1",
+            payload={"_id": "stoat-vc1"},
+            callback=lambda url, **kwargs: edit_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        await run_channels(config, state, exports, events.append)
+
+    assert len(edit_bodies) == 1
+    # created_as_voice is False, so the voice kwarg must be omitted.
+    assert "voice" not in edit_bodies[0]
+    # slowmode still applies to the text-fallback channel.
+    assert edit_bodies[0].get("slowmode") == 15
+    assert state.native_fidelity_counts == {"slowmode": 1}
+
+
 async def test_run_channels_applies_channel_permission_overrides(tmp_path: Path) -> None:
     """CHANNELS phase applies role permission overrides via PUT after channel creation."""
     events: list[MigrationEvent] = []

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
 
@@ -15,6 +16,7 @@ from discord_ferry.discord.metadata import (
     RoleOverride,
     save_discord_metadata,
 )
+from discord_ferry.errors import AutumnUploadError
 from discord_ferry.migrator.structure import (
     FERRY_MIN_PERMISSIONS,
     make_unique_channel_name,
@@ -428,6 +430,156 @@ async def test_run_roles_hoist_skipped_without_metadata(tmp_path: Path) -> None:
         await run_roles(config, state, exports, events.append)
 
     assert any(w.get("type") == "hoist_skipped" for w in state.warnings)
+
+
+async def test_run_roles_image_icon_uploaded_and_folded(tmp_path: Path) -> None:
+    """ROLES downloads an image role icon, uploads to Autumn, folds icon into edit."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="VIP")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"PNGDATA"),
+        ),
+        patch(
+            "discord_ferry.migrator.structure.upload_to_autumn",
+            new=AsyncMock(return_value="autumn-id"),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "VIP"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert any(body.get("icon") == "autumn-id" for body in patch_bodies)
+    assert state.native_fidelity_counts.get("role_icons") == 1
+
+
+async def test_run_roles_emoji_icon_skipped_with_warning(tmp_path: Path) -> None:
+    """ROLES skips an emoji-only role icon with a warning and no icon kwarg."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Fire")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=False, position=0, unicode_emoji="🔥")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"PNGDATA"),
+        ) as mock_download,
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Fire"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert any(w.get("type") == "role_icon_skipped" for w in state.warnings)
+    assert all("icon" not in body for body in patch_bodies)
+    mock_download.assert_not_called()
+
+
+async def test_run_roles_icon_upload_error_is_token_safe(tmp_path: Path) -> None:
+    """A failed icon upload never leaks the HTTP body and preserves hoist/rank."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="VIP", position=3)
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    patch_bodies: list[dict[str, object]] = []
+    upload_error = AutumnUploadError("Upload failed with status 500: x-session-token=SECRET")
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"PNGDATA"),
+        ),
+        patch(
+            "discord_ferry.migrator.structure.upload_to_autumn",
+            new=AsyncMock(side_effect=upload_error),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "VIP"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    for w in state.warnings:
+        msg = str(w.get("message", ""))
+        assert "SECRET" not in msg
+        assert "x-session-token" not in msg
+    # The role still receives hoist despite the failed icon; no icon kwarg leaks.
+    assert any(body.get("hoist") is True for body in patch_bodies)
+    assert all("icon" not in body for body in patch_bodies)
 
 
 async def test_run_roles_truncates_long_name(tmp_path: Path) -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -432,6 +432,53 @@ async def test_run_roles_hoist_skipped_without_metadata(tmp_path: Path) -> None:
     assert any(w.get("type") == "hoist_skipped" for w in state.warnings)
 
 
+async def test_batch2_fields_skip_without_metadata(tmp_path: Path) -> None:
+    """S5 graceful-degrade: channels + roles emit batch-2 skip warnings without metadata.
+
+    With no discord_metadata.json present, run_channels and run_roles must complete
+    (populating channel_map/role_map) and emit one-time skip warnings for the batch-2
+    fields: slowmode_skipped, user_limit_skipped (channels) and role_icon_skipped (roles).
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [
+        _make_export(
+            channel_id="ch1",
+            channel_name="general",
+            category_id="",
+            messages=[_make_message("m1", roles=[role])],
+        )
+    ]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch1", "name": "general"},
+        )
+
+        await run_roles(config, state, exports, events.append)
+        await run_channels(config, state, exports, events.append)
+
+    # Migration completed: maps populated.
+    assert state.role_map.get("r1") == "stoat-r1"
+    assert state.channel_map.get("ch1") == "stoat-ch1"
+
+    warning_types = [w.get("type") for w in state.warnings]
+    assert "role_icon_skipped" in warning_types
+    assert "slowmode_skipped" in warning_types
+    assert "user_limit_skipped" in warning_types
+    # v2.3.0 hoist_skipped still fires alongside the new role_icon_skipped.
+    assert "hoist_skipped" in warning_types
+    # One-time warnings, not per-item.
+    assert warning_types.count("slowmode_skipped") == 1
+    assert warning_types.count("user_limit_skipped") == 1
+    assert warning_types.count("role_icon_skipped") == 1
+
+
 async def test_run_roles_image_icon_uploaded_and_folded(tmp_path: Path) -> None:
     """ROLES downloads an image role icon, uploads to Autumn, folds icon into edit."""
     events: list[MigrationEvent] = []

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.4.2"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Successor to the v2.3.0 native-fidelity batch (#62). Migrates three more native Discord properties into Stoat when a \`discord_token\` is supplied — all source-verified against \`stoatchat/stoatchat\` @ a15a542:

- **Per-channel slowmode** (S1) — Discord \`rate_limit_per_user\` → \`TextChannel.slowmode\` via a new \`api_edit_channel\` PATCH (flat field, clamped \`0..=21600\`).
- **Voice channel user-limit** (S2) — Discord \`user_limit\` → \`voice={"max_users": N}\` (nested); \`0\`/unlimited → omitted (never sends \`0\`). Gated by \`created_as_voice\` so it never PATCHes a Bug #194 Text-fallback channel.
- **Image role icons** (S3) — Discord CDN → Autumn \`icons\` upload → \`DataEditRole.icon\`; emoji-only icons skipped with a warning.
- **Reporter credit + CLI/GUI surfacing** (S4) — \`native_fidelity_counts\` in state (serialized), \`report["native_fidelity"]\`, \`## Native Fidelity\` markdown, CLI line, GUI label.
- **Graceful degradation** (S5) — without a token, all three skip with distinct one-time warnings; migration completes, v2.3.0 fields unaffected.

## Security
Role-icon Autumn failures are caught as \`AutumnUploadError\` and reported with a fixed role-name-only message — never \`str(exc)\`, whose body can echo the session token (per \`security.md\`). No new warning interpolates a token-bearing string.

## Quality gates
- **988 tests pass** (970 baseline + 18 new); ruff + ruff format + mypy strict all clean.
- Built via the full \`/df-\` pipeline: brief → spec → brainstorm → critique (R1 ITERATE → R2 PASS) → plan → subagent-driven build.
- Per-task spec+quality reviews (all Approved) + a whole-branch Opus review = **READY TO MERGE** (no Critical/Important).
- Mistral second opinion (security focus): **0 Critical**; all five invariants (token-safety, Bug #194 gate, graceful-degrade, engine/shell separation, rate-limit routing) upheld.
- v2.3.0 fields (hoist, server desc/NSFW, category order) regression-checked; \`uv.lock\` re-synced + \`--locked\` verified.

## Non-buildables (filed as backlog)
This batch deliberately excludes \`mentionable\` (impossible on Stoat) and unicode-emoji role icons (image-only). Other gap-analysis items are tracked as #65–#68 (\`blocked:stoat-limitation\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)