### PR TITLE
fix(incremental): self-heal previously-failed messages + guard non-numeric carried offset (v2.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.4] - 2026-06-25
+
+### Fixed
+
+- **Incremental mode now self-heals previously-failed messages, and a non-numeric carried offset no longer crashes the skip gate** (`migrator/messages.py`, `core/engine.py`). Closes the v2.6.3 **known limitation** (GitHub #76) and a folded-in pre-existing crash (GitHub #77), both surfaced by the whole-branch review of the v2.6.3 work.
+  - **A message that failed to POST on a prior run is now re-attempted automatically on the next `--incremental` run** (#76). The durable `channel_high_water` mark tracks the highest message id *seen*, not *successfully copied*, so a failed id sat below the mark and was skipped forever — and the engine carry-over reset `failed_messages`, wiping its retry record. Now the incremental carry-over **carries `failed_messages` forward** (as independent copies), the within-channel skip gate **excludes previously-failed ids for that channel** so the messages phase re-POSTs them, and a completion-time **reconciliation** drops ids that succeeded this run and collapses the carried + fresh-re-fail duplicate to a single entry (so the failure count stays stable across runs). Running `ferry retry` before `--incremental` is **no longer required** — the v2.6.3 known-limitation note is resolved. `--resume` is unaffected (it does not consult `failed_messages`); an unchanged channel with no prior failures still makes zero POSTs.
+  - **A non-numeric carried offset no longer fails the channel worker** (#77). The skip threshold used `max(…, key=int)` / `int(_skip_below)`, but the periodic checkpoint persisted the raw `msg.id`, which can be non-numeric for some system messages; a prior run that crashed right after such a checkpoint then raised `ValueError` (swallowed by `asyncio.gather` → the channel was silently skipped). The threshold now filters/normalizes non-numeric values to "no threshold" (copy, never crash) for both `--incremental` and `--resume`, and the checkpoint write is guarded with `isdigit()`.
+  - The incremental per-channel completion event now distinguishes re-attempted failures from new messages (`"{n} new, {m} already present, {k} retried"`; the `retried` clause is omitted when zero, byte-identical to the prior message).
+
+### Notes
+
+- A permanently-unsendable message is re-attempted (one idempotent POST) on each incremental run, matching the existing `ferry retry` semantics (no retry cap); `retry_count` is preserved if a cap is ever wanted. Edited/deleted-message sync remains out of scope.
+
 ## [2.6.3] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.3"
+version = "2.6.4"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.3"
+__version__ = "2.6.4"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import re
 import socket
 from collections.abc import Callable, Coroutine
@@ -183,6 +184,9 @@ async def run_migration(
             # CLEAR completed_channel_ids so every channel is re-entered (new messages may exist).
             state.channel_message_offsets = dict(prior.channel_message_offsets)
             state.channel_high_water = dict(prior.channel_high_water)
+            # #76: carry failed messages forward (as independent copies) so an
+            # incremental run self-heals prior failures instead of wiping the record.
+            state.failed_messages = [dataclasses.replace(fm) for fm in prior.failed_messages]
             state.completed_channel_ids = set()
             # S3 + I2: carry forum index + per-channel counts so REPORT's
             # _rebuild_forum_indexes PATCHes (not re-posts) with cumulative counts,
@@ -204,6 +208,7 @@ async def run_migration(
             #     invite_code / invite_url, channel_message_offsets,
             #     channel_high_water (durable per-channel high-water mark for
             #     --incremental delta skipping),
+            #     failed_messages (so incremental self-heals prior failures — #76),
             #     channel_message_counts, forum_channel_members /
             #     forum_category_names / forum_index_message_ids,
             #     native_fidelity_counts (cumulative fidelity counter), and the
@@ -213,7 +218,6 @@ async def run_migration(
             #   RESET each run: completed_channel_ids (re-enter every channel for
             #     new msgs); pending_pins / pending_reactions (consumed by the
             #     reactions/pins phases — carrying a stale list would re-pin/re-react);
-            #     failed_messages,
             #     warnings / errors, validation_results, embeds_* / replies_*
             #     (per-run fidelity counters); current_phase, started_at,
             #     completed_at, export_completed, rollback_progress, is_dry_run.

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -685,16 +685,33 @@ async def _process_single_channel(
                         state.channel_high_water.get(export.channel.id, ""),
                         state.channel_message_offsets.get(export.channel.id, ""),
                     )
-                    if v
+                    if v and v.isdigit()
                 ),
                 key=int,
                 default="",
             )
         else:
             _skip_below = ""
+        # #77: a checkpoint can persist a non-numeric raw msg.id as the transient
+        # offset. Normalize so the single loop comparison int(_skip_below) is always
+        # safe for BOTH resume and incremental — degrade to "no threshold", never crash.
+        if _skip_below and not _skip_below.isdigit():
+            _skip_below = ""
+        # #76: ids that failed to POST on a prior run sit below the high-water mark;
+        # on incremental, exclude them from the skip so the phase re-POSTs them
+        # (self-heal). Empty unless incremental, so --resume is unaffected.
+        if config.incremental:
+            _failed_ids_here = {
+                fm.discord_msg_id
+                for fm in state.failed_messages
+                if fm.stoat_channel_id == stoat_channel_id
+            }
+        else:
+            _failed_ids_here = set()
         _channel_max_id = 0
         _skipped = 0
         _copied = 0
+        _retried = 0
         for idx, msg in enumerate(message_source):
             # Cancel check inside the message loop.
             if config.cancel_event and config.cancel_event.is_set():
@@ -706,11 +723,17 @@ async def _process_single_channel(
             _mid = int(msg.id) if msg.id.isdigit() else None
             if _mid is not None and _mid > _channel_max_id:
                 _channel_max_id = _mid
-            # Skip messages already copied (resume offset or incremental high-water).
-            if _skip_below and _mid is not None and _mid <= int(_skip_below):
+            # Skip messages already copied (resume offset or incremental high-water),
+            # UNLESS this id failed on a prior run (#76 self-heal) — then re-attempt it.
+            _would_skip = bool(_skip_below) and _mid is not None and _mid <= int(_skip_below)
+            _is_retry = msg.id in _failed_ids_here
+            if _would_skip and not _is_retry:
                 _skipped += 1
                 continue
-            _copied += 1
+            if _would_skip and _is_retry:
+                _retried += 1
+            else:
+                _copied += 1
 
             await _process_message(
                 msg=msg,
@@ -728,7 +751,10 @@ async def _process_single_channel(
                 now = time.monotonic()
                 if now - _last_save_time >= 5.0:
                     async with save_lock:
-                        state.channel_message_offsets[export.channel.id] = msg.id
+                        # #77: only persist numeric ids so a system-message id never
+                        # poisons the offset (the read-side guard above is the real fix).
+                        if msg.id.isdigit():
+                            state.channel_message_offsets[export.channel.id] = msg.id
                         # Merge partial result before saving so checkpoint includes progress.
                         _merge_channel_result(state, result)
                         save_state(state, config.output_dir)
@@ -758,14 +784,34 @@ async def _process_single_channel(
             if _channel_max_id:
                 state.channel_high_water[export.channel.id] = str(_channel_max_id)
             state.channel_message_offsets.pop(export.channel.id, None)
+            # #76 reconcile this channel's previously-failed ids: drop any that
+            # succeeded this run (now in message_map), and collapse the carried +
+            # fresh-re-fail duplicate to a single entry. Scoped to this channel so
+            # other channels' and brand-new failures are untouched.
+            if config.incremental and _failed_ids_here:
+                _seen: set[str] = set()
+                _reconciled: list[FailedMessage] = []
+                for fm in state.failed_messages:
+                    if (
+                        fm.stoat_channel_id == stoat_channel_id
+                        and fm.discord_msg_id in _failed_ids_here
+                    ):
+                        if fm.discord_msg_id in state.message_map:
+                            continue  # succeeded this run -> drop (S2-AC6)
+                        if fm.discord_msg_id in _seen:
+                            continue  # carried + re-fail dup -> collapse (S2-AC7)
+                        _seen.add(fm.discord_msg_id)
+                    _reconciled.append(fm)
+                state.failed_messages = _reconciled
             save_state(state, config.output_dir)
             # Return empty result since we already merged.
             result = ChannelResult(channel_id=export.channel.id)
 
         if config.incremental:
-            _complete_msg = (
-                f"Completed {export.channel.name!r}: {_copied} new, {_skipped} already present."
-            )
+            _parts = [f"{_copied} new", f"{_skipped} already present"]
+            if _retried:
+                _parts.append(f"{_retried} retried")
+            _complete_msg = f"Completed {export.channel.name!r}: {', '.join(_parts)}."
         else:
             _complete_msg = f"Completed {export.channel.name!r} ({total} messages)."
         on_event(

--- a/tests/test_delta_migration.py
+++ b/tests/test_delta_migration.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PhaseFunction, run_migration
-from discord_ferry.state import MigrationState, save_state
+from discord_ferry.state import FailedMessage, MigrationState, save_state
 
 if TYPE_CHECKING:
     from discord_ferry.core.events import EventCallback, MigrationEvent
@@ -264,3 +264,29 @@ async def test_incremental_carries_channel_high_water(tmp_path: Path) -> None:
     state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
     assert state.channel_high_water == {"ch1": "300"}
     assert state.completed_channel_ids == set()
+
+
+async def test_incremental_carries_failed_messages(tmp_path: Path) -> None:
+    """SC-1: incremental carry-over copies prior.failed_messages forward."""
+    _make_prior_state(
+        tmp_path,
+        channel_map={"ch1": "stoat_ch1"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert [fm.discord_msg_id for fm in state.failed_messages] == ["200"]
+
+
+async def test_incremental_carried_failed_messages_are_independent_copies(tmp_path: Path) -> None:
+    """SC-2: mutating a carried FailedMessage must not affect the prior state object."""
+    prior = _make_prior_state(
+        tmp_path,
+        channel_map={"ch1": "stoat_ch1"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom", retry_count=2)],
+    )
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    state.failed_messages[0].retry_count = 99
+    assert prior.failed_messages[0].retry_count == 2  # no aliasing
+    assert state.failed_messages[0] is not prior.failed_messages[0]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2501,3 +2501,343 @@ async def test_new_thread_posts_header(tmp_path: Path) -> None:
         k.get("content") for k in sent if k.get("idempotency_key", "").startswith("ferry-header-")
     ]
     assert headers == ["[Thread migrated from #general]"]
+
+
+# ---------------------------------------------------------------------------
+# #77 — non-numeric carried offset crash guard (S3)
+# ---------------------------------------------------------------------------
+
+
+async def test_incremental_non_numeric_offset_does_not_crash(tmp_path: Path) -> None:
+    """SC-11: a non-numeric carried offset degrades to no-threshold, never raises."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(channel_message_offsets={"ch1": "sys-abc"})  # non-numeric
+    export = _make_export(messages=[_make_message(id="100"), _make_message(id="200")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"100", "200"}  # no threshold -> both copied
+
+
+async def test_resume_non_numeric_offset_does_not_crash(tmp_path: Path) -> None:
+    """SC-12: resume path shares the guard — non-numeric offset, no ValueError."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, resume=True, output_dir=tmp_path)
+    state = _make_state(channel_message_offsets={"ch1": "sys-abc"})
+    export = _make_export(messages=[_make_message(id="100"), _make_message(id="200")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"100", "200"}
+
+
+async def test_incremental_numeric_high_water_still_governs(tmp_path: Path) -> None:
+    """SC-13: a numeric high-water still skips at-or-below it (no behaviour change)."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(channel_high_water={"ch1": "200"})
+    export = _make_export(
+        messages=[_make_message(id="100"), _make_message(id="200"), _make_message(id="300")]
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"300"}
+
+
+async def test_incremental_non_numeric_offset_with_numeric_high_water(tmp_path: Path) -> None:
+    """SC-14: non-numeric offset is ignored; the numeric high-water governs."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_message_offsets={"ch1": "sys-abc"}, channel_high_water={"ch1": "200"}
+    )
+    export = _make_export(
+        messages=[_make_message(id="100"), _make_message(id="200"), _make_message(id="300")]
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"300"}
+
+
+# ---------------------------------------------------------------------------
+# #76 — incremental failed-message self-heal: skip-gate exclusion (S2)
+# ---------------------------------------------------------------------------
+
+
+async def test_incremental_reattempts_failed_id(tmp_path: Path) -> None:
+    """SC-4 (CRITICAL): a previously-failed id is re-POSTed alongside genuinely-new ids."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300", "400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"200", "400"}
+
+
+async def test_incremental_unchanged_channel_no_failures_zero_posts(tmp_path: Path) -> None:
+    """SC-6: no prior failures + all ids <= marker -> zero POSTs (v2.6.3 regression guard)."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(channel_high_water={"ch1": "300"})
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert _sent_message_ids(sent) == []
+
+
+async def test_resume_does_not_reattempt_failed_id(tmp_path: Path) -> None:
+    """SC-7: --resume must NOT consult failed_messages (no self-heal on resume)."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, resume=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_message_offsets={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert _sent_message_ids(sent) == []  # 200 NOT re-attempted under resume
+
+
+async def test_incremental_marker_monotonicity(tmp_path: Path) -> None:
+    """SC-8: re-attempting low failed 200 under higher new 400 keeps the marker at 400."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300", "400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert state.channel_high_water["ch1"] == "400"
+
+
+async def test_incremental_failed_id_equals_marker_boundary(tmp_path: Path) -> None:
+    """SC-18: failed id == marker (skip uses <=) is still re-attempted."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "200"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id="100"), _make_message(id="200")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert _sent_message_ids(sent) == ["200"]
+    assert state.channel_high_water["ch1"] == "200"
+
+
+async def test_incremental_empty_failed_is_pure_v263(tmp_path: Path) -> None:
+    """SC-19: empty failed_messages -> only genuinely-new ids POST."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(channel_high_water={"ch1": "300"}, failed_messages=[])
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300", "400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"400"}
+
+
+async def test_incremental_multiple_failed_ids_one_channel(tmp_path: Path) -> None:
+    """SC-21: multiple carried failures in one channel are all re-attempted."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[
+            FailedMessage("150", "stoat_ch1", "boom"),
+            FailedMessage("250", "stoat_ch1", "boom"),
+        ],
+    )
+    export = _make_export(
+        messages=[_make_message(id=i) for i in ("100", "150", "200", "250", "300", "400")]
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert set(_sent_message_ids(sent)) == {"150", "250", "400"}
+
+
+# ---------------------------------------------------------------------------
+# #76 — completion-time reconciliation: drop-on-success / collapse-on-re-fail (S2)
+# ---------------------------------------------------------------------------
+
+
+def _capture_sends_failing(sent: list[dict[str, Any]], fail_ids: set[str]) -> Any:
+    """Capture that RAISES for ids in fail_ids (re-fail path), succeeds otherwise."""
+
+    async def _send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        sent.append(kwargs)
+        key = kwargs.get("idempotency_key", "")
+        if key.removeprefix("ferry-") in fail_ids:
+            raise RuntimeError("simulated send failure")
+        return {"_id": f"stoat-{key}"}
+
+    return _send
+
+
+async def test_reconcile_drops_succeeded_failed_id(tmp_path: Path) -> None:
+    """SC-9 (CRITICAL): a re-attempt that succeeds is dropped from failed_messages."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert all(fm.discord_msg_id != "200" for fm in state.failed_messages)
+    assert "200" in state.message_map
+
+
+async def test_reconcile_collapses_refailed_id(tmp_path: Path) -> None:
+    """SC-10 (CRITICAL): a re-attempt that fails again leaves exactly one entry, stable."""
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+
+    def _ids(s: MigrationState) -> list[str]:
+        return [fm.discord_msg_id for fm in s.failed_messages if fm.discord_msg_id == "200"]
+
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300")])
+    sent1: list[dict[str, Any]] = []
+    with patch(
+        "discord_ferry.migrator.messages.api_send_message",
+        _capture_sends_failing(sent1, {"200"}),
+    ):
+        await run_messages(config, state, [export], lambda e: None)
+    assert _ids(state) == ["200"]  # exactly one, not two
+    # second identical incremental run keeps it stable (not growing)
+    sent2: list[dict[str, Any]] = []
+    with patch(
+        "discord_ferry.migrator.messages.api_send_message",
+        _capture_sends_failing(sent2, {"200"}),
+    ):
+        await run_messages(config, state, [export], lambda e: None)
+    assert _ids(state) == ["200"]
+
+
+async def test_reconcile_isolation_across_channels(tmp_path: Path) -> None:
+    """SC-20: each channel's reconcile only touches its own failures."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_map={"ch1": "stoat_ch1", "ch2": "stoat_ch2"},
+        channel_high_water={"ch1": "300", "ch2": "600"},
+        failed_messages=[
+            FailedMessage("100", "stoat_ch1", "boom"),  # in ch1 export -> succeeds -> drop
+            FailedMessage("500", "stoat_ch2", "boom"),  # absent from ch2 export -> retained
+        ],
+    )
+    export1 = _make_export(channel_id="ch1", messages=[_make_message(id="100")])
+    export2 = _make_export(channel_id="ch2", messages=[_make_message(id="550")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export1, export2], lambda e: None)
+    remaining = {fm.discord_msg_id for fm in state.failed_messages}
+    assert "100" not in remaining  # ch1 failure succeeded -> dropped
+    assert "500" in remaining  # ch2 failure not in export -> retained
+
+
+async def test_dry_run_incremental_does_not_touch_failed_messages(tmp_path: Path) -> None:
+    """SC-22: reconcile is unreachable in dry-run (run_messages returns early)."""
+    config = _make_config(tmp_path, incremental=True, dry_run=True, output_dir=tmp_path)
+    state = _make_state(failed_messages=[FailedMessage("200", "stoat_ch1", "boom")])
+    export = _make_export(messages=[_make_message(id="200")])
+    await run_messages(config, state, [export], lambda e: None)
+    assert [fm.discord_msg_id for fm in state.failed_messages] == ["200"]
+
+
+async def test_reconcile_keeps_deleted_unrecoverable_failed_id(tmp_path: Path) -> None:
+    """SC-23: a carried failed id absent from the re-export lingers, no POST."""
+    sent: list[dict[str, Any]] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "300", "400")])  # no 200
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert "200" not in _sent_message_ids(sent)
+    assert any(fm.discord_msg_id == "200" for fm in state.failed_messages)
+
+
+# ---------------------------------------------------------------------------
+# #76 — observability: retried count in the incremental complete event (S4)
+# ---------------------------------------------------------------------------
+
+
+async def test_incremental_complete_event_reports_retried(tmp_path: Path) -> None:
+    """SC-15: incremental complete event distinguishes retried from new."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(
+        channel_high_water={"ch1": "300"},
+        failed_messages=[FailedMessage("200", "stoat_ch1", "boom")],
+    )
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300", "400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends([])):
+        await run_messages(config, state, [export], events.append)
+    msgs = [e.message for e in events if e.message.startswith("Completed 'general':")]
+    assert msgs[-1] == "Completed 'general': 1 new, 2 already present, 1 retried."
+
+
+async def test_incremental_complete_event_omits_retried_when_zero(tmp_path: Path) -> None:
+    """SC-16: with no retries the message is byte-identical to today's form."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path)
+    state = _make_state(channel_high_water={"ch1": "300"}, failed_messages=[])
+    export = _make_export(messages=[_make_message(id=i) for i in ("100", "200", "300", "400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends([])):
+        await run_messages(config, state, [export], events.append)
+    msgs = [e.message for e in events if e.message.startswith("Completed 'general':")]
+    assert msgs[-1] == "Completed 'general': 1 new, 3 already present."
+
+
+# ---------------------------------------------------------------------------
+# #77 — defensive write-side guard for the transient offset (S5, P2)
+# ---------------------------------------------------------------------------
+
+
+async def test_checkpoint_skips_non_numeric_offset_write(tmp_path: Path, monkeypatch: Any) -> None:
+    """SC-17: a non-numeric msg.id is never persisted as a transient offset.
+
+    The offset is popped at channel completion, so an end-state assertion would be
+    trivially green. Spy on save_state to capture the offset value at each checkpoint
+    save — the moment the guard acts.
+    """
+    import discord_ferry.migrator.messages as messages_mod
+
+    captured: list[Any] = []
+
+    def _spy_save(state: Any, output_dir: Any) -> None:
+        captured.append(state.channel_message_offsets.get("ch1"))
+
+    monkeypatch.setattr(messages_mod, "save_state", _spy_save)
+
+    # Force the checkpoint's 5s save gate to pass on every message.
+    clock = {"v": 0.0}
+
+    def _fake_monotonic() -> float:
+        clock["v"] += 100.0
+        return clock["v"]
+
+    monkeypatch.setattr(messages_mod.time, "monotonic", _fake_monotonic)
+
+    config = _make_config(tmp_path, incremental=True, output_dir=tmp_path, checkpoint_interval=1)
+    state = _make_state(channel_high_water={"ch1": "300"})
+    # A non-numeric (system-message) id followed by a numeric one.
+    export = _make_export(messages=[_make_message(id="sys-xyz"), _make_message(id="400")])
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends([])):
+        await run_messages(config, state, [export], lambda e: None)
+    # No checkpoint ever persisted the non-numeric id as an offset.
+    assert all(off is None or off.isdigit() for off in captured)
+    assert "sys-xyz" not in captured

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.3"
+version = "2.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #76 (finding I1 — data integrity) and #77 (finding M1 — crash guard), both surfaced by the whole-branch review of v2.6.3 (PR #75).

## Problem
v2.6.3's durable `channel_high_water` mark tracks the highest message id **seen**, not **successfully copied** — so a message that *failed* to POST sat below the mark and was skipped forever on the next `--incremental` run. The engine carry-over also **reset** `failed_messages`, wiping the retry record, and `run_retry_failed` isn't on the default pipeline. Net: a failed message was silently never retried (documented as a v2.6.3 known limitation). Separately, a non-numeric carried offset crashed the skip gate's `max(key=int)` / `int(_skip_below)` (swallowed by `asyncio.gather` → channel silently skipped).

## Fix
- **Self-heal (#76):** incremental carry-over now copies `failed_messages` forward (as independent `dataclasses.replace` copies); the within-channel skip gate **excludes previously-failed ids for that channel** so the messages phase re-POSTs them (three-way partition `_skipped`/`_retried`/`_copied`; the high-water marker tracking is untouched → monotonicity preserved); and a **completion-time reconciliation** under the existing `save_lock` drops ids now in `message_map` (succeeded) and collapses carried+re-fail duplicates to a single entry (so the failure count is stable across runs). Running `ferry retry` before `--incremental` is **no longer required**.
- **Crash guard (#77):** the skip threshold filters/normalizes non-numeric values to "no threshold" (copy, never crash) for both `--incremental` and `--resume`, and the checkpoint offset write is `isdigit()`-guarded.
- Incremental per-channel completion event now reports `"{n} new, {m} already present, {k} retried"` (the `retried` clause omitted when zero — byte-identical to the prior message).

No new state field — `failed_messages` already exists and is serialized. `--resume` is unaffected (it does not consult `failed_messages`); an unchanged channel with no prior failures still makes zero POSTs; old `state.json` loads with `failed_messages == []`.

## Tests
21 new scenarios (`tests/test_messages.py`, `tests/test_delta_migration.py`) driving the **real** messages phase against captured Stoat POSTs. 4 CRITICAL falsification anchors verified red-on-removal then restored green (skip exclusion, drop-on-success, collapse-on-re-fail, isdigit guard). Full suite: **1079 passed**; ruff/format/mypy clean.

## Out of scope (separate follow-ups)
#78 (gate the thread `merge` strategy), #79 (forum-type header test). Edited/deleted-message sync remains out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)