### PR TITLE
fix: reporting-integrity batch — reaction/pin counters + message fidelity (v2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.1] - 2026-06-24
+
+### Fixed
+
+- **Reporting integrity: post-migration reports were wrong on every run** (reaction/pin counters + message-fidelity denominator). From the 2026-06-24 v2.5.1 bug-hunt refresh; affects all three reporting surfaces (`ferry stats`, `migration_report.json`, the markdown report).
+  - **Reaction fidelity is no longer stuck at 50%** (`migrator/reactions.py`, `reporter.py`, `stats.py`): `state.pending_reactions` was never cleared, so every surface computed `reactions_total = reactions_applied + len(pending_reactions) = 2N` after a fully successful run → a flat 50% reaction sub-score. `run_reactions` now consumes `pending_reactions` as a work queue (applied entries removed, failed retained, cap-skipped removed), so the derived total self-corrects to N (100%).
+  - **Resume no longer double-counts** (`migrator/reactions.py`, `migrator/pins.py`): the engine re-runs the in-progress phase on resume; with the pending list never consumed, `reactions_applied`/`pins_applied` re-incremented over the persisted value. The phases now checkpoint progress via `save_state` (periodic, mirroring the messages phase) so a resumed phase processes only the remainder. A new persisted `MigrationState.reaction_message_counts` keeps the 20-reactions-per-message cap exact across a resume.
+  - **`ferry stats` no longer reports 0% Messages fidelity on a normal run** (`stats.py`, `core/engine.py`, `state.py`): `summarize_state` used the incremental-only `prior_messages_total` (default 0) as the message denominator. A new persisted `MigrationState.source_messages_total` (set by the engine from the post-filter export total, on every run incl. resume) is now the shared denominator for both `ferry stats` and the JSON/markdown report (legacy fallback to imported+failed / `sum(exports)`), so the two surfaces agree.
+  - **Dry-run** now reports 100% for reactions/pins (clears the pending list) instead of 50%.
+
+### Notes
+
+- Server-side state was always correct — Stoat reaction/pin PUTs are idempotent; these were purely local counter/stats bugs. Out of scope (tracked separately): the incremental message-offset re-stream (`migrator/messages.py`) and the forum-index count double-count (`core/engine.py`).
+
 ## [2.6.0] - 2026-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.0"
+version = "2.6.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -208,8 +208,9 @@ async def run_migration(
             #     reactions_applied, pins_applied). prior_messages_total is DERIVED
             #     here from len(prior.message_map).
             #   RESET each run: completed_channel_ids (re-enter every channel for
-            #     new msgs); pending_pins / pending_reactions (consumed by REPORT —
-            #     carrying a stale list would re-pin/re-react); failed_messages,
+            #     new msgs); pending_pins / pending_reactions (consumed by the
+            #     reactions/pins phases — carrying a stale list would re-pin/re-react);
+            #     failed_messages,
             #     warnings / errors, validation_results, embeds_* / replies_*
             #     (per-run fidelity counters); current_phase, started_at,
             #     completed_at, export_completed, rollback_progress, is_dry_run.

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -393,6 +393,11 @@ async def run_migration(
                 filtered_exports.append(export)
         exports = filtered_exports
 
+    # Persist the post-filter source message total so stats.summarize_state (state-only)
+    # and reporter.generate_report share ONE denominator. Set unconditionally — the
+    # messages phase is skipped on resume, so this must not be gated on it.
+    state.source_messages_total = sum(e.message_count for e in exports)
+
     # Pre-creation review: emit summary event and optionally wait for user confirmation
     if not config.dry_run and not config.resume:
         discord_meta = load_discord_metadata(config.output_dir)

--- a/src/discord_ferry/migrator/pins.py
+++ b/src/discord_ferry/migrator/pins.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_pin_message, get_session
+from discord_ferry.state import save_state
 
 if TYPE_CHECKING:
     from discord_ferry.config import FerryConfig
@@ -54,6 +56,7 @@ async def run_pins(
 
     if config.dry_run:
         state.pins_applied = len(state.pending_pins)
+        state.pending_pins = []
         on_event(
             MigrationEvent(
                 phase="pins",
@@ -63,24 +66,29 @@ async def run_pins(
         )
         return
 
+    queue = list(state.pending_pins)  # snapshot
+    remaining: list[tuple[str, str]] = []
+    checkpoint_interval = max(config.checkpoint_interval, 1)
+    last_save = time.monotonic()
+
     async with get_session(config) as session:
-        for idx, (channel_id, message_id) in enumerate(state.pending_pins, start=1):
+        for pos, (channel_id, message_id) in enumerate(queue, start=1):
             try:
                 await api_pin_message(
                     session, config.stoat_url, config.token, channel_id, message_id
                 )
                 state.pins_applied += 1
-
                 on_event(
                     MigrationEvent(
                         phase="pins",
                         status="progress",
                         message=f"Pinned message {message_id} in channel {channel_id}",
-                        current=idx,
+                        current=pos,
                         total=total,
                     )
                 )
             except Exception as exc:  # noqa: BLE001
+                remaining.append((channel_id, message_id))
                 state.errors.append(
                     {
                         "phase": "pins",
@@ -96,12 +104,21 @@ async def run_pins(
                         phase="pins",
                         status="error",
                         message=f"Failed to pin message {message_id}: {exc}",
-                        current=idx,
+                        current=pos,
                         total=total,
                     )
                 )
 
+            now = time.monotonic()
+            if pos % checkpoint_interval == 0 and now - last_save >= 5.0:
+                state.pending_pins = remaining + queue[pos:]
+                save_state(state, config.output_dir)
+                last_save = now
+
             await asyncio.sleep(0.5)
+
+    state.pending_pins = remaining
+    save_state(state, config.output_dir)
 
     on_event(
         MigrationEvent(

--- a/src/discord_ferry/migrator/reactions.py
+++ b/src/discord_ferry/migrator/reactions.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.security import safe_sanitize
 from discord_ferry.migrator.api import api_add_reaction, get_session
+from discord_ferry.state import save_state
 
 if TYPE_CHECKING:
     from discord_ferry.config import FerryConfig
@@ -58,7 +60,9 @@ async def run_reactions(
     )
 
     if config.dry_run:
-        state.reactions_applied = len(state.pending_reactions)
+        state.reactions_applied = total
+        state.reaction_message_counts = {}
+        state.pending_reactions = []
         on_event(
             MigrationEvent(
                 phase="reactions",
@@ -68,11 +72,15 @@ async def run_reactions(
         )
         return
 
-    # Track per-message reaction counts to enforce the 20-per-message Stoat limit.
-    per_message_counts: dict[str, int] = {}
+    # Resume-safe: seed per-message cap counts from persisted state.
+    per_message_counts: dict[str, int] = dict(state.reaction_message_counts)
+    queue = list(state.pending_reactions)  # snapshot — we reassign state.pending_reactions below
+    remaining: list[dict[str, object]] = []
+    checkpoint_interval = max(config.checkpoint_interval, 1)
+    last_save = time.monotonic()
 
     async with get_session(config) as session:
-        for idx, entry in enumerate(state.pending_reactions, start=1):
+        for pos, entry in enumerate(queue, start=1):
             channel_id = str(entry["channel_id"])
             message_id = str(entry["message_id"])
             emoji = str(entry["emoji"])
@@ -87,11 +95,11 @@ async def run_reactions(
                             f"Skipping reaction on message {message_id} "
                             f"— already at {_MAX_REACTIONS_PER_MESSAGE} reactions"
                         ),
-                        current=idx,
+                        current=pos,
                         total=total,
                     )
                 )
-                continue
+                continue  # cap-skipped: consumed (not retried, not retained)
 
             try:
                 await api_add_reaction(
@@ -99,17 +107,17 @@ async def run_reactions(
                 )
                 state.reactions_applied += 1
                 per_message_counts[message_id] = current_count + 1
-
                 on_event(
                     MigrationEvent(
                         phase="reactions",
                         status="progress",
                         message=f"Added reaction {emoji} to message {message_id}",
-                        current=idx,
+                        current=pos,
                         total=total,
                     )
                 )
             except Exception as exc:  # noqa: BLE001
+                remaining.append(entry)  # retained for resume
                 state.errors.append(
                     {
                         "phase": "reactions",
@@ -124,13 +132,27 @@ async def run_reactions(
                     MigrationEvent(
                         phase="reactions",
                         status="error",
-                        message=f"Failed reaction {emoji} on {message_id}: {exc}",
-                        current=idx,
+                        message=f"Failed to add reaction {emoji} to message {message_id}: {exc}",
+                        current=pos,
                         total=total,
                     )
                 )
 
+            # Periodic checkpoint: persist counter + remaining (incl. unprocessed tail)
+            # + per-message counts together in ONE save_state — never a subset.
+            now = time.monotonic()
+            if pos % checkpoint_interval == 0 and now - last_save >= 5.0:
+                state.pending_reactions = remaining + queue[pos:]
+                state.reaction_message_counts = per_message_counts
+                save_state(state, config.output_dir)
+                last_save = now
+
             await asyncio.sleep(0.5)
+
+    # Final settle: only un-applied (failed) entries remain.
+    state.pending_reactions = remaining
+    state.reaction_message_counts = per_message_counts
+    save_state(state, config.output_dir)
 
     on_event(
         MigrationEvent(

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -100,7 +100,7 @@ def generate_report(
     else:
         source_guild = {"id": "", "name": ""}
 
-    total_messages = sum(e.message_count for e in exports)
+    total_messages = state.source_messages_total or sum(e.message_count for e in exports)
     messages_imported = len(state.message_map)
     messages_skipped = max(0, total_messages - messages_imported)
 
@@ -343,7 +343,7 @@ def generate_markdown_report(
     lines.append(f"**Completed:** {state.completed_at}\n")
 
     # S18: Fidelity score section.
-    total_msgs = sum(e.message_count for e in exports)
+    total_msgs = state.source_messages_total or sum(e.message_count for e in exports)
     fidelity = compute_fidelity_score(
         total_messages=total_msgs,
         failed_count=len(state.failed_messages),

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -128,6 +128,9 @@ class MigrationState:
     # Incremental/delta migration tracking
     # prior_messages_total: message count from the prior run (set at init for delta mode)
     prior_messages_total: int = 0
+    # source_messages_total: total source messages in this run's exports (post-filter),
+    # set by the engine. Denominator for message fidelity in stats/reporter. 0 = unset (legacy).
+    source_messages_total: int = 0
 
     # Forum index tracking: populated during CHANNELS phase, consumed by REPORT phase.
     # forum_channel_members: forum_cat_key -> list of discord_channel_ids in that forum
@@ -137,6 +140,9 @@ class MigrationState:
     # Per-channel message counts: discord_channel_id -> messages migrated.
     # Incremented by _process_message; used by forum index rebuild in REPORT phase.
     channel_message_counts: dict[str, int] = field(default_factory=dict)
+    # reaction_message_counts: Stoat message_id -> reactions applied, persisted so the
+    # 20-per-message cap stays exact across a resume (reactions phase clears pending as it goes).
+    reaction_message_counts: dict[str, int] = field(default_factory=dict)
 
     # Forum index message IDs: forum_cat_key -> stoat_message_id.
     # Populated by _rebuild_forum_indexes; used to PATCH (not re-POST) on re-runs.
@@ -264,9 +270,11 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "failed_messages": [dataclasses.asdict(fm) for fm in state.failed_messages],
         "validation_results": state.validation_results,
         "prior_messages_total": state.prior_messages_total,
+        "source_messages_total": state.source_messages_total,
         "forum_channel_members": state.forum_channel_members,
         "forum_category_names": state.forum_category_names,
         "channel_message_counts": state.channel_message_counts,
+        "reaction_message_counts": state.reaction_message_counts,
         "forum_index_message_ids": state.forum_index_message_ids,
         "embeds_total": state.embeds_total,
         "embeds_dropped": state.embeds_dropped,
@@ -332,9 +340,11 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             failed_messages=[FailedMessage(**d) for d in data.get("failed_messages", [])],
             validation_results=data.get("validation_results", {}),
             prior_messages_total=data.get("prior_messages_total", 0),
+            source_messages_total=data.get("source_messages_total", 0),
             forum_channel_members=data.get("forum_channel_members", {}),
             forum_category_names=data.get("forum_category_names", {}),
             channel_message_counts=data.get("channel_message_counts", {}),
+            reaction_message_counts=data.get("reaction_message_counts", {}),
             forum_index_message_ids=data.get("forum_index_message_ids", {}),
             embeds_total=data.get("embeds_total", 0),
             embeds_dropped=data.get("embeds_dropped", 0),

--- a/src/discord_ferry/stats.py
+++ b/src/discord_ferry/stats.py
@@ -84,6 +84,14 @@ class StateSummary:
     current_phase: str
 
 
+def _message_denominator(state: MigrationState) -> int:
+    """Total source messages for fidelity. Prefer the engine-set source total;
+    fall back to imported+failed for legacy states that never recorded it."""
+    if state.source_messages_total:
+        return state.source_messages_total
+    return len(state.message_map) + len(state.failed_messages)
+
+
 def summarize_state(state: MigrationState) -> StateSummary:
     """Build a state-only summary suitable for ``ferry stats`` rendering.
 
@@ -97,15 +105,11 @@ def summarize_state(state: MigrationState) -> StateSummary:
     value equals ``reactions_applied`` and the sub-score becomes 100%. In
     partial migrations the derived value reflects "attempted so far",
     giving a meaningful denominator.
-
-    Note: ``reporter.generate_report`` passes ``len(pending_reactions)``
-    alone — a latent overestimate in partial state. The two surfaces
-    diverge intentionally; aligning ``reporter.py`` is tracked separately.
     """
     reactions_total = state.reactions_applied + len(state.pending_reactions)
 
     score_dict = compute_fidelity_score(
-        total_messages=state.prior_messages_total,
+        total_messages=_message_denominator(state),
         failed_count=len(state.failed_messages),
         attachments_uploaded=state.attachments_uploaded,
         attachments_skipped=state.attachments_skipped,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -313,6 +313,56 @@ async def test_run_migration_validate_total_in_event(tmp_path: Path) -> None:
     assert completed.total > 0
 
 
+async def test_run_migration_sets_source_messages_total(tmp_path: Path) -> None:
+    """source_messages_total is set from the parsed exports on a fresh run."""
+    from discord_ferry.parser.dce_parser import parse_export_directory
+
+    config = _make_config(tmp_path)
+    expected = sum(
+        e.message_count for e in parse_export_directory(config.export_dir, metadata_only=True)
+    )
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert expected > 0
+    assert state.source_messages_total == expected
+
+
+async def test_run_migration_resume_repopulates_source_messages_total(tmp_path: Path) -> None:
+    """A resume run re-derives source_messages_total even though MESSAGES is skipped."""
+    from discord_ferry.state import load_state, save_state
+
+    prior = MigrationState()
+    prior.current_phase = "report"
+    prior.source_messages_total = 0  # legacy/never-set
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, resume=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.source_messages_total > 0
+    _ = load_state  # silence unused import if not needed
+
+
+async def test_run_migration_source_messages_total_post_filter(tmp_path: Path) -> None:
+    """source_messages_total reflects only exports that survive the thread filter (R1 guard).
+
+    Fixtures have two thread exports (msg_count=1 and msg_count=2) and four non-thread
+    exports. Setting min_thread_messages=5 filters both threads, so the post-filter total
+    must be strictly less than the unfiltered total.
+    """
+    from discord_ferry.parser.dce_parser import parse_export_directory
+
+    all_exports = parse_export_directory(FIXTURES_DIR, metadata_only=True)
+    unfiltered_total = sum(e.message_count for e in all_exports)
+    # min_thread_messages=5 filters threads with msg_count < 5 (both thread fixtures)
+    post_filter_total = sum(
+        e.message_count for e in all_exports if not (e.is_thread and e.message_count < 5)
+    )
+    assert post_filter_total < unfiltered_total, "fixture sanity: filter must actually remove msgs"
+
+    config = _make_config(tmp_path, min_thread_messages=5)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.source_messages_total == post_filter_total
+
+
 async def test_run_migration_default_connect_phase(tmp_path: Path) -> None:
     """Connect phase runs by default when no override is provided (uses _DEFAULT_PHASES)."""
     from aioresponses import aioresponses

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -18,10 +20,10 @@ TOKEN = "test-token"
 # ---------------------------------------------------------------------------
 
 
-def _make_config() -> FerryConfig:
-    from pathlib import Path
-
-    return FerryConfig(export_dir=Path("/tmp"), stoat_url=BASE_URL, token=TOKEN)
+def _make_config(output_dir: Path) -> FerryConfig:
+    return FerryConfig(
+        export_dir=Path("/tmp"), stoat_url=BASE_URL, token=TOKEN, output_dir=output_dir
+    )
 
 
 def _make_state(pending: list[tuple[str, str]] | None = None) -> MigrationState:
@@ -37,10 +39,10 @@ def _make_state(pending: list[tuple[str, str]] | None = None) -> MigrationState:
 # ---------------------------------------------------------------------------
 
 
-async def test_run_pins_empty_pending() -> None:
+async def test_run_pins_empty_pending(tmp_path: Path) -> None:
     """Emits 'completed' immediately when there are no pending pins."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     state = _make_state(pending=[])
 
     await run_pins(config, state, [], events.append)
@@ -50,10 +52,10 @@ async def test_run_pins_empty_pending() -> None:
     assert state.pins_applied == 0
 
 
-async def test_run_pins_successful_pin() -> None:
+async def test_run_pins_successful_pin(tmp_path: Path) -> None:
     """Pins a message successfully and increments the counter."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     state = _make_state(pending=[("ch1", "msg1")])
 
     mock_pin = AsyncMock(return_value={})
@@ -73,15 +75,11 @@ async def test_run_pins_successful_pin() -> None:
     assert state.pins_applied == 1
 
 
-async def test_run_pins_error_handling() -> None:
-    """Logs error for a failed pin but continues processing remaining pins."""
+async def test_run_pins_error_handling(tmp_path: Path) -> None:
+    """Failed pin stays in pending; successful one is consumed."""
     events: list[Any] = []
-    config = _make_config()
-    pending = [
-        ("ch1", "msg1"),  # will fail
-        ("ch1", "msg2"),  # should succeed
-    ]
-    state = _make_state(pending=pending)
+    config = _make_config(tmp_path)
+    state = _make_state(pending=[("ch1", "msg1"), ("ch1", "msg2")])  # 1 fails, 1 ok
 
     call_count = 0
 
@@ -99,14 +97,14 @@ async def test_run_pins_error_handling() -> None:
         await run_pins(config, state, [], events.append)
 
     assert len(state.errors) == 1
-    assert "pin failed" in state.errors[0]["message"]
     assert state.pins_applied == 1
+    assert state.pending_pins == [("ch1", "msg1")]
 
 
-async def test_run_pins_counter_increment() -> None:
+async def test_run_pins_counter_increment(tmp_path: Path) -> None:
     """pins_applied increments correctly for each successful pin."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     pending = [("ch1", f"msg{i}") for i in range(4)]
     state = _make_state(pending=pending)
 
@@ -123,10 +121,10 @@ async def test_run_pins_counter_increment() -> None:
     assert "4" in completed[0].message
 
 
-async def test_run_pins_emits_progress_events() -> None:
+async def test_run_pins_emits_progress_events(tmp_path: Path) -> None:
     """Progress events are emitted with correct current/total values."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     pending = [("ch1", "msgA"), ("ch2", "msgB"), ("ch3", "msgC")]
     state = _make_state(pending=pending)
 
@@ -142,3 +140,69 @@ async def test_run_pins_emits_progress_events() -> None:
     assert progress_events[0].current == 1
     assert progress_events[0].total == 3
     assert progress_events[2].current == 3
+
+
+async def test_run_pins_clears_pending_on_success(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    state = _make_state(pending=[("ch1", f"msg{i}") for i in range(4)])
+
+    with (
+        patch("discord_ferry.migrator.pins.api_pin_message", new=AsyncMock(return_value={})),
+        patch("discord_ferry.migrator.pins.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_pins(config, state, [], [].append)
+
+    assert state.pins_applied == 4
+    assert state.pending_pins == []
+
+
+async def test_run_pins_resume_no_double_count(tmp_path: Path) -> None:
+    from discord_ferry.state import load_state
+
+    config = _make_config(tmp_path)
+    config.checkpoint_interval = 1
+    state = _make_state(pending=[("ch1", f"msg{i}") for i in range(5)])
+
+    n = 0
+
+    async def crashing(*args: Any, **kwargs: Any) -> dict[str, object]:
+        nonlocal n
+        n += 1
+        if n > 3:
+            raise KeyboardInterrupt
+        return {}
+
+    with (
+        patch("discord_ferry.migrator.pins.api_pin_message", new=crashing),
+        patch("discord_ferry.migrator.pins.asyncio.sleep", new=AsyncMock()),
+        patch("discord_ferry.migrator.pins.time.monotonic", side_effect=range(0, 1000, 10)),
+        contextlib.suppress(KeyboardInterrupt),
+    ):
+        await run_pins(config, state, [], [].append)
+
+    reloaded = load_state(tmp_path)
+    assert reloaded.pins_applied == 3
+    assert len(reloaded.pending_pins) == 2
+
+    with (
+        patch("discord_ferry.migrator.pins.api_pin_message", new=AsyncMock(return_value={})),
+        patch("discord_ferry.migrator.pins.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_pins(config, reloaded, [], [].append)
+
+    assert reloaded.pins_applied == 5
+    assert reloaded.pending_pins == []
+
+
+async def test_run_pins_dry_run_reports_full(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    config.dry_run = True
+    state = _make_state(pending=[("ch1", f"msg{i}") for i in range(3)])
+
+    mock_pin = AsyncMock(return_value={})
+    with patch("discord_ferry.migrator.pins.api_pin_message", new=mock_pin):
+        await run_pins(config, state, [], [].append)
+
+    assert mock_pin.await_count == 0
+    assert state.pins_applied == 3
+    assert state.pending_pins == []

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -18,10 +20,13 @@ TOKEN = "test-token"
 # ---------------------------------------------------------------------------
 
 
-def _make_config() -> FerryConfig:
-    from pathlib import Path
-
-    return FerryConfig(export_dir=Path("/tmp"), stoat_url=BASE_URL, token=TOKEN)
+def _make_config(output_dir: Path) -> FerryConfig:
+    return FerryConfig(
+        export_dir=Path("/tmp"),
+        stoat_url=BASE_URL,
+        token=TOKEN,
+        output_dir=output_dir,
+    )
 
 
 def _make_state(pending: list[dict[str, object]] | None = None) -> MigrationState:
@@ -45,10 +50,10 @@ def _reaction(
 # ---------------------------------------------------------------------------
 
 
-async def test_run_reactions_empty_pending() -> None:
+async def test_run_reactions_empty_pending(tmp_path: Path) -> None:
     """Emits 'completed' immediately when there are no pending reactions."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     state = _make_state(pending=[])
 
     await run_reactions(config, state, [], events.append)
@@ -58,10 +63,10 @@ async def test_run_reactions_empty_pending() -> None:
     assert state.reactions_applied == 0
 
 
-async def test_run_reactions_unicode_emoji() -> None:
+async def test_run_reactions_unicode_emoji(tmp_path: Path) -> None:
     """Applies a Unicode emoji reaction successfully."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     state = _make_state(pending=[_reaction(emoji="\U0001f44d")])
 
     mock_add = AsyncMock(return_value={})
@@ -75,10 +80,10 @@ async def test_run_reactions_unicode_emoji() -> None:
     assert state.reactions_applied == 1
 
 
-async def test_run_reactions_custom_emoji() -> None:
+async def test_run_reactions_custom_emoji(tmp_path: Path) -> None:
     """Applies a custom emoji ID reaction successfully."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     state = _make_state(pending=[_reaction(emoji="customEmojiId")])
 
     mock_add = AsyncMock(return_value={})
@@ -92,10 +97,10 @@ async def test_run_reactions_custom_emoji() -> None:
     assert state.reactions_applied == 1
 
 
-async def test_run_reactions_per_message_limit() -> None:
+async def test_run_reactions_per_message_limit(tmp_path: Path) -> None:
     """Stops adding reactions once a message reaches 20 (Stoat hard limit)."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     # 25 reactions all on the same message.
     pending = [_reaction(message_id="msg1", emoji=f"e{i}") for i in range(25)]
     state = _make_state(pending=pending)
@@ -112,14 +117,11 @@ async def test_run_reactions_per_message_limit() -> None:
     assert mock_add.await_count == 20
 
 
-async def test_run_reactions_error_handling() -> None:
-    """Logs error for a failed reaction but continues processing remaining reactions."""
+async def test_run_reactions_error_handling(tmp_path: Path) -> None:
+    """Failed reaction stays in pending; successful one is consumed."""
     events: list[Any] = []
-    config = _make_config()
-    pending = [
-        _reaction(message_id="msg1"),  # will fail
-        _reaction(message_id="msg2"),  # should succeed
-    ]
+    config = _make_config(tmp_path)
+    pending = [_reaction(message_id="msg1"), _reaction(message_id="msg2")]  # 1 fails, 1 ok
     state = _make_state(pending=pending)
 
     call_count = 0
@@ -138,14 +140,15 @@ async def test_run_reactions_error_handling() -> None:
         await run_reactions(config, state, [], events.append)
 
     assert len(state.errors) == 1
-    assert "network error" in state.errors[0]["message"]
     assert state.reactions_applied == 1
+    # The failed entry is retained for resume; the successful one consumed.
+    assert state.pending_reactions == [_reaction(message_id="msg1")]
 
 
-async def test_run_reactions_counter_increment() -> None:
+async def test_run_reactions_counter_increment(tmp_path: Path) -> None:
     """reactions_applied increments correctly for each successful reaction."""
     events: list[Any] = []
-    config = _make_config()
+    config = _make_config(tmp_path)
     pending = [_reaction(message_id=f"msg{i}") for i in range(5)]
     state = _make_state(pending=pending)
 
@@ -160,3 +163,102 @@ async def test_run_reactions_counter_increment() -> None:
     completed = [e for e in events if e.status == "completed"]
     assert completed
     assert "5" in completed[0].message
+
+
+async def test_run_reactions_clears_pending_on_success(tmp_path: Path) -> None:
+    """A fully successful run empties pending → reactions_total == applied → 100%."""
+    from discord_ferry.stats import summarize_state
+
+    events: list[Any] = []
+    config = _make_config(tmp_path)
+    state = _make_state(pending=[_reaction(message_id=f"msg{i}") for i in range(3)])
+
+    with (
+        patch("discord_ferry.migrator.reactions.api_add_reaction", new=AsyncMock(return_value={})),
+        patch("discord_ferry.migrator.reactions.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_reactions(config, state, [], events.append)
+
+    assert state.reactions_applied == 3
+    assert state.pending_reactions == []
+    assert summarize_state(state).fidelity.reactions == 100.0
+
+
+async def test_run_reactions_resume_no_double_count(tmp_path: Path) -> None:
+    """3-of-5 applied then crash; resume applies the remaining 2 → applied == 5, not 8."""
+    from discord_ferry.state import load_state
+
+    config = _make_config(tmp_path)
+    state = _make_state(pending=[_reaction(message_id=f"msg{i}") for i in range(5)])
+
+    crash_after = 0
+
+    async def crashing(*args: Any, **kwargs: Any) -> dict[str, object]:
+        nonlocal crash_after
+        crash_after += 1
+        if crash_after > 3:
+            raise KeyboardInterrupt  # simulate hard crash after 3 applied
+        return {}
+
+    with (
+        patch("discord_ferry.migrator.reactions.api_add_reaction", new=crashing),
+        patch("discord_ferry.migrator.reactions.asyncio.sleep", new=AsyncMock()),
+        # Force a checkpoint save after every entry so the crash persists progress.
+    ):
+        config.checkpoint_interval = 1
+        # Make the 5s throttle a no-op: values spaced 10 apart so every checkpoint fires.
+        monotonic_patch = patch(
+            "discord_ferry.migrator.reactions.time.monotonic",
+            side_effect=range(0, 1000, 10),
+        )
+        with monotonic_patch, contextlib.suppress(KeyboardInterrupt):
+            await run_reactions(config, state, [], [].append)
+
+    reloaded = load_state(tmp_path)
+    assert reloaded.reactions_applied == 3
+    assert len(reloaded.pending_reactions) == 2  # only the un-applied remain
+
+    with (
+        patch("discord_ferry.migrator.reactions.api_add_reaction", new=AsyncMock(return_value={})),
+        patch("discord_ferry.migrator.reactions.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_reactions(config, reloaded, [], [].append)
+
+    assert reloaded.reactions_applied == 5
+    assert reloaded.pending_reactions == []
+
+
+async def test_run_reactions_cap_persists_across_resume(tmp_path: Path) -> None:
+    """A message already at the 20 cap is not re-applied past 20 after a resume."""
+    config = _make_config(tmp_path)
+    state = _make_state(pending=[])
+    state.reaction_message_counts = {"msgX": 20}  # already capped in a prior run
+    state.pending_reactions = [_reaction(message_id="msgX", emoji=f"e{i}") for i in range(3)]
+
+    mock_add = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.migrator.reactions.api_add_reaction", new=mock_add),
+        patch("discord_ferry.migrator.reactions.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_reactions(config, state, [], [].append)
+
+    assert mock_add.await_count == 0  # all 3 skipped — already at cap
+    assert state.pending_reactions == []  # cap-skipped consumed, not retained
+
+
+async def test_run_reactions_dry_run_reports_full(tmp_path: Path) -> None:
+    """Dry-run counts all pending as applied and clears pending → 100%, no API calls."""
+    from discord_ferry.stats import summarize_state
+
+    config = _make_config(tmp_path)
+    config.dry_run = True
+    state = _make_state(pending=[_reaction(message_id=f"msg{i}") for i in range(4)])
+
+    mock_add = AsyncMock(return_value={})
+    with patch("discord_ferry.migrator.reactions.api_add_reaction", new=mock_add):
+        await run_reactions(config, state, [], [].append)
+
+    assert mock_add.await_count == 0
+    assert state.reactions_applied == 4
+    assert state.pending_reactions == []
+    assert summarize_state(state).fidelity.reactions == 100.0

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -837,3 +837,46 @@ def test_report_omits_invite_when_absent(tmp_path: Path) -> None:
     state = MigrationState()
     report = generate_report(config, state, exports=[])
     assert not report.get("invite", {}).get("code")
+
+
+# ---------------------------------------------------------------------------
+# S3: stats==JSON equality — reporter and summarize_state share denominator
+# ---------------------------------------------------------------------------
+
+
+def test_report_messages_matches_stats(tmp_path: Path) -> None:
+    """generate_report fidelity.messages equals summarize_state fidelity.messages (S3).
+
+    Divergence scenario: source_messages_total (100) != sum(export.message_count)
+    (80) simulates post-filter divergence.  With 10 failures the two denominators
+    produce different percentages:
+      old reporter (sum=80): (80-10)/80 = 87.5%
+      stats / new reporter (source_total=100): (100-10)/100 = 90.0%
+    The test is RED on pre-fix code and GREEN after reporter adopts source_messages_total.
+    """
+    from discord_ferry.stats import summarize_state
+
+    # exports total = 80, but engine recorded 100 source messages before filtering
+    exports = [
+        _make_export(channel_id="c1", message_count=50),
+        _make_export(channel_id="c2", message_count=30),
+    ]
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        source_messages_total=100,
+        message_map={f"m{i}": f"sm{i}" for i in range(90)},  # 90 imported
+        failed_messages=[
+            FailedMessage(discord_msg_id=f"fail{i}", stoat_channel_id="c1", error="err")
+            for i in range(10)
+        ],
+        reactions_applied=5,
+        pending_reactions=[],  # cleared — reactions sub-score = 100%
+    )
+
+    report = generate_report(config, state, exports)
+    summary = summarize_state(state)
+
+    # Core assertion: both surfaces agree on message fidelity %
+    assert report["fidelity"]["messages"] == summary.fidelity.messages
+    # Reactions: pending cleared → 100% on both surfaces
+    assert report["fidelity"]["reactions"] == 100.0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -545,3 +545,31 @@ def test_invite_fields_default_when_absent(tmp_path: Path) -> None:
     loaded = load_state(tmp_path)
     assert loaded.invite_code == ""
     assert loaded.invite_url == ""
+
+
+def test_new_reporting_fields_round_trip(tmp_path: Path) -> None:
+    """source_messages_total and reaction_message_counts survive save/load."""
+    from discord_ferry.state import MigrationState, load_state, save_state
+
+    state = MigrationState()
+    state.source_messages_total = 1234
+    state.reaction_message_counts = {"01HMSG": 7}
+    save_state(state, tmp_path)
+
+    loaded = load_state(tmp_path)
+    assert loaded.source_messages_total == 1234
+    assert loaded.reaction_message_counts == {"01HMSG": 7}
+
+
+def test_new_reporting_fields_default_when_absent(tmp_path: Path) -> None:
+    """Legacy state.json without the new fields loads with safe defaults."""
+    import json
+
+    from discord_ferry.state import load_state
+
+    (tmp_path / "state.json").write_text(json.dumps({"stoat_server_id": "srv1"}), encoding="utf-8")
+    (tmp_path / "message_map.json").write_text(json.dumps({}), encoding="utf-8")
+
+    loaded = load_state(tmp_path)
+    assert loaded.source_messages_total == 0
+    assert loaded.reaction_message_counts == {}

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -109,6 +109,7 @@ def _full_state() -> MigrationState:
     state.embeds_dropped = 1
     state.failed_messages = []
     state.prior_messages_total = 1000
+    state.source_messages_total = 1000
     state.errors = [{"phase": "MESSAGES", "message": "rate limited at message 42"}]
     state.warnings = [{"phase": "STRUCTURE", "message": "emoji slot near cap"}]
     state.channel_message_counts = {"c0": 600, "c1": 300, "c2": 100}
@@ -449,3 +450,24 @@ def test_stats_channels_section_omitted_when_empty(runner: CliRunner, tmp_path: 
     result = runner.invoke(main, ["stats", str(out)])
     assert result.exit_code == 0
     assert "Per-Channel Messages" not in result.output
+
+
+def test_summarize_state_messages_fidelity_uses_source_total() -> None:
+    """A fresh run (prior_messages_total=0) still reports correct Messages fidelity."""
+    state = MigrationState()
+    state.message_map = {f"m{i}": f"sm{i}" for i in range(100)}
+    state.failed_messages = []
+    state.source_messages_total = 100  # set by engine, even on a fresh run
+    state.prior_messages_total = 0  # incremental-only; must NOT be the denominator
+    summary = summarize_state(state)
+    assert summary.fidelity.messages == 100.0
+
+
+def test_summarize_state_messages_fidelity_legacy_fallback() -> None:
+    """Legacy state (source_messages_total absent/0) falls back to map+failed, not 0%."""
+    state = MigrationState()
+    state.message_map = {f"m{i}": f"sm{i}" for i in range(50)}
+    state.failed_messages = []
+    state.source_messages_total = 0  # legacy
+    summary = summarize_state(state)
+    assert summary.fidelity.messages == 100.0  # 50/50, not 0/0

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes the cluster of counter/fidelity bugs from the 2026-06-24 v2.5.1 bug-hunt refresh that made ferry's post-migration reports **wrong on every run**, across all three surfaces (`ferry stats`, `migration_report.json`, the markdown report).

### Bugs fixed
- **Reaction fidelity stuck at 50%** — `state.pending_reactions` was never cleared, so every surface computed `reactions_total = applied + len(pending) = 2N` after a fully successful run.
- **Resume double-counted** `reactions_applied` / `pins_applied` — the engine re-runs the in-progress phase on resume over a never-consumed pending list.
- **`ferry stats` reported 0% Messages fidelity on normal runs** — it used the incremental-only `prior_messages_total` (default 0) as the denominator, disagreeing with the JSON report's `sum(exports)`.

### Approach
1. **Clear-pending work queue** — `run_reactions`/`run_pins` consume their pending list as entries succeed (applied removed, failed retained, cap-skipped removed), iterating a snapshot and checkpointing via `save_state`, so the derived total self-corrects (2N→N) and resume processes only the remainder.
2. **Shared denominator** — new persisted `MigrationState.source_messages_total` (set by the engine post-filter, on every run incl. resume) feeds both stats and reporter (legacy fallback), guaranteeing `ferry stats` == JSON report.
3. **Persisted cap** — new `MigrationState.reaction_message_counts` keeps the 20-per-message reaction cap exact across a resume.

### Out of scope (tracked separately)
Incremental message-offset re-stream (`migrator/messages.py`) and forum-index count double-count (`core/engine.py`). Server-side state was always correct (Stoat reaction/pin PUTs are idempotent); these were purely local counter/stats bugs.

## Testing
- `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest` → **1036 passed** (1021 @ v2.6.0; **+15** new real-phase tests).
- Each regression test proven RED on pre-fix code → GREEN after (incl. crash-then-resume asserting counters reach exactly N not 2N, a post-filter `source_messages_total` guard, and a genuine stats==JSON equality test).

## Process
Full `/df` pipeline (brief → spec → brainstorm → critique ×2 PASS) → subagent-driven build (per-task review each) → final whole-branch review (opus, Ready-to-merge) → Mistral second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)