### PR TITLE
fix: empty-message guard tests built content (v2.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.6] - 2026-06-25
+
+### Fixed
+
+- **Empty-message fallback no longer silently clobbers poll/sticker/placeholder/embed-note bodies** (`migrator/messages.py`). From the 2026-06-24 v2.5.1 bug-hunt refresh (HIGH-severity silent content data loss). The Step 6 empty-message guard tested the **raw** `msg.content == ""`, but `_build_content` and the caller append several optional bodies into the built `content` *before* that guard — poll text (`flatten_poll`), sticker text (`handle_stickers`), oversized/expired-attachment placeholders, and the "[N embed(s) could not be migrated]" note. A message whose entire body came from one of those paths (e.g. a poll-only or sticker-only message, which has empty raw content) was therefore overwritten with `[empty message]` — silent loss the user never saw. The guard now tests the **built** `content`: it compares `content.strip()` against a reconstructed empty baseline (the timestamp prefix plus, for edited messages, the `*(edited)*` marker), so any pre-guard append path is preserved. The `not autumn_ids and not stoat_embeds` conditions are retained, so attachment-only and embed-only messages are still **not** labeled empty, and a whitespace-only message is now (correctly) treated as empty. Empty **edited** messages are relabeled `[empty message] *(edited)*` instead of dropping the edit marker. The `" *(edited)*"` literal was extracted into a shared `_EDITED_MARKER` constant so `_build_content` and the guard stay byte-identical.
+
 ## [2.6.5] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.5"
+version = "2.6.6"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.5"
+__version__ = "2.6.6"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 
 _VALID_REACTION_MODES = frozenset({"text", "native", "skip"})
 
+# Edited-message marker appended by _build_content; shared with the empty-message
+# guard so the two stay byte-identical. Changing this changes migrated content.
+_EDITED_MARKER = " *(edited)*"
+
 # ---------------------------------------------------------------------------
 # Message splitting
 # ---------------------------------------------------------------------------
@@ -1102,9 +1106,18 @@ async def _process_message(
                 }
             )
 
-    # Step 6: Empty message fallback.
-    if msg.content == "" and not autumn_ids and not stoat_embeds:
-        content = f"{format_original_timestamp(msg.timestamp)} [empty message]"
+    # Step 6: Empty message fallback — test the BUILT content, not raw msg.content.
+    # Every PRE-guard append path (poll, sticker text, attachment placeholders,
+    # failed-embed notes, cross-channel reply fallback) lands in `content` above, so a
+    # body that came only from one of those is preserved. The empty baseline is rebuilt
+    # from the same parts _build_content uses: prefix + " " join, plus the edited marker
+    # (which carries its own leading space -> the empty-edited baseline has a DOUBLE space
+    # by construction). Both sides are .strip()ed, so the internal double space matches.
+    timestamp_prefix = format_original_timestamp(msg.timestamp)
+    edited_suffix = _EDITED_MARKER if msg.timestamp_edited else ""
+    empty_built = f"{timestamp_prefix} {edited_suffix}"
+    if content.strip() == empty_built.strip() and not autumn_ids and not stoat_embeds:
+        content = f"{timestamp_prefix} [empty message]{edited_suffix}"
 
     # Step 6b: Append reaction text if text mode.
     _effective_mode = (
@@ -1293,7 +1306,7 @@ def _build_content(msg: DCEMessage, state: MigrationState) -> str:
     content = f"{format_original_timestamp(msg.timestamp)} {content}"
 
     if msg.timestamp_edited:
-        content += " *(edited)*"
+        content += _EDITED_MARKER
 
     # Append sticker representations (text only — images uploaded separately).
     sticker_text, _ = handle_stickers(msg.stickers)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -626,19 +626,21 @@ async def test_reply_reference_not_in_map_is_silently_skipped(
 # ---------------------------------------------------------------------------
 
 
-async def test_empty_message_gets_placeholder(tmp_path: Path, mock_aiohttp: aioresponses) -> None:
-    """Empty content + no attachments + no embeds → placeholder text sent."""
-    mock_aiohttp.post(CHANNEL_MSG_URL, payload={"_id": "stoat_msg"})
-
+async def test_empty_message_gets_placeholder(tmp_path: Path) -> None:
+    """Empty content + no attachments + no embeds → [empty message] in the SENT content."""
+    sent: list[dict[str, Any]] = []
     state = _make_state()
     config = _make_config(tmp_path)
     # Use a Default type — GuildMemberJoin is now a skip type.
     msg = _make_message(id="msg1", content="", msg_type="Default")
     export = _make_export(messages=[msg])
 
-    await run_messages(config, state, [export], lambda e: None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
 
     assert "msg1" in state.message_map
+    assert len(sent) == 1
+    assert "[empty message]" in sent[0]["content"]
 
 
 # ---------------------------------------------------------------------------
@@ -2873,3 +2875,203 @@ async def test_checkpoint_skips_non_numeric_offset_write(tmp_path: Path, monkeyp
     # No checkpoint ever persisted the non-numeric id as an offset.
     assert all(off is None or off.isdigit() for off in captured)
     assert "sys-xyz" not in captured
+
+
+# ---------------------------------------------------------------------------
+# Empty-message guard tests the BUILT content (poll/sticker/placeholder/embed)
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_only_message_preserves_poll_text(tmp_path: Path) -> None:
+    """A poll-only message (empty raw content) keeps its poll text, not [empty message]."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="poll1",
+        content="",
+        msg_type="Default",
+        poll={"question": {"text": "Fav?"}, "answers": [{"text": "Blue", "votes": 3}]},
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    content = sent[0]["content"]
+    assert "Poll: Fav?" in content
+    assert "Blue" in content
+    assert "[empty message]" not in content
+
+
+async def test_sticker_text_only_message_preserves_sticker_text(tmp_path: Path) -> None:
+    """A sticker-text-only message (remote sticker, no local image) keeps the sticker text."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="stick1",
+        content="",
+        msg_type="Default",
+        stickers=[{"name": "wave", "sourceUrl": "https://cdn.test/wave.png"}],
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    content = sent[0]["content"]
+    assert "[Sticker: wave]" in content
+    assert "[empty message]" not in content
+
+
+async def test_placeholder_only_message_preserves_placeholder(tmp_path: Path) -> None:
+    """An oversized-attachment-only message keeps the skip placeholder, not [empty message]."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    att = DCEAttachment(
+        id="big1", url="big.png", file_name="big.png", file_size_bytes=21 * 1024 * 1024
+    )
+    msg = _make_message(id="ph1", content="", msg_type="Default", attachments=[att])
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    content = sent[0]["content"]
+    assert "File too large: big.png" in content
+    assert "[empty message]" not in content
+
+
+async def test_failed_embed_note_only_message_preserves_note(tmp_path: Path) -> None:
+    """A message whose only embed cannot migrate keeps the failed-embed note."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    # Embed with neither title nor description -> dropped -> failed-embed note appended.
+    msg = _make_message(id="emb1", content="", msg_type="Default", embeds=[{"url": "x"}])
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    content = sent[0]["content"]
+    assert "embed(s) could not be migrated" in content
+    assert "[empty message]" not in content
+
+
+async def test_empty_edited_message_relabeled_with_edited_marker(tmp_path: Path) -> None:
+    """A truly-empty edited message is labeled [empty message] *(edited)* (S6 relabel)."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="ee1",
+        content="",
+        msg_type="Default",
+        timestamp="2024-01-15T12:00:00+00:00",
+        timestamp_edited="2024-01-15T13:00:00+00:00",
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    # M1: pin the EXACT built string, not just a substring.
+    assert sent[0]["content"] == "*[2024-01-15 12:00 UTC]* [empty message] *(edited)*"
+
+
+async def test_truly_empty_message_still_labeled_empty(tmp_path: Path) -> None:
+    """A truly-empty non-edited message still gets the [empty message] placeholder (S4.1)."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="te1", content="", msg_type="Default", timestamp="2024-01-15T12:00:00+00:00"
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    assert sent[0]["content"] == "*[2024-01-15 12:00 UTC]* [empty message]"
+
+
+async def test_attachment_only_message_not_labeled_empty(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """An attachment-only message (uploads OK) is NOT labeled [empty message] (S4.2)."""
+    att_file = tmp_path / "file.png"
+    att_file.write_bytes(b"data")
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "att_id"})
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    att = DCEAttachment(id="att1", url="file.png", file_name="file.png")
+    msg = _make_message(id="ao1", content="", msg_type="Default", attachments=[att])
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    assert "[empty message]" not in sent[0]["content"]
+
+
+async def test_embed_only_message_not_labeled_empty(tmp_path: Path) -> None:
+    """An embed-only message (embed has title/description) is NOT labeled empty (S4.3)."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="eo1",
+        content="",
+        msg_type="Default",
+        embeds=[{"title": "Hi", "description": "there"}],
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    assert "[empty message]" not in sent[0]["content"]
+
+
+async def test_whitespace_only_message_labeled_empty(tmp_path: Path) -> None:
+    """A whitespace-only message strips to the baseline and is labeled [empty message]."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(
+        id="ws1", content="   ", msg_type="Default", timestamp="2024-01-15T12:00:00+00:00"
+    )
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    assert sent[0]["content"] == "*[2024-01-15 12:00 UTC]* [empty message]"
+
+
+async def test_emoji_only_message_not_falsely_labeled_empty(tmp_path: Path) -> None:
+    """M4: a real text message (emoji/spoiler) never collapses to the empty baseline."""
+    sent: list[dict[str, Any]] = []
+    state = _make_state()
+    config = _make_config(tmp_path)
+    msg = _make_message(id="em1", content="||boo||", msg_type="Default")
+    export = _make_export(messages=[msg])
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert len(sent) == 1
+    assert "[empty message]" not in sent[0]["content"]

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.5"
+version = "2.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
HIGH-severity **silent content data loss** fix in the message-migration phase, from the 2026-06-24 v2.5.1 bug-hunt refresh.

The Step 6 empty-message fallback in \`migrator/messages.py\` tested the **raw** \`msg.content == ""\` but then overwrote the **built** \`content\` with \`[empty message]\`. However \`_build_content\` and the caller append several optional bodies into \`content\` *before* that guard:
- poll text (\`flatten_poll\`)
- sticker text (\`handle_stickers\`)
- oversized/expired-attachment placeholders
- the "[N embed(s) could not be migrated]" note

So a message whose entire body came from one of those paths (e.g. a **poll-only** or **sticker-only** message, which has empty raw content) was silently overwritten with \`[empty message]\` — loss the user never saw.

## Fix
The guard now tests the **built** \`content\`: it compares \`content.strip()\` against a reconstructed empty baseline (timestamp prefix + optional \`*(edited)*\` marker), so every pre-guard append path is preserved. One check covers all paths instead of enumerating per-feature flags (the audit's own list omitted two paths).

- \`not autumn_ids and not stoat_embeds\` retained → attachment-only and embed-only messages still **not** labeled empty.
- Whitespace-only messages are now (correctly) treated as empty.
- Empty **edited** messages relabel to \`[empty message] *(edited)*\` instead of dropping the marker.
- The \`" *(edited)*"\` literal extracted into a shared \`_EDITED_MARKER\` constant (byte-identical), used by both \`_build_content\` and the guard.

## Tests
10 new tests + upgraded the existing \`test_empty_message_gets_placeholder\` (was a false-green that only asserted map population). All assert on the **sent \`content\`** payload. Each guard test was falsified (revert prod line → RED). Full suite: **1099 passed**.

## Pipeline
Full \`/df\` pipeline: brief → spec → brainstorm → critique (fresh-context opus, PASS) → plan → controller-driven build → ship. Whole-branch opus code review APPROVE; Mistral second opinion raised 3 "Critical" + 4 "Important" — all verified false-positive/cosmetic against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)