### PR TITLE
fix: CLI display & blueprint round-trip robustness (v2.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.11] - 2026-06-27
+
+### Fixed
+
+CLI display & blueprint round-trip robustness — the fifth batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 5). All in the CLI shell (`cli.py`); the engine, migrators, GUI shell, and blueprint module are unchanged (the GUI shell was audited and uses no Rich markup and has no blueprint-build path, so none of these findings apply to it).
+
+- **A markup-hostile channel/server/guild name can no longer abort a migration** (`cli.py`, S1/F5a). `Console` renders with markup enabled, so a Discord name containing Rich metacharacters (`spam[/]`, `[bold]news`, an unbalanced `]`) interpolated into a progress line raised `rich.errors.MarkupError`. Because `_ProgressTracker.on_event` runs synchronously inside the engine's `emit`, that exception unwound into the engine and was re-raised as a `MigrationError`, aborting an otherwise-healthy migration over a cosmetic display string. Every user-controlled value (event message, channel name, server/guild name, warnings, exception text, rollback suspect names, failure errors, the `ferry stats` error/warning previews) is now escaped via a new `_safe()` helper before markup interpolation; static format tags and integer/ID values are left live. A narrow `except MarkupError` guard around each tracker's render body is a defense-in-depth net (it falls back to an unstyled print and never swallows control flow — the rollback confirm/pause path is deliberately kept outside it).
+- **`build` no longer aborts mid-build and orphans a server on a voice-channel failure** (`cli.py`, S2/F5b). The blueprint `build` command POSTed `channel_type="Voice"` with no error handling; a voice-create failure (Stoat "Bug #194") propagated and `sys.exit`ed after the server, roles, and earlier channels were already created — leaving an orphan server with no rollback. A new `_build_blueprint_channel()` helper mirrors the main migration path's voice→Text fallback (retry the channel as Text with a warning; non-voice errors still propagate); both build loops use it, and the categorized loop preserves the recovered channel's id into its category. This also un-breaks `ferry build --template gaming|community|education`, whose shipped templates contain Voice channels.
+- **`build` now replays a blueprint's role hierarchy** (`cli.py`, S4/F5d). `BlueprintRole.rank` survived the export→import JSON round-trip but the build role loop applied only colour and permissions, so every built role got Stoat's default rank and the hierarchy was silently lost. The role loop now folds colour + rank into a single `api_edit_role` PATCH. This also restores the shipped templates' role ranks (Admin/Moderator/Member ordering).
+- **`export-blueprint` is unchanged** (S3/F5c, decision A1). A Discord voice channel is still exported as `type="Voice"`, consistent with the migration path and the shipped templates; S2's new `build` fallback makes that value build-safe.
+
+Internal: the build command's six Stoat API helpers were hoisted from a function-local import to module level (no import-cost change — the module already loads them via `run_migration`), giving the new module-level channel helper access to them and a single uniform mock-patch target for tests.
+
+**Behaviour note:** S1 is a robustness fix (a hostile name no longer crashes the run) and is otherwise display-preserving; S2 narrows the abort surface (voice failures now recover; all other errors behave as before). **Known limitations:** (1) a hand-authored blueprint that sets an *explicit* `rank: 0` will not have that rank replayed — rank 0 is treated as "unranked" and left at Stoat's default (the shipped templates all use rank ≥ 1, and `export-blueprint` never emits roles, so neither is affected); (2) a *non-voice* channel-create failure during `build` still aborts mid-build and leaves a partial server (pre-existing behaviour, unchanged — S2 only recovers the voice-create case; orphan-server teardown is out of scope).
+
 ## [2.6.10] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.10"
+version = "2.6.11"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.10"
+__version__ = "2.6.11"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -14,13 +14,23 @@ import aiohttp
 import click
 from dotenv import load_dotenv
 from rich.console import Console
+from rich.errors import MarkupError
 from rich.live import Live
+from rich.markup import escape
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 from rich.table import Table
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.errors import MigrationError, StateError
+from discord_ferry.migrator.api import (
+    api_create_channel,
+    api_create_role,
+    api_create_server,
+    api_edit_role,
+    api_set_role_permissions,
+    api_upsert_categories,
+)
 from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
 from discord_ferry.state import MigrationState, load_state
 from discord_ferry.stats import summarize_state
@@ -148,12 +158,12 @@ def _build_stats_table(summary: StateSummary) -> Table:
         table.add_row("  Errors", "0 (clean)")
     else:
         preview = textwrap.shorten(summary.last_error or "", width=80, placeholder="…")
-        table.add_row("  Errors", f"{summary.error_count} — last: {preview}")
+        table.add_row("  Errors", f"{summary.error_count} — last: {_safe(preview)}")
     if summary.warning_count == 0:
         table.add_row("  Warnings", "0 (clean)")
     else:
         preview = textwrap.shorten(summary.last_warning or "", width=80, placeholder="…")
-        table.add_row("  Warnings", f"{summary.warning_count} — last: {preview}")
+        table.add_row("  Warnings", f"{summary.warning_count} — last: {_safe(preview)}")
 
     # Elapsed
     table.add_row("[bold]Timing[/]", "")
@@ -214,6 +224,52 @@ def _build_rollback_table(summary: StateSummary) -> Table | None:
     return table
 
 
+def _safe(value: object) -> str:
+    """Escape a user-controlled value for safe Rich-markup interpolation.
+
+    Discord/blueprint names can contain Rich markup metacharacters (``[``, ``]``,
+    ``[/]``). Interpolating them raw into a markup string either corrupts the
+    rendered output or raises ``rich.errors.MarkupError`` — and since CLI event
+    handlers run synchronously inside the engine's ``emit``, that exception would
+    abort the whole migration. Escaping neutralises the metacharacters.
+    """
+    return escape(str(value))
+
+
+async def _build_blueprint_channel(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    server_id: str,
+    ch: Any,
+) -> str:
+    """Create a blueprint channel, retrying a failed Voice channel as Text (Stoat Bug #194).
+
+    Mirrors the migration path's voice fallback (``structure.py``). Only a ``"Voice"``-type
+    create failure is retried as ``"Text"``; any other ``MigrationError`` propagates. Returns
+    the created channel's Stoat ``_id``.
+    """
+    try:
+        result = await api_create_channel(
+            session, stoat_url, token, server_id, name=ch.name, channel_type=ch.type, nsfw=ch.nsfw
+        )
+    except MigrationError:
+        if ch.type == "Voice":
+            console.print(f"  [yellow]Voice channel '{_safe(ch.name)}' failed, retrying as text[/]")
+            result = await api_create_channel(
+                session,
+                stoat_url,
+                token,
+                server_id,
+                name=ch.name,
+                channel_type="Text",
+                nsfw=ch.nsfw,
+            )
+        else:
+            raise
+    return str(result["_id"])
+
+
 class _ProgressTracker:
     """Track migration progress and render Rich output with live progress bars."""
 
@@ -261,7 +317,7 @@ class _ProgressTracker:
             f"Warnings: {self.warning_count}"
         )
         if self._current_channel:
-            stats += f"  Channel: {self._current_channel}"
+            stats += f"  Channel: {_safe(self._current_channel)}"
         grid.add_row(stats)
         return grid
 
@@ -276,74 +332,85 @@ class _ProgressTracker:
         """Handle a migration event — update state and progress bars."""
         self.phase_status[event.phase] = event.status
 
-        match event.status:
-            case "started":
-                self._phase_progress.update(
-                    self._phase_task_id, description=f"Phase: {event.phase}"
-                )
-                self._log(f"[bold cyan][>>][/] {event.phase}: {event.message}")
-            case "completed":
-                completed = sum(1 for s in self.phase_status.values() if s == "completed")
-                self._phase_progress.update(self._phase_task_id, completed=completed)
-                self._log(f"[bold green][OK][/] {event.phase}: {event.message}")
-            case "skipped":
-                self._log(f"[dim][--][/] {event.phase}: {event.message}")
-            case "error":
-                self.error_count += 1
-                self._log(f"[bold red][!!][/] {event.phase}: {event.message}")
-            case "warning":
-                self.warning_count += 1
-                if self.verbose:
-                    self._log(f"[yellow][!!][/] {event.phase}: {event.message}")
-            case "confirm":
-                # Print review summary and ask for confirmation
-                if event.detail:
-                    self._log("\n[bold]Pre-Migration Review[/]")
-                    review_table = Table(show_header=True, header_style="bold")
-                    review_table.add_column("Item", style="cyan")
-                    review_table.add_column("Count", justify="right")
-                    detail = event.detail
-                    review_table.add_row("Server Name", str(detail.get("server_name", "")))
-                    review_table.add_row("Roles", str(detail.get("roles", 0)))
-                    review_table.add_row("Categories", str(detail.get("categories", 0)))
-                    review_table.add_row("Channels", str(detail.get("channels", 0)))
-                    review_table.add_row("Emoji", str(detail.get("emoji", 0)))
-                    review_table.add_row("Messages", f"{detail.get('messages', 0):,}")
-                    review_table.add_row("Threads", str(detail.get("threads", 0)))
-                    review_table.add_row(
-                        "Permissions", "Yes" if detail.get("has_permissions") else "No"
+        # User-controlled values (event.message, channel_name, server_name, warnings) are escaped
+        # before interpolation into Rich markup. The whole render is additionally guarded against
+        # MarkupError so a missed escape site can never propagate into the engine's synchronous
+        # emit() and abort an otherwise-healthy migration (defense-in-depth).
+        try:
+            match event.status:
+                case "started":
+                    self._phase_progress.update(
+                        self._phase_task_id, description=f"Phase: {event.phase}"
                     )
-                    if detail.get("nsfw_channels"):
-                        review_table.add_row("NSFW Channels", str(detail.get("nsfw_channels", 0)))
+                    self._log(f"[bold cyan][>>][/] {event.phase}: {_safe(event.message)}")
+                case "completed":
+                    completed = sum(1 for s in self.phase_status.values() if s == "completed")
+                    self._phase_progress.update(self._phase_task_id, completed=completed)
+                    self._log(f"[bold green][OK][/] {event.phase}: {_safe(event.message)}")
+                case "skipped":
+                    self._log(f"[dim][--][/] {event.phase}: {_safe(event.message)}")
+                case "error":
+                    self.error_count += 1
+                    self._log(f"[bold red][!!][/] {event.phase}: {_safe(event.message)}")
+                case "warning":
+                    self.warning_count += 1
+                    if self.verbose:
+                        self._log(f"[yellow][!!][/] {event.phase}: {_safe(event.message)}")
+                case "confirm":
+                    # Print review summary and ask for confirmation
+                    if event.detail:
+                        self._log("\n[bold]Pre-Migration Review[/]")
+                        review_table = Table(show_header=True, header_style="bold")
+                        review_table.add_column("Item", style="cyan")
+                        review_table.add_column("Count", justify="right")
+                        detail = event.detail
+                        review_table.add_row("Server Name", _safe(detail.get("server_name", "")))
+                        review_table.add_row("Roles", str(detail.get("roles", 0)))
+                        review_table.add_row("Categories", str(detail.get("categories", 0)))
+                        review_table.add_row("Channels", str(detail.get("channels", 0)))
+                        review_table.add_row("Emoji", str(detail.get("emoji", 0)))
+                        review_table.add_row("Messages", f"{detail.get('messages', 0):,}")
+                        review_table.add_row("Threads", str(detail.get("threads", 0)))
+                        review_table.add_row(
+                            "Permissions", "Yes" if detail.get("has_permissions") else "No"
+                        )
+                        if detail.get("nsfw_channels"):
+                            review_table.add_row(
+                                "NSFW Channels", str(detail.get("nsfw_channels", 0))
+                            )
+                        self._log("")
+                        console.print(review_table)
+                        raw_warnings = detail.get("warnings")
+                        warnings_list: list[object] = (
+                            raw_warnings if isinstance(raw_warnings, list) else []
+                        )
+                        for w in warnings_list:
+                            self._log(f"  [yellow]Warning: {_safe(w)}[/]")
                     self._log("")
-                    console.print(review_table)
-                    raw_warnings = detail.get("warnings")
-                    warnings_list: list[object] = (
-                        raw_warnings if isinstance(raw_warnings, list) else []
-                    )
-                    for w in warnings_list:
-                        self._log(f"  [yellow]Warning: {w}[/]")
-                self._log("")
-            case "progress":
-                if event.total > 0:
-                    self.messages_sent = event.current
-                    self._msg_progress.update(
-                        self._msg_task_id,
-                        total=event.total,
-                        completed=event.current,
-                    )
-                if event.channel_name:
-                    self._current_channel = event.channel_name
-                    self._msg_progress.update(
-                        self._msg_task_id,
-                        description=f"  {event.channel_name}",
-                    )
-                if self.verbose:
-                    self._log(f"[dim]    {event.message}[/]")
+                case "progress":
+                    if event.total > 0:
+                        self.messages_sent = event.current
+                        self._msg_progress.update(
+                            self._msg_task_id,
+                            total=event.total,
+                            completed=event.current,
+                        )
+                    if event.channel_name:
+                        self._current_channel = event.channel_name
+                        self._msg_progress.update(
+                            self._msg_task_id,
+                            description=f"  {_safe(event.channel_name)}",
+                        )
+                    if self.verbose:
+                        self._log(f"[dim]    {_safe(event.message)}[/]")
 
-        # Refresh live display if active.
-        if self._live is not None:
-            self._live.update(self._make_display())
+            # Refresh live display if active.
+            if self._live is not None:
+                self._live.update(self._make_display())
+        except MarkupError:
+            # A dynamic value slipped through un-escaped; surface it unstyled rather than abort.
+            sink = self._live.console if self._live is not None else console
+            sink.print(f"{event.phase}: {event.message}", markup=False)
 
     def print_summary(self) -> None:
         """Print a final summary line."""
@@ -546,7 +613,7 @@ def migrate(**kwargs: Any) -> None:
     try:
         config = _build_config(kwargs)
     except click.UsageError as exc:
-        console.print(f"[bold red]Error:[/] {exc}")
+        console.print(f"[bold red]Error:[/] {_safe(exc)}")
         sys.exit(1)
 
     if not config.skip_export and not kwargs.get("yes"):
@@ -567,7 +634,7 @@ def migrate(**kwargs: Any) -> None:
         with tracker.start_live():
             final_state = asyncio.run(run_migration(config, on_event=tracker.on_event))
     except MigrationError as exc:
-        console.print(f"\n[bold red]Migration failed:[/] {exc}")
+        console.print(f"\n[bold red]Migration failed:[/] {_safe(exc)}")
         sys.exit(1)
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/] State saved — use --resume to continue.")
@@ -605,7 +672,7 @@ def validate(export_dir: str, rate_limit: float) -> None:
         sys.exit(1)
 
     guild_name = exports[0].guild.name
-    console.print(f"[bold]Discord Ferry[/] — validating export for [cyan]{guild_name}[/]\n")
+    console.print(f"[bold]Discord Ferry[/] — validating export for [cyan]{_safe(guild_name)}[/]\n")
 
     table = _build_validate_table(exports)
     console.print(table)
@@ -615,7 +682,7 @@ def validate(export_dir: str, rate_limit: float) -> None:
     if warnings:
         console.print(f"[yellow bold]Warnings ({len(warnings)}):[/]")
         for w in warnings:
-            console.print(f"  [yellow]- {w['message']}[/]")
+            console.print(f"  [yellow]- {_safe(w['message'])}[/]")
         console.print()
 
     total_messages = sum(e.message_count for e in exports)
@@ -662,14 +729,6 @@ def build(
     import importlib.resources
 
     from discord_ferry.blueprint import ServerBlueprint, import_blueprint
-    from discord_ferry.migrator.api import (
-        api_create_channel,
-        api_create_role,
-        api_create_server,
-        api_edit_role,
-        api_set_role_permissions,
-        api_upsert_categories,
-    )
 
     if not template and not blueprint:
         console.print("[bold red]Error:[/] Provide --template or --blueprint")
@@ -688,22 +747,29 @@ def build(
     if name:
         bp.name = name
 
-    console.print(f"[bold]Discord Ferry[/] — building server '{bp.name}'\n")
+    console.print(f"[bold]Discord Ferry[/] — building server '{_safe(bp.name)}'\n")
 
     async def _build() -> None:
         async with aiohttp.ClientSession() as session:
             # Create server
             result = await api_create_server(session, stoat_url, token, bp.name)
             server_id = result["_id"]
-            console.print(f"  Created server '{bp.name}' ({server_id})")
+            console.print(f"  Created server '{_safe(bp.name)}' ({server_id})")
 
             # Create roles
             for role in bp.roles:
                 role_result = await api_create_role(session, stoat_url, token, server_id, role.name)
                 role_id = role_result["id"]
+                # Replay colour + rank in a single PATCH. Skip rank 0 (the default) so an
+                # unranked blueprint role keeps Stoat's default ordering rather than being pinned.
+                edit_kwargs: dict[str, Any] = {}
                 if role.colour:
+                    edit_kwargs["colour"] = role.colour
+                if role.rank:
+                    edit_kwargs["rank"] = role.rank
+                if edit_kwargs:
                     await api_edit_role(
-                        session, stoat_url, token, server_id, role_id, colour=role.colour
+                        session, stoat_url, token, server_id, role_id, **edit_kwargs
                     )
                 if role.permissions:
                     await api_set_role_permissions(
@@ -715,7 +781,7 @@ def build(
                         allow=role.permissions,
                         deny=0,
                     )
-                console.print(f"  Created role '{role.name}'")
+                console.print(f"  Created role '{_safe(role.name)}'")
 
             # Create categories and channels
             import uuid
@@ -725,17 +791,12 @@ def build(
                 cat_id = uuid.uuid4().hex[:26]
                 channel_ids: list[str] = []
                 for ch in category.channels:
-                    ch_result = await api_create_channel(
-                        session,
-                        stoat_url,
-                        token,
-                        server_id,
-                        name=ch.name,
-                        channel_type=ch.type,
-                        nsfw=ch.nsfw,
+                    channel_ids.append(
+                        await _build_blueprint_channel(session, stoat_url, token, server_id, ch)
                     )
-                    channel_ids.append(ch_result["_id"])
-                    console.print(f"  Created channel '{ch.name}' in '{category.name}'")
+                    console.print(
+                        f"  Created channel '{_safe(ch.name)}' in '{_safe(category.name)}'"
+                    )
                 all_categories.append(
                     {
                         "id": cat_id,
@@ -748,23 +809,15 @@ def build(
 
             # Create uncategorized channels
             for ch in bp.uncategorized_channels:
-                await api_create_channel(
-                    session,
-                    stoat_url,
-                    token,
-                    server_id,
-                    name=ch.name,
-                    channel_type=ch.type,
-                    nsfw=ch.nsfw,
-                )
-                console.print(f"  Created channel '{ch.name}'")
+                await _build_blueprint_channel(session, stoat_url, token, server_id, ch)
+                console.print(f"  Created channel '{_safe(ch.name)}'")
 
-            console.print(f"\n[bold green]Done![/] Server '{bp.name}' created ({server_id})")
+            console.print(f"\n[bold green]Done![/] Server '{_safe(bp.name)}' created ({server_id})")
 
     try:
         asyncio.run(_build())
     except MigrationError as exc:
-        console.print(f"\n[bold red]Build failed:[/] {exc}")
+        console.print(f"\n[bold red]Build failed:[/] {_safe(exc)}")
         sys.exit(1)
 
 
@@ -828,7 +881,7 @@ def export_blueprint_cmd(from_dir: str, output: str, name: str | None) -> None:
 
     export_blueprint(bp, Path(output))
     console.print(
-        f"[bold green]Blueprint exported[/] to {output} "
+        f"[bold green]Blueprint exported[/] to {_safe(output)} "
         f"({len(bp.categories)} categories, "
         f"{sum(len(c.channels) for c in bp.categories) + len(uncategorized)} channels)"
     )
@@ -850,7 +903,7 @@ def stats(output_dir: str) -> None:
     try:
         state = load_state(Path(output_dir))
     except StateError as e:
-        console.print(f"[bold red]Error:[/] {e}")
+        console.print(f"[bold red]Error:[/] {_safe(e)}")
         sys.exit(1)
 
     summary = summarize_state(state)
@@ -888,31 +941,43 @@ class _RollbackProgressTracker:
         self.last_summary: RollbackSummary | None = None
 
     def on_event(self, event: MigrationEvent) -> None:
-        match event.status:
-            case "started":
-                console.print(f"[bold cyan][>>][/] {event.message}")
-            case "confirm_rollback":
-                self._render_summary_and_prompt(event)
-            case "progress":
-                if self.verbose:
-                    console.print(f"[dim]    {event.message}[/]")
-            case "completed":
-                console.print(f"[bold green][OK][/] {event.message}")
-                if event.detail is not None:
-                    self._render_final(event.detail.get("summary"))
-            case "completed_with_failures":
-                console.print(f"[bold yellow][!!][/] {event.message}")
-                if event.detail is not None:
-                    self._render_final(event.detail.get("summary"))
-            case "cancelled":
-                console.print(f"[yellow][--][/] {event.message}")
-            case "warning":
-                self.warning_count += 1
-                if self.verbose:
-                    console.print(f"[yellow]    {event.message}[/]")
-            case "error":
-                self.error_count += 1
-                console.print(f"[bold red][!!][/] {event.message}")
+        # confirm_rollback renders a table AND gates control flow (pause_event / click.confirm).
+        # It self-escapes user values and is kept OUTSIDE the MarkupError guard below so a
+        # swallowed error could never skip pause_event.set() and hang the rollback — a clean crash
+        # there beats a silent hang.
+        if event.status == "confirm_rollback":
+            self._render_summary_and_prompt(event)
+            return
+
+        # The remaining cases only print (or render the final summary, which has no control flow).
+        # User-controlled values are escaped; the render is additionally guarded against a missed
+        # escape site so a MarkupError can't propagate into the engine's synchronous emit().
+        try:
+            match event.status:
+                case "started":
+                    console.print(f"[bold cyan][>>][/] {_safe(event.message)}")
+                case "progress":
+                    if self.verbose:
+                        console.print(f"[dim]    {_safe(event.message)}[/]")
+                case "completed":
+                    console.print(f"[bold green][OK][/] {_safe(event.message)}")
+                    if event.detail is not None:
+                        self._render_final(event.detail.get("summary"))
+                case "completed_with_failures":
+                    console.print(f"[bold yellow][!!][/] {_safe(event.message)}")
+                    if event.detail is not None:
+                        self._render_final(event.detail.get("summary"))
+                case "cancelled":
+                    console.print(f"[yellow][--][/] {_safe(event.message)}")
+                case "warning":
+                    self.warning_count += 1
+                    if self.verbose:
+                        console.print(f"[yellow]    {_safe(event.message)}[/]")
+                case "error":
+                    self.error_count += 1
+                    console.print(f"[bold red][!!][/] {_safe(event.message)}")
+        except MarkupError:
+            console.print(f"{event.message}", markup=False)
 
     def _render_summary_and_prompt(self, event: MigrationEvent) -> None:
         """Render the RollbackSummary table and gate on user confirmation."""
@@ -933,7 +998,7 @@ class _RollbackProgressTracker:
         table = Table(show_header=True, header_style="bold")
         table.add_column("Item", style="cyan")
         table.add_column("Count", justify="right")
-        table.add_row("Server", f"{summary.stoat_server_name} ({summary.stoat_server_id})")
+        table.add_row("Server", f"{_safe(summary.stoat_server_name)} ({summary.stoat_server_id})")
         table.add_row("Channels to delete", str(len(summary.channels_to_delete)))
         table.add_row("Roles to delete", str(len(summary.roles_to_delete)))
         table.add_row("Emoji to delete", str(len(summary.emoji_to_delete)))
@@ -958,7 +1023,7 @@ class _RollbackProgressTracker:
                 # Display-layer translation: None -> "unknown" so users don't see literal "None".
                 created = s.created_at_iso if s.created_at_iso is not None else "unknown"
                 name = s.name if s.name else "(no name available)"
-                suspect_table.add_row(name, created, s.stoat_id)
+                suspect_table.add_row(_safe(name), created, s.stoat_id)
             console.print(suspect_table)
 
         if self.skip_confirmations:
@@ -1014,7 +1079,7 @@ class _RollbackProgressTracker:
             for f in failures:
                 status = f.http_status if f.http_status is not None else "n/a"
                 console.print(
-                    f"  [red]- {f.entity_type} {f.stoat_id} (HTTP {status})[/]: {f.error}"
+                    f"  [red]- {f.entity_type} {f.stoat_id} (HTTP {status})[/]: {_safe(f.error)}"
                 )
 
 
@@ -1082,7 +1147,7 @@ def rollback_cmd(
     try:
         state = load_state(out_path)
     except StateError as exc:
-        console.print(f"[bold red]Error:[/] state.json not found or unreadable: {exc}")
+        console.print(f"[bold red]Error:[/] state.json not found or unreadable: {_safe(exc)}")
         sys.exit(2)
 
     config = FerryConfig(
@@ -1117,7 +1182,7 @@ def rollback_cmd(
     try:
         asyncio.run(_runner())
     except MigrationError as exc:
-        console.print(f"\n[bold red]Rollback failed:[/] {exc}")
+        console.print(f"\n[bold red]Rollback failed:[/] {_safe(exc)}")
         sys.exit(1)
     except click.exceptions.Abort:
         console.print("\n[yellow]Aborted.[/]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,3 +746,518 @@ def test_create_invite_default_true(runner: CliRunner) -> None:
         )
     config: FerryConfig = mock_engine.call_args[0][0]
     assert config.create_invite is True
+
+
+# ---------------------------------------------------------------------------
+# Batch 5 — S1 markup escape + I2 guard (T1)
+# ---------------------------------------------------------------------------
+
+
+def _b5_console() -> tuple[object, object]:
+    """A StringIO-backed Rich Console for capturing rendered tracker output."""
+    import io
+
+    from rich.console import Console as _Console
+
+    buf = io.StringIO()
+    return buf, _Console(file=buf, force_terminal=False, no_color=True, width=140)
+
+
+def test_progress_tracker_escapes_hostile_message() -> None:  # SC-1
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(phase="channels", status="started", message="spam[/]")
+        )
+    assert "spam[/]" in buf.getvalue()  # literal text survived (escaped, not parsed away)
+
+
+def test_progress_tracker_escapes_channel_name() -> None:  # SC-2
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    tracker = _ProgressTracker(verbose=False)
+    tracker.on_event(
+        MigrationEvent(
+            phase="messages",
+            status="progress",
+            message="m",
+            channel_name="news[/]",
+            current=1,
+            total=10,
+        )
+    )
+    # Rendering the display must not raise on the hostile channel name, and it survives literally.
+    buf, fake = _b5_console()
+    fake.print(tracker._make_display())
+    assert "news[/]" in buf.getvalue()
+
+
+def _b5_confirm_detail(
+    server_name: str = "S", warnings: list[str] | None = None
+) -> dict[str, object]:
+    return {
+        "server_name": server_name,
+        "roles": 3,
+        "categories": 2,
+        "channels": 10,
+        "emoji": 5,
+        "messages": 1000,
+        "threads": 1,
+        "has_permissions": True,
+        "nsfw_channels": 0,
+        "warnings": warnings if warnings is not None else [],
+    }
+
+
+def test_progress_tracker_confirm_escapes_server_name() -> None:  # SC-3
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(
+                phase="VALIDATE",
+                status="confirm",
+                message="r",
+                detail=_b5_confirm_detail(server_name="Evil [/] Server"),
+            )
+        )
+    out = buf.getvalue()
+    assert "Evil [/] Server" in out
+    assert "1,000" in out  # int count rows still render
+
+
+def test_progress_tracker_confirm_escapes_warning() -> None:  # SC-4
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _ProgressTracker(verbose=True).on_event(
+            MigrationEvent(
+                phase="V",
+                status="confirm",
+                message="r",
+                detail=_b5_confirm_detail(warnings=["danger [/] zone"]),
+            )
+        )
+    assert "danger [/] zone" in buf.getvalue()
+
+
+def test_rollback_tracker_escapes_message() -> None:  # SC-5
+    import asyncio
+
+    from discord_ferry.cli import _RollbackProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _RollbackProgressTracker(pause_event=asyncio.Event(), skip_confirmations=True).on_event(
+            MigrationEvent(phase="rollback", status="started", message="boom[/]")
+        )
+    assert "boom[/]" in buf.getvalue()
+
+
+def test_rollback_tracker_escapes_table_cells() -> None:  # SC-6 (I1)
+    import asyncio
+
+    from discord_ferry.cli import _RollbackProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.review import RollbackSummary, UntrackedSuspectChannel
+
+    summary = RollbackSummary(
+        stoat_server_id="srv01",
+        stoat_server_name="Srv [/] X",
+        channels_to_delete=[],
+        roles_to_delete=[],
+        emoji_to_delete=[],
+        categories_to_clean=0,
+        autumn_orphan_count=0,
+        has_failures_from_prior_run=False,
+        untracked_ferry_suspect=[
+            UntrackedSuspectChannel(stoat_id="01ABC", name="orphan[/]", created_at_iso=None)
+        ],
+    )
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _RollbackProgressTracker(pause_event=asyncio.Event(), skip_confirmations=True).on_event(
+            MigrationEvent(
+                phase="rollback",
+                status="confirm_rollback",
+                message="r",
+                detail={"summary": summary},
+            )
+        )
+    out = buf.getvalue()
+    assert "Srv [/] X" in out
+    assert "orphan[/]" in out
+
+
+def test_progress_tracker_guard_catches_missed_escape() -> None:  # SC-7 (I2)
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    # Simulate a missed/broken escape site: _safe becomes the identity function.
+    with (
+        patch("discord_ferry.cli.console", fake),
+        patch("discord_ferry.cli._safe", lambda v: str(v)),
+    ):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(phase="channels", status="started", message="bad[/]")
+        )
+    # No exception propagated (guard caught MarkupError); content surfaced unstyled.
+    assert "bad[/]" in buf.getvalue()
+
+
+def test_rollback_tracker_guard_catches_missed_escape() -> None:  # SC-7b (I2, rollback)
+    import asyncio
+
+    from discord_ferry.cli import _RollbackProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with (
+        patch("discord_ferry.cli.console", fake),
+        patch("discord_ferry.cli._safe", lambda v: str(v)),
+    ):
+        _RollbackProgressTracker(pause_event=asyncio.Event(), skip_confirmations=True).on_event(
+            MigrationEvent(phase="rollback", status="started", message="bad[/]")
+        )
+    assert "bad[/]" in buf.getvalue()
+
+
+def test_progress_tracker_keeps_styling_for_clean_message() -> None:  # SC-8
+    import io
+
+    from rich.console import Console as _Console
+
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf = io.StringIO()
+    styled = _Console(file=buf, force_terminal=True, width=140)  # render ANSI styles
+    with patch("discord_ferry.cli.console", styled):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(phase="channels", status="completed", message="all good")
+        )
+    out = buf.getvalue()
+    assert "all good" in out
+    assert "[bold green]" not in out  # static tag was applied as style, not shown literally
+
+
+def test_progress_tracker_only_markup_name() -> None:  # SC-22
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(phase="x", status="started", message="[/]")
+        )
+    assert "[/]" in buf.getvalue()
+
+
+def test_cli_exposes_api_helpers_module_level() -> None:  # SC-20 (C1)
+    from discord_ferry.cli import api_create_channel, api_edit_role
+
+    assert callable(api_create_channel)
+    assert callable(api_edit_role)
+
+
+# ---------------------------------------------------------------------------
+# Batch 5 — S2 build voice->Text fallback (T2)
+# ---------------------------------------------------------------------------
+
+
+def _write_bp(tmp_path: Path, bp: object) -> Path:
+    from discord_ferry.blueprint import export_blueprint
+
+    p = tmp_path / "bp.json"
+    export_blueprint(bp, p)  # type: ignore[arg-type]
+    return p
+
+
+def test_build_channel_voice_retries_as_text() -> None:  # SC-9
+    import asyncio
+
+    from discord_ferry.blueprint import BlueprintChannel
+    from discord_ferry.cli import _build_blueprint_channel
+
+    ch = BlueprintChannel(name="VC", type="Voice")
+    mock = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
+    with patch("discord_ferry.cli.api_create_channel", mock):
+        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+    assert rid == "ch_text"
+    assert mock.await_count == 2
+    assert mock.await_args_list[0].kwargs["channel_type"] == "Voice"
+    assert mock.await_args_list[1].kwargs["channel_type"] == "Text"
+
+
+def test_build_channel_non_voice_propagates() -> None:  # SC-10
+    import asyncio
+
+    from discord_ferry.blueprint import BlueprintChannel
+    from discord_ferry.cli import _build_blueprint_channel
+
+    ch = BlueprintChannel(name="TC", type="Text")
+    mock = AsyncMock(side_effect=MigrationError("text fail"))
+    with (
+        patch("discord_ferry.cli.api_create_channel", mock),
+        pytest.raises(MigrationError),
+    ):
+        asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+    assert mock.await_count == 1
+
+
+def test_build_channel_voice_happy_path() -> None:  # SC-11
+    import asyncio
+
+    from discord_ferry.blueprint import BlueprintChannel
+    from discord_ferry.cli import _build_blueprint_channel
+
+    ch = BlueprintChannel(name="VC", type="Voice")
+    mock = AsyncMock(return_value={"_id": "ch1"})
+    with patch("discord_ferry.cli.api_create_channel", mock):
+        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+    assert rid == "ch1"
+    assert mock.await_count == 1
+
+
+def test_build_categorized_voice_preserves_id(runner: CliRunner, tmp_path: Path) -> None:  # SC-12
+    from discord_ferry.blueprint import BlueprintCategory, BlueprintChannel, ServerBlueprint
+
+    bp = ServerBlueprint(
+        name="S",
+        categories=[
+            BlueprintCategory(name="Cat", channels=[BlueprintChannel(name="VC", type="Voice")])
+        ],
+    )
+    p = _write_bp(tmp_path, bp)
+    create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
+    upsert = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_channel", create),
+        patch("discord_ferry.cli.api_upsert_categories", upsert),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    cats = upsert.await_args.args[-1]  # the categories list (5th positional)
+    assert any("ch_text" in c["channels"] for c in cats)
+
+
+def test_build_uncategorized_voice_fallback(runner: CliRunner, tmp_path: Path) -> None:  # SC-13
+    from discord_ferry.blueprint import BlueprintChannel, ServerBlueprint
+
+    bp = ServerBlueprint(
+        name="S", uncategorized_channels=[BlueprintChannel(name="VC", type="Voice")]
+    )
+    p = _write_bp(tmp_path, bp)
+    create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_channel", create),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert create.await_count == 2
+
+
+def test_build_non_voice_failure_aborts(runner: CliRunner, tmp_path: Path) -> None:  # SC-19
+    from discord_ferry.blueprint import BlueprintChannel, ServerBlueprint
+
+    bp = ServerBlueprint(
+        name="S", uncategorized_channels=[BlueprintChannel(name="TC", type="Text")]
+    )
+    p = _write_bp(tmp_path, bp)
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch(
+            "discord_ferry.cli.api_create_channel", AsyncMock(side_effect=MigrationError("boom"))
+        ),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+        )
+    assert result.exit_code == 1
+    assert "Build failed" in result.output
+
+
+def test_build_empty_blueprint(runner: CliRunner, tmp_path: Path) -> None:  # SC-21
+    from discord_ferry.blueprint import ServerBlueprint
+
+    bp = ServerBlueprint(name="Empty")
+    p = _write_bp(tmp_path, bp)
+    create = AsyncMock(return_value={"_id": "ch"})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_channel", create),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert create.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Batch 5 — S4 build applies role rank (T3)
+# ---------------------------------------------------------------------------
+
+
+def test_build_applies_distinct_ranks(runner: CliRunner, tmp_path: Path) -> None:  # SC-15
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(
+        name="S",
+        roles=[
+            BlueprintRole(name="Admin", colour=0xFF0000, rank=3),
+            BlueprintRole(name="Mod", rank=2),
+        ],
+    )
+    p = _write_bp(tmp_path, bp)
+    edit = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    ranks = {c.kwargs.get("rank") for c in edit.await_args_list}
+    assert {2, 3} <= ranks
+
+
+def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC-16
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="Plain", rank=0)])
+    p = _write_bp(tmp_path, bp)
+    edit = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+    ):
+        runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert edit.await_count == 0  # no colour, no rank -> no edit call
+
+
+def test_build_folds_colour_and_rank_one_patch(runner: CliRunner, tmp_path: Path) -> None:  # SC-17
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", colour=0x00FF00, rank=5)])
+    p = _write_bp(tmp_path, bp)
+    edit = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+    ):
+        runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert edit.await_count == 1
+    kw = edit.await_args.kwargs
+    assert kw.get("colour") == 0x00FF00
+    assert kw.get("rank") == 5
+
+
+def test_build_preserves_permissions(runner: CliRunner, tmp_path: Path) -> None:  # SC-18
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", permissions=15, rank=2)])
+    p = _write_bp(tmp_path, bp)
+    perms = AsyncMock(return_value={})
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.cli.api_set_role_permissions", perms),
+    ):
+        runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert perms.await_count == 1
+    assert perms.await_args.kwargs.get("allow") == 15
+
+
+# ---------------------------------------------------------------------------
+# Batch 5 — S3 export-blueprint keeps voice type, builds via S2 (T4, A1)
+# ---------------------------------------------------------------------------
+
+
+def _write_dce_channel(dir_path: Path, fname: str, ch_id: str, ch_type: int, ch_name: str) -> None:
+    import json
+
+    doc = {
+        "guild": {"id": "111", "name": "Test", "iconUrl": ""},
+        "channel": {
+            "id": ch_id,
+            "type": ch_type,
+            "categoryId": "999",
+            "category": "Cat",
+            "name": ch_name,
+            "topic": "",
+        },
+        "dateRange": {"after": None, "before": None},
+        "exportedAt": "2024-06-15T10:30:00+00:00",
+        "messages": [],
+        "messageCount": 0,
+    }
+    (dir_path / fname).write_text(json.dumps(doc), encoding="utf-8")
+
+
+def test_export_blueprint_keeps_voice_type(runner: CliRunner, tmp_path: Path) -> None:  # SC-14
+    import json
+
+    src = tmp_path / "exp"
+    src.mkdir()
+    _write_dce_channel(src, "voice.json", "201", 2, "General Voice")
+    _write_dce_channel(src, "text.json", "202", 0, "general")
+    out = tmp_path / "bp.json"
+    result = runner.invoke(
+        main,
+        ["export-blueprint", "--from", str(src), "-o", str(out)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    all_ch = [c for cat in data.get("categories", []) for c in cat["channels"]] + data.get(
+        "uncategorized_channels", []
+    )
+    types = {c["name"]: c["type"] for c in all_ch}
+    assert types.get("General Voice") == "Voice"  # A1: export unchanged
+    assert types.get("general") == "Text"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.10"
+version = "2.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Batch 5 of the 2026-06-25 v2.6.6 whole-codebase bug-hunt — **CLI display & blueprint round-trip robustness**. Four confirmed, adversarially-verified findings, all in the CLI shell (`cli.py`); the engine, migrators, GUI shell, and blueprint module are unchanged.

## Fixes
- **S1/F5a — a markup-hostile name no longer aborts a migration.** `Console` renders with markup enabled, so a Discord channel/server name with Rich metacharacters (`spam[/]`, `[bold]news`, an unbalanced `]`) raised `rich.errors.MarkupError`. Since `_ProgressTracker.on_event` runs *synchronously inside* the engine's `emit`, that unwound into the engine and was re-raised as `MigrationError` — aborting an otherwise-healthy migration over a cosmetic string. Every user-controlled value (event message, channel/server/guild name, warnings, exception text, rollback suspect names, failure errors, `ferry stats` previews) is now escaped via a new `_safe()` helper; static format tags + integer/ID values stay live. A narrow `except MarkupError` defense-in-depth guard wraps each tracker's render body (unstyled fallback; never swallows control flow — the rollback confirm/pause path is kept outside it).
- **S2/F5b — `build` no longer orphans a server on a voice-channel failure.** The blueprint `build` command POSTed `channel_type="Voice"` with no error handling; a voice-create failure (Stoat Bug #194) `sys.exit`ed after the server/roles/earlier channels were live. A new `_build_blueprint_channel()` helper mirrors the migration path's voice→Text fallback (non-voice errors still propagate); the categorized loop preserves the recovered channel's id into its category. Also un-breaks `ferry build --template gaming|community|education` (shipped templates contain Voice channels).
- **S4/F5d — `build` replays role hierarchy.** `BlueprintRole.rank` round-trips through export/import but was never applied at build; now folded into the colour `api_edit_role` PATCH (rank 0 skipped). Also restores the shipped templates' role ranks.
- **S3/F5c — `export-blueprint` unchanged** (decision A1): a voice channel is still exported as `type="Voice"` (consistent with the migration path + templates); S2 makes that build-safe.

Internal: hoisted the build command's six Stoat API helpers from a function-local import to module level (no import-cost change) for the new channel helper + a uniform test mock-patch target.

## Behaviour / known limitations
S1 is a robustness fix (otherwise display-preserving); S2 narrows the abort surface to voice-only recovery. **Known limitations:** (1) a hand-authored blueprint with an *explicit* `rank: 0` won't be replayed (rank 0 = unranked; templates use rank ≥ 1 and export emits no roles, so unaffected); (2) a *non-voice* channel-create failure during `build` still aborts mid-build (pre-existing; orphan teardown out of scope).

## Verification
- Full `/df` pipeline: brief → spec → brainstorm → critique (fresh opus, ITERATE → PASS — caught the local-import mock-target blocker, the wrong rollback escape sink, and the need for the guard) → test-scenarios → plan → controller-driven build.
- `ruff check .` + `ruff format --check .` + `mypy src/` clean; **1197 tests pass** (23 new, **0 existing modified** — append-only).
- GUI shell audited clean (0 Rich usage, no blueprint-build path).
- Fresh-opus code review: **APPROVE WITH NITS** (the one nit — `ferry stats` error/warning previews sharing the S1 class — fixed before commit). Mistral second opinion: 10 findings, **all rebutted against source**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
