### PR TITLE
fix: rate-limit hardening — non-JSON 429/2xx robustness (v2.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.12] - 2026-06-27
+
+### Fixed
+
+Rate-limit hardening — the sixth batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt
+(`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 6). Two engine-side HTTP clients
+(`migrator/api.py`, `discord/client.py`); no GUI/CLI/state changes. Root cause: `await resp.json()`
+was called unguarded inside the 429 (and Stoat's 2xx) branch, so a non-JSON body from a proxy/CDN
+(Cloudflare HTML) raised `aiohttp.ContentTypeError` — a `ClientError` subclass — that escaped into
+the generic network-error path.
+
+- **A rate-limited Stoat request no longer trips the circuit breaker** (`migrator/api.py`, S1/F6a).
+  A 429 with a non-JSON body fell through to the network-error handler, incremented
+  `consecutive_failures`, and ignored the server's `Retry-After` — violating the code's own
+  "429 is not a circuit-breaker failure" invariant. The 429 delay is now resolved by a
+  content-type-guarded helper that honours the `Retry-After` / `X-RateLimit-Reset-After` headers
+  (seconds) first, then the JSON body `retry_after` (Stoat milliseconds), then a 1s fallback — all
+  capped at 60s. A 429 now never primes the breaker, **even when it exhausts the retry budget**
+  (the final-attempt failure bump is skipped for 429); a 5xx / genuine network error still primes it.
+- **A non-JSON Stoat 2xx now fails with a clear, correctly-classified error** (`migrator/api.py`,
+  S2/F6b). A 200/201 with an HTML body was retried and re-raised as "Network error after 3 retries",
+  hiding the real cause and mis-routing rollback classification. It now raises a distinct
+  `MigrationError` naming the content-type; the "Network error after 3 retries" message is preserved
+  for genuine connection errors.
+- **Discord rate limits are honoured with a separate, bounded budget** (`discord/client.py`, S3/F6c).
+  Both metadata getters read the 429 delay from the JSON body and shared the 3-attempt network-retry
+  budget, so a Cloudflare HTML 429 was retried with a fixed 1s (ignoring a 60s+ `Retry-After`) and
+  three such retries aborted the metadata-fetch phase. The two byte-identical getters are unified
+  into one `_discord_request` that honours the `Retry-After` header, retries 429s on a separate
+  bounded budget (`_MAX_429_RETRIES`) that no longer consumes the network-error budget, and
+  content-type-guards both the 429 and the 200 body parse.
+
+**Behaviour note:** behaviour-preserving for well-formed JSON responses and genuine network errors
+(the "Network error after 3 retries" message is unchanged for real `ClientError`s). The change makes
+the clients robust to non-JSON 429/2xx bodies from reverse proxies/CDNs and ensures the server's
+`Retry-After` is respected. The circuit-breaker thresholds and the adaptive rate-multiplier are
+unchanged. As a side benefit, an exhausted HTML-429 that was previously misclassified as a
+network error (no HTTP status) is now correctly classified as a 429.
+
 ## [2.6.11] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.11"
+version = "2.6.12"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.11"
+__version__ = "2.6.12"

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+import json
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 
 from discord_ferry.discord.models import DiscordChannel, DiscordRole, PermissionOverwrite
 from discord_ferry.errors import DiscordAuthError, MigrationError
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 DISCORD_API = "https://discord.com/api/v10"
 _MAX_RETRIES = 3
+_MAX_429_RETRIES = 5  # separate bounded budget for 429s (does not consume _MAX_RETRIES)
+_MAX_RETRY_DELAY_SECONDS = 60  # cap any server/body-advertised 429 retry delay
 
 
 async def fetch_guild(session: aiohttp.ClientSession, token: str, guild_id: str) -> dict[str, Any]:
@@ -74,18 +80,65 @@ async def fetch_guild_channels(
     return [_parse_channel(c) for c in data]
 
 
-async def _discord_get(
-    session: aiohttp.ClientSession, token: str, path: str
-) -> list[dict[str, Any]]:
-    """Make an authenticated GET request to the Discord API with retry on 429."""
+def _retry_after_seconds(headers: Mapping[str, str]) -> float | None:
+    """Parse a rate-limit delay (seconds) from standard headers; None if absent/non-numeric.
+
+    ``Retry-After`` may be an HTTP-date rather than delta-seconds — a non-numeric value is
+    ignored (returns None) so the caller falls back to the body / default delay.
+    """
+    for name in ("Retry-After", "X-RateLimit-Reset-After"):
+        raw = headers.get(name)
+        if raw:
+            try:
+                return float(raw)
+            except ValueError:
+                continue
+    return None
+
+
+async def _discord_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
+    """Resolve the 429 sleep (seconds): header → body ``retry_after`` (Discord secs) → 1s; capped.
+
+    The body parse is content-type-guarded so a non-JSON 429 (Cloudflare HTML) can't escape into
+    the network-error path.
+    """
+    header_s = _retry_after_seconds(resp.headers)
+    if header_s is not None:
+        return min(header_s, _MAX_RETRY_DELAY_SECONDS)
+    try:
+        body = await resp.json(content_type=None)
+    except (json.JSONDecodeError, ValueError):
+        body = None
+    raw = body.get("retry_after") if isinstance(body, dict) else None
+    try:
+        retry_after = float(raw)  # type: ignore[arg-type]  # None/non-numeric → fallback below
+    except (TypeError, ValueError):
+        retry_after = 1.0
+    return min(retry_after, _MAX_RETRY_DELAY_SECONDS)
+
+
+async def _discord_request(session: aiohttp.ClientSession, token: str, path: str) -> Any:
+    """GET the Discord API, honouring Retry-After with separate bounded 429/network budgets.
+
+    429s advance only ``rate_limit_retries`` (bounded by ``_MAX_429_RETRIES``); network errors
+    advance only ``network_attempts`` (bounded by ``_MAX_RETRIES``) — a 429 burst can no longer
+    exhaust the network budget and abort the metadata phase.
+    """
     url = f"{DISCORD_API}{path}"
     headers = {"Authorization": token, "Content-Type": "application/json"}
+    network_attempts = 0
+    rate_limit_retries = 0
 
-    for attempt in range(_MAX_RETRIES):
+    while True:
         try:
             async with session.get(url, headers=headers) as resp:
                 if resp.status == 200:
-                    return await resp.json()  # type: ignore[no-any-return]
+                    try:
+                        return await resp.json()
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError) as exc:
+                        raise MigrationError(
+                            f"Unexpected non-JSON 200 response (content-type: {resp.content_type})"
+                        ) from exc
                 if resp.status == 401:
                     raise DiscordAuthError("Discord token is invalid or expired")
                 if resp.status == 403:
@@ -94,56 +147,36 @@ async def _discord_get(
                         "The token must belong to a member of the guild."
                     )
                 if resp.status == 429:
-                    body = await resp.json()
-                    retry_after = float(body.get("retry_after", 1))
-                    await asyncio.sleep(retry_after)
+                    rate_limit_retries += 1
+                    if rate_limit_retries >= _MAX_429_RETRIES:
+                        raise MigrationError(
+                            f"Discord API rate-limited after {_MAX_429_RETRIES} retries"
+                        )
+                    await asyncio.sleep(await _discord_429_delay_seconds(resp))
                     continue
                 text = await resp.text()
                 raise MigrationError(f"Discord API error {resp.status}: {text}")
         except (DiscordAuthError, MigrationError):
             raise
         except aiohttp.ClientError as exc:
-            if attempt == _MAX_RETRIES - 1:
+            network_attempts += 1
+            if network_attempts >= _MAX_RETRIES:
                 raise MigrationError(f"Discord API network error: {exc}") from exc
             await asyncio.sleep(1)
 
-    raise MigrationError(f"Discord API request failed after {_MAX_RETRIES} retries")
+
+async def _discord_get(
+    session: aiohttp.ClientSession, token: str, path: str
+) -> list[dict[str, Any]]:
+    """Make an authenticated GET request to the Discord API with retry on 429."""
+    return cast("list[dict[str, Any]]", await _discord_request(session, token, path))
 
 
 async def _discord_get_object(
     session: aiohttp.ClientSession, token: str, path: str
 ) -> dict[str, Any]:
     """Make an authenticated GET request returning a single JSON object."""
-    url = f"{DISCORD_API}{path}"
-    headers = {"Authorization": token, "Content-Type": "application/json"}
-
-    for attempt in range(_MAX_RETRIES):
-        try:
-            async with session.get(url, headers=headers) as resp:
-                if resp.status == 200:
-                    return await resp.json()  # type: ignore[no-any-return]
-                if resp.status == 401:
-                    raise DiscordAuthError("Discord token is invalid or expired")
-                if resp.status == 403:
-                    raise MigrationError(
-                        "Insufficient permissions to read guild metadata. "
-                        "The token must belong to a member of the guild."
-                    )
-                if resp.status == 429:
-                    body = await resp.json()
-                    retry_after = float(body.get("retry_after", 1))
-                    await asyncio.sleep(retry_after)
-                    continue
-                text = await resp.text()
-                raise MigrationError(f"Discord API error {resp.status}: {text}")
-        except (DiscordAuthError, MigrationError):
-            raise
-        except aiohttp.ClientError as exc:
-            if attempt == _MAX_RETRIES - 1:
-                raise MigrationError(f"Discord API network error: {exc}") from exc
-            await asyncio.sleep(1)
-
-    raise MigrationError(f"Discord API request failed after {_MAX_RETRIES} retries")
+    return cast("dict[str, Any]", await _discord_request(session, token, path))
 
 
 _ROLE_ICON_MAX_BYTES = 2_500_000  # Autumn "icons" tag limit (stoatchat Revolt.toml)

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import random
 import time
@@ -16,7 +17,7 @@ import aiohttp  # noqa: TCH002
 from discord_ferry.errors import MigrationError
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping
 
     from discord_ferry.config import FerryConfig
 
@@ -27,6 +28,8 @@ _RETRYABLE_STATUSES = {429, 502, 503, 504}
 
 _CIRCUIT_THRESHOLD = 5
 _CIRCUIT_PAUSE_SECONDS = 30
+
+_MAX_RETRY_DELAY_SECONDS = 60  # cap any server/body-advertised 429 retry delay
 
 
 @dataclass
@@ -141,6 +144,43 @@ async def _api_request(
     )
 
 
+def _retry_after_seconds(headers: Mapping[str, str]) -> float | None:
+    """Parse a rate-limit delay (seconds) from standard headers; None if absent/non-numeric.
+
+    ``Retry-After`` may be an HTTP-date rather than delta-seconds — a non-numeric value is
+    ignored (returns None) so the caller falls back to the body / default delay.
+    """
+    for name in ("Retry-After", "X-RateLimit-Reset-After"):
+        raw = headers.get(name)
+        if raw:
+            try:
+                return float(raw)
+            except ValueError:
+                continue
+    return None
+
+
+async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
+    """Resolve the 429 sleep in seconds: header → body ``retry_after`` (Stoat ms) → 1s; capped.
+
+    The body parse is content-type-guarded so a non-JSON 429 (proxy HTML) can't raise
+    ``ContentTypeError`` into the network-error path and prime the circuit breaker.
+    """
+    header_s = _retry_after_seconds(resp.headers)
+    if header_s is not None:
+        return min(header_s, _MAX_RETRY_DELAY_SECONDS)
+    try:
+        body = await resp.json(content_type=None)
+    except (json.JSONDecodeError, ValueError):
+        body = None
+    raw = body.get("retry_after") if isinstance(body, dict) else None
+    try:
+        retry_ms = float(raw)  # type: ignore[arg-type]  # None/non-numeric → fallback below
+    except (TypeError, ValueError):
+        retry_ms = 1000.0
+    return min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS)
+
+
 async def _api_request_inner(
     session: aiohttp.ClientSession,
     method: str,
@@ -179,7 +219,13 @@ async def _api_request_inner(
                         time.monotonic() - t < 30 for t in _rate_429_window
                     ):
                         _rate_multiplier = max(_rate_multiplier * 0.75, 1.0)
-                    return await resp.json()  # type: ignore[no-any-return]
+                    try:
+                        return await resp.json()  # type: ignore[no-any-return]
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError) as exc:
+                        raise MigrationError(
+                            f"Unexpected non-JSON {resp.status} response "
+                            f"(content-type: {resp.content_type})"
+                        ) from exc
                 if resp.status == 204 or (resp.status == 404 and expected_404_ok):
                     _circuit_state.consecutive_failures = 0
                     # Decay the rate multiplier gradually on successful requests.
@@ -192,16 +238,19 @@ async def _api_request_inner(
                 if resp.status in _RETRYABLE_STATUSES:
                     if attempt == MAX_API_RETRIES - 1:
                         text = await resp.text()
-                        _circuit_state.consecutive_failures += 1
+                        # A 429 is rate-limiting, never a circuit-breaker failure — even on
+                        # budget exhaustion. A 5xx still primes the breaker.
+                        if resp.status != 429:
+                            _circuit_state.consecutive_failures += 1
                         raise MigrationError(
                             f"API request failed after {MAX_API_RETRIES} retries: "
                             f"{resp.status} {text}"
                         )
                     if resp.status == 429:
-                        # Rate-limited — NOT a circuit-breaker failure.
-                        body_data: dict[str, Any] = await resp.json()
-                        retry_ms = body_data.get("retry_after", 1000)
-                        await asyncio.sleep(retry_ms / 1000)
+                        # Rate-limited — NOT a circuit-breaker failure. The body parse is
+                        # content-type-guarded so a non-JSON 429 can't escape into the network
+                        # path and prime the breaker; honour Retry-After over the body delay.
+                        await asyncio.sleep(await _resolve_429_delay_seconds(resp))
                         # Track 429 frequency and ramp up the rate multiplier.
                         _rate_429_window.append(time.monotonic())
                         recent = sum(1 for t in _rate_429_window if time.monotonic() - t < 60)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1091,3 +1091,214 @@ async def test_api_fetch_root_returns_empty_on_malformed_json():
         )
         async with aiohttp.ClientSession() as s:
             assert await api_fetch_root(s, "https://stoat.test") == {}
+
+
+# ---------------------------------------------------------------------------
+# Batch 6 — S1 (non-JSON 429 + Retry-After + breaker invariant) + S2 (non-JSON 2xx)
+# ---------------------------------------------------------------------------
+
+
+def _sleep_capture() -> tuple[list[float], AsyncMock]:
+    calls: list[float] = []
+    return calls, AsyncMock(side_effect=lambda d: calls.append(d))
+
+
+async def test_429_non_json_body_honors_header_no_breaker(
+    mock_aiohttp: aioresponses,
+) -> None:  # SC-1
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        body="<html>rl</html>",
+        content_type="text/html",
+        headers={"Retry-After": "2"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1", "name": "OK"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            result = await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert result["_id"] == "srv1"
+    assert _circuit_state.consecutive_failures == 0  # breaker NOT primed by a non-JSON 429
+    assert calls[0] == pytest.approx(2.0, abs=0.05)  # header seconds honored
+
+
+async def test_429_non_json_no_header_default_no_breaker(
+    mock_aiohttp: aioresponses,
+) -> None:  # SC-2
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1", status=429, body="<html>rl</html>", content_type="text/html"
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures == 0
+    assert calls[0] == pytest.approx(1.0, abs=0.05)  # default fallback
+
+
+async def test_429_header_beats_body(mock_aiohttp: aioresponses) -> None:  # SC-3
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        payload={"retry_after": 5000},
+        headers={"Retry-After": "2"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == pytest.approx(2.0, abs=0.05)  # header, not body 5.0s
+
+
+async def test_429_x_ratelimit_reset_after(mock_aiohttp: aioresponses) -> None:  # SC-4
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        body="<html>",
+        content_type="text/html",
+        headers={"X-RateLimit-Reset-After": "1.5"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == pytest.approx(1.5, abs=0.05)
+
+
+async def test_429_http_date_header_ignored(mock_aiohttp: aioresponses) -> None:  # SC-5
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        payload={"retry_after": 300},
+        headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == pytest.approx(0.3, abs=0.05)  # HTTP-date ignored → body 300ms
+
+
+async def test_429_delay_capped(mock_aiohttp: aioresponses) -> None:  # SC-6
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        body="<html>",
+        content_type="text/html",
+        headers={"Retry-After": "9999"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == 60  # _MAX_RETRY_DELAY_SECONDS
+
+
+async def test_429_exhausted_does_not_prime_breaker(mock_aiohttp: aioresponses) -> None:  # SC-7
+    for _ in range(3):
+        mock_aiohttp.get(
+            f"{BASE_URL}/servers/srv1", status=429, body="<html>", content_type="text/html"
+        )
+    with patch("discord_ferry.migrator.api.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="after 3 retries: 429"):
+                await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures == 0  # 429 never primes, even exhausted
+
+
+async def test_502_exhausted_primes_breaker(mock_aiohttp: aioresponses) -> None:  # SC-8 (contrast)
+    for _ in range(3):
+        mock_aiohttp.get(f"{BASE_URL}/servers/srv1", status=502, body="Bad Gateway")
+    with patch("discord_ferry.migrator.api.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="after 3 retries: 502"):
+                await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures == 3  # 5xx DOES prime (contrast SC-7)
+
+
+async def test_429_empty_body_falls_back(mock_aiohttp: aioresponses) -> None:  # SC-9
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", status=429, body="", content_type="text/html")
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures == 0
+    assert calls[0] == pytest.approx(1.0, abs=0.05)
+
+
+async def test_non_json_200_clear_error(mock_aiohttp: aioresponses) -> None:  # SC-10
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1", status=200, body="<html>nope</html>", content_type="text/html"
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert "Network error after 3 retries" not in str(exc.value)
+    assert "text/html" in str(exc.value)
+
+
+async def test_non_json_201_clear_error(mock_aiohttp: aioresponses) -> None:  # SC-11
+    mock_aiohttp.post(
+        f"{BASE_URL}/servers/create",
+        status=201,
+        body="<html>nope</html>",
+        content_type="text/html",
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, BASE_URL, TOKEN, "My Server")
+    assert "Network error after 3 retries" not in str(exc.value)
+    assert "text/html" in str(exc.value)
+
+
+async def test_json_200_unaffected(mock_aiohttp: aioresponses) -> None:  # SC-12
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1", "name": "OK"})
+    async with aiohttp.ClientSession() as session:
+        result = await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert result == {"_id": "srv1", "name": "OK"}
+
+
+async def test_genuine_client_error_still_network_error(
+    mock_aiohttp: aioresponses,
+) -> None:  # SC-13
+    for _ in range(3):
+        mock_aiohttp.get(f"{BASE_URL}/servers/srv1", exception=aiohttp.ClientError("reset"))
+    with patch("discord_ferry.migrator.api.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="Network error after 3 retries"):
+                await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures >= 1
+
+
+async def test_malformed_json_200_clear_error(mock_aiohttp: aioresponses) -> None:  # SC-14
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=200,
+        body="{not valid json",
+        content_type="application/json",
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert "Network error after 3 retries" not in str(exc.value)
+
+
+async def test_429_null_retry_after_falls_back(
+    mock_aiohttp: aioresponses,
+) -> None:  # SC-9b (review M2)
+    """A 429 body with retry_after=null must not crash; falls back to the default delay."""
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", status=429, payload={"retry_after": None})
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert _circuit_state.consecutive_failures == 0
+    assert calls[0] == pytest.approx(1.0, abs=0.05)

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -438,3 +438,171 @@ async def test_capture_role_name_and_hex_color() -> None:
     assert meta.role_metadata["200"].name == "Mod"
     assert meta.role_metadata["200"].color == "#ff0000"  # 16711680 -> hex
     assert meta.role_metadata["201"].color == ""  # color 0 -> ""
+
+
+# ---------------------------------------------------------------------------
+# Batch 6 — S3: Discord 429 honors Retry-After + separate bounded budget + DRY
+# ---------------------------------------------------------------------------
+
+
+def _sleep_capture():  # type: ignore[no-untyped-def]
+    from unittest.mock import AsyncMock
+
+    calls: list[float] = []
+    return calls, AsyncMock(side_effect=lambda d: calls.append(d))
+
+
+async def test_discord_get_429_html_honors_header(mock_discord: aioresponses) -> None:  # SC-15
+    from unittest.mock import patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(
+        url,
+        status=429,
+        body="<html>rl</html>",
+        content_type="text/html",
+        headers={"Retry-After": "2"},
+    )
+    mock_discord.get(url, payload=[])
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            roles = await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert roles == []
+    assert calls[0] == pytest.approx(2.0, abs=0.05)  # header seconds, not fixed 1s
+
+
+async def test_discord_object_429_html_honors_header(mock_discord: aioresponses) -> None:  # SC-16
+    from unittest.mock import patch
+
+    from discord_ferry.discord.client import _discord_get_object
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}"
+    mock_discord.get(
+        url,
+        status=429,
+        body="<html>rl</html>",
+        content_type="text/html",
+        headers={"Retry-After": "2"},
+    )
+    mock_discord.get(url, payload={"id": GUILD_ID, "name": "G"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            obj = await _discord_get_object(session, TOKEN, f"/guilds/{GUILD_ID}")
+    assert obj["id"] == GUILD_ID
+    assert calls[0] == pytest.approx(2.0, abs=0.05)  # DRY: same fix covers both getters
+
+
+async def test_discord_429_json_body_seconds(mock_discord: aioresponses) -> None:  # SC-17
+    from unittest.mock import patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(url, status=429, payload={"retry_after": 0.5})
+    mock_discord.get(url, payload=[])
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert calls[0] == pytest.approx(0.5, abs=0.05)  # Discord body = seconds (no ÷1000)
+
+
+async def test_discord_429_separate_budget(mock_discord: aioresponses) -> None:  # SC-18
+    from unittest.mock import AsyncMock, patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    for _ in range(4):  # 4 > _MAX_RETRIES(3) but < _MAX_429_RETRIES(5)
+        mock_discord.get(url, status=429, payload={"retry_after": 0.0})
+    mock_discord.get(url, payload=[])
+    with patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            roles = await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert roles == []  # 429s did NOT exhaust the network budget
+
+
+async def test_discord_429_budget_bounded(mock_discord: aioresponses) -> None:  # SC-19
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.errors import MigrationError
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    for _ in range(5):
+        mock_discord.get(url, status=429, payload={"retry_after": 0.0})
+    with patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="rate-limited after 5 retries"):
+                await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+
+async def test_discord_network_error_bounded(mock_discord: aioresponses) -> None:  # SC-20
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.errors import MigrationError
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    for _ in range(3):
+        mock_discord.get(url, exception=aiohttp.ClientError("boom"))
+    with patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError, match="Discord API network error"):
+                await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+
+async def test_discord_403_raises_migration_error(mock_discord: aioresponses) -> None:  # SC-21
+    from discord_ferry.errors import MigrationError
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(url, status=403, body="Forbidden")
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError, match="Insufficient permissions"):
+            await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+
+async def test_discord_429_delay_capped(mock_discord: aioresponses) -> None:  # SC-22
+    from unittest.mock import patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(
+        url,
+        status=429,
+        body="<html>",
+        content_type="text/html",
+        headers={"Retry-After": "9999"},
+    )
+    mock_discord.get(url, payload=[])
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert calls[0] == 60  # _MAX_RETRY_DELAY_SECONDS
+
+
+async def test_discord_non_json_200_clear_error(
+    mock_discord: aioresponses,
+) -> None:  # SC-23 (review M1)
+    """A non-JSON 200 raises a clear content-type error, not a misclassified network error."""
+    from discord_ferry.errors import MigrationError
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(url, status=200, body="<html>nope</html>", content_type="text/html")
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert "network error" not in str(exc.value).lower()
+    assert "text/html" in str(exc.value)
+
+
+async def test_discord_429_null_retry_after_falls_back(
+    mock_discord: aioresponses,
+) -> None:  # SC-24 (review M2)
+    """A 429 body with retry_after=null must not crash; falls back to the default delay."""
+    from unittest.mock import patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(url, status=429, payload={"retry_after": None})
+    mock_discord.get(url, payload=[])
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await fetch_guild_roles(session, TOKEN, GUILD_ID)
+    assert calls[0] == pytest.approx(1.0, abs=0.05)

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.11"
+version = "2.6.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Batch 6 of the 2026-06-25 v2.6.6 whole-codebase bug-hunt — **rate-limit hardening**. Three confirmed, adversarially-verified findings across two engine-side HTTP clients (`migrator/api.py`, `discord/client.py`); no GUI/CLI/state changes. The unifying root: `await resp.json()` was called unguarded inside the 429 (and Stoat's 2xx) branch, so a non-JSON body from a reverse proxy/CDN (Cloudflare HTML) raised `aiohttp.ContentTypeError` — a `ClientError` subclass — that escaped into the generic network-error path.

## Fixes
- **S1/F6a — a rate-limited Stoat request no longer trips the circuit breaker.** A 429 with a non-JSON body fell to the network-error handler, bumped `consecutive_failures`, and ignored `Retry-After` — violating the code's own "429 is not a circuit-breaker failure" invariant. The 429 delay is now resolved by a content-type-guarded helper: `Retry-After`/`X-RateLimit-Reset-After` headers (seconds) → JSON body `retry_after` (Stoat ms) → 1s fallback, all capped at 60s. A 429 never primes the breaker, **even on budget exhaustion** (the final-attempt failure bump is skipped for 429); a 5xx / genuine network error still primes it. (Side benefit: an exhausted HTML-429 that was misclassified as a network error — no HTTP status for rollback DLQ — is now correctly a 429.)
- **S2/F6b — a non-JSON Stoat 2xx fails with a clear, correctly-classified error.** A 200/201 with an HTML body was re-raised as "Network error after 3 retries". It now raises a distinct `MigrationError` naming the content-type; the network-error message is preserved for genuine `ClientError`s (a contract used by rollback classification).
- **S3/F6c — Discord rate limits are honoured with a separate bounded budget.** Both metadata getters read the 429 delay from the JSON body and shared the 3-attempt network-retry budget, so a Cloudflare HTML 429 retried with a fixed 1s (ignoring a 60s+ `Retry-After`) and three such retries aborted the metadata phase. The two byte-identical getters are unified into one `_discord_request` honouring the `Retry-After` header, with 429 retries on a separate bounded budget (`_MAX_429_RETRIES`) that no longer consumes the network budget; both the 429 and 200 body parses are content-type-guarded.

## Behaviour
Behaviour-preserving for well-formed JSON responses and genuine network errors (the "Network error after 3 retries" message is unchanged for real `ClientError`s). Circuit-breaker thresholds and the adaptive rate-multiplier are unchanged. The clients are now robust to non-JSON 429/2xx bodies from proxies/CDNs and respect the server's `Retry-After`.

## Verification
- Full `/df` pipeline: brief → spec → brainstorm (aiohttp APIs **Context7-verified**, 3.13.2) → critique (fresh opus, PASS — caught + closed an I1 hole where an exhausted 429 still primed the breaker, re-confirmed by the reviewer) → test-scenarios → plan → controller-driven build.
- `ruff check .` + `ruff format --check .` + `mypy src/` clean; **1222 tests pass** (22 new, **0 existing modified** — append-only). Every new guard was falsified then restored.
- Fresh-opus code review: **APPROVE** — two sub-threshold nits (Discord 200 non-JSON symmetry with S2; defensive `retry_after: null` coercion) fixed + covered before commit. Mistral second opinion (API focus): 10 findings, **all rebutted against the diff**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
