### PR TITLE
fix(gui): token lifecycle — keep Stoat token through export, clear both at terminal screen (v2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.1] - 2026-06-24
+
+### Fixed
+
+- **GUI token lifecycle — two HIGH security/state-lifecycle defects in the NiceGUI shell** (`gui.py`), from the 2026-06-24 codebase bug hunt. Token cleanup is now centralised through a single `_clear_tokens(storage, keys)` helper and a `_SESSION_TOKEN_KEYS = ("token", "discord_token")` constant (`stoat_url` intentionally excluded — it is an instance URL, not a credential).
+  - **Orchestrated export no longer clears the still-needed Stoat token.** `_run_export`'s `finally` cleared both the Discord token and the Stoat `token`, but the orchestrated flow immediately redirects to `/validate`, whose guard (and `/migrate`'s) requires `storage["token"]`. The synchronous `finally` runs before the queued redirect loads, so the 1-Click flow bounced the user back to setup with an empty Stoat field. The export `finally` now clears only `discord_token`; the Stoat token is cleared at the terminal migration screen.
+  - **Offline-mode migration now clears the Stoat token from on-disk storage.** The migration `_run` had no `finally`, and offline mode (setup → /validate → /migrate, skipping /export) never reached the export cleanup — so the plaintext Stoat token persisted in `.nicegui/storage-user.json` after completion or error (a `security.md` violation). The migration `_run` gained a terminal `finally` that clears both tokens on success AND error, for both offline and orchestrated modes. Safe for the in-flight migration: `FerryConfig` holds its own token copy (built before the task), the engine never reads `app.storage`, and the only in-`_run` storage read precedes `run_migration`.
+  - Guarded by a constant-pin unit test (`tests/test_gui.py`) that fails CI if the security-critical key list ever silently shrinks, plus helper behaviour tests.
+
+### Notes
+
+- Two non-terminal abandonment cases remain out of scope (tokens linger if the user opens `/migrate` or lands on `/validate` but never proceeds — fixing them needs client-disconnect hooks). Bounded by the single-user, local-only (`127.0.0.1`), gitignored-storage nature of the tool.
+
 ## [2.6.0] - 2026-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.0"
+version = "2.6.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1404,6 +1404,15 @@ def migrate_page() -> None:
         except Exception as exc:
             log_display.push(f"[ERROR] Unexpected error: {exc}")
             ui.notify(f"Unexpected error: {exc}", type="negative")
+        finally:
+            # Terminal owner of session-token cleanup, for BOTH offline and
+            # orchestrated modes, on success AND error. (Offline mode never
+            # visits /export, so its finally is the only cleanup point.) Safe
+            # because this runs AFTER run_migration returns: config already holds
+            # its own token copy (a plain str), the engine never reads
+            # app.storage, and the only in-_run storage read (config.resume,
+            # above) has already completed. Do NOT move token reads below this.
+            _clear_tokens(storage, _SESSION_TOKEN_KEYS)
 
     background_tasks.create(_run())
 

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -774,9 +774,13 @@ def export_page() -> None:
             on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
             ui.notify(f"Export failed: {exc}", type="negative")
         finally:
-            # Clear tokens from storage (security — avoid persisting to disk)
-            storage.pop("discord_token", None)
-            storage.pop("token", None)
+            # Clear ONLY the Discord token here — export is its sole consumer.
+            # The Stoat token MUST survive: this finally runs synchronously
+            # BEFORE the queued ui.navigate.to("/validate") redirect loads, and
+            # both validate_page and migrate_page guard on storage["token"].
+            # Clearing it here bounces the user back to setup. The Stoat token is
+            # cleared by the terminal migration screen (migrate_page._run).
+            _clear_tokens(storage, ("discord_token",))
 
     background_tasks.create(_run_export())
 

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -29,6 +29,8 @@ except ImportError:
     pass
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, MutableMapping
+
     from discord_ferry.core.events import MigrationEvent
     from discord_ferry.parser.models import DCEExport
 
@@ -108,6 +110,26 @@ def _format_bytes(n: int | float) -> str:
             return f"{value:,.1f} {unit}"
         value /= 1024
     return f"{value:,.1f} TB"
+
+
+# Session credentials that must never persist to app.storage.user on disk.
+# Per security.md (GUI Storage): clear all token-like values when migration
+# completes or errors. `stoat_url` is also stored at setup but is intentionally
+# EXCLUDED here — it is an instance URL, not a credential.
+_SESSION_TOKEN_KEYS: tuple[str, ...] = ("token", "discord_token")
+
+
+def _clear_tokens(storage: MutableMapping[str, Any], keys: Iterable[str]) -> None:
+    """Best-effort removal of session secret keys from GUI storage.
+
+    Total and non-throwing: a missing key is a no-op (``storage.pop(k, None)``),
+    so this is idempotent and safe on any path (dry-run, partially-populated
+    storage, repeat calls). Cleanup ownership: the export phase clears only
+    ``discord_token``; the terminal migration screen clears
+    ``_SESSION_TOKEN_KEYS`` (both tokens).
+    """
+    for key in keys:
+        storage.pop(key, None)
 
 
 def _format_eta(total_messages: int, rate_limit: float) -> str:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from discord_ferry.config import FerryConfig
-from discord_ferry.gui import _compute_summary, _format_eta, _msgs_per_hour
+from discord_ferry.gui import (
+    _SESSION_TOKEN_KEYS,
+    _clear_tokens,
+    _compute_summary,
+    _format_eta,
+    _msgs_per_hour,
+)
 from discord_ferry.parser.dce_parser import parse_export_directory
 
 if TYPE_CHECKING:
@@ -307,3 +313,44 @@ def test_gui_imports_run_rollback() -> None:
     import discord_ferry.gui as gui_mod
 
     assert hasattr(gui_mod, "run_rollback")
+
+
+# ---------------------------------------------------------------------------
+# _clear_tokens + _SESSION_TOKEN_KEYS unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_clear_tokens_discord_only_leaves_stoat() -> None:
+    storage: dict[str, Any] = {
+        "token": "stoat-tok",
+        "discord_token": "disc-tok",
+        "stoat_url": "https://stoat.example",
+    }
+    _clear_tokens(storage, ("discord_token",))
+    assert "discord_token" not in storage
+    assert storage["token"] == "stoat-tok"
+    assert storage["stoat_url"] == "https://stoat.example"
+
+
+def test_clear_tokens_session_keys_clears_both() -> None:
+    storage: dict[str, Any] = {
+        "token": "stoat-tok",
+        "discord_token": "disc-tok",
+        "stoat_url": "https://stoat.example",
+    }
+    _clear_tokens(storage, _SESSION_TOKEN_KEYS)
+    assert "token" not in storage
+    assert "discord_token" not in storage
+    assert storage["stoat_url"] == "https://stoat.example"
+
+
+def test_clear_tokens_missing_key_is_noop() -> None:
+    storage: dict[str, Any] = {}
+    _clear_tokens(storage, _SESSION_TOKEN_KEYS)  # must not raise
+    assert storage == {}
+
+
+def test_session_token_keys_pinned() -> None:
+    # Constant-pin: the security-critical key list must never silently shrink.
+    # This is the load-bearing CI guard against the recurring token-leak vector.
+    assert _SESSION_TOKEN_KEYS == ("token", "discord_token")

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Fixes two HIGH, recurring token-lifecycle defects in the NiceGUI shell (`gui.py`), from the 2026-06-24 codebase bug hunt. Patch release **v2.6.1**.

- **S1 — export no longer clears the still-needed Stoat token.** `_run_export`'s `finally` cleared both the Discord token and the Stoat `token`, but the orchestrated flow immediately redirects to `/validate`, whose guard (and `/migrate`'s) requires `storage["token"]`. The synchronous `finally` runs before the queued redirect loads → the 1-Click flow bounced the user back to setup with an empty Stoat field. Now the export `finally` clears only `discord_token`.
- **S2 — offline migration now clears the Stoat token from disk.** The migration `_run` had no `finally`, and offline mode (setup → /validate → /migrate, skipping /export) never reached the export cleanup — so the plaintext Stoat token persisted in `.nicegui/storage-user.json` after completion/error (a `security.md` violation). The migration `_run` gained a terminal `finally` clearing both tokens on success AND error, both modes.

## How

One module-level helper `_clear_tokens(storage, keys)` (best-effort `storage.pop`) + a centralized `_SESSION_TOKEN_KEYS = ("token", "discord_token")` constant. Export clears `("discord_token",)`; the terminal migration screen clears `_SESSION_TOKEN_KEYS`. `stoat_url` intentionally excluded (URL, not a credential).

**Safety:** clearing storage in the migration `finally` cannot break the in-flight migration — `FerryConfig` holds its own token copy (built before the task), the engine never reads `app.storage`, and the only in-`_run` storage read precedes `run_migration`.

## Tests / scope

- 4 unit tests for the helper + a **constant-pin** (`_SESSION_TOKEN_KEYS == ("token", "discord_token")`) that fails CI if the key list silently shrinks (the recurring-leak vector).
- Call-site correctness (export key set; migration `finally`) is guarded by in-code invariant comments + code review, not CI — a deliberate, documented scope choice (the call sites live in `@ui.page` closures; `nicegui.testing` deferred as disproportionate).
- GUI-shell-only; no engine/API/config/state changes. `1025 passed`, ruff + mypy --strict clean.

## Accepted limitations (out of scope)

Tokens linger if the user opens `/migrate` or lands on `/validate` but never proceeds (non-terminal states needing client-disconnect hooks). Bounded by the single-user, local-only (`127.0.0.1`), gitignored-storage nature of the tool.

Built via the full df- pipeline (brief → spec → brainstorm → fresh-context critique → plan → SDD with per-task + whole-branch opus reviews) + Mistral security second opinion (0 critical/important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)