### PR TITLE
feat: live role discovery — migrate all server roles, not just active-poster roles (v2.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.0] - 2026-06-24
+
+### Added
+
+- **Live role discovery — migrate every server role, not just roles whose members posted** (`migrator/structure.py`, `discord/metadata.py`, `discord/__init__.py`, `migrator/api.py`). Previously `run_roles` derived its role set from `msg.author.roles`, so a role only migrated if someone wearing it posted in an exported channel — empty/structural/staff roles silently vanished. When a `discord_token` is supplied, role creation now sources from the **union** of export-derived roles and the full live Discord role list (already captured in `discord_metadata.role_metadata`, which enumerates every non-managed, non-@everyone role). For a role present in both, the **live** name/colour/position win over the (possibly stale) export snapshot. `RoleMeta` gained `name` and `color` (normalised to hex at capture); a `_role_from_metadata` adapter synthesises a `DCERole` for live-only roles so all three existing role passes (create / rank / permissions) cover them unchanged.
+- **Graceful Stoat role-cap handling.** Stoat enforces a configurable `server_roles` limit (default 200) that the wider role set can now reach. The live limit is read best-effort from `GET /` (`features.limits.global.server_roles`, via a new `api_fetch_root` wrapper, 200 fallback); if the union exceeds it, the lowest-priority roles by `(position, id)` are dropped with a single `role_limit_exceeded` warning, and a `TooManyRoles` create-time backstop stops gracefully rather than crashing the phase.
+- **Reporter credit** (`reporter.py`): the `## Native Fidelity` section now reports the count of recovered "structural" roles (live-only roles absent from the export), counted per-run.
+
+### Changed
+
+- Role rank ordering now sorts by `(position, id)` (string id) for a deterministic tie-break when multiple roles share a Discord position — relevant now that the full live role list (with denser positions) feeds the rank pass.
+
+### Notes
+
+- Without a `discord_token` (no live metadata), role sourcing falls back to the prior export-derived behaviour byte-for-byte — same role set, same create order. Managed/integration roles and `@everyone` remain excluded. This does not assign members to roles (that requires a Discord→Stoat identity map, which does not exist); it only ensures the roles themselves are created.
+
 ## [2.5.1] - 2026-06-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.5.1"
+version = "2.6.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"

--- a/src/discord_ferry/discord/__init__.py
+++ b/src/discord_ferry/discord/__init__.py
@@ -69,6 +69,8 @@ async def fetch_and_translate_guild_metadata(
             position=role.position,
             icon_hash=role.icon,
             unicode_emoji=role.unicode_emoji,
+            name=role.name,
+            color=f"#{role.color:06x}" if role.color > 0 else "",
         )
 
     # Build channel metadata (filter user overrides, translate permissions)

--- a/src/discord_ferry/discord/metadata.py
+++ b/src/discord_ferry/discord/metadata.py
@@ -31,6 +31,8 @@ class RoleMeta:
     position: int = 0
     icon_hash: str = ""
     unicode_emoji: str = ""
+    name: str = ""
+    color: str = ""  # hex "#rrggbb", or "" for no color
 
 
 @dataclass
@@ -97,6 +99,8 @@ def _meta_to_dict(meta: DiscordMetadata) -> dict[str, Any]:
                 "position": v.position,
                 "icon_hash": v.icon_hash,
                 "unicode_emoji": v.unicode_emoji,
+                "name": v.name,
+                "color": v.color,
             }
             for k, v in meta.role_metadata.items()
         },
@@ -146,6 +150,8 @@ def _dict_to_meta(data: dict[str, Any]) -> DiscordMetadata:
                 position=v.get("position", 0),
                 icon_hash=v.get("icon_hash", ""),
                 unicode_emoji=v.get("unicode_emoji", ""),
+                name=v.get("name", ""),
+                color=v.get("color", ""),
             )
             for k, v in data.get("role_metadata", {}).items()
         },

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -276,9 +276,7 @@ async def api_fetch_server(
     return await _api_request(session, "GET", url, token)
 
 
-async def api_fetch_root(
-    session: aiohttp.ClientSession, stoat_url: str
-) -> dict[str, Any]:
+async def api_fetch_root(session: aiohttp.ClientSession, stoat_url: str) -> dict[str, Any]:
     """Best-effort GET / for instance config (limits, app URL).
 
     Returns the parsed config dict, or ``{}`` on any non-200 status, network

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -281,9 +281,10 @@ async def api_fetch_root(
 ) -> dict[str, Any]:
     """Best-effort GET / for instance config (limits, app URL).
 
-    Returns the parsed config dict, or ``{}`` on any non-200 status or network
-    error. Intentionally NOT routed through ``_api_request`` -- this is a
-    best-effort probe and must not carry the retry/circuit-breaker machinery.
+    Returns the parsed config dict, or ``{}`` on any non-200 status, network
+    error, or malformed JSON body. Intentionally NOT routed through
+    ``_api_request`` -- this is a best-effort probe and must not carry the
+    retry/circuit-breaker machinery.
     """
     url = f"{stoat_url.rstrip('/')}/"
     try:
@@ -291,7 +292,7 @@ async def api_fetch_root(
             if resp.status != 200:
                 return {}
             return await resp.json()  # type: ignore[no-any-return]
-    except aiohttp.ClientError:
+    except (aiohttp.ClientError, ValueError):
         return {}
 
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -276,6 +276,25 @@ async def api_fetch_server(
     return await _api_request(session, "GET", url, token)
 
 
+async def api_fetch_root(
+    session: aiohttp.ClientSession, stoat_url: str
+) -> dict[str, Any]:
+    """Best-effort GET / for instance config (limits, app URL).
+
+    Returns the parsed config dict, or ``{}`` on any non-200 status or network
+    error. Intentionally NOT routed through ``_api_request`` -- this is a
+    best-effort probe and must not carry the retry/circuit-breaker machinery.
+    """
+    url = f"{stoat_url.rstrip('/')}/"
+    try:
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                return {}
+            return await resp.json()  # type: ignore[no-any-return]
+    except aiohttp.ClientError:
+        return {}
+
+
 async def api_edit_server(
     session: aiohttp.ClientSession,
     stoat_url: str,

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -451,6 +451,11 @@ async def run_roles(
     # Filter out the @everyone role.
     roles_to_create = [r for r in unique_roles if r.id != guild_id]
 
+    # Classify provenance before the live-role union: any role created this run
+    # whose id is NOT in this set came from live-only discovery (a "structural"
+    # role absent from the export because no member posted it).
+    export_role_ids = {r.id for r in unique_roles}
+
     # Live role discovery: union the export-derived roles with the full live role
     # list (already captured in discord_metadata.role_metadata, which enumerates
     # every non-managed, non-@everyone role). Live wins on name/color/position.
@@ -532,6 +537,14 @@ async def run_roles(
                 raise
             stoat_role_id: str = result["id"]
             state.role_map[role.id] = stoat_role_id
+
+            # Credit recovered structural roles: created THIS run (the
+            # pre_existing_role_ids guard above already excludes prior-run roles)
+            # and absent from the export-derived set, i.e. live-only discovery.
+            if role.id not in export_role_ids:
+                state.native_fidelity_counts["structural_roles"] = (
+                    state.native_fidelity_counts.get("structural_roles", 0) + 1
+                )
 
             # Apply colour if present (British spelling required by Stoat API).
             if role.color:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -526,7 +526,7 @@ async def run_roles(
     # metadata). Both fold into a single api_edit_role call per role when present.
     discord_metadata = load_discord_metadata(config.output_dir)
     role_meta = discord_metadata.role_metadata if discord_metadata else {}
-    ranked_roles = sorted(roles_to_create, key=lambda r: r.position)
+    ranked_roles = sorted(roles_to_create, key=lambda r: (r.position, r.id))
     async with get_session(config) as session:
         for role in ranked_roles:
             if role.id in pre_existing_role_ids:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.discord.client import download_role_icon
-from discord_ferry.discord.metadata import load_discord_metadata
+from discord_ferry.discord.metadata import RoleMeta, load_discord_metadata
 from discord_ferry.errors import AutumnUploadError, MigrationError
 from discord_ferry.migrator.api import (
     api_create_channel,
@@ -31,6 +31,7 @@ from discord_ferry.migrator.api import (
 )
 from discord_ferry.migrator.sanitize import truncate_name
 from discord_ferry.parser.dce_parser import stream_messages
+from discord_ferry.parser.models import DCERole
 from discord_ferry.uploader.autumn import upload_to_autumn, upload_with_cache
 
 if TYPE_CHECKING:
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
-    from discord_ferry.parser.models import DCEChannel, DCEExport, DCERole
+    from discord_ferry.parser.models import DCEChannel, DCEExport
     from discord_ferry.state import MigrationState
 
 logger = logging.getLogger(__name__)
@@ -403,6 +404,14 @@ async def _resolve_role_icon(
         temp_path.unlink(missing_ok=True)
 
 
+def _role_from_metadata(role_id: str, rm: RoleMeta) -> DCERole:
+    """Build a DCERole from live Discord metadata (for roles absent from the export).
+
+    Lives here (not in parser/models) so parser/ never imports discord/metadata.
+    """
+    return DCERole(id=role_id, name=rm.name, color=rm.color or None, position=rm.position)
+
+
 async def run_roles(
     config: FerryConfig,
     state: MigrationState,
@@ -440,6 +449,16 @@ async def run_roles(
 
     # Filter out the @everyone role.
     roles_to_create = [r for r in unique_roles if r.id != guild_id]
+
+    # Live role discovery: union the export-derived roles with the full live role
+    # list (already captured in discord_metadata.role_metadata, which enumerates
+    # every non-managed, non-@everyone role). Live wins on name/color/position.
+    discord_metadata = load_discord_metadata(config.output_dir)
+    if discord_metadata is not None:
+        merged_roles: dict[str, DCERole] = {r.id: r for r in roles_to_create}
+        for role_id, live_rm in discord_metadata.role_metadata.items():
+            merged_roles[role_id] = _role_from_metadata(role_id, live_rm)
+        roles_to_create = list(merged_roles.values())
 
     # Incremental: capture which roles already exist BEFORE the creation loop
     # populates role_map, so the create/attributes/perms passes can skip them.

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -19,6 +19,7 @@ from discord_ferry.migrator.api import (
     api_edit_channel,
     api_edit_role,
     api_edit_server,
+    api_fetch_root,
     api_fetch_server,
     api_pin_message,
     api_send_message,
@@ -460,6 +461,33 @@ async def run_roles(
             merged_roles[role_id] = _role_from_metadata(role_id, live_rm)
         roles_to_create = list(merged_roles.values())
 
+        # Role cap: read the live server_roles limit (best-effort; 200 fallback).
+        # The union can exceed Stoat's cap, so pre-flight truncate by lowest
+        # (position, id) and keep the top-N. Scoped to the union path only.
+        async with get_session(config) as _root_session:
+            root = await api_fetch_root(_root_session, config.stoat_url)
+        role_limit = (
+            root.get("features", {}).get("limits", {}).get("global", {}).get("server_roles", 200)
+        )
+        # Order the union position-desc so that (a) pre-flight truncation keeps the
+        # highest-priority roles and (b) the per-instance TooManyRoles backstop, if
+        # it fires, drops the least-important roles first. Scoped to the union path;
+        # the export-only create order is left byte-for-byte unchanged.
+        roles_to_create.sort(key=lambda r: (r.position, r.id), reverse=True)
+        if len(roles_to_create) > role_limit:
+            dropped = len(roles_to_create) - role_limit
+            roles_to_create = roles_to_create[:role_limit]
+            state.warnings.append(
+                {
+                    "phase": "roles",
+                    "type": "role_limit_exceeded",
+                    "message": (
+                        f"Server role limit ({role_limit}) exceeded; "
+                        f"skipped {dropped} lowest-priority role(s)."
+                    ),
+                }
+            )
+
     # Incremental: capture which roles already exist BEFORE the creation loop
     # populates role_map, so the create/attributes/perms passes can skip them.
     pre_existing_role_ids = set(state.role_map)
@@ -480,13 +508,28 @@ async def run_roles(
         for idx, role in enumerate(roles_to_create, start=1):
             if role.id in pre_existing_role_ids:
                 continue
-            result = await api_create_role(
-                session,
-                config.stoat_url,
-                config.token,
-                state.stoat_server_id,
-                truncate_name(role.name),
-            )
+            try:
+                result = await api_create_role(
+                    session,
+                    config.stoat_url,
+                    config.token,
+                    state.stoat_server_id,
+                    truncate_name(role.name),
+                )
+            except MigrationError as exc:
+                if "TooManyRoles" in str(exc) or "too many" in str(exc).lower():
+                    state.warnings.append(
+                        {
+                            "phase": "roles",
+                            "type": "role_limit_exceeded",
+                            "message": (
+                                f"Stoat role limit reached at '{role.name}'; "
+                                "remaining roles skipped."
+                            ),
+                        }
+                    )
+                    break
+                raise
             stoat_role_id: str = result["id"]
             state.role_map[role.id] = stoat_role_id
 

--- a/src/discord_ferry/parser/models.py
+++ b/src/discord_ferry/parser/models.py
@@ -7,7 +7,7 @@ from typing import Any
 
 @dataclass
 class DCERole:
-    """Parsed role from author's role list."""
+    """A Discord role record — from a DCE export author list or a live guild fetch."""
 
     id: str
     name: str

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -405,6 +405,10 @@ def generate_markdown_report(
             lines.append(f"- Voice user-limit set on {nf['user_limit']} channel(s)\n")
         if nf.get("role_icons"):
             lines.append(f"- Icons set on {nf['role_icons']} role(s)\n")
+        if nf.get("structural_roles"):
+            lines.append(
+                f"- Recovered {nf['structural_roles']} structural role(s) absent from the export\n"
+            )
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
     output_path = config.output_dir / "migration_report.md"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1042,3 +1042,27 @@ async def test_api_edit_channel_patches_body():
                 voice={"max_users": 5},
             )
     assert result["_id"] == "ch1"
+
+
+@pytest.mark.asyncio
+async def test_api_fetch_root_returns_config():
+    from discord_ferry.migrator.api import api_fetch_root
+
+    with aioresponses() as m:
+        m.get(
+            "https://stoat.test/",
+            payload={"features": {"limits": {"global": {"server_roles": 200}}}},
+        )
+        async with aiohttp.ClientSession() as s:
+            root = await api_fetch_root(s, "https://stoat.test")
+    assert root["features"]["limits"]["global"]["server_roles"] == 200
+
+
+@pytest.mark.asyncio
+async def test_api_fetch_root_returns_empty_on_error():
+    from discord_ferry.migrator.api import api_fetch_root
+
+    with aioresponses() as m:
+        m.get("https://stoat.test/", status=500)
+        async with aiohttp.ClientSession() as s:
+            assert await api_fetch_root(s, "https://stoat.test") == {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1066,3 +1066,28 @@ async def test_api_fetch_root_returns_empty_on_error():
         m.get("https://stoat.test/", status=500)
         async with aiohttp.ClientSession() as s:
             assert await api_fetch_root(s, "https://stoat.test") == {}
+
+
+@pytest.mark.asyncio
+async def test_api_fetch_root_returns_empty_on_client_error():
+    from discord_ferry.migrator.api import api_fetch_root
+
+    with aioresponses() as m:
+        m.get("https://stoat.test/", exception=aiohttp.ClientError())
+        async with aiohttp.ClientSession() as s:
+            assert await api_fetch_root(s, "https://stoat.test") == {}
+
+
+@pytest.mark.asyncio
+async def test_api_fetch_root_returns_empty_on_malformed_json():
+    from discord_ferry.migrator.api import api_fetch_root
+
+    with aioresponses() as m:
+        m.get(
+            "https://stoat.test/",
+            body="not json",
+            status=200,
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as s:
+            assert await api_fetch_root(s, "https://stoat.test") == {}

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -395,3 +395,46 @@ async def test_download_role_icon_none_on_client_error():
             from discord_ferry.discord.client import download_role_icon
 
             assert await download_role_icon(s, "r1", "hash") is None
+
+
+@pytest.mark.asyncio
+async def test_capture_role_name_and_hex_color() -> None:
+    guild_id = "100"
+    with aioresponses() as m:
+        m.get(
+            f"{DISCORD_API}/guilds/{guild_id}",
+            payload={"description": "", "nsfw_level": 0, "banner": None},
+        )
+        m.get(
+            f"{DISCORD_API}/guilds/{guild_id}/roles",
+            payload=[
+                {
+                    "id": "200",
+                    "name": "Mod",
+                    "permissions": "0",
+                    "position": 2,
+                    "color": 16711680,
+                    "hoist": False,
+                    "managed": False,
+                    "icon": None,
+                    "unicode_emoji": None,
+                },
+                {
+                    "id": "201",
+                    "name": "NoColor",
+                    "permissions": "0",
+                    "position": 1,
+                    "color": 0,
+                    "hoist": False,
+                    "managed": False,
+                    "icon": None,
+                    "unicode_emoji": None,
+                },
+            ],
+        )
+        m.get(f"{DISCORD_API}/guilds/{guild_id}/channels", payload=[])
+        async with aiohttp.ClientSession() as s:
+            meta = await fetch_and_translate_guild_metadata(s, "tok", guild_id)
+    assert meta.role_metadata["200"].name == "Mod"
+    assert meta.role_metadata["200"].color == "#ff0000"  # 16711680 -> hex
+    assert meta.role_metadata["201"].color == ""  # color 0 -> ""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -420,3 +420,40 @@ def test_batch2_fields_default_on_legacy_json():
     assert restored.channel_metadata["c1"].slowmode == 0
     assert restored.channel_metadata["c1"].user_limit == 0
     assert restored.role_metadata["r1"].icon_hash == ""
+
+
+def test_rolemeta_name_color_round_trip():
+    from discord_ferry.discord.metadata import (
+        DiscordMetadata,
+        RoleMeta,
+        _dict_to_meta,
+        _meta_to_dict,
+    )
+
+    meta = DiscordMetadata(
+        guild_id="g",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=3, name="Mod", color="#ff0000")},
+    )
+    restored = _dict_to_meta(_meta_to_dict(meta))
+    assert restored.role_metadata["r1"].name == "Mod"
+    assert restored.role_metadata["r1"].color == "#ff0000"
+
+
+def test_rolemeta_legacy_json_defaults_name_color():
+    from discord_ferry.discord.metadata import _dict_to_meta
+
+    legacy = {
+        "guild_id": "g",
+        "fetched_at": "t",
+        "server_default_permissions": 0,
+        "role_permissions": {},
+        "channel_metadata": {},
+        "role_metadata": {"r1": {"hoist": False, "position": 0}},  # no name/color keys
+    }
+    restored = _dict_to_meta(legacy)
+    assert restored.role_metadata["r1"].name == ""
+    assert restored.role_metadata["r1"].color == ""

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -81,6 +81,19 @@ def test_report_includes_native_fidelity(tmp_path: Path) -> None:
     assert "Slowmode set on 1 channel(s)" in md
 
 
+def test_report_surfaces_structural_roles(tmp_path: Path) -> None:
+    """The markdown report credits recovered structural roles when counted."""
+    config = _make_config(tmp_path)
+    state = MigrationState()
+    state.native_fidelity_counts = {"structural_roles": 3}
+    exports = [_make_export()]
+
+    generate_markdown_report(config, state, exports)
+    md = (tmp_path / "migration_report.md").read_text()
+    assert "## Native Fidelity" in md
+    assert "Recovered 3 structural role(s)" in md
+
+
 def test_generate_report_summary_keys(tmp_path: Path) -> None:
     """Summary dict contains all required keys."""
     config = _make_config(tmp_path)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -826,6 +826,82 @@ async def test_managed_role_not_created(tmp_path: Path) -> None:
     assert state.role_map == {"r1": "stoat-r1"}
 
 
+async def test_structural_roles_counted_for_live_only(tmp_path: Path) -> None:
+    """A live-only role (in role_metadata, absent from the export) increments
+    native_fidelity_counts['structural_roles']; an overlap role does not."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    # r1 appears in the export (overlap); r2 is live-only (no member posted it).
+    role = DCERole(id="r1", name="Member")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(name="Member", position=1),
+            "r2": RoleMeta(name="Ghost", position=0),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "Member"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r2", "name": "Ghost"},
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r2", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    # Both roles created; only the live-only r2 counts as structural.
+    assert set(state.role_map) == {"r1", "r2"}
+    assert state.native_fidelity_counts.get("structural_roles") == 1
+
+
+async def test_structural_roles_zero_when_all_overlap(tmp_path: Path) -> None:
+    """When every created role also appears in the export, no structural-role
+    credit is recorded."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role = DCERole(id="r1", name="Member")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(name="Member", position=0)},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "Member"},
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert state.role_map == {"r1": "stoat-r1"}
+    assert state.native_fidelity_counts.get("structural_roles") is None
+
+
 async def test_no_token_fallback_unchanged(tmp_path: Path) -> None:
     """With no discord_metadata.json, the created set equals the export-derived set."""
     events: list[MigrationEvent] = []
@@ -2446,9 +2522,7 @@ async def test_role_cap_truncates_and_warns(tmp_path: Path) -> None:
                 kwargs.get("json", {}).get("name", "")
             ),
         )
-        m.patch(
-            f"{STOAT_URL}/servers/srv1/roles/stoat-x", payload={}, repeat=True
-        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-x", payload={}, repeat=True)
 
         await run_roles(config, state, exports, events.append)
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -683,6 +683,173 @@ async def test_run_roles_colour_without_hash(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phase 4: ROLES — live role discovery (union sourcing)
+# ---------------------------------------------------------------------------
+
+
+async def test_live_only_role_is_created(tmp_path: Path) -> None:
+    """A live role absent from every export author is still created via the union."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    # Export author posts under r1 only; r2 exists live but nobody posted under it.
+    role_a = DCERole(id="r1", name="Admin")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role_a])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(name="Admin", position=0),
+            "r2": RoleMeta(name="LiveOnly", position=1),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    created_names: list[str] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "Admin"},
+            callback=lambda url, **kwargs: created_names.append(  # type: ignore[misc]
+                kwargs.get("json", {}).get("name", "")
+            ),
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r2", "name": "LiveOnly"},
+            callback=lambda url, **kwargs: created_names.append(  # type: ignore[misc]
+                kwargs.get("json", {}).get("name", "")
+            ),
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r2", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert "LiveOnly" in created_names
+    assert state.role_map.get("r2") == "stoat-r2"
+
+
+async def test_overlap_role_uses_live_name_color(tmp_path: Path) -> None:
+    """A role in both export and live metadata uses the LIVE name/colour."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    # Export carries the stale name/no colour; live metadata wins.
+    role = DCERole(id="r1", name="OldName")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(name="NewName", color="#00ff00", position=0)},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    created_names: list[str] = []
+    patch_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "NewName"},
+            callback=lambda url, **kwargs: created_names.append(  # type: ignore[misc]
+                kwargs.get("json", {}).get("name", "")
+            ),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    assert created_names == ["NewName"]
+    assert any(body.get("colour") == 0x00FF00 for body in patch_bodies)
+
+
+async def test_managed_role_not_created(tmp_path: Path) -> None:
+    """A managed role (excluded at capture, absent from role_metadata) is not created."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role = DCERole(id="r1", name="Admin")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    # role_metadata enumerates only non-managed roles; the managed "rbot" is absent.
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(name="Admin", position=0)},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    created_ids: list[str] = []
+
+    def _capture(url: object, **kwargs: object) -> None:
+        name = kwargs.get("json", {}).get("name", "")  # type: ignore[union-attr]
+        created_ids.append(name)
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-r1", "name": "Admin"},
+            callback=_capture,
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert created_ids == ["Admin"]
+    assert state.role_map == {"r1": "stoat-r1"}
+
+
+async def test_no_token_fallback_unchanged(tmp_path: Path) -> None:
+    """With no discord_metadata.json, the created set equals the export-derived set."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role_a = DCERole(id="r1", name="Admin")
+    role_b = DCERole(id="r2", name="Mod")
+    exports = [
+        _make_export(
+            messages=[
+                _make_message("m1", roles=[role_a]),
+                _make_message("m2", roles=[role_b]),
+            ]
+        )
+    ]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r2", "name": "Mod"})
+
+        await run_roles(config, state, exports, events.append)
+
+    # Exactly the two export-derived roles, no live union.
+    assert state.role_map == {"r1": "stoat-r1", "r2": "stoat-r2"}
+
+
+# ---------------------------------------------------------------------------
 # Phase 5: CATEGORIES
 # ---------------------------------------------------------------------------
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1596,6 +1596,57 @@ async def test_run_roles_sets_rank_from_position(tmp_path: Path) -> None:
     assert any(b.get("rank") == 3 for b in rank_bodies)
 
 
+async def test_run_roles_rank_tie_break_is_deterministic(tmp_path: Path) -> None:
+    """On equal position, the rank pass processes roles in a deterministic id order.
+
+    Two roles share position 5 but have ids "30" and "20". The deterministic sort
+    key (position, id) must process role "20" before role "30" regardless of input
+    order. The functional goal is determinism — same-position roles emit a stable
+    processing order independent of export/union insertion order.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    # Export order lists "30" first, then "20" — so a position-only (stable) sort
+    # would preserve that input order and process "30" before "20".
+    role_30 = DCERole(id="30", name="Thirty", position=5)
+    role_20 = DCERole(id="20", name="Twenty", position=5)
+    exports = [
+        _make_export(
+            messages=[
+                _make_message("m1", roles=[role_30]),
+                _make_message("m2", roles=[role_20]),
+            ]
+        )
+    ]
+
+    # FIFO POST registration mirrors first-pass insertion (export) order:
+    # "30" -> stoat-30, "20" -> stoat-20.
+    patched_role_ids: list[str] = []
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-30", "name": "Thirty"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-20", "name": "Twenty"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-30",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patched_role_ids.append("30"),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-20",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patched_role_ids.append("20"),  # type: ignore[misc]
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    # Real processing order: the rank PATCH for the lexically-smaller id fires first.
+    assert patched_role_ids == ["20", "30"]
+
+
 async def test_run_roles_rank_failure_is_non_fatal(tmp_path: Path) -> None:
     """ROLES phase logs a warning and continues if rank setting fails."""
     events: list[MigrationEvent] = []

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -16,7 +16,7 @@ from discord_ferry.discord.metadata import (
     RoleOverride,
     save_discord_metadata,
 )
-from discord_ferry.errors import AutumnUploadError
+from discord_ferry.errors import AutumnUploadError, MigrationError
 from discord_ferry.migrator.structure import (
     FERRY_MIN_PERMISSIONS,
     make_unique_channel_name,
@@ -733,7 +733,11 @@ async def test_live_only_role_is_created(tmp_path: Path) -> None:
         await run_roles(config, state, exports, events.append)
 
     assert "LiveOnly" in created_names
-    assert state.role_map.get("r2") == "stoat-r2"
+    # The union creates roles position-desc, so the FIFO mock id pairing is not
+    # insertion-ordered; assert the live-only role is mapped to a created id.
+    assert "r2" in state.role_map
+    assert state.role_map["r2"] in {"stoat-r1", "stoat-r2"}
+    assert set(state.role_map) == {"r1", "r2"}
 
 
 async def test_overlap_role_uses_live_name_color(tmp_path: Path) -> None:
@@ -2393,3 +2397,169 @@ async def test_banner_download_no_auth_header_when_no_token(tmp_path: Path) -> N
 
     assert captured_headers, "Banner CDN request was not made"
     assert "Authorization" not in captured_headers[0]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: ROLES — Stoat role-cap handling (Task 6)
+# ---------------------------------------------------------------------------
+
+
+async def test_role_cap_truncates_and_warns(tmp_path: Path) -> None:
+    """When the union exceeds the live server_roles limit, only the top-N by
+    position are created and a role_limit_exceeded warning names the dropped count."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    # Export author posts under r1 only; the live metadata supplies four roles
+    # at distinct positions. The limit is 2, so the two highest positions win.
+    role_a = DCERole(id="r1", name="Admin")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role_a])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(name="Admin", position=0),
+            "r2": RoleMeta(name="Mod", position=1),
+            "r3": RoleMeta(name="VIP", position=2),
+            "r4": RoleMeta(name="Top", position=3),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    created_names: list[str] = []
+
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/",
+            payload={"features": {"limits": {"global": {"server_roles": 2}}}},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-x", "name": "x"},
+            repeat=True,
+            callback=lambda url, **kwargs: created_names.append(  # type: ignore[misc]
+                kwargs.get("json", {}).get("name", "")
+            ),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-x", payload={}, repeat=True
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    # Only the two highest-position roles are created.
+    assert len(created_names) == 2
+    assert set(created_names) == {"Top", "VIP"}
+
+    warnings = [w for w in state.warnings if w.get("type") == "role_limit_exceeded"]
+    assert warnings, "expected a role_limit_exceeded warning"
+    assert "2" in warnings[0]["message"]  # dropped count of 2 (4 union - 2 limit)
+
+
+async def test_too_many_roles_backstop_non_fatal(tmp_path: Path) -> None:
+    """If api_create_role raises a TooManyRoles MigrationError mid-loop, the phase
+    does not crash and a role_limit_exceeded warning is recorded."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role_a = DCERole(id="r1", name="Admin")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role_a])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(name="Admin", position=0),
+            "r2": RoleMeta(name="Mod", position=1),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    call_count = {"n": 0}
+
+    async def _fake_create_role(*_args: object, **_kwargs: object) -> dict[str, str]:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"id": "stoat-r2", "name": "Mod"}
+        raise MigrationError("Stoat API error 400: TooManyRoles")
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.api_create_role",
+            side_effect=_fake_create_role,
+        ),
+    ):
+        # Live limit high enough that pre-flight truncation does NOT engage;
+        # the backstop is what must fire.
+        m.get(
+            f"{STOAT_URL}/",
+            payload={"features": {"limits": {"global": {"server_roles": 200}}}},
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r2", payload={}, repeat=True)
+
+        # Must not raise.
+        await run_roles(config, state, exports, events.append)
+
+    warnings = [w for w in state.warnings if w.get("type") == "role_limit_exceeded"]
+    assert warnings, "expected a role_limit_exceeded backstop warning"
+
+
+async def test_resume_truncation_deterministic(tmp_path: Path) -> None:
+    """Two runs over identical discord_metadata truncate to the same top-N set."""
+    config = _make_config(tmp_path)
+
+    role_a = DCERole(id="r1", name="Admin")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role_a])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={
+            "r1": RoleMeta(name="Admin", position=0),
+            "r2": RoleMeta(name="Mod", position=1),
+            "r3": RoleMeta(name="VIP", position=2),
+            "r4": RoleMeta(name="Top", position=3),
+        },
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    # Run twice over identical metadata; the truncated set must be stable.
+    first = await _run_and_collect(config, exports)
+    second = await _run_and_collect(config, exports)
+    assert first == second
+    assert first == {"Top", "VIP"}
+
+
+async def _run_and_collect(config: FerryConfig, exports: list[DCEExport]) -> set[str]:
+    events: list[MigrationEvent] = []
+    state = MigrationState(stoat_server_id="srv1")
+    created_names: list[str] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/",
+            payload={"features": {"limits": {"global": {"server_roles": 2}}}},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-x", "name": "x"},
+            repeat=True,
+            callback=lambda url, **kwargs: created_names.append(  # type: ignore[misc]
+                kwargs.get("json", {}).get("name", "")
+            ),
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-x", payload={}, repeat=True)
+        await run_roles(config, state, exports, events.append)
+    return set(created_names)

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.5.1"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
The **last buildable item** from the 2026-06-23 gap analysis. Previously `run_roles` derived roles from `msg.author.roles`, so a role only migrated if someone wearing it posted in an exported channel — empty/structural/staff roles silently vanished.

When a \`discord_token\` is supplied, role creation now sources from the **union** of export-derived roles and the full **live** Discord role list (already captured in \`discord_metadata.role_metadata\`). For a role in both, the **live** name/colour/position win over the (possibly stale) export snapshot. A \`_role_from_metadata\` adapter synthesises a \`DCERole\` for live-only roles, so all three existing role passes (create / rank / permissions) cover them unchanged.

## Highlights
- **\`RoleMeta\`** gains \`name\`+\`color\` (normalised int→hex at capture); backward-compatible serialization (legacy \`discord_metadata.json\` loads).
- **Role-cap handling** — Stoat's \`server_roles\` cap (default 200) is read best-effort from \`GET /\` via new \`api_fetch_root\`; the union is truncated by lowest \`(position, id)\` with a \`role_limit_exceeded\` warning, plus a \`TooManyRoles\` create-time backstop. Source-verified against \`stoatchat/stoatchat\` (\`roles_create.rs\`, \`root.rs\`).
- **Deterministic rank tie-break** by \`(position, id)\` (string id — numeric \`int(id)\` would crash on edge ids).
- **Reporter** credits recovered "structural" roles.

## Safety
- **No-token path is byte-for-byte unchanged** — same role set, same create order (all new logic gated behind \`discord_metadata is not None\`).
- Managed/integration roles and \`@everyone\` excluded. Does **not** assign members to roles (needs an identity map that doesn't exist) — only ensures roles exist.

## Quality gates
- **1021 tests pass** (1003 baseline + 18 new); ruff + format + mypy strict clean.
- Full \`/df-\` pipeline: brief → spec → brainstorm → critique (R1 ITERATE → R2 PASS) → plan → subagent-driven build.
- Per-task spec+quality reviews (all Approved) + whole-branch Opus review = **READY TO MERGE** (0 Critical/Important).
- Mistral second opinion: 0 Critical (its 2 non-criticals were a misread + a best-effort-contract misunderstanding).
- \`uv.lock\` re-synced + \`--locked\` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)