### PR TITLE
test(incremental): forum-type (15/16) zero-POST header coverage (#79)

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2467,11 +2467,13 @@ async def test_non_numeric_message_id_not_skipped_or_marked(tmp_path: Path) -> N
 
 
 def _make_thread_export(
-    channel_id: str = "ch1", messages: list[DCEMessage] | None = None
+    channel_id: str = "ch1",
+    messages: list[DCEMessage] | None = None,
+    channel_type: int = 0,
 ) -> DCEExport:
     return DCEExport(
         guild=_make_guild(),
-        channel=DCEChannel(id=channel_id, type=0, name="thread"),
+        channel=DCEChannel(id=channel_id, type=channel_type, name="thread"),
         messages=messages or [],
         is_thread=True,
         parent_channel_name="general",
@@ -2501,6 +2503,36 @@ async def test_new_thread_posts_header(tmp_path: Path) -> None:
         k.get("content") for k in sent if k.get("idempotency_key", "").startswith("ferry-header-")
     ]
     assert headers == ["[Thread migrated from #general]"]
+
+
+async def test_unchanged_forum_makes_zero_posts(tmp_path: Path) -> None:
+    """#79: an unchanged forum channel (type 15, marker present) posts nothing — no header."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state(channel_high_water={"ch1": "200"}, channel_message_offsets={})
+    config = _make_config(tmp_path, incremental=True)
+    export = _make_thread_export(
+        messages=[_make_message(id="100"), _make_message(id="200")], channel_type=15
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+    assert sent == []
+
+
+async def test_new_forum_posts_forum_header(tmp_path: Path) -> None:
+    """#79: a brand-new forum channel (type 15/16, no marker) posts the Forum-post header."""
+    for forum_type in (15, 16):
+        sent: list[dict[str, Any]] = []
+        state = _make_state(channel_high_water={}, channel_message_offsets={})
+        config = _make_config(tmp_path, incremental=True)
+        export = _make_thread_export(messages=[_make_message(id="100")], channel_type=forum_type)
+        with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+            await run_messages(config, state, [export], lambda e: None)
+        headers = [
+            k.get("content")
+            for k in sent
+            if k.get("idempotency_key", "").startswith("ferry-header-")
+        ]
+        assert headers == ["[Forum post migrated from #general]"], f"type={forum_type}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #79 (finding M3) — the last of the four PR #75 follow-ups. **Test-only**, no production change, no version bump.

## Gap
The incremental thread/forum header gate (`export.channel.id not in state.channel_high_water`, `messages.py:629`) is **type-agnostic** — `channel.type` only selects the header *string* (`messages.py:634` emits `[Forum post migrated from #…]` for forum types 15/16 vs `[Thread migrated from #…]`). PR #75 added thread-type coverage (`test_unchanged_thread_makes_zero_posts`, `test_new_thread_posts_header`) but no forum-type variant.

## Added
- `_make_thread_export` gains an optional `channel_type` param (default `0`, backward-compatible).
- `test_unchanged_forum_makes_zero_posts` — a forum channel (type 15) with a marker present makes zero POSTs (no header).
- `test_new_forum_posts_forum_header` — a brand-new forum channel (types **15 and 16**, no marker) posts `[Forum post migrated from #general]`.

Mirrors the existing thread-header tests 1:1. Full suite: **1089 passed**; ruff/format/mypy clean. This closes the PR #75 follow-up backlog (#76, #77, #78, #79 all done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)