### PR TITLE
fix: incremental-mode delta — reuse server + structure, no duplication (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.5.1] - 2026-06-24
+
+### Fixed
+
+- **Incremental (`--incremental`) migration now reuses the prior server and structure instead of duplicating everything.** Fixes the dominant cluster from the 2026-06-23 codebase bug hunt: the structure phases had no idempotency guard, so every delta re-run re-created all roles/categories/channels and `run_server` minted a brand-new server (stranding the carried ID maps).
+  - **Server reuse** (`migrator/structure.py`): `run_server` reuses the carried `state.stoat_server_id` (not only `--server-id`); a deleted prior server raises a clear `MigrationError` instead of silently creating a new server.
+  - **Structure-phase idempotency** (`run_roles`/`run_categories`/`run_channels`): a capture-before-mutate `pre_existing_*_ids` snapshot skips already-migrated roles (across the create, attributes, and permissions passes), reuses carried category/channel IDs, preserves category membership (no orphaning), reuses forum-index channels, and excludes carried channels from the `--max-channels` truncation budget.
+  - **Exact category membership** (`state.py`, `core/engine.py`): a persisted `channel_categories` map reconstructs carried-only categories exactly on a partial re-export (no cross-contamination).
+  - **Carry-over completeness** (`core/engine.py`): the incremental carry-over now also carries `forum_channel_members`, `forum_category_names`, `forum_index_message_ids`, `channel_message_counts`, `category_names`, `channel_categories`, and `native_fidelity_counts`, with a field-by-field audit comment. `_rebuild_forum_indexes` PATCHes the existing pinned index with cumulative counts instead of posting duplicates.
+  - Locked by `tests/test_incremental_structure.py` (real-phase two-run tests). The prior `tests/test_delta_migration.py` mocked the structure phases, which is why this shipped undetected.
+
 ## [2.5.0] - 2026-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.5.0"
+version = "2.5.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -195,13 +195,15 @@ async def run_migration(
             state.channel_message_counts = dict(prior.channel_message_counts)
             state.category_names = dict(prior.category_names)
             state.channel_categories = dict(prior.channel_categories)
+            state.native_fidelity_counts = dict(prior.native_fidelity_counts)
             # Carry-over audit (every MigrationState field classified):
             #   CARRY: role_map / channel_map / category_map / emoji_map,
             #     category_names, channel_categories, message_map, avatar_cache,
             #     upload_cache, author_names, stoat_server_id, autumn_url,
             #     invite_code / invite_url, channel_message_offsets,
             #     channel_message_counts, forum_channel_members /
-            #     forum_category_names / forum_index_message_ids, and the
+            #     forum_category_names / forum_index_message_ids,
+            #     native_fidelity_counts (cumulative fidelity counter), and the
             #     cumulative counters (attachments_uploaded/skipped,
             #     reactions_applied, pins_applied). prior_messages_total is DERIVED
             #     here from len(prior.message_map).

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -183,6 +183,37 @@ async def run_migration(
             # CLEAR completed_channel_ids so every channel is re-entered (new messages may exist).
             state.channel_message_offsets = dict(prior.channel_message_offsets)
             state.completed_channel_ids = set()
+            # S3 + I2: carry forum index + per-channel counts so REPORT's
+            # _rebuild_forum_indexes PATCHes (not re-posts) with cumulative counts,
+            # and channel_categories so the CHANNELS upsert re-attaches carried
+            # channels to the correct category on a partial re-export.
+            state.forum_channel_members = {
+                k: list(v) for k, v in prior.forum_channel_members.items()
+            }
+            state.forum_category_names = dict(prior.forum_category_names)
+            state.forum_index_message_ids = dict(prior.forum_index_message_ids)
+            state.channel_message_counts = dict(prior.channel_message_counts)
+            state.category_names = dict(prior.category_names)
+            state.channel_categories = dict(prior.channel_categories)
+            # Carry-over audit (every MigrationState field classified):
+            #   CARRY: role_map / channel_map / category_map / emoji_map,
+            #     category_names, channel_categories, message_map, avatar_cache,
+            #     upload_cache, author_names, stoat_server_id, autumn_url,
+            #     invite_code / invite_url, channel_message_offsets,
+            #     channel_message_counts, forum_channel_members /
+            #     forum_category_names / forum_index_message_ids, and the
+            #     cumulative counters (attachments_uploaded/skipped,
+            #     reactions_applied, pins_applied). prior_messages_total is DERIVED
+            #     here from len(prior.message_map).
+            #   RESET each run: completed_channel_ids (re-enter every channel for
+            #     new msgs); pending_pins / pending_reactions (consumed by REPORT —
+            #     carrying a stale list would re-pin/re-react); failed_messages,
+            #     warnings / errors, validation_results, embeds_* / replies_*
+            #     (per-run fidelity counters); current_phase, started_at,
+            #     completed_at, export_completed, rollback_progress, is_dry_run.
+            #   DECISION: autumn_uploads / referenced_autumn_ids stay reset —
+            #     orphan-sweep is per-run; carrying matters only if a cross-run
+            #     sweep is added (none today).
             on_event(
                 MigrationEvent(
                     phase="validate",

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -592,6 +592,10 @@ async def run_categories(
             seen_cat_ids.add(cat_id)
             unique_categories.append((cat_id, cat_name))
 
+    # Snapshot already-mapped categories BEFORE mutation so incremental re-runs
+    # reuse carried Stoat IDs and can detect whether anything is genuinely new.
+    pre_existing_category_ids = set(state.category_map)
+
     if config.dry_run:
         for discord_cat_id, _cat_name in unique_categories:
             state.category_map[discord_cat_id] = f"dry-cat-{discord_cat_id}"
@@ -607,8 +611,9 @@ async def run_categories(
     async with get_session(config) as session:
         stoat_categories: list[dict[str, Any]] = []
         for idx, (discord_cat_id, cat_name) in enumerate(unique_categories, start=1):
-            stoat_cat_id = _generate_category_id()
+            stoat_cat_id = state.category_map.get(discord_cat_id) or _generate_category_id()
             state.category_map[discord_cat_id] = stoat_cat_id
+            state.category_names[discord_cat_id] = cat_name
             stoat_categories.append(
                 {
                     "id": stoat_cat_id,
@@ -627,7 +632,11 @@ async def run_categories(
                 )
             )
 
-        if stoat_categories:
+        # Suppress this transient upsert when no category is genuinely new: it
+        # would set empty channels arrays and orphan carried channels until the
+        # CHANNELS phase re-PATCHes. run_channels owns the authoritative upsert.
+        any_new_category = any(cid not in pre_existing_category_ids for cid, _ in unique_categories)
+        if stoat_categories and any_new_category:
             await api_upsert_categories(
                 session,
                 config.stoat_url,
@@ -663,6 +672,11 @@ async def run_channels(
         MigrationError: If any API call fails unrecoverably.
     """
     discord_metadata = load_discord_metadata(config.output_dir)
+
+    # Snapshot already-mapped channels BEFORE the dedup scan so incremental
+    # re-runs reuse carried Stoat IDs (no re-create) and the truncation budget
+    # can exclude carried channels.
+    pre_existing_channel_ids = set(state.channel_map)
 
     # Deduplicate exports by channel ID and skip category channels (type 4).
     seen_channel_ids: set[str] = set()
@@ -721,29 +735,35 @@ async def run_channels(
 
     # Reserve channel slots for forum index channels (one per forum category).
     index_channel_slots = len(forum_categories) if forum_categories else 0
-    effective_max = config.max_channels - index_channel_slots
 
-    if len(channels_to_create) > effective_max:
-        overflow = len(channels_to_create) - effective_max
+    # Incremental: carried channels (already in channel_map) are never re-created
+    # and never dropped. Only NEW channels are subject to the truncation budget.
+    carried_candidates = [t for t in channels_to_create if t[0].id in pre_existing_channel_ids]
+    new_candidates = [t for t in channels_to_create if t[0].id not in pre_existing_channel_ids]
+    new_budget = max(0, config.max_channels - index_channel_slots - len(carried_candidates))
+
+    if len(new_candidates) > new_budget:
+        overflow = len(new_candidates) - new_budget
         # Sort: main channels first (False < True), then threads by message_count
         # descending so higher-traffic threads survive truncation.
         export_by_ch = {exp.channel.id: exp for exp in exports}
-        channels_to_create.sort(
+        new_candidates.sort(
             key=lambda t: (
                 t[4],  # is_thread: False (main) before True (thread)
                 -(export_by_ch[t[0].id].message_count if t[0].id in export_by_ch else 0),
             )
         )
-        dropped = channels_to_create[effective_max:]
-        channels_to_create = channels_to_create[:effective_max]
+        dropped = new_candidates[new_budget:]
+        new_candidates = new_candidates[:new_budget]
         dropped_names = [entry[2] for entry in dropped]
         on_event(
             MigrationEvent(
                 phase="channels",
                 status="warning",
                 message=(
-                    f"Total channels ({effective_max + overflow}) exceeds Stoat limit "
-                    f"of {config.max_channels}. Dropped {overflow} channel(s): "
+                    f"Total channels ({len(carried_candidates) + new_budget + overflow}) "
+                    f"exceeds Stoat limit of {config.max_channels}. "
+                    f"Dropped {overflow} channel(s): "
                     f"{', '.join(dropped_names[:10])}"
                     f"{'...' if len(dropped_names) > 10 else ''}"
                 ),
@@ -760,11 +780,16 @@ async def run_channels(
             }
         )
 
+    channels_to_create = carried_candidates + new_candidates
+
     # Create forum-derived categories (before dry_run check so they get mapped).
     if forum_categories and not config.dry_run:
         for forum_key, forum_name in forum_categories.items():
-            stoat_forum_id = _generate_category_id()
+            # Incremental: reuse the carried Stoat category id (no new id) so the
+            # forum category and its channels are not orphaned on re-run.
+            stoat_forum_id = state.category_map.get(forum_key) or _generate_category_id()
             state.category_map[forum_key] = stoat_forum_id
+            state.category_names[forum_key] = forum_name
             state.forum_category_names[forum_key] = forum_name  # S15: track for REPORT rebuild
             on_event(
                 MigrationEvent(
@@ -808,54 +833,104 @@ async def run_channels(
             nsfw = ch_meta.nsfw if ch_meta else False
 
             stoat_channel_id: str
-            try:
-                result = await api_create_channel(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    state.stoat_server_id,
-                    name=unique_name,
-                    channel_type=stoat_type,
-                    description=description,
-                    nsfw=nsfw,
-                )
-                stoat_channel_id = result["_id"]
-            except MigrationError as exc:
-                if stoat_type == "Voice":
-                    # Voice channels may fail (Bug #194) — retry as text.
-                    state.warnings.append(
-                        {
-                            "phase": "channels",
-                            "type": "voice_channel_bug",
-                            "message": (
-                                f"Voice channel '{unique_name}' failed, retrying as text: {exc}"
-                            ),
-                        }
-                    )
-                    on_event(
-                        MigrationEvent(
-                            phase="channels",
-                            status="warning",
-                            message=f"Voice channel '{unique_name}' failed, retrying as text",
-                        )
-                    )
+            if ch.id in pre_existing_channel_ids:
+                # Incremental: reuse the carried Stoat channel id — no create, no
+                # permission overrides (already applied on the original run).
+                stoat_channel_id = state.channel_map[ch.id]
+            else:
+                try:
                     result = await api_create_channel(
                         session,
                         config.stoat_url,
                         config.token,
                         state.stoat_server_id,
                         name=unique_name,
-                        channel_type="Text",
+                        channel_type=stoat_type,
                         description=description,
                         nsfw=nsfw,
                     )
                     stoat_channel_id = result["_id"]
-                else:
-                    raise
+                except MigrationError as exc:
+                    if stoat_type == "Voice":
+                        # Voice channels may fail (Bug #194) — retry as text.
+                        state.warnings.append(
+                            {
+                                "phase": "channels",
+                                "type": "voice_channel_bug",
+                                "message": (
+                                    f"Voice channel '{unique_name}' failed, retrying as text: {exc}"
+                                ),
+                            }
+                        )
+                        on_event(
+                            MigrationEvent(
+                                phase="channels",
+                                status="warning",
+                                message=f"Voice channel '{unique_name}' failed, retrying as text",
+                            )
+                        )
+                        result = await api_create_channel(
+                            session,
+                            config.stoat_url,
+                            config.token,
+                            state.stoat_server_id,
+                            name=unique_name,
+                            channel_type="Text",
+                            description=description,
+                            nsfw=nsfw,
+                        )
+                        stoat_channel_id = result["_id"]
+                    else:
+                        raise
 
-            state.channel_map[ch.id] = stoat_channel_id
+                state.channel_map[ch.id] = stoat_channel_id
 
-            # Track forum post info for index channel generation.
+                # Apply channel permission overrides from Discord metadata.
+                if ch_meta and not config.dry_run:
+                    if ch_meta.default_override:
+                        try:
+                            await api_set_channel_default_permissions(
+                                session,
+                                config.stoat_url,
+                                config.token,
+                                stoat_channel_id,
+                                allow=ch_meta.default_override.allow,
+                                deny=ch_meta.default_override.deny,
+                            )
+                            await asyncio.sleep(config.upload_delay)
+                        except Exception as exc:  # noqa: BLE001
+                            state.warnings.append(
+                                {
+                                    "phase": "channels",
+                                    "type": "channel_default_perm_failed",
+                                    "message": f"Default override for '{unique_name}': {exc}",
+                                }
+                            )
+                    for ow in ch_meta.role_overrides:
+                        stoat_role_id = state.role_map.get(ow.discord_role_id)
+                        if stoat_role_id:
+                            try:
+                                await api_set_channel_role_permissions(
+                                    session,
+                                    config.stoat_url,
+                                    config.token,
+                                    stoat_channel_id,
+                                    stoat_role_id,
+                                    allow=ow.allow,
+                                    deny=ow.deny,
+                                )
+                                await asyncio.sleep(config.upload_delay)
+                            except Exception as exc:  # noqa: BLE001
+                                state.warnings.append(
+                                    {
+                                        "phase": "channels",
+                                        "type": "channel_role_perm_failed",
+                                        "message": f"Role override for '{unique_name}': {exc}",
+                                    }
+                                )
+
+            # Forum tracking + category membership run for BOTH carried and new
+            # channels so the authoritative upsert never orphans a carried channel.
             if discord_cat_id.startswith("forum-"):
                 exp = export_by_channel.get(ch.id)
                 msg_count = exp.message_count if exp else 0
@@ -863,51 +938,9 @@ async def run_channels(
                     (stoat_channel_id, unique_name, msg_count)
                 )
                 # S15: Track discord channel membership for REPORT phase rebuild.
-                state.forum_channel_members.setdefault(discord_cat_id, []).append(ch.id)
-
-            # Apply channel permission overrides from Discord metadata.
-            if ch_meta and not config.dry_run:
-                if ch_meta.default_override:
-                    try:
-                        await api_set_channel_default_permissions(
-                            session,
-                            config.stoat_url,
-                            config.token,
-                            stoat_channel_id,
-                            allow=ch_meta.default_override.allow,
-                            deny=ch_meta.default_override.deny,
-                        )
-                        await asyncio.sleep(config.upload_delay)
-                    except Exception as exc:  # noqa: BLE001
-                        state.warnings.append(
-                            {
-                                "phase": "channels",
-                                "type": "channel_default_perm_failed",
-                                "message": f"Default override for '{unique_name}': {exc}",
-                            }
-                        )
-                for ow in ch_meta.role_overrides:
-                    stoat_role_id = state.role_map.get(ow.discord_role_id)
-                    if stoat_role_id:
-                        try:
-                            await api_set_channel_role_permissions(
-                                session,
-                                config.stoat_url,
-                                config.token,
-                                stoat_channel_id,
-                                stoat_role_id,
-                                allow=ow.allow,
-                                deny=ow.deny,
-                            )
-                            await asyncio.sleep(config.upload_delay)
-                        except Exception as exc:  # noqa: BLE001
-                            state.warnings.append(
-                                {
-                                    "phase": "channels",
-                                    "type": "channel_role_perm_failed",
-                                    "message": f"Role override for '{unique_name}': {exc}",
-                                }
-                            )
+                # Guard against double-append on incremental re-runs.
+                if ch.id not in state.forum_channel_members.get(discord_cat_id, []):
+                    state.forum_channel_members.setdefault(discord_cat_id, []).append(ch.id)
 
             # Track which Stoat category this channel belongs to.
             if discord_cat_id and discord_cat_id in state.category_map:
@@ -928,6 +961,15 @@ async def run_channels(
         for forum_key, forum_name in forum_categories.items():
             forum_cat_stoat_id = state.category_map.get(forum_key)
             if not forum_cat_stoat_id:
+                continue
+
+            # Incremental: a carried forum-index channel is reused verbatim — no
+            # create, no index message, no pin. Re-attach it at position 0.
+            index_key = f"forum-index-{forum_key}"
+            if index_key in pre_existing_channel_ids:
+                category_channels.setdefault(forum_cat_stoat_id, []).insert(
+                    0, state.channel_map[index_key]
+                )
                 continue
             try:
                 index_name = make_unique_channel_name(f"{forum_name}-index", existing_names)
@@ -1008,9 +1050,10 @@ async def run_channels(
                 )
 
         # Assign channels to categories via a single PATCH.
-        # This replaces the categories array set by run_categories(). Safe because
-        # cat_titles is built from state.category_map (all categories) and every
-        # category has at least one channel (DCE only exports non-empty categories).
+        # This replaces the categories array set by run_categories(). The upsert is
+        # full-replace, so it must enumerate EVERY category in state.category_map
+        # (carried + new) — a carried-only category absent from this run's (partial)
+        # export would otherwise be dropped and its channels orphaned (I-NEW-2).
         if category_channels:
             cat_titles: dict[str, str] = {}
             for export in exports:
@@ -1022,6 +1065,37 @@ async def run_channels(
                 stoat_forum_cat_id = state.category_map.get(forum_key)
                 if stoat_forum_cat_id:
                     cat_titles[stoat_forum_cat_id] = truncate_name(forum_name)
+
+            # Backfill titles for every carried category not seen in this export,
+            # sourced from state.category_names (I-NEW-2). Without this a carried-only
+            # category would have no title in the full-replace payload.
+            for discord_cat_id, stoat_cat_id in state.category_map.items():
+                if stoat_cat_id not in cat_titles:
+                    cat_titles[stoat_cat_id] = truncate_name(
+                        state.category_names.get(discord_cat_id, "Category")
+                    )
+
+            # Re-attach carried channels that this run did not place into any
+            # category (their category is absent from a partial re-export). They are
+            # distributed to carried-only categories (those with no channels recorded
+            # this run) so the full-replace upsert does not orphan them. Membership is
+            # not persisted, so with multiple carried-only categories the partition is
+            # best-effort; in the common case (DCE re-exports full structure, or a
+            # single carried-only category) it is exact.
+            placed_channel_ids = {cid for ids in category_channels.values() for cid in ids}
+            unplaced_carried = [
+                stoat_ch_id
+                for ch_id, stoat_ch_id in state.channel_map.items()
+                if not ch_id.startswith("forum-index-") and stoat_ch_id not in placed_channel_ids
+            ]
+            if unplaced_carried:
+                carried_only_cats = [
+                    state.category_map[discord_cat_id]
+                    for discord_cat_id in state.category_map
+                    if state.category_map[discord_cat_id] not in category_channels
+                ]
+                for stoat_cat_id in carried_only_cats:
+                    category_channels.setdefault(stoat_cat_id, []).extend(unplaced_carried)
 
             # Build the full categories array.
             all_categories: list[dict[str, Any]] = []

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -128,15 +128,25 @@ async def run_server(
         return
 
     async with get_session(config) as session:
-        if config.server_id:
-            # Use an existing server — verify it exists.
-            await api_fetch_server(session, config.stoat_url, config.token, config.server_id)
-            state.stoat_server_id = config.server_id
+        # Reuse an explicit --server-id OR a server_id carried from a prior
+        # incremental run (FerryConfig is frozen, so reuse is resolved here).
+        effective_server_id = config.server_id or state.stoat_server_id
+        if effective_server_id:
+            # Verify it still exists. api_fetch_server raises MigrationError on 404.
+            try:
+                await api_fetch_server(session, config.stoat_url, config.token, effective_server_id)
+            except MigrationError as exc:
+                raise MigrationError(
+                    f"Prior Stoat server '{effective_server_id}' was not found "
+                    f"({exc}). It may have been deleted — start a fresh migration "
+                    f"(omit --incremental)."
+                ) from exc
+            state.stoat_server_id = effective_server_id
             on_event(
                 MigrationEvent(
                     phase="server",
                     status="progress",
-                    message=f"Using existing server {config.server_id}",
+                    message=f"Using existing server {effective_server_id}",
                 )
             )
         else:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -942,6 +942,13 @@ async def run_channels(
                 if ch.id not in state.forum_channel_members.get(discord_cat_id, []):
                     state.forum_channel_members.setdefault(discord_cat_id, []).append(ch.id)
 
+            # Persist the effective Discord category for this channel (the forum
+            # key for forum channels). Runs for BOTH carried and new channels so a
+            # future incremental re-run can re-attach carried channels to the
+            # CORRECT category — exact even with multiple carried-only categories.
+            if discord_cat_id:
+                state.channel_categories[ch.id] = discord_cat_id
+
             # Track which Stoat category this channel belongs to.
             if discord_cat_id and discord_cat_id in state.category_map:
                 stoat_cat_id = state.category_map[discord_cat_id]
@@ -1076,26 +1083,17 @@ async def run_channels(
                     )
 
             # Re-attach carried channels that this run did not place into any
-            # category (their category is absent from a partial re-export). They are
-            # distributed to carried-only categories (those with no channels recorded
-            # this run) so the full-replace upsert does not orphan them. Membership is
-            # not persisted, so with multiple carried-only categories the partition is
-            # best-effort; in the common case (DCE re-exports full structure, or a
-            # single carried-only category) it is exact.
-            placed_channel_ids = {cid for ids in category_channels.values() for cid in ids}
-            unplaced_carried = [
-                stoat_ch_id
-                for ch_id, stoat_ch_id in state.channel_map.items()
-                if not ch_id.startswith("forum-index-") and stoat_ch_id not in placed_channel_ids
-            ]
-            if unplaced_carried:
-                carried_only_cats = [
-                    state.category_map[discord_cat_id]
-                    for discord_cat_id in state.category_map
-                    if state.category_map[discord_cat_id] not in category_channels
-                ]
-                for stoat_cat_id in carried_only_cats:
-                    category_channels.setdefault(stoat_cat_id, []).extend(unplaced_carried)
+            # category (their category is absent from a partial re-export) so the
+            # full-replace upsert does not orphan them. Seed EXACTLY from the
+            # persisted channel->category map: each carried channel goes back under
+            # its own recorded category, which is correct for ANY number of
+            # simultaneously carried-only categories (no cross-contamination). The
+            # ``not in`` guard dedups against channels already placed this run.
+            for discord_ch_id, discord_cat_id in state.channel_categories.items():
+                stoat_cat = state.category_map.get(discord_cat_id)
+                stoat_ch = state.channel_map.get(discord_ch_id)
+                if stoat_cat and stoat_ch and stoat_ch not in category_channels.get(stoat_cat, []):
+                    category_channels.setdefault(stoat_cat, []).append(stoat_ch)
 
             # Build the full categories array.
             all_categories: list[dict[str, Any]] = []

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -388,6 +388,10 @@ async def run_roles(
     # Filter out the @everyone role.
     roles_to_create = [r for r in unique_roles if r.id != guild_id]
 
+    # Incremental: capture which roles already exist BEFORE the creation loop
+    # populates role_map, so the create/attributes/perms passes can skip them.
+    pre_existing_role_ids = set(state.role_map)
+
     if config.dry_run:
         for role in roles_to_create:
             state.role_map[role.id] = f"dry-role-{role.id}"
@@ -402,6 +406,8 @@ async def run_roles(
 
     async with get_session(config) as session:
         for idx, role in enumerate(roles_to_create, start=1):
+            if role.id in pre_existing_role_ids:
+                continue
             result = await api_create_role(
                 session,
                 config.stoat_url,
@@ -451,6 +457,8 @@ async def run_roles(
     ranked_roles = sorted(roles_to_create, key=lambda r: r.position)
     async with get_session(config) as session:
         for role in ranked_roles:
+            if role.id in pre_existing_role_ids:
+                continue
             rank_role_id = state.role_map.get(role.id)
             if not rank_role_id:
                 continue
@@ -499,6 +507,8 @@ async def run_roles(
     if discord_metadata and not config.dry_run:
         async with get_session(config) as session:
             for role in roles_to_create:
+                if role.id in pre_existing_role_ids:
+                    continue
                 stoat_role_id_or_none = state.role_map.get(role.id)
                 if not stoat_role_id_or_none:
                     continue

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -59,6 +59,7 @@ class MigrationState:
     role_map: dict[str, str] = field(default_factory=dict)
     channel_map: dict[str, str] = field(default_factory=dict)
     category_map: dict[str, str] = field(default_factory=dict)
+    category_names: dict[str, str] = field(default_factory=dict)  # discord_cat_id -> title
     message_map: dict[str, str] = field(default_factory=dict)
     emoji_map: dict[str, str] = field(default_factory=dict)
 
@@ -226,6 +227,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "role_map": state.role_map,
         "channel_map": state.channel_map,
         "category_map": state.category_map,
+        "category_names": state.category_names,
         "message_map": state.message_map,
         "emoji_map": state.emoji_map,
         "avatar_cache": state.avatar_cache,
@@ -291,6 +293,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             role_map=data.get("role_map", {}),
             channel_map=data.get("channel_map", {}),
             category_map=data.get("category_map", {}),
+            category_names=data.get("category_names", {}),
             message_map=data.get("message_map", {}),
             emoji_map=data.get("emoji_map", {}),
             avatar_cache=data.get("avatar_cache", {}),

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -60,6 +60,11 @@ class MigrationState:
     channel_map: dict[str, str] = field(default_factory=dict)
     category_map: dict[str, str] = field(default_factory=dict)
     category_names: dict[str, str] = field(default_factory=dict)  # discord_cat_id -> title
+    # discord_ch_id -> effective discord_cat_id (the forum key for forum channels).
+    # Persisted so incremental re-runs can re-attach carried channels to the
+    # CORRECT category in the full-replace upsert, even with multiple
+    # simultaneously carried-only categories (exact, not best-effort).
+    channel_categories: dict[str, str] = field(default_factory=dict)
     message_map: dict[str, str] = field(default_factory=dict)
     emoji_map: dict[str, str] = field(default_factory=dict)
 
@@ -228,6 +233,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "channel_map": state.channel_map,
         "category_map": state.category_map,
         "category_names": state.category_names,
+        "channel_categories": state.channel_categories,
         "message_map": state.message_map,
         "emoji_map": state.emoji_map,
         "avatar_cache": state.avatar_cache,
@@ -294,6 +300,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             channel_map=data.get("channel_map", {}),
             category_map=data.get("category_map", {}),
             category_names=data.get("category_names", {}),
+            channel_categories=data.get("channel_categories", {}),
             message_map=data.get("message_map", {}),
             emoji_map=data.get("emoji_map", {}),
             avatar_cache=data.get("avatar_cache", {}),

--- a/tests/test_delta_migration.py
+++ b/tests/test_delta_migration.py
@@ -217,6 +217,7 @@ async def test_incremental_carries_forum_state_and_counts(tmp_path: Path) -> Non
         forum_index_message_ids={forum_key: "idx-msg-1"},
         channel_message_counts={"fp1": 800},
         channel_categories={"fp1": forum_key, "ch1": "cat1"},
+        native_fidelity_counts={"slowmode": 2, "user_limit": 1},
     )
     # Non-empty message_map so prior_messages_total is meaningful.
     prior.message_map["old-1"] = "stoat-old-1"
@@ -232,6 +233,8 @@ async def test_incremental_carries_forum_state_and_counts(tmp_path: Path) -> Non
     assert state.channel_message_counts == {"fp1": 800}
     assert state.category_names == {forum_key: "my-forum", "cat1": "General"}
     assert state.channel_categories == {"fp1": forum_key, "ch1": "cat1"}
+    # native_fidelity_counts carried cumulatively so the report reflects all runs.
+    assert state.native_fidelity_counts == {"slowmode": 2, "user_limit": 1}
     # Carried lists are copies, not aliases of the prior structures.
     assert state.forum_channel_members[forum_key] is not prior.forum_channel_members[forum_key]
 

--- a/tests/test_delta_migration.py
+++ b/tests/test_delta_migration.py
@@ -197,6 +197,45 @@ async def test_incremental_new_channel_full_migration(tmp_path: Path) -> None:
     assert "300" in processed_ids
 
 
+async def test_incremental_carries_forum_state_and_counts(tmp_path: Path) -> None:
+    """SC-8: incremental carry-over copies forum fields + counts + category maps.
+
+    Regression: on main only the ID maps are carried, so forum_channel_members,
+    forum_category_names, forum_index_message_ids, channel_message_counts,
+    category_names, and channel_categories are silently reset to empty — which
+    makes the forum-index rebuild re-POST (instead of PATCH) and report delta
+    (instead of cumulative) counts on the 2nd run.
+    """
+    forum_key = "forum-my-forum"
+    prior = _make_prior_state(
+        tmp_path,
+        channel_map={"fp1": "stoat-fp1", f"forum-index-{forum_key}": "stoat-idx1"},
+        category_map={forum_key: "stoat-forumcat", "cat1": "stoat-cat1"},
+        category_names={forum_key: "my-forum", "cat1": "General"},
+        forum_channel_members={forum_key: ["fp1"]},
+        forum_category_names={forum_key: "my-forum"},
+        forum_index_message_ids={forum_key: "idx-msg-1"},
+        channel_message_counts={"fp1": 800},
+        channel_categories={"fp1": forum_key, "ch1": "cat1"},
+    )
+    # Non-empty message_map so prior_messages_total is meaningful.
+    prior.message_map["old-1"] = "stoat-old-1"
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+
+    # All forum-rebuild + membership fields carried verbatim from the prior run.
+    assert state.forum_channel_members == {forum_key: ["fp1"]}
+    assert state.forum_category_names == {forum_key: "my-forum"}
+    assert state.forum_index_message_ids == {forum_key: "idx-msg-1"}
+    assert state.channel_message_counts == {"fp1": 800}
+    assert state.category_names == {forum_key: "my-forum", "cat1": "General"}
+    assert state.channel_categories == {"fp1": forum_key, "ch1": "cat1"}
+    # Carried lists are copies, not aliases of the prior structures.
+    assert state.forum_channel_members[forum_key] is not prior.forum_channel_members[forum_key]
+
+
 async def test_incremental_delta_stats_in_report(tmp_path: Path) -> None:
     """Report includes delta stats: this_run, cumulative, prior_run_total."""
     from discord_ferry.reporter import generate_report

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -1,0 +1,120 @@
+"""Tests for incremental-mode structure phase behaviour (SC-11, SC-12)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from aioresponses import aioresponses
+
+from discord_ferry.config import FerryConfig
+from discord_ferry.errors import MigrationError
+from discord_ferry.migrator.structure import run_server
+from discord_ferry.parser.models import (
+    DCEAuthor,
+    DCEChannel,
+    DCEExport,
+    DCEGuild,
+    DCEMessage,
+    DCERole,
+)
+from discord_ferry.state import MigrationState
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from discord_ferry.core.events import MigrationEvent
+
+STOAT_URL = "https://api.test"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/test_structure.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path: Path, **overrides: object) -> FerryConfig:
+    defaults: dict[str, object] = {
+        "export_dir": tmp_path,
+        "stoat_url": STOAT_URL,
+        "token": "tok",
+        "output_dir": tmp_path,
+    }
+    defaults.update(overrides)
+    return FerryConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _make_export(
+    guild_id: str = "111",
+    guild_name: str = "Test",
+    guild_icon_url: str = "",
+    channel_id: str = "222",
+    channel_name: str = "general",
+    channel_type: int = 0,
+    category_id: str = "cat1",
+    category: str = "General",
+    is_thread: bool = False,
+    parent_channel_name: str = "",
+    messages: list[DCEMessage] | None = None,
+    message_count: int = 0,
+) -> DCEExport:
+    guild = DCEGuild(id=guild_id, name=guild_name, icon_url=guild_icon_url)
+    channel = DCEChannel(
+        id=channel_id,
+        type=channel_type,
+        name=channel_name,
+        category_id=category_id,
+        category=category,
+    )
+    return DCEExport(
+        guild=guild,
+        channel=channel,
+        messages=messages or [],
+        message_count=message_count,
+        is_thread=is_thread,
+        parent_channel_name=parent_channel_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SC-12: Server reuse via carried id (no --server-id)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_server_reuses_carried_stoat_server_id(tmp_path: Path) -> None:
+    """SC-12: run_server uses state.stoat_server_id when config.server_id is None.
+
+    POST /servers/create is intentionally NOT registered. If run_server were to
+    attempt a create, aioresponses would raise a ConnectionError for the
+    unmatched request and the test would fail.
+    """
+    state = MigrationState(stoat_server_id="srv1")
+    config = _make_config(tmp_path, incremental=True, server_id=None)
+    exports = [_make_export()]
+
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
+        # /servers/create intentionally absent — a create attempt would error.
+        await run_server(config, state, exports, lambda e: None)
+
+    assert state.stoat_server_id == "srv1"
+
+
+# ---------------------------------------------------------------------------
+# SC-11: Deleted prior server → clear MigrationError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_server_deleted_prior_server_raises_clear_error(tmp_path: Path) -> None:
+    """SC-11: run_server raises MigrationError naming the id when server is 404.
+
+    No POST /servers/create should be attempted after a 404 on the carried id.
+    """
+    state = MigrationState(stoat_server_id="gone")
+    config = _make_config(tmp_path, incremental=True, server_id=None)
+    exports = [_make_export()]
+
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/gone", status=404, payload={"type": "NotFound"})
+        with pytest.raises(MigrationError, match="gone"):
+            await run_server(config, state, exports, lambda e: None)

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -41,7 +41,6 @@ from discord_ferry.state import MigrationState
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from discord_ferry.core.events import MigrationEvent
 
 STOAT_URL = "https://api.test"
 

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -13,6 +13,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core.engine import _rebuild_forum_indexes
 from discord_ferry.discord.metadata import (
     DiscordMetadata,
     PermissionPair,
@@ -20,6 +21,7 @@ from discord_ferry.discord.metadata import (
     save_discord_metadata,
 )
 from discord_ferry.errors import MigrationError
+from discord_ferry.migrator.messages import ChannelResult, _merge_channel_result
 from discord_ferry.migrator.structure import (
     run_categories,
     run_channels,
@@ -614,11 +616,14 @@ async def test_rerun_partial_export_keeps_carried_only_category(tmp_path: Path) 
         ),
     ]
     # Prior: category C (cat1) with two carried channels; cat2 not yet mapped.
+    # channel_categories is what a real prior run persists — the upsert seeds
+    # carried-channel membership from it (exact), not from a heuristic.
     state = MigrationState(
         stoat_server_id="srv1",
         category_map={"cat1": "stoat-cat1"},
         channel_map={"ch1": "stoat-ch1", "ch2": "stoat-ch2"},
         category_names={"cat1": "General"},
+        channel_categories={"ch1": "cat1", "ch2": "cat1"},
     )
     config = _make_config(tmp_path, incremental=True)
 
@@ -726,3 +731,180 @@ async def test_rerun_forum_index_channel_not_recreated(tmp_path: Path) -> None:
     forum_channels = by_id["stoat-forumcat"]["channels"]  # type: ignore[index]
     assert forum_channels[0] == "stoat-idx1", "Carried index channel not re-attached at top"
     assert "stoat-fp1" in forum_channels
+
+
+# ---------------------------------------------------------------------------
+# SC-7b: Two simultaneously carried-only categories — exact membership
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_two_carried_only_categories_keep_own_channels(tmp_path: Path) -> None:
+    """SC-7b: two carried-only categories each retain ONLY their own channels.
+
+    Prior state has cat A with {a1, a2} and cat B with {b1, b2}, all carried,
+    plus a persisted ``channel_categories`` mapping every channel to its category.
+    The current (partial) export contains only a new channel in a THIRD category.
+
+    The authoritative upsert must place a1,a2 under A and b1,b2 under B — no
+    cross-contamination and no duplication. This FAILS against Task 3's
+    best-effort heuristic (which extends every unplaced carried channel onto
+    every carried-only category) and PASSES with exact channel_categories seeding.
+    """
+    # Current export: only a new channel in a third category (catC).
+    exports = [
+        _make_export(
+            channel_id="new1", channel_name="newchan", category_id="catC", category="Fresh"
+        ),
+    ]
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"catA": "stoat-catA", "catB": "stoat-catB"},
+        channel_map={
+            "a1": "stoat-a1",
+            "a2": "stoat-a2",
+            "b1": "stoat-b1",
+            "b2": "stoat-b2",
+        },
+        category_names={"catA": "Alpha", "catB": "Bravo"},
+        channel_categories={
+            "a1": "catA",
+            "a2": "catA",
+            "b1": "catB",
+            "b2": "catB",
+        },
+    )
+    config = _make_config(tmp_path, incremental=True, upload_delay=0)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-new1", "name": "newchan"},
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    # Each carried-only category contains ONLY its own channels — no cross-talk.
+    assert set(by_id["stoat-catA"]["channels"]) == {"stoat-a1", "stoat-a2"}  # type: ignore[index]
+    assert set(by_id["stoat-catB"]["channels"]) == {"stoat-b1", "stoat-b2"}  # type: ignore[index]
+    # No duplication within either category.
+    assert len(by_id["stoat-catA"]["channels"]) == 2  # type: ignore[index]
+    assert len(by_id["stoat-catB"]["channels"]) == 2  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# SC-9 (rebuild): _rebuild_forum_indexes PATCHes the carried index message
+# ---------------------------------------------------------------------------
+
+
+async def test_rebuild_forum_indexes_patches_on_rerun(tmp_path: Path) -> None:
+    """SC-9: with a carried forum_index_message_ids, the rebuild edits (PATCHes).
+
+    When ``forum_index_message_ids`` is carried from the prior run, the REPORT
+    phase's ``_rebuild_forum_indexes`` must call ``api_edit_message`` (PATCH on
+    /channels/{id}/messages/{msg}) exactly once per forum and must NOT POST a new
+    message. On main this map is reset, so the rebuild re-POSTs a duplicate.
+    """
+    forum_key = "forum-my-forum"
+    state = MigrationState(
+        stoat_server_id="srv1",
+        channel_map={"fp1": "stoat-fp1", f"forum-index-{forum_key}": "stoat-idx1"},
+        forum_category_names={forum_key: "my-forum"},
+        forum_channel_members={forum_key: ["fp1"]},
+        forum_index_message_ids={forum_key: "idx-msg-1"},
+        channel_message_counts={"fp1": 5},
+    )
+    config = _make_config(tmp_path, incremental=True, upload_delay=0)
+
+    patch_calls: list[object] = []
+    post_calls: list[object] = []
+
+    with aioresponses() as m:
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg-1",
+            payload={"_id": "idx-msg-1"},
+            repeat=True,
+            callback=lambda url, **kw: patch_calls.append(url),  # type: ignore[misc]
+        )
+        # A POST would only fire if the carried message id were ignored (the bug).
+        m.post(
+            f"{STOAT_URL}/channels/stoat-idx1/messages",
+            payload={"_id": "new-msg"},
+            repeat=True,
+            callback=lambda url, **kw: post_calls.append(url),  # type: ignore[misc]
+        )
+
+        await _rebuild_forum_indexes(config, state, lambda e: None)
+
+    assert len(patch_calls) == 1, f"Expected exactly 1 PATCH (edit), got {len(patch_calls)}"
+    assert post_calls == [], "Expected 0 new index-message POSTs on re-run"
+
+
+# ---------------------------------------------------------------------------
+# SC-10: Rebuilt forum index reports CUMULATIVE counts (prior + new)
+# ---------------------------------------------------------------------------
+
+
+async def test_rebuild_forum_indexes_reports_cumulative_counts(tmp_path: Path) -> None:
+    """SC-10: carried count (800) + this-run delta (47) → index shows 847.
+
+    Mirrors the 2nd-run flow: the incremental carry-over seeds
+    ``channel_message_counts={'fp1': 800}``; the MESSAGES phase then accumulates
+    47 new messages via ``+=`` (simulated through ``_merge_channel_result``);
+    the rebuild's PATCH body must report 847, not the delta 47. On main the count
+    is not carried, so the body would show 47.
+    """
+    forum_key = "forum-my-forum"
+    state = MigrationState(
+        stoat_server_id="srv1",
+        channel_map={"fp1": "stoat-fp1", f"forum-index-{forum_key}": "stoat-idx1"},
+        forum_category_names={forum_key: "my-forum"},
+        forum_channel_members={forum_key: ["fp1"]},
+        forum_index_message_ids={forum_key: "idx-msg-1"},
+        # Carried cumulative count from the prior run.
+        channel_message_counts={"fp1": 800},
+    )
+    # This run's MESSAGES phase migrates 47 new messages; accumulates via +=.
+    _merge_channel_result(state, ChannelResult(channel_id="fp1", messages_migrated=47))
+    assert state.channel_message_counts["fp1"] == 847  # sanity: carry + delta
+
+    config = _make_config(tmp_path, incremental=True, upload_delay=0)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.patch(
+            f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg-1",
+            payload={"_id": "idx-msg-1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await _rebuild_forum_indexes(config, state, lambda e: None)
+
+    assert patch_bodies, "Expected an api_edit_message PATCH"
+    content = patch_bodies[-1].get("content", "")
+    assert isinstance(content, str)
+    # The fp1 line must report the cumulative 847, not the delta 47. Match the
+    # full per-channel line so "847" is not mistaken for a substring of "47".
+    assert "<#stoat-fp1> — 847 messages migrated" in content, (
+        f"Expected cumulative 847 for fp1, got: {content!r}"
+    )
+    assert "<#stoat-fp1> — 47 messages migrated" not in content, (
+        "Index showed delta count, not cumulative"
+    )

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -1,4 +1,9 @@
-"""Tests for incremental-mode structure phase behaviour (SC-3, SC-4, SC-5, SC-11, SC-12)."""
+"""Tests for incremental-mode structure phase behaviour.
+
+Role/server scenarios: SC-3, SC-4 (role), SC-5, SC-11, SC-12.
+Category/channel idempotency scenarios (Task 3): SC-1, SC-2, SC-4 (channel),
+SC-6, SC-7, SC-9.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +20,12 @@ from discord_ferry.discord.metadata import (
     save_discord_metadata,
 )
 from discord_ferry.errors import MigrationError
-from discord_ferry.migrator.structure import run_roles, run_server
+from discord_ferry.migrator.structure import (
+    run_categories,
+    run_channels,
+    run_roles,
+    run_server,
+)
 from discord_ferry.parser.models import (
     DCEAuthor,
     DCEChannel,
@@ -330,3 +340,389 @@ async def test_run_roles_fresh_run_creates_and_attributes_all_roles(
     assert len(edit_calls) >= 2, (
         f"Expected >= 2 attribute edits on fresh run, got {len(edit_calls)}"
     )
+
+
+# ===========================================================================
+# Task 3: run_categories + run_channels map-aware idempotency
+# ===========================================================================
+
+
+def _make_forum_export(
+    channel_id: str,
+    channel_name: str,
+    parent_channel_name: str,
+    message_count: int = 0,
+) -> DCEExport:
+    """Build a forum-thread export (type 15) keyed under a parent forum."""
+    return _make_export(
+        channel_id=channel_id,
+        channel_name=channel_name,
+        channel_type=15,
+        is_thread=True,
+        parent_channel_name=parent_channel_name,
+        category_id="cat1",
+        category="General",
+        message_count=message_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SC-1: Unchanged-export re-run creates zero structure
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_unchanged_export_creates_zero_structure(tmp_path: Path) -> None:
+    """SC-1: re-running run_categories + run_channels with carried maps → 0 creates.
+
+    No POST endpoints are registered; the only registered endpoint is the
+    authoritative PATCH /servers/srv1. On the unfixed code, the create loop fires
+    POST /servers/srv1/channels (and the categories phase PATCHes a transient
+    array), so the test fails. After the fix, the maps are reused verbatim.
+    """
+    exports = [
+        _make_export(
+            channel_id="ch1", channel_name="general", category_id="cat1", category="General"
+        ),
+        _make_export(
+            channel_id="ch2", channel_name="random", category_id="cat1", category="General"
+        ),
+    ]
+
+    prior_category_map = {"cat1": "stoat-cat1"}
+    prior_channel_map = {"ch1": "stoat-ch1", "ch2": "stoat-ch2"}
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map=dict(prior_category_map),
+        channel_map=dict(prior_channel_map),
+        category_names={"cat1": "General"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+
+    create_calls: list[object] = []
+
+    with aioresponses() as m:
+        # Create endpoints registered ONLY to count — any call means a regression.
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            repeat=True,
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        # The channels phase still issues an authoritative full-replace PATCH.
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"}, repeat=True)
+
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+
+    assert create_calls == [], f"Expected 0 channel creates, got {len(create_calls)}"
+    assert state.category_map == prior_category_map
+    assert state.channel_map == prior_channel_map
+
+
+# ---------------------------------------------------------------------------
+# SC-2: Existing channels stay attached to their categories
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_keeps_existing_channels_attached_to_categories(tmp_path: Path) -> None:
+    """SC-2: re-run upsert still lists carried channels under their category.
+
+    Guards against a naive ``continue`` that would skip the category-membership
+    recording for carried channels, orphaning them in the full-replace PATCH.
+    """
+    exports = [
+        _make_export(
+            channel_id="ch1", channel_name="general", category_id="cat1", category="General"
+        ),
+        _make_export(
+            channel_id="ch2", channel_name="random", category_id="cat1", category="General"
+        ),
+    ]
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"cat1": "stoat-cat1"},
+        channel_map={"ch1": "stoat-ch1", "ch2": "stoat-ch2"},
+        category_names={"cat1": "General"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/channels", repeat=True)
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_channels(config, state, exports, lambda e: None)
+
+    # The authoritative upsert is the last PATCH body.
+    assert patch_bodies, "Expected an api_upsert_categories PATCH"
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    # Every category present in the map must be present in the payload.
+    for stoat_cat_id in state.category_map.values():
+        assert stoat_cat_id in by_id, f"Category {stoat_cat_id} orphaned from upsert"
+    # The carried channels must still be attached to cat1.
+    cat1_channels = by_id["stoat-cat1"]["channels"]  # type: ignore[index]
+    assert set(cat1_channels) == {"stoat-ch1", "stoat-ch2"}
+
+
+# ---------------------------------------------------------------------------
+# SC-4: New structure since prior run IS created (full delta)
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_creates_only_new_channel_and_category(tmp_path: Path) -> None:
+    """SC-4: prior maps cover all-but-one channel + category; export adds new ones.
+
+    Exactly the new channel is created (1 POST), the new category is generated,
+    existing ones skipped, and the new channel is attached to its category.
+    """
+    exports = [
+        _make_export(
+            channel_id="ch1", channel_name="general", category_id="cat1", category="General"
+        ),
+        _make_export(
+            channel_id="ch2", channel_name="announcements", category_id="cat2", category="News"
+        ),
+    ]
+    # Prior: cat1/ch1 mapped; cat2 + ch2 are new this run.
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"cat1": "stoat-cat1"},
+        channel_map={"ch1": "stoat-ch1"},
+        category_names={"cat1": "General"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+
+    create_calls: list[object] = []
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch2", "name": "announcements"},
+            repeat=True,
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+
+    # Exactly one channel created (ch2); ch1 reused.
+    assert len(create_calls) == 1, f"Expected exactly 1 channel create, got {len(create_calls)}"
+    assert state.channel_map["ch1"] == "stoat-ch1"
+    assert state.channel_map["ch2"] == "stoat-ch2"
+    # New category generated.
+    assert "cat2" in state.category_map
+    # New channel attached to its (new) category in the final upsert.
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    new_cat_id = state.category_map["cat2"]
+    assert new_cat_id in by_id
+    assert "stoat-ch2" in by_id[new_cat_id]["channels"]  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# SC-6: Channels near --max-channels are not dropped on re-run
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_carried_channels_not_dropped_near_max(tmp_path: Path) -> None:
+    """SC-6: 5 carried channels with max_channels=5 + 1 new → carried survive, new dropped.
+
+    The truncation budget excludes carried channels:
+    ``new_budget = max(0, max_channels - index_slots - len(carried))`` = 0 here,
+    so the one new channel is dropped (with a warning) and all 5 carried pass
+    through. On the unfixed code, the 6 candidates are sorted/sliced to 5 and a
+    carried channel is dropped.
+    """
+    exports = []
+    for i in range(5):
+        exports.append(
+            _make_export(channel_id=f"ch{i}", channel_name=f"channel-{i}", category_id="")
+        )
+    # One brand-new channel beyond the prior 5.
+    exports.append(_make_export(channel_id="new1", channel_name="new-channel", category_id=""))
+
+    prior_channel_map = {f"ch{i}": f"stoat-ch{i}" for i in range(5)}
+    state = MigrationState(
+        stoat_server_id="srv1",
+        channel_map=dict(prior_channel_map),
+    )
+    config = _make_config(tmp_path, incremental=True, max_channels=5)
+
+    create_calls: list[object] = []
+    warnings_seen: list[str] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            repeat=True,
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"}, repeat=True)
+
+        await run_channels(
+            config,
+            state,
+            exports,
+            lambda e: warnings_seen.append(e.message) if e.status == "warning" else None,
+        )
+
+    # All 5 carried channels survive (no create, still in map).
+    for i in range(5):
+        assert f"ch{i}" in state.channel_map
+        assert state.channel_map[f"ch{i}"] == f"stoat-ch{i}"
+    # The new channel is dropped (budget 0) and not created.
+    assert create_calls == [], f"Expected 0 creates (new channel over budget), got {create_calls}"
+    assert "new1" not in state.channel_map
+    assert any("new-channel" in w for w in warnings_seen), (
+        "Expected a drop warning for the new channel"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SC-7: Partial re-export — carried-only category not dropped/orphaned
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_partial_export_keeps_carried_only_category(tmp_path: Path) -> None:
+    """SC-7: category C is carried but absent from the (partial) current export.
+
+    The full-replace upsert must still include C with its carried channels +
+    a title, sourced from ``state.category_names`` (I-NEW-2). Otherwise C's
+    channels are orphaned.
+    """
+    # Current export contains ONLY a new channel in a different category (cat2).
+    exports = [
+        _make_export(
+            channel_id="new1", channel_name="newchan", category_id="cat2", category="Fresh"
+        ),
+    ]
+    # Prior: category C (cat1) with two carried channels; cat2 not yet mapped.
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"cat1": "stoat-cat1"},
+        channel_map={"ch1": "stoat-ch1", "ch2": "stoat-ch2"},
+        category_names={"cat1": "General"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-new1", "name": "newchan"},
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    # Carried-only category C must still be present, titled, with its channels.
+    assert "stoat-cat1" in by_id, "Carried-only category orphaned from upsert"
+    assert by_id["stoat-cat1"]["title"] == "General"  # type: ignore[index]
+    assert set(by_id["stoat-cat1"]["channels"]) == {"stoat-ch1", "stoat-ch2"}  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# SC-9: 2nd run over a forum export does NOT re-create the forum-index channel
+# ---------------------------------------------------------------------------
+
+
+async def test_rerun_forum_index_channel_not_recreated(tmp_path: Path) -> None:
+    """SC-9: forum-index channel is reused (no create, no pin, no index message).
+
+    Prior state carries the forum category, the forum post channel, the
+    forum-index channel, and forum_channel_members. On re-run, run_channels must
+    NOT POST a new index channel nor send/pin a new index message; it reuses the
+    carried index channel and re-attaches it at position 0.
+    """
+    exports = [
+        _make_forum_export(
+            channel_id="fp1",
+            channel_name="first-post",
+            parent_channel_name="my-forum",
+            message_count=42,
+        ),
+    ]
+    forum_key = "forum-my-forum"
+    index_key = f"forum-index-{forum_key}"
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={forum_key: "stoat-forumcat"},
+        channel_map={"fp1": "stoat-fp1", index_key: "stoat-idx1"},
+        forum_category_names={forum_key: "my-forum"},
+        forum_channel_members={forum_key: ["fp1"]},
+    )
+    config = _make_config(tmp_path, incremental=True)
+
+    create_calls: list[object] = []
+    send_calls: list[object] = []
+    pin_calls: list[object] = []
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            repeat=True,
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        # Index-message send + pin would only fire if the index were re-created.
+        m.post(
+            f"{STOAT_URL}/channels/stoat-idx1/messages",
+            repeat=True,
+            callback=lambda url, **kw: send_calls.append(url),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg1/pin",
+            repeat=True,
+            callback=lambda url, **kw: pin_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_channels(config, state, exports, lambda e: None)
+
+    assert create_calls == [], f"Expected 0 channel creates on forum re-run, got {create_calls}"
+    assert send_calls == [], "Expected 0 forum-index messages on re-run"
+    assert pin_calls == [], "Expected 0 forum-index pins on re-run"
+    # forum_channel_members must NOT double-append fp1.
+    assert state.forum_channel_members[forum_key] == ["fp1"]
+    # The carried index channel is re-attached at position 0 of the forum category.
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    forum_channels = by_id["stoat-forumcat"]["channels"]  # type: ignore[index]
+    assert forum_channels[0] == "stoat-idx1", "Carried index channel not re-attached at top"
+    assert "stoat-fp1" in forum_channels

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -1,4 +1,4 @@
-"""Tests for incremental-mode structure phase behaviour (SC-11, SC-12)."""
+"""Tests for incremental-mode structure phase behaviour (SC-3, SC-4, SC-5, SC-11, SC-12)."""
 
 from __future__ import annotations
 
@@ -8,8 +8,14 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.discord.metadata import (
+    DiscordMetadata,
+    PermissionPair,
+    RoleMeta,
+    save_discord_metadata,
+)
 from discord_ferry.errors import MigrationError
-from discord_ferry.migrator.structure import run_server
+from discord_ferry.migrator.structure import run_roles, run_server
 from discord_ferry.parser.models import (
     DCEAuthor,
     DCEChannel,
@@ -118,3 +124,209 @@ async def test_run_server_deleted_prior_server_raises_clear_error(tmp_path: Path
         m.get(f"{STOAT_URL}/servers/gone", status=404, payload={"type": "NotFound"})
         with pytest.raises(MigrationError, match="gone"):
             await run_server(config, state, exports, lambda e: None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for role tests
+# ---------------------------------------------------------------------------
+
+
+def _make_role_export(roles: list[DCERole], guild_id: str = "111") -> DCEExport:
+    """Build a minimal DCEExport whose single message carries the given roles."""
+    msg = DCEMessage(
+        id="m1",
+        type="Default",
+        timestamp="2024-01-01T00:00:00Z",
+        content="hi",
+        author=DCEAuthor(id="u1", name="User", roles=roles),
+    )
+    return _make_export(guild_id=guild_id, messages=[msg])
+
+
+# ---------------------------------------------------------------------------
+# SC-3: Existing roles get zero attribute/permission edits on re-run
+# ---------------------------------------------------------------------------
+
+
+async def test_run_roles_skips_all_passes_for_already_migrated_roles(
+    tmp_path: Path,
+) -> None:
+    """SC-3: re-run with all roles already in role_map → 0 creates, 0 edits, 0 perm calls.
+
+    Registers create/edit/perm endpoints with call-counting callbacks.
+    Any call to these endpoints means the guard is missing.
+    """
+    # Two roles; role r1 has position=2 (would trigger attributes pass) and we
+    # supply Discord metadata with hoist=True so both passes would definitely fire
+    # if the guard were absent.
+    role_a = DCERole(id="r1", name="Admin", position=2)
+    role_b = DCERole(id="r2", name="Mod", position=1)
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={"r1": PermissionPair(allow=8, deny=0)},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(hoist=True, position=2),
+            "r2": RoleMeta(hoist=False, position=1),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    # Prior state: both roles already mapped.
+    state = MigrationState(
+        stoat_server_id="srv1",
+        role_map={"r1": "stoat-r1", "r2": "stoat-r2"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    exports = [_make_role_export([role_a, role_b])]
+
+    create_calls: list[object] = []
+    edit_calls: list[object] = []
+    perm_calls: list[object] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            repeat=True,
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            repeat=True,
+            callback=lambda url, **kw: edit_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r2",
+            repeat=True,
+            callback=lambda url, **kw: edit_calls.append(url),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/servers/srv1/permissions/stoat-r1",
+            repeat=True,
+            callback=lambda url, **kw: perm_calls.append(url),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/servers/srv1/permissions/stoat-r2",
+            repeat=True,
+            callback=lambda url, **kw: perm_calls.append(url),  # type: ignore[misc]
+        )
+
+        await run_roles(config, state, exports, lambda e: None)
+
+    assert create_calls == [], f"Expected 0 create calls, got {len(create_calls)}"
+    assert edit_calls == [], f"Expected 0 attribute edit calls, got {len(edit_calls)}"
+    assert perm_calls == [], f"Expected 0 permission calls, got {len(perm_calls)}"
+    # Maps unchanged.
+    assert state.role_map == {"r1": "stoat-r1", "r2": "stoat-r2"}
+
+
+# ---------------------------------------------------------------------------
+# SC-4: New role since prior run IS created (only the new one)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_roles_creates_only_new_roles_on_incremental_rerun(
+    tmp_path: Path,
+) -> None:
+    """SC-4: prior role_map has r1; export now also has r2 → only r2 created."""
+    role_a = DCERole(id="r1", name="Admin")
+    role_b = DCERole(id="r2", name="Mod")
+
+    # Prior state: only r1 mapped.
+    state = MigrationState(
+        stoat_server_id="srv1",
+        role_map={"r1": "stoat-r1"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    exports = [_make_role_export([role_a, role_b])]
+
+    create_calls: list[object] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r2", "name": "Mod"},
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+
+        await run_roles(config, state, exports, lambda e: None)
+
+    assert len(create_calls) == 1, f"Expected exactly 1 create call, got {len(create_calls)}"
+    assert state.role_map["r2"] == "stoat-r2"
+    assert state.role_map["r1"] == "stoat-r1"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# SC-5: Fresh run still creates + attributes ALL roles (snapshot empty)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_roles_fresh_run_creates_and_attributes_all_roles(
+    tmp_path: Path,
+) -> None:
+    """SC-5: empty state → pre_existing_role_ids is empty → every role created AND
+    api_edit_role (attributes) fires for roles with position != 0 or hoist set.
+
+    Guards against the trap where a guard on the live role_map would wrongly
+    skip attributes for roles created earlier in the same pass.
+    """
+    # role_a: position=2 → attributes pass fires (rank)
+    # role_b: position=1, hoist=True via metadata → attributes pass fires (hoist)
+    role_a = DCERole(id="r1", name="Admin", position=2)
+    role_b = DCERole(id="r2", name="Mod", position=1)
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r2": RoleMeta(hoist=True, position=1),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    state = MigrationState(stoat_server_id="srv1")  # empty role_map
+    config = _make_config(tmp_path)
+    exports = [_make_role_export([role_a, role_b])]
+
+    create_calls: list[object] = []
+    edit_calls: list[object] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "Admin"},
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r2", "name": "Mod"},
+            callback=lambda url, **kw: create_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: edit_calls.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r2",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: edit_calls.append(url),  # type: ignore[misc]
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r2", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, lambda e: None)
+
+    assert len(create_calls) == 2, f"Expected 2 creates on fresh run, got {len(create_calls)}"
+    # Both roles should have had attributes applied (r1: rank, r2: hoist).
+    assert len(edit_calls) >= 2, (
+        f"Expected >= 2 attribute edits on fresh run, got {len(edit_calls)}"
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1775,7 +1775,7 @@ async def test_banner_download_includes_auth_header(tmp_path: Path) -> None:
         captured_headers.append(dict(headers))  # type: ignore[arg-type]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
         m.get(
             f"{BANNER_CDN}/111/testhash.png?size=1024",
             body=b"FAKEPNG",
@@ -1815,7 +1815,7 @@ async def test_banner_download_no_auth_header_when_no_token(tmp_path: Path) -> N
         captured_headers.append(dict(headers))  # type: ignore[arg-type]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
         m.get(
             f"{BANNER_CDN}/111/testhash.png?size=1024",
             body=b"FAKEPNG",

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes the **dominant cluster from the 2026-06-23 codebase bug hunt**: `--incremental` (delta) migration re-created everything on every run instead of reusing the prior server and structure. Ships as **v2.5.1** (built off v2.4.2, with `main`'s v2.5.0 merged in).

The structure phases had no idempotency guard, so a delta re-run re-created all roles/categories/channels and `run_server` minted a brand-new server — stranding the carried ID maps and writing messages into a mismatched structure.

## What changed

| Area | Fix |
|------|-----|
| **Server reuse** (`structure.py`) | `run_server` reuses the carried `state.stoat_server_id` (not only `--server-id`); a deleted prior server raises a clear `MigrationError` instead of silently creating a new one. |
| **Structure-phase idempotency** (`run_roles`/`run_categories`/`run_channels`) | A capture-before-mutate `pre_existing_*_ids` snapshot skips already-migrated roles (create + attributes + perms passes), reuses carried category/channel IDs, preserves category membership (no orphaning), reuses forum-index channels, and excludes carried channels from the `--max-channels` truncation budget. |
| **Exact category membership** (`state.py`, `engine.py`) | A persisted `channel_categories` map reconstructs carried-only categories exactly on a partial re-export — correct for any number of simultaneously carried-only categories (no cross-contamination). |
| **Carry-over completeness** (`engine.py`) | The incremental carry-over now also carries `forum_channel_members`, `forum_category_names`, `forum_index_message_ids`, `channel_message_counts`, `category_names`, `channel_categories`, and `native_fidelity_counts`, with a field-by-field audit comment. `_rebuild_forum_indexes` PATCHes the existing pinned index with cumulative counts instead of posting duplicates. |

## Tests

New `tests/test_incremental_structure.py` — **real-phase two-run tests** that drive the actual `run_server`/`run_roles`/`run_categories`/`run_channels` against a populated prior `MigrationState`. The prior `tests/test_delta_migration.py` **mocked the structure phases**, which is exactly why this duplication bug shipped undetected.

## Verification

- `ruff check` + `ruff format` + `mypy --strict` clean; **1003 tests pass**.
- Designed through the full `/df` pipeline: brief → spec → brainstorm → **3 rounds of fresh-context critique** (ITERATE→ITERATE→PASS) → test-scenarios → plan.
- Built via subagent-driven development (fresh implementer + reviewer per task); **whole-branch review = READY TO MERGE**; Mistral second opinion = "correct and robust."

## Non-goals

Reconciling deletions / renames / reordering / message edits; the pre-existing first-run forum double-pin (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
