### PR TITLE
fix: resume & migration-lock integrity — lock survives SERVER, no dup server on resume, roles finalized on resume (v2.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.8] - 2026-06-26
+
+### Fixed
+
+Resume & migration-lock integrity cluster — the second batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 2). All in `core/engine.py`, `migrator/structure.py`, and `state.py`.
+
+- **The advisory migration lock now survives the SERVER phase** (`core/engine.py`, `migrator/structure.py`). The S17 lock is a `[FERRY_LOCK:{ts}:{host}]` marker appended to the live server description by `_acquire_migration_lock`; the SERVER phase then PATCHed the description with the Discord guild description — a full-field replacement that **wiped the marker**, so the lock protected only the connect+server phases and a second concurrent existing-server migration saw no lock during the hours-long message/reaction/pin tail. The engine now stashes the marker it wrote into a transient `state.migration_lock_marker` (never persisted, re-acquired each run), and `run_server` folds it into the description it already PATCHes — no extra API call. `_release_migration_lock` clears the field.
+- **A `--resume` after a kill mid-SERVER no longer creates a duplicate server** (`migrator/structure.py`). `run_server` set `state.stoat_server_id` from `api_create_server` but only the engine's post-phase save persisted it; a kill in that window left an on-disk state with no server id, so `--resume` re-entered the create branch and made a second server (orphaning the first with all its channels/roles). The id is now persisted with `save_state` immediately after creation, so `--resume` takes the reuse branch.
+- **`run_roles` resume now finalizes attributes and permissions for roles created before a crash** (`migrator/structure.py`, `state.py`, `core/engine.py`). `pre_existing_role_ids = set(role_map)` (captured at phase start) gated all three role passes, so on resume the roles created in the prior run were treated as pre-existing and their rank/hoist/icon/permissions were **never applied**. A new persisted `state.roles_finalized` set now gates the attributes + permissions passes (the create pass still gates on `pre_existing_role_ids` to avoid duplicate creation); roles are marked finalized at the **end** of a completed `run_roles` (regardless of the metadata-gated permissions pass), so a crash before the end re-runs both passes idempotently on resume. `roles_finalized` is carried into `--incremental` state and back-compat-seeded from `role_map` for migrations completed by an older version, so incremental runs still skip re-editing. A periodic intra-phase save in the create loop gives hard-kill durability.
+
 ## [2.6.7] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.7"
+version = "2.6.8"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.7"
+__version__ = "2.6.8"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -163,6 +163,9 @@ async def run_migration(
             # Carry over ID maps so structure phases are skipped / reused
             state.channel_map = dict(prior.channel_map)
             state.role_map = dict(prior.role_map)
+            # C1: carry finalized-roles so incremental skips re-editing (load_state seeds `prior`
+            # for old-ferry states). Without this every incremental run re-PATCHes all roles.
+            state.roles_finalized = set(prior.roles_finalized)
             state.category_map = dict(prior.category_map)
             state.emoji_map = dict(prior.emoji_map)
             state.avatar_cache = dict(prior.avatar_cache)
@@ -771,6 +774,8 @@ async def _acquire_migration_lock(
             config.server_id or "",
             description=new_description,
         )
+        # S1: stash the marker so the SERVER phase's description PATCH preserves it (transient).
+        state.migration_lock_marker = lock_marker
         on_event(
             MigrationEvent(
                 phase="connect",
@@ -815,6 +820,7 @@ async def _release_migration_lock(
                     config.server_id or "",
                     description=description,
                 )
+        state.migration_lock_marker = ""
         on_event(
             MigrationEvent(
                 phase="connect",

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -33,6 +33,7 @@ from discord_ferry.migrator.api import (
 from discord_ferry.migrator.sanitize import truncate_name
 from discord_ferry.parser.dce_parser import stream_messages
 from discord_ferry.parser.models import DCERole
+from discord_ferry.state import save_state
 from discord_ferry.uploader.autumn import upload_to_autumn, upload_with_cache
 
 if TYPE_CHECKING:
@@ -167,6 +168,9 @@ async def run_server(
 
             result = await api_create_server(session, config.stoat_url, config.token, name)
             state.stoat_server_id = result["_id"]
+            # S2: persist immediately so a kill before the post-phase save still records the
+            # server id — on --resume the reuse branch fires instead of creating a duplicate.
+            save_state(state, config.output_dir)
             on_event(
                 MigrationEvent(
                     phase="server",
@@ -283,7 +287,11 @@ async def run_server(
         if discord_meta is not None:
             server_kwargs: dict[str, Any] = {"nsfw": discord_meta.guild_nsfw}
             if discord_meta.guild_description:
-                server_kwargs["description"] = discord_meta.guild_description
+                desc = discord_meta.guild_description
+                # S1: preserve the advisory-lock marker the engine wrote (else this PATCH wipes it).
+                if state.migration_lock_marker:
+                    desc = f"{desc} {state.migration_lock_marker}"
+                server_kwargs["description"] = desc
             try:
                 await api_edit_server(
                     session,
@@ -537,6 +545,10 @@ async def run_roles(
                 raise
             stoat_role_id: str = result["id"]
             state.role_map[role.id] = stoat_role_id
+            # S3: persist periodically so a hard-kill mid-create leaves role_map durable
+            # (resume then skips already-created roles instead of duplicating them).
+            if idx % 10 == 0:
+                save_state(state, config.output_dir)
 
             # Credit recovered structural roles: created THIS run (the
             # pre_existing_role_ids guard above already excludes prior-run roles)
@@ -585,7 +597,9 @@ async def run_roles(
     ranked_roles = sorted(roles_to_create, key=lambda r: (r.position, r.id))
     async with get_session(config) as session:
         for role in ranked_roles:
-            if role.id in pre_existing_role_ids:
+            # S3: gate on roles_finalized (not pre_existing) so resume finalizes created-but-
+            # unfinished roles; --incremental skips prior-completed (finalized) roles.
+            if role.id in state.roles_finalized:
                 continue
             rank_role_id = state.role_map.get(role.id)
             if not rank_role_id:
@@ -658,7 +672,8 @@ async def run_roles(
     if discord_metadata and not config.dry_run:
         async with get_session(config) as session:
             for role in roles_to_create:
-                if role.id in pre_existing_role_ids:
+                # S3: gate on roles_finalized (not pre_existing) — see attributes pass above.
+                if role.id in state.roles_finalized:
                     continue
                 stoat_role_id_or_none = state.role_map.get(role.id)
                 if not stoat_role_id_or_none:
@@ -706,6 +721,13 @@ async def run_roles(
                             "message": f"Failed to set server default permissions: {exc}",
                         }
                     )
+
+    # S3: mark every mapped role finalized (regardless of whether the metadata-gated perms pass
+    # ran) so --incremental skips re-editing; a crash before here leaves them un-finalized and
+    # resume re-runs attrs+perms idempotently. Unmapped roles (e.g. after a TooManyRoles break)
+    # are excluded by the `in state.role_map` filter.
+    state.roles_finalized.update(r.id for r in roles_to_create if r.id in state.role_map)
+    save_state(state, config.output_dir)
 
     on_event(
         MigrationEvent(

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -94,6 +94,10 @@ class MigrationState:
     stoat_server_id: str = ""
     autumn_url: str = ""
 
+    # S17 lock marker the engine wrote this run (transient — re-acquired each run, NOT persisted).
+    # run_server appends it to the description PATCH so the SERVER phase doesn't wipe the lock.
+    migration_lock_marker: str = ""
+
     # Resume tracking
     current_phase: str = ""
     completed_channel_ids: set[str] = field(default_factory=set)
@@ -122,6 +126,11 @@ class MigrationState:
     # Orphan upload tracking: detect Autumn files uploaded but never referenced in a message
     autumn_uploads: dict[str, str] = field(default_factory=dict)  # autumn_id -> source_id
     referenced_autumn_ids: set[str] = field(default_factory=set)  # confirmed used
+
+    # S3: roles whose attributes+permissions passes completed (a full run_roles). Gates the
+    # attrs/perms passes so resume finalizes created-but-unfinished roles while --incremental
+    # skips re-editing prior-completed ones.
+    roles_finalized: set[str] = field(default_factory=set)
 
     # Dead-letter queue: messages that failed to send (typed, retryable)
     failed_messages: list[FailedMessage] = field(default_factory=list)
@@ -272,6 +281,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "export_completed": state.export_completed,
         "autumn_uploads": state.autumn_uploads,
         "referenced_autumn_ids": list(state.referenced_autumn_ids),
+        "roles_finalized": list(state.roles_finalized),
         "failed_messages": [dataclasses.asdict(fm) for fm in state.failed_messages],
         "validation_results": state.validation_results,
         "prior_messages_total": state.prior_messages_total,
@@ -312,7 +322,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
         )
 
     try:
-        return MigrationState(
+        state = MigrationState(
             role_map=data.get("role_map", {}),
             channel_map=data.get("channel_map", {}),
             category_map=data.get("category_map", {}),
@@ -343,6 +353,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             export_completed=data.get("export_completed", False),
             autumn_uploads=data.get("autumn_uploads", {}),
             referenced_autumn_ids=set(data.get("referenced_autumn_ids", [])),
+            roles_finalized=set(data.get("roles_finalized", [])),
             failed_messages=[FailedMessage(**d) for d in data.get("failed_messages", [])],
             validation_results=data.get("validation_results", {}),
             prior_messages_total=data.get("prior_messages_total", 0),
@@ -361,6 +372,12 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             invite_url=data.get("invite_url", ""),
             native_fidelity_counts=data.get("native_fidelity_counts", {}),
         )
+        # S3 back-compat seed: an older completed migration has no roles_finalized; treat all
+        # mapped roles as finalized so its first --incremental run does not re-edit them. A
+        # crashed migration has no completed_at -> not seeded -> resume finalizes the remainder.
+        if state.completed_at and state.role_map and not state.roles_finalized:
+            state.roles_finalized = set(state.role_map)
+        return state
     except (TypeError, ValueError) as e:
         raise StateError(f"Invalid state data: {e}") from e
 

--- a/tests/test_delta_migration.py
+++ b/tests/test_delta_migration.py
@@ -290,3 +290,24 @@ async def test_incremental_carried_failed_messages_are_independent_copies(tmp_pa
     state.failed_messages[0].retry_count = 99
     assert prior.failed_messages[0].retry_count == 2  # no aliasing
     assert state.failed_messages[0] is not prior.failed_messages[0]
+
+
+async def test_incremental_carries_roles_finalized(tmp_path: Path) -> None:
+    """SC-19: incremental carry-over copies prior.roles_finalized (C1)."""
+    _make_prior_state(
+        tmp_path,
+        role_map={"r1": "s1"},
+        roles_finalized={"r1"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.roles_finalized == {"r1"}
+
+
+async def test_incremental_seeds_then_carries_roles_finalized_for_old_state(tmp_path: Path) -> None:
+    """SC-19 (seed+carry): a completed prior state with no roles_finalized is seeded."""
+    # _make_prior_state sets completed_at; roles_finalized defaults empty -> simulates an old ferry.
+    _make_prior_state(tmp_path, role_map={"r1": "s1", "r2": "s2"})
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.roles_finalized == {"r1", "r2"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import aiohttp
 import pytest
 from aioresponses import aioresponses
 
@@ -1698,3 +1699,45 @@ def test_select_invite_channel_none_when_only_voice(tmp_path: Path) -> None:
     state = MigrationState(channel_map={"d_voice": "s_voice"})
     exports = _exports_voice_only("d_voice")
     assert _select_invite_channel(config, state, exports) is None
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — S1: migration-lock marker plumbing (engine _acquire/_release)
+# ---------------------------------------------------------------------------
+
+
+async def test_acquire_raises_on_live_lock_marker(tmp_path: Path) -> None:
+    """S1 SC-4: a live (unexpired) lock marker blocks a concurrent acquire."""
+    from discord_ferry.core.engine import _acquire_migration_lock
+    from discord_ferry.errors import MigrationError
+
+    config = _make_config(tmp_path, server_id="srv1")
+    state = MigrationState()
+    with aioresponses() as m:
+        # ts far in the future -> age < expiry -> treated as a live lock.
+        m.get(
+            "https://api.test/servers/srv1",
+            payload={"_id": "srv1", "description": "x [FERRY_LOCK:9999999999:host]"},
+        )
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="Another migration is in progress"):
+                await _acquire_migration_lock(config, state, session, lambda e: None)
+
+
+async def test_acquire_sets_and_release_clears_lock_marker(tmp_path: Path) -> None:
+    """S1 SC-5: _acquire stashes the marker in state; _release clears it."""
+    from discord_ferry.core.engine import _acquire_migration_lock, _release_migration_lock
+
+    config = _make_config(tmp_path, server_id="srv1")
+    state = MigrationState()
+    with aioresponses() as m:
+        m.get(
+            "https://api.test/servers/srv1", payload={"_id": "srv1", "description": ""}, repeat=True
+        )
+        m.patch("https://api.test/servers/srv1", payload={}, repeat=True)
+        async with aiohttp.ClientSession() as session:
+            acquired = await _acquire_migration_lock(config, state, session, lambda e: None)
+            assert acquired is True
+            assert state.migration_lock_marker.startswith("[FERRY_LOCK:")
+            await _release_migration_lock(config, state, session, lambda e: None)
+            assert state.migration_lock_marker == ""

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -186,10 +186,13 @@ async def test_run_roles_skips_all_passes_for_already_migrated_roles(
     )
     save_discord_metadata(meta, tmp_path)
 
-    # Prior state: both roles already mapped.
+    # Prior COMPLETED migration: both roles mapped AND finalized. Under S3, roles_finalized
+    # (not role_map membership) is the signal that the attrs/perms passes already ran, so an
+    # incremental run skips them. (A completed migration carries/seeds roles_finalized.)
     state = MigrationState(
         stoat_server_id="srv1",
         role_map={"r1": "stoat-r1", "r2": "stoat-r2"},
+        roles_finalized={"r1", "r2"},
     )
     config = _make_config(tmp_path, incremental=True)
     exports = [_make_role_export([role_a, role_b])]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -593,3 +593,52 @@ def test_load_state_defaults_channel_high_water(tmp_path: Path) -> None:
     path.write_text(json.dumps(data))
     loaded = load_state(tmp_path)
     assert loaded.channel_high_water == {}
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — S3: roles_finalized round-trip + seed; S1 marker not persisted
+# ---------------------------------------------------------------------------
+
+
+def test_roles_finalized_roundtrip(tmp_path: Path) -> None:
+    """S3 SC-16: roles_finalized survives save/load."""
+    state = MigrationState(roles_finalized={"r1", "r2"})
+    save_state(state, tmp_path)
+    loaded = load_state(tmp_path)
+    assert loaded.roles_finalized == {"r1", "r2"}
+
+
+def test_load_seeds_roles_finalized_for_completed_migration(tmp_path: Path) -> None:
+    """S3 SC-17: a completed migration with no roles_finalized key is seeded from role_map."""
+    state = MigrationState(
+        completed_at="2026-06-26T00:00:00+00:00", role_map={"r1": "s1", "r2": "s2"}
+    )
+    save_state(state, tmp_path)
+    path = tmp_path / "state.json"
+    data = json.loads(path.read_text())
+    data.pop("roles_finalized", None)  # emulate an older ferry state file
+    path.write_text(json.dumps(data))
+    loaded = load_state(tmp_path)
+    assert loaded.roles_finalized == {"r1", "r2"}
+
+
+def test_load_does_not_seed_roles_finalized_without_completed_at(tmp_path: Path) -> None:
+    """S3 SC-17 (control): a crashed (not completed) migration is NOT seeded."""
+    state = MigrationState(role_map={"r1": "s1"})  # no completed_at
+    save_state(state, tmp_path)
+    path = tmp_path / "state.json"
+    data = json.loads(path.read_text())
+    data.pop("roles_finalized", None)
+    path.write_text(json.dumps(data))
+    loaded = load_state(tmp_path)
+    assert loaded.roles_finalized == set()
+
+
+def test_migration_lock_marker_not_persisted(tmp_path: Path) -> None:
+    """S1 SC-18: the transient lock marker is never serialized."""
+    state = MigrationState(migration_lock_marker="[FERRY_LOCK:1:h]")
+    save_state(state, tmp_path)
+    path = tmp_path / "state.json"
+    assert "migration_lock_marker" not in json.loads(path.read_text())
+    loaded = load_state(tmp_path)
+    assert loaded.migration_lock_marker == ""

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -2738,3 +2738,263 @@ async def test_run_roles_icon_oserror_degrades(tmp_path: Path) -> None:
         await run_roles(config, state, exports, events.append)
 
     assert any(w.get("type") == "role_icon_upload_failed" for w in state.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — S1: migration lock survives the SERVER phase
+# ---------------------------------------------------------------------------
+
+
+def _meta_with_description(desc: str = "Cosy") -> DiscordMetadata:
+    return DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        guild_description=desc,
+    )
+
+
+async def test_lock_marker_preserved_in_server_description_patch(tmp_path: Path) -> None:
+    """S1 SC-1: run_server folds the lock marker into the description PATCH (token-safe)."""
+    config = _make_config(tmp_path, server_id="srv1", token="secret-token-xyz")
+    state = MigrationState(
+        stoat_server_id="srv1", migration_lock_marker="[FERRY_LOCK:9999999999:host]"
+    )
+    save_discord_metadata(_meta_with_description("Cosy"), tmp_path)
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1", "name": "S"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_server(config, state, [_make_export()], lambda e: None)
+    desc_bodies = [b for b in bodies if "description" in b]
+    assert len(desc_bodies) == 1
+    assert "Cosy" in desc_bodies[0]["description"]  # type: ignore[operator]
+    assert "[FERRY_LOCK:9999999999:host]" in desc_bodies[0]["description"]  # type: ignore[operator]
+    assert all("secret-token-xyz" not in w.get("message", "") for w in state.warnings)
+
+
+async def test_lock_marker_adds_no_extra_server_patch(tmp_path: Path) -> None:
+    """S1 SC-2: the marker folds into the existing description PATCH — no extra PATCH."""
+    config = _make_config(tmp_path, server_id="srv1")
+    state = MigrationState(stoat_server_id="srv1", migration_lock_marker="[FERRY_LOCK:1:h]")
+    save_discord_metadata(_meta_with_description("Cosy"), tmp_path)
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1", "name": "S"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_server(config, state, [_make_export()], lambda e: None)
+    # Exactly one description-bearing PATCH (the marker is folded in, not a separate call).
+    assert len([b for b in bodies if "description" in b]) == 1
+    # The permission-bootstrap PATCH (default_permissions only) carries no description.
+    assert any("default_permissions" in b and "description" not in b for b in bodies)
+
+
+async def test_create_path_description_has_no_lock_marker(tmp_path: Path) -> None:
+    """S1 SC-3: the create path has no lock (empty marker) → description PATCH carries no marker."""
+    config = _make_config(tmp_path)  # no server_id -> create path
+    state = MigrationState()  # migration_lock_marker == ""
+    save_discord_metadata(_meta_with_description("Cosy"), tmp_path)
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "new1", "name": "S"})
+        m.patch(
+            f"{STOAT_URL}/servers/new1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_server(config, state, [_make_export()], lambda e: None)
+    desc_bodies = [b for b in bodies if "description" in b]
+    assert desc_bodies and desc_bodies[0]["description"] == "Cosy"
+    assert all("[FERRY_LOCK" not in str(b.get("description", "")) for b in bodies)
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — S2: persist stoat_server_id immediately after create (--resume)
+# ---------------------------------------------------------------------------
+
+
+async def test_server_id_persisted_right_after_create(tmp_path: Path) -> None:
+    """S2 SC-6: save_state runs right after create, with stoat_server_id already set."""
+    config = _make_config(tmp_path)
+    state = MigrationState()
+    recorded: list[str] = []
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.save_state",
+            side_effect=lambda s, d: recorded.append(s.stoat_server_id),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "new1", "name": "S"})
+        m.patch(f"{STOAT_URL}/servers/new1", payload={}, repeat=True)
+        await run_server(config, state, [_make_export()], lambda e: None)
+    assert recorded and recorded[0] == "new1"  # persisted immediately after create
+
+
+async def test_resume_after_create_reuses_server(tmp_path: Path) -> None:
+    """S2 SC-7: a --resume from a kill-after-create state reuses the server (no second create)."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")  # persisted post-create state
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1", "name": "S"})
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={}, repeat=True)
+        # No /servers/create mock — aioresponses raises if create fires.
+        await run_server(config, state, [_make_export()], lambda e: None)
+    assert state.stoat_server_id == "srv1"
+
+
+async def test_dry_run_server_unchanged(tmp_path: Path) -> None:
+    """S2 SC-8: dry-run uses a placeholder id and makes no HTTP calls."""
+    config = _make_config(tmp_path, dry_run=True)
+    state = MigrationState()
+    with aioresponses():  # any request would raise
+        await run_server(config, state, [_make_export()], lambda e: None)
+    assert state.stoat_server_id.startswith("dry-server")
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — S3: run_roles resume finalizes attributes + permissions
+# ---------------------------------------------------------------------------
+
+
+def _meta_with_role(role_id: str = "r1") -> DiscordMetadata:
+    return DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={role_id: PermissionPair(allow=1, deny=0)},
+        channel_metadata={},
+        role_metadata={role_id: RoleMeta(hoist=True, position=2)},
+    )
+
+
+async def test_resume_finalizes_unfinalized_role(tmp_path: Path) -> None:
+    """S3 SC-9: a created-but-unfinalized role gets attrs PATCH + perms PUT on resume."""
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv1", role_map={"r1": "stoat-r1"}, roles_finalized=set()
+    )
+    exports = [_make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="Mods")])])]
+    save_discord_metadata(_meta_with_role("r1"), tmp_path)
+    patched: list[dict[str, object]] = []
+    putted: list[dict[str, object]] = []
+    with aioresponses() as m:
+        # No POST /roles mock — create must NOT fire for the already-mapped role.
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: patched.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/servers/srv1/permissions/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: putted.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_roles(config, state, exports, lambda e: None)
+    assert patched and putted  # attrs + perms both applied on resume
+    assert "r1" in state.roles_finalized
+
+
+async def test_resume_does_not_recreate_mapped_role(tmp_path: Path) -> None:
+    """S3 SC-10: the create pass skips an already-mapped role (no duplicate api_create_role)."""
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv1", role_map={"r1": "stoat-r1"}, roles_finalized=set()
+    )
+    exports = [_make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="Mods")])])]
+    save_discord_metadata(_meta_with_role("r1"), tmp_path)
+    creates: list[object] = []
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "should-not-happen"},
+            repeat=True,
+            callback=lambda url, **kw: creates.append(url),  # type: ignore[misc]
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+        await run_roles(config, state, exports, lambda e: None)
+    assert creates == []  # no create POST fired
+
+
+async def test_incremental_finalized_role_skips_attrs_and_perms(tmp_path: Path) -> None:
+    """S3 SC-11: a finalized role is skipped by both attrs and perms passes (no HTTP)."""
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv1", role_map={"r1": "stoat-r1"}, roles_finalized={"r1"}
+    )
+    exports = [_make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="Mods")])])]
+    save_discord_metadata(_meta_with_role("r1"), tmp_path)
+    with aioresponses():  # NO mocks — any role PATCH/PUT/POST would raise
+        await run_roles(config, state, exports, lambda e: None)
+    assert state.roles_finalized == {"r1"}
+
+
+async def test_mark_at_end_finalizes_without_metadata(tmp_path: Path) -> None:
+    """S3 SC-12: a completed run finalizes created roles even with no Discord metadata."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [_make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="Mods")])])]
+    # No save_discord_metadata -> permissions pass skipped, attrs no-op (position 0).
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1"}, repeat=True)
+        await run_roles(config, state, exports, lambda e: None)
+    assert "r1" in state.roles_finalized
+
+
+async def test_completed_run_finalizes_all_created_roles(tmp_path: Path) -> None:
+    """S3 SC-13: a normal completed run finalizes every created role."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [DCERole(id="r1", name="A"), DCERole(id="r2", name="B")]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r2"})
+        await run_roles(config, state, exports, lambda e: None)
+    assert state.roles_finalized == {"r1", "r2"}
+
+
+async def test_create_loop_saves_state_periodically(tmp_path: Path) -> None:
+    """S3 SC-14: the create loop persists mid-phase (hard-kill durability)."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [DCERole(id=f"r{i}", name=f"R{i}") for i in range(1, 11)]  # 10 roles -> idx%10 fires
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+    with (
+        aioresponses() as m,
+        patch("discord_ferry.migrator.structure.save_state") as spy,
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-x"}, repeat=True)
+        await run_roles(config, state, exports, lambda e: None)
+    # One intra-loop save (at idx==10) + one finalize-at-end save.
+    assert spy.call_count >= 2
+
+
+async def test_too_many_roles_break_leaves_unmapped_unfinalized(tmp_path: Path) -> None:
+    """S3 SC-15: a TooManyRoles break leaves the unmapped role out of roles_finalized."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [DCERole(id="r1", name="A"), DCERole(id="r2", name="B")]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", status=400, body=b'{"type":"TooManyRoles"}')
+        await run_roles(config, state, exports, lambda e: None)
+    assert "r1" in state.role_map and "r2" not in state.role_map
+    assert "r1" in state.roles_finalized and "r2" not in state.roles_finalized

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.7"
+version = "2.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
**Bug-hunt Batch 2** from the 2026-06-25 v2.6.6 whole-codebase adversarial bug-hunt (local audit `docs/plans/audits/2026-06-25-bug-hunt.md` §4). Three HIGH-severity resume/concurrency-integrity defects — all confirmed by 3-skeptic adversarial verification.

## What & why
| Story | Fix |
|------|-----|
| **S1** | The S17 advisory migration lock is a `[FERRY_LOCK:...]` marker in the server description, which the SERVER phase overwrote with the guild description — so the lock protected only connect+server, leaving the hours-long message/reaction/pin tail unguarded against a concurrent existing-server migration. The engine now stashes the marker in a **transient** `state.migration_lock_marker` (never persisted, re-acquired each run), and `run_server` folds it into the description it already PATCHes (no extra API call); `_release` clears it. |
| **S2** | `run_server` set `state.stoat_server_id` but only the engine's post-phase save persisted it; a kill in that window made a **`--resume` create a duplicate server**. The id is now persisted with `save_state` immediately after creation, so `--resume` takes the reuse branch. |
| **S3** | `pre_existing_role_ids` gated all three role passes, so **`run_roles` resume never applied rank/hoist/icon/permissions** to roles created before a crash. A new persisted `state.roles_finalized` set gates the attributes + permissions passes (the create pass still gates on `pre_existing_role_ids`); roles are finalized at the **end** of a completed run (metadata-independent); `roles_finalized` is carried into `--incremental` state and back-compat-seeded for older completed migrations; a periodic intra-phase save in the create loop gives hard-kill durability. |

## Tests & quality
- +21 tests across `test_structure.py`/`test_state.py`/`test_engine.py`/`test_delta_migration.py`; **full suite green** (`ruff` + `format` + `mypy --strict` + `pytest` = **1142 passed**).
- Guards **falsified** (7 structure + 2 delta tests RED on reverted source, GREEN on restore).
- One **existing** test (`test_incremental_structure.py::test_run_roles_skips_all_passes_for_already_migrated_roles`) was updated to the corrected `roles_finalized` semantics — role_map membership alone no longer skips the attrs/perms passes (that was the bug).
- Fresh-context opus code review: **APPROVE WITH NITS** (2 pre-existing, out-of-scope nits: role-colour-on-resume asymmetry; lock no-op in server-id-less `--incremental`).
- Mistral second opinion: 10 findings, all rebutted against source (documented false-positive pattern).

## Scope
Out of scope (intentional): all other audit batches; Batch-1 follow-ups; lock-mechanism rework beyond surviving the PATCH; the two code-review nits (logged as follow-ups); resume for phases other than server/roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
