### PR TITLE
fix: message-phase control flow — retry/cancel/resume integrity (v2.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.9] - 2026-06-26
+
+### Fixed
+
+Message-phase control-flow cluster — the third batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 3). All in `migrator/messages.py` and `core/engine.py`. Common root: `asyncio.gather(*tasks, return_exceptions=True)` collapsed every `BaseException` (including `asyncio.CancelledError`) into a swallowed warning, and the `_process_message` retry path returned instead of re-raising.
+
+- **`ferry retry` no longer hangs or silently drops a still-failing message** (`migrator/messages.py`, `core/engine.py`). On the retry path (`_process_message` called with `channel_result=None`), a send failure was caught, appended to `state.failed_messages`, and the function **returned without re-raising**. The retry loop `for fm in state.failed_messages` then (a) appended to the very list it was iterating → mutate-during-iteration → an infinite loop on a deterministically-failing message, and (b) counted the re-failure as `retried` (reported success) and dropped it. `_process_message` now re-raises on failure **only when `channel_result is None`** (the parallel per-channel path keeps degrade-in-loop), and `run_retry_failed` iterates a `list(...)` snapshot — so the retry terminates, keeps the message failed with `retry_count` incremented, and accounts it correctly.
+- **User cancellation during the parallel message phase is now handled cleanly** (`migrator/messages.py`). `gather(..., return_exceptions=True)` returned a worker's `asyncio.CancelledError` as a result item, which the result loop logged as a `channel_worker_failed` warning before emitting the phase `completed` event — so the engine's clean-cancel handler never ran. The result loop now detects `CancelledError` first (it is a `BaseException`, not an `Exception`) and re-raises `asyncio.CancelledError` after checkpointing the channels that finished before the cancel, so the engine saves state and reports "Cancelled during messages". The in-loop cancel check also raises instead of `break`-ing, so a cancelled-mid-channel worker no longer falls through to self-marking the channel complete (which would lose its un-sent tail on `--resume`).
+- **A channel worker that crashes before its per-message loop is no longer silently lost** (`migrator/messages.py`, `core/engine.py`). Such a crash was recorded as a warning while the phase reported `completed` and `current_phase` advanced past `messages`, so on `--resume` the channel was skipped — never migrated, never retried, no DLQ entry. The result loop now collects the first non-cancel exception and re-raises it after checkpointing the successful channels, so the phase fails with `current_phase` still `"messages"`; `--resume` then re-runs the crashed channel while already-completed channels skip via `completed_channel_ids`. All surfaced failure strings are sanitised once via `safe_sanitize` and reused for both the persisted error and the emitted event (no raw exception/token in the event).
+
+**Behaviour change:** a channel worker raising an unexpected exception **before** sending any message now **aborts the run** (resumable via `--resume`) instead of degrading to a warning and reporting the phase `completed`. This trades a silent, unrecoverable per-channel data loss for a surfaced, resumable failure. A single message failing *inside* a channel's send loop still degrades-in-loop (recorded as a `FailedMessage`, channel continues) exactly as before.
+
 ## [2.6.8] - 2026-06-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.8"
+version = "2.6.9"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.8"
+__version__ = "2.6.9"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -998,7 +998,11 @@ async def run_retry_failed(
         config.session = session
         retried = 0
         still_failed: list[FailedMessage] = []
-        for fm in state.failed_messages:
+        # Batch 3 (S1): iterate a snapshot — _process_message (channel_result=None) appends
+        # a FailedMessage to state.failed_messages on a re-fail, so a live-list loop would
+        # never terminate (mutate-during-iteration). state.failed_messages is rebuilt from
+        # still_failed below, discarding the in-loop duplicate.
+        for fm in list(state.failed_messages):
             found_msg = found_messages.get(fm.discord_msg_id)
             if found_msg is None:
                 on_event(

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -374,30 +374,56 @@ async def run_messages(
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        # Batch 3 (S2/S3): re-classify the gather outcome. Workers self-checkpoint
+        # (completed_channel_ids + merge under save_lock) before returning, so successes are
+        # already persisted; this loop merges defensively (idempotent — the worker resets its
+        # result to empty after its own merge) then re-raises so cancel/crash PROPAGATE
+        # instead of being swallowed as warnings.
+        cancelled = False
+        first_exc: BaseException | None = None
         for export, result in zip(eligible_exports, results, strict=True):
+            # CancelledError is a BaseException (NOT Exception) — check it FIRST so a user
+            # cancel never lands in the generic-exception branch (cancel wins — see below).
+            if isinstance(result, asyncio.CancelledError):
+                cancelled = True
+                continue
             if isinstance(result, BaseException):
-                # Channel worker raised an unhandled exception — record as error.
+                # Channel worker raised an unhandled exception — record (token-safe: sanitise
+                # once, use for BOTH the persisted error and the emitted event).
+                safe_res = safe_sanitize(config.token_store, str(result))
                 state.errors.append(
                     {
                         "phase": "messages",
                         "type": "channel_worker_failed",
-                        "message": safe_sanitize(
-                            config.token_store,
-                            f"Channel {export.channel.name!r} worker failed: {result}",
-                        ),
+                        "message": f"Channel {export.channel.name!r} worker failed: {safe_res}",
                     }
                 )
                 on_event(
                     MigrationEvent(
                         phase="messages",
                         status="warning",
-                        message=f"Channel {export.channel.name!r} failed: {result}",
+                        message=f"Channel {export.channel.name!r} failed: {safe_res}",
                         channel_name=export.channel.name,
                     )
                 )
-            else:
-                _merge_channel_result(state, result)
-                state.completed_channel_ids.add(export.channel.id)
+                if first_exc is None:
+                    first_exc = result
+                continue
+            # Success — merge + mark complete (idempotent with the worker's own self-merge +
+            # result-reset; kept defensively, NOT load-bearing).
+            _merge_channel_result(state, result)
+            state.completed_channel_ids.add(export.channel.id)
+
+        # Cancel takes precedence over a concurrent crash: a user cancel must reach the
+        # engine's clean-cancel handler, not phase_failed.
+        if cancelled or (config.cancel_event and config.cancel_event.is_set()):
+            raise asyncio.CancelledError("Migration cancelled by user")
+        # B1 abort-and-resume (S3): a pre-loop worker crash fails the phase so current_phase
+        # stays "messages" and --resume re-runs it (completed channels skip). first_exc may be
+        # a non-Exception BaseException (e.g. SystemExit) — re-raise as-is rather than filter
+        # to Exception, which would silently drop it.
+        if first_exc is not None:
+            raise first_exc
 
     # Process thread exports for merge/archive modes (after parent channels complete).
     if thread_strategy == "merge" and thread_exports:
@@ -744,9 +770,12 @@ async def _process_single_channel(
         _copied = 0
         _retried = 0
         for idx, msg in enumerate(message_source):
-            # Cancel check inside the message loop.
+            # Cancel check inside the message loop. Batch 3 (S2): raise (not break) so a
+            # cancelled-mid-channel worker propagates like the _rate_limit_with_pause path
+            # and never falls through to the self-mark-complete at the loop end (which would
+            # lose the un-sent tail on --resume).
             if config.cancel_event and config.cancel_event.is_set():
-                break
+                raise asyncio.CancelledError("Migration cancelled by user")
 
             # Track the highest numeric message id seen (durable high-water mark).
             # isdigit() guard: real Discord ids are numeric snowflakes, but tests and
@@ -1250,6 +1279,13 @@ async def _process_message(
                 message=f"Message {msg.id} failed: {safe_exc}",
             )
         )
+        # Batch 3 (S1): the retry path (engine.run_retry_failed) calls this with
+        # channel_result=None and relies on an exception to mark a re-failure. Re-raise so
+        # the retry loop accounts correctly and terminates. The parallel per-channel path
+        # (channel_result set) keeps degrade-in-loop. Guard is provably retry-path-only:
+        # only engine.py's retry loop passes channel_result=None.
+        if channel_result is None:
+            raise
         return
 
     # Step 9: Resume checkpoint handled in the caller's periodic save loop.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,5 +1,6 @@
 """Tests for the migration engine orchestrator."""
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -949,6 +950,86 @@ async def test_retry_failed_mixed_results(tmp_path: Path) -> None:
     assert any("1 succeeded" in e.message and "1 still failed" in e.message for e in events)
 
 
+async def test_retry_failed_deterministic_failure_terminates(tmp_path: Path) -> None:
+    """SC-1: a deterministically-failing retry TERMINATES (no mutate-during-iteration hang)
+    via the REAL _process_message append path; the message stays failed with retry_count+1.
+
+    M2: patch api_send_message (one level BELOW _process_message), NOT _process_message — so
+    the real append to state.failed_messages happens. The pre-fix code (silent return + a
+    live-list loop) hangs forever; asyncio.wait_for turns that into a TimeoutError.
+    """
+    config = _make_retry_config(tmp_path)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    _write_dce_json(config.export_dir, "ch1", [_dce_msg_dict("msg_fail")])
+    exports = _make_exports_from_dir(config.export_dir)
+    state = MigrationState(
+        channel_map={"ch1": "stoat_ch1"},
+        autumn_url=AUTUMN_URL,
+        failed_messages=[
+            FailedMessage(discord_msg_id="msg_fail", stoat_channel_id="stoat_ch1", error="err")
+        ],
+    )
+
+    async def always_fail_send(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        # Yield + throttle: a true await suspension lets asyncio.wait_for enforce its
+        # timeout (a synchronous raise would never yield, so a regression would hang
+        # UNBOUNDED instead of timing out); the small sleep bounds a regression's growth.
+        await asyncio.sleep(0.01)
+        raise RuntimeError("still broken")
+
+    events: list[MigrationEvent] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", always_fail_send):
+        await asyncio.wait_for(run_retry_failed(config, state, exports, events.append), timeout=5.0)
+
+    assert len(state.failed_messages) == 1
+    assert state.failed_messages[0].discord_msg_id == "msg_fail"
+    assert state.failed_messages[0].retry_count == 1
+    assert any("0 succeeded" in e.message and "1 still failed" in e.message for e in events)
+
+
+async def test_retry_failed_mixed_with_real_failure_terminates(tmp_path: Path) -> None:
+    """SC-4: success + real re-failure + not-found, all under a timeout (no hang).
+
+    Uses the real _process_message append path (patches api_send_message) for the failing
+    channel so the snapshot-iteration fix is genuinely exercised.
+    """
+    config = _make_retry_config(tmp_path)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    _write_dce_json(config.export_dir, "ch_ok", [_dce_msg_dict("msg_ok")])
+    _write_dce_json(config.export_dir, "ch_fail", [_dce_msg_dict("msg_fail")])
+    exports = _make_exports_from_dir(config.export_dir)
+    state = MigrationState(
+        channel_map={"ch_ok": "stoat_ch_ok", "ch_fail": "stoat_ch_fail"},
+        autumn_url=AUTUMN_URL,
+        failed_messages=[
+            FailedMessage(discord_msg_id="msg_ok", stoat_channel_id="stoat_ch_ok", error="e"),
+            FailedMessage(discord_msg_id="msg_fail", stoat_channel_id="stoat_ch_fail", error="e"),
+            FailedMessage(discord_msg_id="msg_gone", stoat_channel_id="stoat_ch_ok", error="e"),
+        ],
+    )
+
+    call = 0
+
+    async def send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        nonlocal call
+        call += 1
+        await asyncio.sleep(0.01)  # yield so wait_for can bound a regression
+        if channel_id == "stoat_ch_fail":
+            raise RuntimeError("still broken")
+        return {"_id": f"ok_{call}"}
+
+    events: list[MigrationEvent] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", send):
+        await asyncio.wait_for(run_retry_failed(config, state, exports, events.append), timeout=5.0)
+
+    ids = {fm.discord_msg_id for fm in state.failed_messages}
+    assert ids == {"msg_fail", "msg_gone"}
+    assert "msg_ok" in state.message_map
+    assert any("1 succeeded" in e.message and "2 still failed" in e.message for e in events)
+
+
 # ---------------------------------------------------------------------------
 # Post-migration validation (S7)
 # ---------------------------------------------------------------------------
@@ -1741,3 +1822,43 @@ async def test_acquire_sets_and_release_clears_lock_marker(tmp_path: Path) -> No
             assert state.migration_lock_marker.startswith("[FERRY_LOCK:")
             await _release_migration_lock(config, state, session, lambda e: None)
             assert state.migration_lock_marker == ""
+
+
+async def test_run_migration_messages_cancel_clean_path(tmp_path: Path) -> None:
+    """SC-10: a CancelledError from the messages phase takes the engine's clean-cancel path
+    (skipped event 'Cancelled during messages'), NOT phase_failed, and run_migration returns."""
+
+    async def cancelling_messages(
+        config: FerryConfig, state: MigrationState, exports: list, emit: EventCallback
+    ) -> None:
+        raise asyncio.CancelledError("Migration cancelled by user")
+
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    overrides = {**_NOOP_OVERRIDES, "messages": cancelling_messages}
+    # Must NOT raise — the engine handles CancelledError cleanly and returns.
+    await run_migration(config, events.append, phase_overrides=overrides)
+
+    msg_events = [e for e in events if e.phase == "messages"]
+    assert any(e.status == "skipped" and "Cancelled" in e.message for e in msg_events)
+    assert not any(e.status == "error" for e in msg_events)
+
+
+async def test_run_migration_messages_crash_keeps_phase_for_resume(tmp_path: Path) -> None:
+    """SC-11 (engine): a non-cancel messages-phase crash → MigrationError, with current_phase
+    persisted as 'messages' so --resume re-runs it."""
+    from discord_ferry.errors import MigrationError
+    from discord_ferry.state import load_state
+
+    async def crashing_messages(
+        config: FerryConfig, state: MigrationState, exports: list, emit: EventCallback
+    ) -> None:
+        raise RuntimeError("channel worker boom")
+
+    config = _make_config(tmp_path)
+    overrides = {**_NOOP_OVERRIDES, "messages": crashing_messages}
+    with pytest.raises(MigrationError, match="messages"):
+        await run_migration(config, lambda e: None, phase_overrides=overrides)
+
+    saved = load_state(tmp_path)
+    assert saved.current_phase == "messages"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -11,8 +11,10 @@ from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.migrator.messages import (
+    ChannelResult,
     _build_content,
     _build_masquerade,
+    _process_message,
     _resolve_attachment_path,
     _skip_attachment,
     _upload_attachments,
@@ -3232,3 +3234,47 @@ async def test_embed_verify_size_pass_through(tmp_path: Path, mock_aiohttp: aior
 
     assert "msg_e4" in state.message_map  # message still sent
     assert "m" not in state.autumn_uploads  # mismatched media not registered
+
+
+async def test_process_message_reraises_only_when_no_channel_result(tmp_path: Path) -> None:
+    """SC-5: a send failure re-raises iff channel_result is None (the retry path); with a
+    ChannelResult it degrades-in-loop (returns, records to the result, not to state).
+
+    This is the S1 contract guard — only the retry path (channel_result=None) must raise; the
+    parallel per-channel path (channel_result set) must keep degrade-in-loop.
+    """
+    state = _make_state(channel_map={"ch1": "stoat_ch1"})
+    config = _make_config(tmp_path)
+    msg = _make_message(id="m1", content="hi", timestamp="2024-06-01T08:30:00+00:00")
+
+    async def fail_send(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("send boom")
+
+    async with aiohttp.ClientSession() as session:
+        with patch("discord_ferry.migrator.messages.api_send_message", fail_send):
+            # (a) channel_result is None → re-raise (retry path).
+            with pytest.raises(RuntimeError):
+                await _process_message(
+                    msg=msg,
+                    stoat_channel_id="stoat_ch1",
+                    config=config,
+                    state=state,
+                    session=session,
+                    on_event=lambda e: None,
+                    channel_result=None,
+                )
+            assert len(state.failed_messages) == 1  # appended before the raise
+
+            # (b) channel_result set → returns (no raise), records to the result.
+            result = ChannelResult(channel_id="ch1")
+            await _process_message(
+                msg=msg,
+                stoat_channel_id="stoat_ch1",
+                config=config,
+                state=state,
+                session=session,
+                on_event=lambda e: None,
+                channel_result=result,
+            )
+            assert len(result.failed_messages) == 1  # recorded to the result
+            assert len(state.failed_messages) == 1  # unchanged from (a) — not state-written

--- a/tests/test_parallel_messages.py
+++ b/tests/test_parallel_messages.py
@@ -10,6 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core.security import SecureTokenStore
 from discord_ferry.migrator.messages import (
     ChannelResult,
     _merge_channel_result,
@@ -420,9 +421,12 @@ async def test_cancel_event_stops_all_workers(tmp_path: Path) -> None:
         ]
         exports.append(_make_export(channel_id=ch_id, name=f"channel-{ch_id}", messages=msgs))
 
-    with patch("discord_ferry.migrator.messages.api_send_message", counting_send):
-        # CancelledError from _rate_limit_with_pause will propagate.
-        # The gather handles exceptions, so run_messages should complete.
+    # Batch 3 (S2): cancellation now PROPAGATES out of run_messages (intended behaviour
+    # change) so the engine takes its clean-cancel path; it no longer "completes".
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", counting_send),
+        pytest.raises(asyncio.CancelledError),
+    ):
         await run_messages(config, state, exports, lambda e: None)
 
     # Not all messages should have been sent — cancellation stopped early.
@@ -474,3 +478,270 @@ async def test_max_concurrent_channels_respected(tmp_path: Path) -> None:
     assert max_concurrent_seen <= 2, (
         f"Expected max 2 concurrent channels, saw {max_concurrent_seen}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch 3 (S2): cancel contract — run_messages must PROPAGATE CancelledError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_messages_raises_on_cancel(tmp_path: Path) -> None:
+    """SC-6: cancel during the parallel phase → run_messages raises CancelledError and
+    emits NO messages 'completed' event (the engine's clean-cancel path handles it)."""
+    cancel_event = asyncio.Event()
+    sent = 0
+
+    async def counting_send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        nonlocal sent
+        sent += 1
+        cancel_event.set()  # cancel after the first send
+        return {"_id": f"id_{sent}"}
+
+    state = _make_state(channel_map={"ch1": "stoat_ch1", "ch2": "stoat_ch2"})
+    config = _make_config(tmp_path, max_concurrent_channels=1, cancel_event=cancel_event)
+    exports = [
+        _make_export(
+            channel_id=c,
+            name=c,
+            messages=[
+                _make_message(
+                    id=f"{c}_{i}", content="m", timestamp=f"2024-01-15T12:{i:02d}:00+00:00"
+                )
+                for i in range(5)
+            ],
+        )
+        for c in ("ch1", "ch2")
+    ]
+    events: list[MigrationEvent] = []
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", counting_send),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_messages(config, state, exports, _collect_events(events))
+
+    assert not any(e.status == "completed" and e.phase == "messages" for e in events)
+
+
+async def test_cancel_preserves_completed_channels(tmp_path: Path) -> None:
+    """SC-8: a channel finished before the cancel is checkpointed; the cancelled channel is
+    NOT marked complete."""
+    cancel_event = asyncio.Event()
+    sent = 0
+
+    async def send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        nonlocal sent
+        sent += 1
+        if channel_id == "stoat_ch2":
+            cancel_event.set()  # cancel once ch2 (processed after ch1) starts sending
+        return {"_id": f"id_{sent}"}
+
+    state = _make_state(channel_map={"ch1": "stoat_ch1", "ch2": "stoat_ch2"})
+    config = _make_config(tmp_path, max_concurrent_channels=1, cancel_event=cancel_event)
+    exports = [
+        _make_export(channel_id="ch1", name="ch1", messages=[_make_message(id="a1", content="m")]),
+        _make_export(
+            channel_id="ch2",
+            name="ch2",
+            messages=[_make_message(id="b1", content="m", timestamp="2024-01-15T13:00:00+00:00")],
+        ),
+    ]
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", send),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_messages(config, state, exports, lambda e: None)
+
+    assert "ch1" in state.completed_channel_ids  # finished before cancel — survives
+    assert "a1" in state.message_map
+    assert "ch2" not in state.completed_channel_ids  # cancelled mid-channel — not complete
+
+
+async def test_cancel_before_first_send_not_marked_complete(tmp_path: Path) -> None:
+    """SC-9: cancel detected at the loop-top (before any send) RAISES (not break), so the
+    channel is NOT self-marked complete (:748 break→raise)."""
+    cancel_event = asyncio.Event()
+    cancel_event.set()  # already cancelled before the run starts
+
+    async def send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        raise AssertionError("should not send when cancelled before the loop starts")
+
+    state = _make_state(channel_map={"ch1": "stoat_ch1"})
+    config = _make_config(tmp_path, max_concurrent_channels=1, cancel_event=cancel_event)
+    exports = [
+        _make_export(channel_id="ch1", name="ch1", messages=[_make_message(id="a1", content="m")])
+    ]
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", send),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_messages(config, state, exports, lambda e: None)
+
+    assert "ch1" not in state.completed_channel_ids
+    assert "ch1" not in state.channel_high_water
+
+
+# ---------------------------------------------------------------------------
+# Batch 3 (S3): resume coverage — a pre-loop worker crash aborts (resumable)
+# ---------------------------------------------------------------------------
+
+
+def _crash_on_progress(bad_name: str) -> Any:
+    """An on_event callback that raises BEFORE the per-message loop for *bad_name*.
+
+    The first "progress" event for a channel ('Importing X...') fires at the top of
+    _process_single_channel, before the message loop — raising there simulates a worker
+    crashing before sending any message (an unexpected setup raise). Only the 'progress'
+    status is targeted so the result-loop's later 'warning' emit is not disturbed.
+    """
+
+    def cb(event: Any) -> None:
+        if event.channel_name == bad_name and event.status == "progress":
+            raise RuntimeError(f"pre-loop boom in {bad_name}")
+
+    return cb
+
+
+async def test_pre_loop_crash_reraises_first_exception(tmp_path: Path) -> None:
+    """SC-11/13: a non-cancel worker crash propagates out of run_messages AFTER the good
+    channels have self-checkpointed (their work survives); the crashed channel is not
+    marked complete and is recorded as a channel_worker_failed error."""
+    state = _make_state(
+        channel_map={
+            "ch_good1": "stoat_good1",
+            "ch_bad": "stoat_bad",
+            "ch_good2": "stoat_good2",
+        }
+    )
+    config = _make_config(tmp_path, max_concurrent_channels=3)
+    exports = [
+        _make_export(
+            channel_id="ch_good1", name="good1", messages=[_make_message(id="g1", content="m")]
+        ),
+        _make_export(
+            channel_id="ch_bad",
+            name="bad",
+            messages=[_make_message(id="b", content="m", timestamp="2024-01-15T12:01:00+00:00")],
+        ),
+        _make_export(
+            channel_id="ch_good2",
+            name="good2",
+            messages=[_make_message(id="g2", content="m", timestamp="2024-01-15T12:02:00+00:00")],
+        ),
+    ]
+
+    async def ok_send(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {"_id": f"id_{channel_id}"}
+
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", ok_send),
+        pytest.raises(RuntimeError),
+    ):
+        await run_messages(config, state, exports, _crash_on_progress("bad"))
+
+    # SC-13: good channels self-checkpointed before the re-raise — their work survives.
+    assert "g1" in state.message_map and "g2" in state.message_map
+    assert "ch_good1" in state.completed_channel_ids
+    assert "ch_good2" in state.completed_channel_ids
+    # SC-11: the crashed channel is NOT marked complete (so --resume re-runs it).
+    assert "ch_bad" not in state.completed_channel_ids
+    # SC-14 (audit signal): a channel_worker_failed error is recorded.
+    assert any(e["type"] == "channel_worker_failed" for e in state.errors)
+
+
+async def test_pre_loop_crash_resume_reruns_only_failed_channel(tmp_path: Path) -> None:
+    """SC-12: on --resume the previously-incomplete channel is re-sent while channels already
+    in completed_channel_ids are skipped (no duplicate sends)."""
+    sends: list[str] = []
+
+    async def record(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        sends.append(channel_id)
+        return {"_id": f"id_{len(sends)}"}
+
+    state = _make_state(channel_map={"ch_bad": "stoat_bad", "ch_good": "stoat_good"})
+    state.completed_channel_ids.add("ch_good")  # good channel already done in a prior run
+    config = _make_config(tmp_path, max_concurrent_channels=2, resume=True)
+    exports = [
+        _make_export(
+            channel_id="ch_good", name="good", messages=[_make_message(id="g", content="m")]
+        ),
+        _make_export(
+            channel_id="ch_bad",
+            name="bad",
+            messages=[_make_message(id="b", content="m", timestamp="2024-01-15T12:01:00+00:00")],
+        ),
+    ]
+    with patch("discord_ferry.migrator.messages.api_send_message", record):
+        await run_messages(config, state, exports, lambda e: None)
+
+    assert "stoat_bad" in sends  # crashed channel re-run
+    assert "stoat_good" not in sends  # completed channel skipped (resume gate)
+    assert "ch_bad" in state.completed_channel_ids
+
+
+async def test_channel_worker_failure_is_token_safe(tmp_path: Path) -> None:
+    """SC-14: the recorded error and the emitted warning are safe_sanitize'd — no raw token."""
+    secret = "stoat_secret_token_value"
+
+    def crash_with_token(event: Any) -> None:
+        if event.channel_name == "bad" and event.status == "progress":
+            raise RuntimeError(f"failure leaking {secret}")
+
+    captured: list[Any] = []
+
+    def on_event(event: Any) -> None:
+        captured.append(event)
+        crash_with_token(event)
+
+    state = _make_state(channel_map={"ch_bad": "stoat_bad"})
+    config = _make_config(tmp_path, token_store=SecureTokenStore({"stoat": secret}))
+    exports = [
+        _make_export(channel_id="ch_bad", name="bad", messages=[_make_message(id="b", content="m")])
+    ]
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", lambda *a, **k: None),
+        pytest.raises(RuntimeError),
+    ):
+        await run_messages(config, state, exports, on_event)
+
+    assert all(secret not in e["message"] for e in state.errors)
+    assert all(secret not in (e.message or "") for e in captured if e.status == "warning")
+
+
+async def test_cancel_precedence_over_crash(tmp_path: Path) -> None:
+    """SC-15: when one worker is cancelled and another crashes in the same gather, cancel
+    wins (run_messages raises CancelledError) and the crashed channel stays resumable."""
+    cancel_event = asyncio.Event()
+    cancel_event.set()  # the non-crashing channel will hit the loop-top cancel check
+
+    async def noop_send(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"_id": "x"}
+
+    state = _make_state(channel_map={"ch_cancel": "stoat_cancel", "ch_crash": "stoat_crash"})
+    config = _make_config(tmp_path, max_concurrent_channels=2, cancel_event=cancel_event)
+    exports = [
+        _make_export(
+            channel_id="ch_cancel", name="cancel", messages=[_make_message(id="c", content="m")]
+        ),
+        _make_export(
+            channel_id="ch_crash",
+            name="crash",
+            messages=[_make_message(id="x", content="m", timestamp="2024-01-15T12:01:00+00:00")],
+        ),
+    ]
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", noop_send),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_messages(config, state, exports, _crash_on_progress("crash"))
+
+    assert "ch_crash" not in state.completed_channel_ids

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.8"
+version = "2.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Batch 3 of the 2026-06-25 v2.6.6 whole-codebase bug-hunt — message-phase control-flow integrity. Three confirmed, adversarially-verified async control-flow defects in `migrator/messages.py` + `core/engine.py`. Common root: `asyncio.gather(*tasks, return_exceptions=True)` collapsed every `BaseException` (including `asyncio.CancelledError`) into a swallowed warning, and the `_process_message` retry path returned instead of re-raising.

## Fixes
- **F1 — retry contract:** `ferry retry` no longer hangs (mutate-during-iteration: `_process_message` appended to the very `state.failed_messages` list the engine loop was iterating) or mis-counts a re-failure as succeeded and drops it. `_process_message` now re-raises on failure **only when `channel_result is None`** (the parallel per-channel path keeps degrade-in-loop); `run_retry_failed` iterates a `list(...)` snapshot.
- **F2 — cancel contract:** user cancellation now propagates cleanly. The post-gather result loop detects `CancelledError` first (it is a `BaseException`, not an `Exception`) and re-raises after checkpointing the channels that finished before the cancel, so the engine's clean-cancel handler runs instead of the phase reporting `completed`. The in-loop cancel check raises instead of `break`-ing, so a cancelled-mid-channel worker doesn't self-mark complete and lose its un-sent tail on resume.
- **F3 — resume coverage:** a channel worker crashing **before** its per-message loop is no longer silently lost. The result loop collects the first non-cancel exception and re-raises it after checkpointing successes, so the phase fails with `current_phase` still `"messages"` — a resume re-runs the crashed channel while already-completed channels skip via `completed_channel_ids`.
- **Token-safety:** worker-failure strings are sanitised once via `safe_sanitize` and reused for both the persisted error and the emitted event (previously the event interpolated the raw exception).

## Behaviour change
A channel worker raising an unexpected exception **before** sending any message now **aborts the run** (resumable via resume) instead of degrading to a warning and reporting the phase `completed`. This trades a silent, unrecoverable per-channel data loss for a surfaced, resumable failure. A single message failing *inside* a channel's send loop still degrades-in-loop (recorded as a `FailedMessage`, channel continues) exactly as before.

## Verification
- Full `/df` pipeline: brief → spec → brainstorm → critique (fresh opus, ITERATE → PASS) → test-scenarios → plan → controller-driven build.
- `ruff check .` + `ruff format --check .` + `mypy src/` clean; **1154 tests pass** (12 new, 1 intentionally modified). Each new guard falsified RED then restored.
- Fresh-opus code review: **APPROVE** (no Critical/Important). Mistral second opinion (architecture/async): 10 findings, **all rebutted against source**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
