### PR TITLE
fix(incremental): gate thread merge strategy on the high-water marker (v2.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.5] - 2026-06-25
+
+### Fixed
+
+- **Thread `merge` strategy now honours the durable high-water marker** (`migrator/messages.py`). Closes GitHub #78 (finding M2). The v2.6.3 incremental gate covered the default `flatten` strategy (via `_process_single_channel`), but `thread_strategy="merge"` runs a separate function (`_merge_threads`) that re-POSTed the separator + **every** thread message into the parent channel on **every** `--incremental` run — idempotency-keyed so it never duplicated content, but wasted O(all-thread-messages) HTTP work each run. `_merge_threads` now: skips the separator and already-copied messages on `--incremental` (gated on `config.incremental`), tracks the thread's max message id (over all messages incl. system/skip-type ones, `isdigit()`-guarded), and writes a per-thread `channel_high_water` marker at completion (every run, so a first full run sets it up). An unchanged merged thread therefore makes **zero** POSTs on an incremental run, matching `flatten`; a thread with K new messages re-POSTs only those K (no re-sent separator). `flatten`, `archive`, and `--resume` behaviour are unchanged. The per-channel completion event now reports the count actually posted this run.
+
 ## [2.6.4] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.4"
+version = "2.6.5"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.4"
+__version__ = "2.6.5"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -459,29 +459,43 @@ async def _merge_threads(
                 )
                 continue
 
-            # Send separator message.
-            separator = (
-                f"\u2500\u2500 Thread: {export.channel.name} "
-                f"({export.message_count} messages) \u2500\u2500"
+            _thread_skip_below = (
+                state.channel_high_water.get(export.channel.id, "") if config.incremental else ""
             )
-            try:
-                await api_send_message(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    parent_stoat_id,
-                    content=separator,
-                    masquerade={"name": "Discord Ferry"},
-                    idempotency_key=f"ferry-thread-sep-{export.channel.id}",
+            # #77 parity: a non-numeric marker (only reachable via a hand-edited
+            # state.json) degrades to "no threshold" rather than crashing int().
+            if _thread_skip_below and not _thread_skip_below.isdigit():
+                _thread_skip_below = ""
+            _thread_max_id = 0
+            _posted = 0
+
+            # Send separator message (skip on incremental when the thread already
+            # has a durable marker \u2014 the separator was posted on the first run).
+            if not (config.incremental and export.channel.id in state.channel_high_water):
+                separator = (
+                    f"\u2500\u2500 Thread: {export.channel.name} "
+                    f"({export.message_count} messages) \u2500\u2500"
                 )
-            except Exception as exc:  # noqa: BLE001
-                state.warnings.append(
-                    {
-                        "phase": "messages",
-                        "type": "merge_separator_failed",
-                        "message": f"Thread separator for {export.channel.name!r} failed: {exc}",
-                    }
-                )
+                try:
+                    await api_send_message(
+                        session,
+                        config.stoat_url,
+                        config.token,
+                        parent_stoat_id,
+                        content=separator,
+                        masquerade={"name": "Discord Ferry"},
+                        idempotency_key=f"ferry-thread-sep-{export.channel.id}",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    state.warnings.append(
+                        {
+                            "phase": "messages",
+                            "type": "merge_separator_failed",
+                            "message": (
+                                f"Thread separator for {export.channel.name!r} failed: {exc}"
+                            ),
+                        }
+                    )
 
             # Send all thread messages to the parent channel.
             if export.json_path is not None:
@@ -489,9 +503,17 @@ async def _merge_threads(
             else:
                 message_source = iter(sorted(export.messages, key=lambda m: m.timestamp))
 
-            msg_count = 0
             for msg in message_source:
+                # Track the thread's max id over ALL messages (incl. skip-types),
+                # ABOVE the _SKIP_TYPES continue, so the marker == max(all ids)
+                # across runs (mirrors flatten _channel_max_id). isdigit-guarded.
+                _mid = int(msg.id) if msg.id.isdigit() else None
+                if _mid is not None and _mid > _thread_max_id:
+                    _thread_max_id = _mid
                 if msg.type in _SKIP_TYPES:
+                    continue
+                # Incremental: skip messages already copied on a prior run.
+                if _thread_skip_below and _mid is not None and _mid <= int(_thread_skip_below):
                     continue
 
                 content = _build_content(msg, state)
@@ -523,8 +545,13 @@ async def _merge_threads(
                             }
                         )
 
-                msg_count += 1
+                _posted += 1
                 await _rate_limit_with_pause(config)
+
+            # Durable high-water mark for this thread (written every run so a later
+            # --incremental run skips already-copied messages). Overwrite, like flatten.
+            if _thread_max_id:
+                state.channel_high_water[export.channel.id] = str(_thread_max_id)
 
             on_event(
                 MigrationEvent(
@@ -532,7 +559,7 @@ async def _merge_threads(
                     status="progress",
                     message=(
                         f"Merged thread {export.channel.name!r} "
-                        f"({msg_count} messages) into parent channel."
+                        f"({_posted} messages) into parent channel."
                     ),
                     channel_name=export.channel.name,
                 )

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -359,3 +359,186 @@ async def test_thread_sort_by_message_count(tmp_path: Path) -> None:
     assert "400" in state.channel_map
     assert "300" in state.channel_map  # high-traffic thread kept
     assert "200" not in state.channel_map  # low-traffic thread dropped
+
+
+# ---------------------------------------------------------------------------
+# #78 — merge strategy honours the durable high-water marker
+# ---------------------------------------------------------------------------
+
+
+def _capture_keys(keys: list[str]) -> object:
+    """Patch target for api_send_message: record idempotency_key, return a fake id."""
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        keys.append(str(kwargs.get("idempotency_key", "")))
+        return {"_id": f"stoat-{kwargs.get('idempotency_key', 'x')}"}
+
+    return _send
+
+
+def _merge_setup(
+    tmp_path: Path,
+    thread_msg_ids: list[str],
+    marker: str | None = None,
+    incremental: bool = True,
+) -> tuple[FerryConfig, MigrationState, DCEExport, DCEExport]:
+    """Parent (ch 100) + one thread (ch 200) with the given message ids."""
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=incremental
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    if marker is not None:
+        state.channel_high_water["200"] = marker
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message(mid, f"msg {mid}") for mid in thread_msg_ids],
+        message_count=len(thread_msg_ids),
+    )
+    return config, state, parent, thread
+
+
+async def test_merge_incremental_unchanged_thread_zero_posts(tmp_path: Path) -> None:
+    """S1: an unchanged merged thread (all ids <= marker) makes zero POSTs."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20"], marker="20")
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert not any(k.startswith("ferry-thread-sep-200") for k in keys)
+    assert not any(k.startswith("ferry-merge-") for k in keys)
+
+
+async def test_merge_brand_new_thread_posts_all_and_records_marker(tmp_path: Path) -> None:
+    """S2: a brand-new thread posts separator + all messages and records the marker."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert "ferry-thread-sep-200" in keys
+    assert {"ferry-merge-10", "ferry-merge-20", "ferry-merge-30"}.issubset(set(keys))
+    assert state.channel_high_water["200"] == "30"
+
+
+async def test_merge_second_run_unchanged_zero_posts(tmp_path: Path) -> None:
+    """S2-AC3: after a brand-new run records the marker, a 2nd run makes zero POSTs."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys([])):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    # second run over the same export, reusing the now-marked state
+    config2, _state2, parent2, thread2 = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    keys2: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys2)):
+        await run_messages(config2, state, [parent2, thread2], lambda e: None)
+    assert keys2 == []
+
+
+async def test_merge_incremental_only_new_messages(tmp_path: Path) -> None:
+    """S3: a thread with K new ids > marker re-POSTs only those K; no separator."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30", "40"], marker="20")
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    merge_keys = sorted(k for k in keys if k.startswith("ferry-merge-"))
+    assert merge_keys == ["ferry-merge-30", "ferry-merge-40"]
+    assert not any(k.startswith("ferry-thread-sep-") for k in keys)
+    assert state.channel_high_water["200"] == "40"
+
+
+async def test_merge_event_reports_posted_count(tmp_path: Path) -> None:
+    """S5: the completion event counts posted (2), not the full history (4)."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30", "40"], marker="20")
+    events: list[MigrationEvent] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys([])):
+        await run_messages(config, state, [parent, thread], events.append)
+    merged = [e.message for e in events if "Merged thread" in e.message]
+    assert any("(2 messages)" in m for m in merged)
+
+
+async def test_merge_skip_type_trailing_high_id_marker(tmp_path: Path) -> None:
+    """Critique I2: a trailing skip-type id still advances the marker (max over ALL ids)."""
+    from unittest.mock import patch
+
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=True
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[
+            _make_message("10", "a"),
+            _make_message("20", "b"),
+            DCEMessage(
+                id="30",
+                type="ThreadCreated",  # a _SKIP_TYPES message
+                timestamp="2024-01-15T12:00:00+00:00",
+                content="",
+                author=_make_author(),
+            ),
+        ],
+        message_count=3,
+    )
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert "ferry-merge-30" not in keys  # skip-type never posted
+    assert state.channel_high_water["200"] == "30"  # but it advances the marker
+
+
+async def test_merge_non_numeric_thread_id_no_crash(tmp_path: Path) -> None:
+    """S4: a non-numeric thread message id never hits int() — no ValueError."""
+    from unittest.mock import patch
+
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=True
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    state.channel_high_water["200"] = "20"  # numeric marker present
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("sys-x", "a system-id message"), _make_message("30", "new")],
+        message_count=2,
+    )
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)  # must not raise
+    assert "ferry-merge-sys-x" in keys  # non-numeric never skipped (no int() compare)
+    assert "ferry-merge-30" in keys  # 30 > 20 marker -> posts
+
+
+async def test_merge_non_numeric_marker_no_crash(tmp_path: Path) -> None:
+    """#77 parity: a non-numeric carried marker degrades to no-threshold, never crashes."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20"], marker="sys-marker")
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)  # must not raise
+    # Threshold normalized to "" -> every message copies (idempotent), no ValueError.
+    assert "ferry-merge-10" in keys
+    assert "ferry-merge-20" in keys

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.4"
+version = "2.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #78 (finding M2), surfaced by the PR #75 review.

## Problem
v2.6.3 gated the default `flatten` thread strategy on the durable `channel_high_water` marker (zero POSTs for an unchanged thread on `--incremental`). But `thread_strategy="merge"` runs a **separate** function, `_merge_threads`, that bypassed the gate: every `--incremental` run re-POSTed the `ferry-thread-sep-*` separator + every `ferry-merge-{id}` thread message into the parent channel. Idempotency-keyed so it never duplicated content — just wasted O(all-thread-messages) HTTP work each run.

## Fix
Mirror the flatten gate **inline** in `_merge_threads` (sequential function, runs after the parallel parent-channel workers complete — no lock needed):
- **Skip on `--incremental`** (both the separator and already-copied messages), gated on `config.incremental` so plain and `--resume` runs are byte-identical apart from an inert marker write.
- **Track the thread's max id** over all messages (incl. system/skip-type ones), `isdigit()`-guarded, *above* the `_SKIP_TYPES continue` so the marker `== max(all ids)` — matching flatten.
- **Write a per-thread `channel_high_water` marker** at completion (every run, keyed by the thread's own channel id) so a later incremental run can skip it.
- A non-numeric carried marker (only via a hand-edited `state.json`) degrades to "no threshold" instead of crashing `int()` — **#77 parity** with the flatten/resume path.
- The completion event reports the count actually posted this run.

An unchanged merged thread makes **zero** POSTs on an incremental run; a thread with K new messages re-POSTs only those K (no re-sent separator). `flatten`, `archive`, and `--resume` are unchanged. No new state field — reuses `channel_high_water`.

## Tests
8 new scenarios in `tests/test_thread_strategy.py` driving the real `run_messages` against captured `idempotency_key`s (not message state): unchanged→zero, brand-new→posts-all-+-records-marker, 2nd-run→zero, K-new-only, posted-count event, skip-type trailing-id marker, non-numeric message id, non-numeric marker. Falsification verified: neutering the separator gate or dropping the marker write turns a specific test red. Full suite: **1087 passed**; ruff/format/mypy clean.

## Out of scope
#79 (forum-type header test) — the last filed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)