### PR TITLE
fix: Autumn upload robustness — malformed/429/verify-size guards + sticker/embed parity (v2.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.7] - 2026-06-25
+
+### Fixed
+
+Autumn upload robustness cluster — the first batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 1). All in `uploader/autumn.py` and its callers.
+
+- **A malformed Autumn `200` no longer aborts the migration with a raw exception** (`uploader/autumn.py`). The success path did `await response.json()` + `result["id"]`, so a non-JSON `200` (reverse-proxy HTML, empty body) raised a raw `aiohttp.ContentTypeError` / `KeyError`, and an empty body would raise `TypeError`. Because `_resolve_role_icon` (`migrator/structure.py`) caught only `AutumnUploadError`, such a raw error escaped its guard and **aborted the entire migration** for any server with custom role icons. The body is now parsed with `json(content_type=None)` inside `try/except (aiohttp.ClientError, ValueError)` and an explicit `isinstance(result, dict) and "id" in result` check; every malformed `200` raises `AutumnUploadError` (carrying only the tag — never the response body or token).
+- **`--verify-uploads` now actually detects a corrupt upload** (`uploader/autumn.py`). On a present-and-mismatched server `size`, `upload_to_autumn` previously popped the cache entry but still **returned** the bad id, which `upload_with_cache` immediately re-inserted — the whole feature was a no-op that propagated the corrupt id forever. A size mismatch is now treated as a failed upload (raises `AutumnUploadError`; never returned, never cached). The now-dead `cache` parameter was removed from `upload_to_autumn`.
+- **A non-JSON `429` no longer crashes the retry path, and `Retry-After` is honoured** (`uploader/autumn.py`). The 429 branch did `await response.json()` assuming a JSON body; an HTML `429` from a reverse proxy raised `ContentTypeError` that bypassed backoff and (in the sticker/attachment loop) dropped the media. A new module-private `_retry_after_ms` computes the backoff defensively: body `retry_after` (ms) → `Retry-After` header (integer seconds) → 1000 ms default, tolerant of any non-JSON body.
+- **Role-icon upload failures degrade instead of aborting** (`migrator/structure.py`). `_resolve_role_icon`'s guard is broadened to `except (AutumnUploadError, OSError)` (also covering the temp-file write), so an icon that can't be uploaded is skipped with a token-safe warning and the roles phase continues — rank/hoist for that role still apply.
+- **Sticker and embed-media uploads reach attachment parity** (`migrator/messages.py`). Both now pass `verify_size=config.verify_uploads` and register in `state.autumn_uploads` like regular attachments. The embed `media_id` is additionally credited to `referenced_autumn_ids` on a successful send (but **not** added to `autumn_ids`, so it does not consume the 5-attachment cap) — without this it would have been reported as a false orphan on every migrated embed image.
+
 ## [2.6.6] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.6"
+version = "2.6.7"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.6"
+__version__ = "2.6.7"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1005,8 +1005,10 @@ async def _process_message(
                 config.token,
                 state.upload_cache,
                 config.upload_delay,
+                verify_size=config.verify_uploads,
             )
             autumn_ids.append(sticker_id)
+            state.autumn_uploads[sticker_id] = f"{msg.id}:sticker:{sticker_path.name}"
             if channel_result is not None:
                 channel_result.attachments_uploaded += 1
             else:
@@ -1032,6 +1034,7 @@ async def _process_message(
 
     # Step 4: Flatten embeds (max 5, only those with title or description).
     stoat_embeds: list[dict[str, Any]] = []
+    embed_media_ids: list[str] = []
     for raw_embed in msg.embeds[:5]:
         flat, embed_media_path = flatten_embed(raw_embed, config.export_dir)
         if flat.get("description") or flat.get("title"):
@@ -1046,8 +1049,11 @@ async def _process_message(
                         config.token,
                         state.upload_cache,
                         config.upload_delay,
+                        verify_size=config.verify_uploads,
                     )
                     flat["media"] = media_id
+                    state.autumn_uploads[media_id] = f"{msg.id}:embed"
+                    embed_media_ids.append(media_id)
                     if channel_result is not None:
                         channel_result.attachments_uploaded += 1
                     else:
@@ -1184,11 +1190,11 @@ async def _process_message(
 
         if channel_result is not None:
             channel_result.message_map_updates[msg.id] = stoat_msg_id
-            channel_result.referenced_autumn_ids.update(autumn_ids)
+            channel_result.referenced_autumn_ids.update(autumn_ids, embed_media_ids)
             channel_result.messages_migrated += 1  # S15: track for forum index rebuild
         else:
             state.message_map[msg.id] = stoat_msg_id
-            state.referenced_autumn_ids.update(autumn_ids)
+            state.referenced_autumn_ids.update(autumn_ids, embed_media_ids)
             # S15: Track per-channel message count (direct-state path, e.g. retry).
             if export_channel_id:
                 state.channel_message_counts[export_channel_id] = (

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -391,7 +391,7 @@ async def _resolve_role_icon(
             state.native_fidelity_counts.get("role_icons", 0) + 1
         )
         return icon_id
-    except AutumnUploadError:
+    except (AutumnUploadError, OSError):
         # Fixed template — never str(exc); the body may echo x-session-token.
         state.warnings.append(
             {

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -28,6 +28,24 @@ TAG_SIZE_LIMITS: dict[str, int] = {
 }
 
 
+async def _retry_after_ms(response: aiohttp.ClientResponse) -> float:
+    """429 backoff in ms: body ``retry_after`` -> ``Retry-After`` header (int seconds) -> 1000ms."""
+    try:
+        body = await response.json(content_type=None)
+    except (aiohttp.ClientError, ValueError):
+        body = None
+    if isinstance(body, dict):
+        ra = body.get("retry_after")
+        if isinstance(ra, (int, float)):
+            return float(ra)
+    header = response.headers.get("Retry-After")
+    if header is not None:
+        stripped = header.strip()
+        if stripped.isascii() and stripped.isdigit():
+            return float(int(stripped) * 1000)
+    return 1000.0
+
+
 async def upload_to_autumn(
     session: aiohttp.ClientSession,
     autumn_url: str,
@@ -36,7 +54,6 @@ async def upload_to_autumn(
     token: str,
     *,
     verify_size: bool = False,
-    cache: dict[str, str] | None = None,
 ) -> str:
     """Upload a file to Autumn and return the file ID.
 
@@ -47,11 +64,9 @@ async def upload_to_autumn(
         file_path: Local path to the file to upload.
         token: Stoat session token for the x-session-token header.
         verify_size: When True, compare the ``size`` field in the Autumn response (if present)
-            against the local file size. On mismatch, the cache entry is invalidated and a
-            warning is logged.  This is best-effort — not all Autumn responses include ``size``.
-        cache: Upload cache dict (``str(file_path)`` → Autumn file ID). When *verify_size*
-            is True and a size mismatch is detected, the cache entry is removed so the file
-            will be re-uploaded on the next attempt.
+            against the local file size. On a present-and-mismatched size, raises
+            ``AutumnUploadError`` — the upload is treated as failed and is never cached. This is
+            best-effort — not all Autumn responses include ``size``.
 
     Returns:
         Autumn file ID string returned by the server.
@@ -85,22 +100,33 @@ async def upload_to_autumn(
 
             async with session.post(url, data=form, headers=headers) as response:
                 if response.status == 200:
-                    result: dict[str, object] = await response.json()
+                    try:
+                        result = await response.json(content_type=None)
+                    except (aiohttp.ClientError, ValueError) as exc:
+                        raise AutumnUploadError(
+                            f"Autumn returned a non-JSON 200 response for tag '{tag}'."
+                        ) from exc
+                    if not isinstance(result, dict) or "id" not in result:
+                        raise AutumnUploadError(
+                            f"Autumn 200 response for tag '{tag}' is missing the 'id' field."
+                        )
                     file_id = str(result["id"])
 
-                    # Best-effort size verification.
+                    # Best-effort: a present-and-mismatched size is a failed upload.
                     if verify_size and "size" in result:
                         server_size = result["size"]
                         if isinstance(server_size, int) and server_size != file_size:
                             logger.warning(
                                 "Upload size mismatch for %r: local=%d bytes, server=%d bytes — "
-                                "invalidating cache entry.",
+                                "treating as a failed upload.",
                                 file_path.name,
                                 file_size,
                                 server_size,
                             )
-                            if cache is not None:
-                                cache.pop(str(file_path), None)
+                            raise AutumnUploadError(
+                                f"Upload size mismatch for '{file_path.name}': "
+                                f"local={file_size} bytes, server={server_size} bytes."
+                            )
 
                     return file_id
 
@@ -111,9 +137,7 @@ async def upload_to_autumn(
                             f"(last status: {response.status})."
                         )
                     if response.status == 429:
-                        body: dict[str, float] = await response.json()
-                        retry_after_ms = body.get("retry_after", 1000)
-                        await asyncio.sleep(retry_after_ms / 1000)
+                        await asyncio.sleep(await _retry_after_ms(response) / 1000)
                     else:
                         await asyncio.sleep(2)
                     continue
@@ -156,8 +180,9 @@ async def upload_with_cache(
         token: Stoat session token.
         cache: Mutable dict mapping str(file_path) -> Autumn file ID.
         delay: Seconds to sleep before uploading (rate-limit courtesy). Default 0.5s.
-        verify_size: When True, pass size verification to the upload call. On mismatch,
-            the cache entry is removed so the next call re-uploads. Best-effort.
+        verify_size: When True, pass size verification to the upload call. On a
+            present-and-mismatched size the upload raises ``AutumnUploadError`` and is never
+            cached. Best-effort — not all Autumn responses include ``size``.
 
     Returns:
         Autumn file ID string.
@@ -174,7 +199,6 @@ async def upload_with_cache(
         file_path,
         token,
         verify_size=verify_size,
-        cache=cache,
     )
     cache[key] = file_id
     return file_id

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -181,3 +181,232 @@ def test_icons_limit_matches_stoat_autumn_config() -> None:
     from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
     assert TAG_SIZE_LIMITS["icons"] == 2_500_000
+
+
+# ---------------------------------------------------------------------------
+# S1 — malformed 200 -> AutumnUploadError
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_non_json_200_raises_autumn_error(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """A 200 with an HTML body raises AutumnUploadError, not ContentTypeError."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=200,
+        body=b"<html>SENTINEL_BODY</html>",
+        content_type="text/html",
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError):
+            await upload_to_autumn(session, AUTUMN_URL, "attachments", file, "secret-token-xyz")
+
+
+async def test_upload_empty_200_body_raises_autumn_error(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """An empty 200 body (json -> None) raises AutumnUploadError."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=200, body=b"")
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError):
+            await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+
+
+async def test_upload_200_missing_id_raises_autumn_error(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """A 200 whose JSON lacks 'id' raises AutumnUploadError."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"size": 50})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError):
+            await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+
+
+async def test_upload_error_message_omits_token_and_body(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """The raised error never contains the response body or the token (Tiger #1)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=200,
+        body=b"<html>SENTINEL_BODY</html>",
+        content_type="text/html",
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError) as ei:
+            await upload_to_autumn(session, AUTUMN_URL, "attachments", file, "secret-token-xyz")
+    text = str(ei.value)
+    assert "SENTINEL_BODY" not in text
+    assert "secret-token-xyz" not in text
+
+
+# ---------------------------------------------------------------------------
+# S2 — verify_size mismatch is a failed upload (raise, never cache)
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_size_mismatch_raises(tmp_path: Path, mock_aiohttp: aioresponses) -> None:
+    """verify_size=True with a server size != local size raises AutumnUploadError."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 100)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "x", "size": 999})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError, match="size mismatch"):
+            await upload_to_autumn(
+                session, AUTUMN_URL, "attachments", file, TOKEN, verify_size=True
+            )
+
+
+async def test_verify_size_mismatch_not_cached(tmp_path: Path, mock_aiohttp: aioresponses) -> None:
+    """A mismatch via upload_with_cache leaves NO cache entry (corrupt id never cached)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 100)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "x", "size": 999})
+    cache: dict[str, str] = {}
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError):
+            await upload_with_cache(
+                session, AUTUMN_URL, "attachments", file, TOKEN, cache, delay=0, verify_size=True
+            )
+    assert str(file) not in cache
+
+
+async def test_verify_size_match_returns_and_caches(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """verify_size=True with matching size returns the id and caches it."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 100)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "x", "size": 100})
+    cache: dict[str, str] = {}
+    async with aiohttp.ClientSession() as session:
+        result = await upload_with_cache(
+            session, AUTUMN_URL, "attachments", file, TOKEN, cache, delay=0, verify_size=True
+        )
+    assert result == "x"
+    assert cache[str(file)] == "x"
+
+
+async def test_verify_size_no_size_field_returns_id(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """verify_size=True with no 'size' field returns the id (best-effort unchanged)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 100)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "x"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(
+            session, AUTUMN_URL, "attachments", file, TOKEN, verify_size=True
+        )
+    assert result == "x"
+
+
+async def test_verify_size_false_ignores_mismatch(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """Default verify_size=False ignores a size mismatch (path unchanged)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 100)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "x", "size": 999})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "x"
+
+
+# ---------------------------------------------------------------------------
+# S3 — 429 non-JSON tolerance + Retry-After header
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record autumn-module asyncio.sleep delays without waiting."""
+    calls: list[float] = []
+
+    async def _fake_sleep(secs: float) -> None:
+        calls.append(secs)
+
+    monkeypatch.setattr("discord_ferry.uploader.autumn.asyncio.sleep", _fake_sleep)
+    return calls
+
+
+async def test_429_html_body_retries_then_succeeds(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A 429 with an HTML body retries (no ContentTypeError) using the default backoff."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments", status=429, body=b"<html>429</html>", content_type="text/html"
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept and slept[0] == 1.0
+
+
+async def test_429_empty_body_default_backoff(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A 429 with an empty body falls back to the 1000 ms default."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=429, body=b"")
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0
+
+
+async def test_429_body_retry_after_honored(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A 429 with a body retry_after sleeps that many ms (existing behavior preserved)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=429, payload={"retry_after": 100})
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 0.1
+
+
+async def test_429_retry_after_header_used(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A 429 with no body field but a Retry-After header sleeps that many seconds."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments", status=429, body=b"", headers={"Retry-After": "2"}
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 2.0
+
+
+async def test_429_exhausted_raises(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """Three consecutive 429s exhaust retries and raise AutumnUploadError (no crash)."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    for _ in range(3):
+        mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=429, body=b"")
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError, match="Upload failed after"):
+            await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3075,3 +3075,160 @@ async def test_emoji_only_message_not_falsely_labeled_empty(tmp_path: Path) -> N
 
     assert len(sent) == 1
     assert "[empty message]" not in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# S5 — sticker/embed upload parity (verify_size + autumn_uploads + referenced)
+# ---------------------------------------------------------------------------
+
+
+async def test_sticker_registered_in_autumn_uploads(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """A successfully-uploaded sticker id is tracked in autumn_uploads and referenced."""
+    sticker_dir = tmp_path / "stickers"
+    sticker_dir.mkdir()
+    (sticker_dir / "cool.png").write_bytes(b"data")
+    msg = _make_message(
+        id="msg_s",
+        content="hi",
+        stickers=[
+            {"id": "sticker1", "name": "Cool", "format": "png", "sourceUrl": "stickers/cool.png"}
+        ],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path)
+    state = _make_state()
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "autumn_s1"}, repeat=True)
+    mock_aiohttp.post(CHANNEL_MSG_URL, payload={"_id": "stoat_s"}, repeat=True)
+
+    await run_messages(config, state, [export], lambda e: None)
+
+    assert "autumn_s1" in state.autumn_uploads
+    assert "autumn_s1" in state.referenced_autumn_ids
+
+
+async def test_sticker_verify_size_pass_through(tmp_path: Path, mock_aiohttp: aioresponses) -> None:
+    """verify_uploads on: a sticker size mismatch skips the sticker; the message still sends."""
+    sticker_dir = tmp_path / "stickers"
+    sticker_dir.mkdir()
+    (sticker_dir / "cool.png").write_bytes(b"data")
+    msg = _make_message(
+        id="msg_s2",
+        content="hi",
+        stickers=[
+            {"id": "sticker1", "name": "Cool", "format": "png", "sourceUrl": "stickers/cool.png"}
+        ],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path, verify_uploads=True)
+    state = _make_state()
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "s", "size": 999}, repeat=True)
+    mock_aiohttp.post(CHANNEL_MSG_URL, payload={"_id": "stoat_s2"}, repeat=True)
+
+    await run_messages(config, state, [export], lambda e: None)
+
+    assert "msg_s2" in state.message_map  # message still sent
+    assert "s" not in state.autumn_uploads  # mismatched sticker not registered
+
+
+async def test_embed_media_registered_and_referenced_not_orphan(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """Embed media id is tracked AND referenced on success -> not reported as an orphan."""
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "thumb.png").write_bytes(b"png")
+    msg = _make_message(
+        id="msg_e",
+        content="x",
+        embeds=[{"title": "T", "description": "D", "thumbnail": {"url": "media/thumb.png"}}],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path)
+    state = _make_state()
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "autumn_m1"}, repeat=True)
+    mock_aiohttp.post(CHANNEL_MSG_URL, payload={"_id": "stoat_e"}, repeat=True)
+
+    await run_messages(config, state, [export], lambda e: None)
+
+    assert "autumn_m1" in state.autumn_uploads
+    assert "autumn_m1" in state.referenced_autumn_ids
+    orphans = set(state.autumn_uploads) - state.referenced_autumn_ids
+    assert "autumn_m1" not in orphans
+
+
+async def test_embed_media_not_a_top_level_attachment(tmp_path: Path) -> None:
+    """Embed media id is set on flat['media'] but NOT in the sent attachments (5-cap untouched)."""
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "thumb.png").write_bytes(b"png")
+    msg = _make_message(
+        id="msg_e2",
+        content="x",
+        embeds=[{"title": "T", "description": "D", "thumbnail": {"url": "media/thumb.png"}}],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path)
+    state = _make_state()
+    sent: list[dict[str, Any]] = []
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", _capture_sends(sent)),
+        patch("discord_ferry.migrator.messages.upload_with_cache", return_value="autumn_m2"),
+    ):
+        await run_messages(config, state, [export], lambda e: None)
+
+    first = sent[0]
+    assert first.get("attachments") in (None, [])  # media not attached as a top-level file
+    assert any(e.get("media") == "autumn_m2" for e in (first.get("embeds") or []))
+
+
+async def test_embed_media_unsent_is_orphan(tmp_path: Path) -> None:
+    """Embed media uploaded but send fails -> tracked but NOT referenced (orphan)."""
+
+    async def always_fail(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        raise RuntimeError("API down")
+
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "thumb.png").write_bytes(b"png")
+    msg = _make_message(
+        id="msg_e3",
+        content="x",
+        embeds=[{"title": "T", "description": "D", "thumbnail": {"url": "media/thumb.png"}}],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path)
+    state = _make_state()
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", always_fail),
+        patch("discord_ferry.migrator.messages.upload_with_cache", return_value="autumn_m3"),
+    ):
+        await run_messages(config, state, [export], lambda e: None)
+
+    assert "autumn_m3" in state.autumn_uploads
+    assert "autumn_m3" not in state.referenced_autumn_ids
+
+
+async def test_embed_verify_size_pass_through(tmp_path: Path, mock_aiohttp: aioresponses) -> None:
+    """verify_uploads on: an embed-media size mismatch skips the media; the message still sends."""
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "thumb.png").write_bytes(b"x" * 100)
+    msg = _make_message(
+        id="msg_e4",
+        content="x",
+        embeds=[{"title": "T", "description": "D", "thumbnail": {"url": "media/thumb.png"}}],
+    )
+    export = _make_export(messages=[msg])
+    config = _make_config(tmp_path, verify_uploads=True)
+    state = _make_state()
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "m", "size": 999}, repeat=True)
+    mock_aiohttp.post(CHANNEL_MSG_URL, payload={"_id": "stoat_e4"}, repeat=True)
+
+    await run_messages(config, state, [export], lambda e: None)
+
+    assert "msg_e4" in state.message_map  # message still sent
+    assert "m" not in state.autumn_uploads  # mismatched media not registered

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -2637,3 +2637,104 @@ async def _run_and_collect(config: FerryConfig, exports: list[DCEExport]) -> set
         m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-x", payload={}, repeat=True)
         await run_roles(config, state, exports, events.append)
     return set(created_names)
+
+
+# ---------------------------------------------------------------------------
+# S4 — role-icon upload failure degrades (never aborts the roles phase)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_roles_icon_upload_failure_degrades(tmp_path: Path) -> None:
+    """A non-JSON Autumn icon response skips the icon (token-safe warning); phase completes."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    patch_bodies: list[dict[str, object]] = []
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        # Non-JSON 200 from Autumn -> AutumnUploadError (post-S1) -> caught by the broadened guard.
+        m.post(
+            f"{AUTUMN_URL}/icons",
+            status=200,
+            body=b"<html>SENTINEL_BODY</html>",
+            content_type="text/html",
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        # Must NOT raise — degrade, not abort.
+        await run_roles(config, state, exports, events.append)
+
+    icon_warnings = [w for w in state.warnings if w.get("type") == "role_icon_upload_failed"]
+    assert icon_warnings  # icon skipped with a warning
+    assert any(b.get("hoist") is True for b in patch_bodies)  # rank/hoist still applied
+    # SC-18 token-safety: the warning carries no response body and no token.
+    for w in icon_warnings:
+        assert "SENTINEL_BODY" not in w["message"]
+        assert config.token not in w["message"]
+
+
+async def test_run_roles_icon_oserror_degrades(tmp_path: Path) -> None:
+    """An OSError writing the temp icon file degrades (warning) instead of aborting."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+    )
+    save_discord_metadata(meta, tmp_path)  # written before the write_bytes patch
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+        patch("pathlib.Path.write_bytes", side_effect=OSError("disk full")),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        # Must NOT raise — the OSError on temp-file write degrades to a warning.
+        await run_roles(config, state, exports, events.append)
+
+    assert any(w.get("type") == "role_icon_upload_failed" for w in state.warnings)

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.6"
+version = "2.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
**Bug-hunt Batch 1** from the 2026-06-25 v2.6.6 whole-codebase adversarial bug-hunt (local audit `docs/plans/audits/2026-06-25-bug-hunt.md` §4). HIGH-severity Autumn-upload cluster — all confirmed by 3-skeptic adversarial verification.

## What & why
Hardens `uploader/autumn.py` and its callers so malformed/transient Autumn responses **degrade gracefully instead of aborting the whole migration**, makes `--verify-uploads` actually detect corrupt uploads, and brings sticker/embed-media uploads to attachment parity.

| Story | Fix |
|------|-----|
| **S1** | Malformed `200` (non-JSON / empty body / missing `id`) now raises `AutumnUploadError` instead of a raw `aiohttp.ContentTypeError`/`KeyError`/`TypeError`. This was the abort path: `_resolve_role_icon` caught only `AutumnUploadError`, so a raw error escaped and killed any migration with custom role icons. |
| **S2** | A `verify_size` mismatch is now a **failed** upload (raises; never returned, never cached). Previously the bad id was returned and re-cached → `--verify-uploads` was a no-op. Dead `cache` param removed from `upload_to_autumn`. |
| **S3** | `429` with a non-JSON body no longer crashes; backoff via new `_retry_after_ms` (body `retry_after` → `Retry-After` header → 1000 ms default). |
| **S4** | `_resolve_role_icon` guard broadened to `(AutumnUploadError, OSError)` — icon failure skips with a token-safe warning; rank/hoist still apply. |
| **S5** | Sticker + embed-media uploads pass `verify_size` and register in `state.autumn_uploads`; embed `media_id` is credited to `referenced_autumn_ids` on success (not added to `autumn_ids`) so it isn't reported as a false orphan and doesn't consume the 5-attachment cap. |

## Tests & quality
- +22 tests (`test_autumn.py` ×14, `test_messages.py` ×6, `test_structure.py` ×2); **full suite green** (`ruff` + `format` + `mypy --strict` + `pytest`).
- Autumn guards **falsified 9/9** (RED on reverted source, GREEN on restore).
- Fresh-context opus code review: **APPROVE WITH NITS** (the one nit — `Retry-After` `.isascii()` guard — applied).
- Mistral second opinion: all findings rebutted against source (documented false-positive pattern).

## Scope
Out of scope (intentional): the refuted `autumn.py` tag-omitted-cache-key item; concurrent-upload dedup (deferred); the identical `api.py`/`discord/client.py` 429 bug (Batch 6); emoji/avatar paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)