### PR TITLE
fix: incremental edge cases — merge self-heal, non-destructive category upsert, clamped fidelity (v2.6.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.13] - 2026-06-27
+
+### Fixed
+
+Incremental edge cases — the seventh batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt
+(`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 7). Three engine-side fixes
+(`migrator/messages.py`, `migrator/structure.py`, `reporter.py`); no GUI/CLI/state-schema changes.
+All three are follow-up gaps in/around the v2.6.x incremental machinery (durable `channel_high_water`
+v2.6.3, the #76 failed-message self-heal v2.6.4, reporting-integrity v2.6.2).
+
+- **Merge-strategy thread failures are no longer permanently lost** (`migrator/messages.py`, S1/F7a).
+  In `thread_strategy="merge"`, a message whose POST failed was recorded only as a warning, never a
+  `FailedMessage`, while the high-water marker was written regardless — so on a later `--incremental`
+  run the failed id sat below the marker and was skipped forever, unrecoverable by `ferry retry`. The
+  shipped #76 self-heal is now ported into the merge loop: a POST failure is recorded as a
+  `FailedMessage` (in all modes); on `--incremental` a prior-failed id is excluded from the skip gate
+  and re-attempted; a completion reconciliation drops ids that succeeded this run and collapses a
+  carried + re-fail duplicate to one entry. The high-water marker write is unchanged
+  (plain/resume byte-identical). Both merge warnings (separator + message) are now sanitized via
+  `safe_sanitize` so a token-bearing exception is never persisted to `state.json`. **Known
+  limitation:** the `--incremental` re-attempt is the idempotency-safe primary recovery; recovering a
+  *partial-success multi-part* merge message via `ferry retry` may re-send already-delivered parts
+  (the `ferry-merge-` vs `ferry-` idempotency-namespace difference) — a proper fix needs the merge
+  context threaded into the retry engine and is out of scope for this batch.
+- **Incremental category sync no longer transiently deletes carried categories** (`migrator/structure.py`,
+  S2/F7b). `run_categories` built its early full-replace category PATCH from only this run's (partial)
+  export, so in incremental mode introducing a new category deleted carried-only categories until the
+  CHANNELS phase re-PATCHed — a window where a crash/cancel left the live server wrong. The early
+  upsert is now skipped in incremental mode; `run_channels`' authoritative upsert (which enumerates the
+  full `category_map`) is the single source of truth. Fresh (non-incremental) runs are unchanged.
+- **Fidelity scores can no longer render negative** (`reporter.py`, S3/F7c). In incremental mode the
+  messages denominator is this run's partial `source_messages_total` while `failed_count` is carried
+  cumulatively, so `compute_fidelity_score` could emit a negative Messages percentage (e.g. -60%) and
+  depress the overall score. All five ratios are now clamped to `[0, 1]` via a `_clamp01` helper — a
+  no-op for in-range inputs. The single helper change also fixes `ferry stats` (it delegates to the
+  same function).
+
 ## [2.6.12] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.12"
+version = "2.6.13"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.12"
+__version__ = "2.6.13"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -498,6 +498,20 @@ async def _merge_threads(
             # state.json) degrades to "no threshold" rather than crashing int().
             if _thread_skip_below and not _thread_skip_below.isdigit():
                 _thread_skip_below = ""
+            # Batch 7 S1 (#76 self-heal ported): ids that failed to POST on a prior run
+            # sit below the high-water mark; on incremental, exclude them from the skip so
+            # the merge re-POSTs them. Empty unless incremental, so --resume is unaffected.
+            # Scoped to parent_stoat_id (mirrors the parallel path's stoat_channel_id filter).
+            _failed_ids_here = (
+                {
+                    fm.discord_msg_id
+                    for fm in state.failed_messages
+                    if fm.stoat_channel_id == parent_stoat_id
+                }
+                if config.incremental
+                else set()
+            )
+            _succeeded_ids: set[str] = set()
             _thread_max_id = 0
             _posted = 0
 
@@ -519,12 +533,13 @@ async def _merge_threads(
                         idempotency_key=f"ferry-thread-sep-{export.channel.id}",
                     )
                 except Exception as exc:  # noqa: BLE001
+                    safe_exc = safe_sanitize(config.token_store, str(exc))
                     state.warnings.append(
                         {
                             "phase": "messages",
                             "type": "merge_separator_failed",
                             "message": (
-                                f"Thread separator for {export.channel.name!r} failed: {exc}"
+                                f"Thread separator for {export.channel.name!r} failed: {safe_exc}"
                             ),
                         }
                     )
@@ -544,14 +559,21 @@ async def _merge_threads(
                     _thread_max_id = _mid
                 if msg.type in _SKIP_TYPES:
                     continue
-                # Incremental: skip messages already copied on a prior run.
-                if _thread_skip_below and _mid is not None and _mid <= int(_thread_skip_below):
+                # Incremental: skip messages already copied on a prior run, UNLESS this id
+                # failed on a prior run (#76 self-heal) — then re-attempt it.
+                _would_skip = (
+                    bool(_thread_skip_below)
+                    and _mid is not None
+                    and _mid <= int(_thread_skip_below)
+                )
+                if _would_skip and msg.id not in _failed_ids_here:
                     continue
 
                 content = _build_content(msg, state)
                 masquerade = await _build_masquerade(msg.author, session, state, config)
                 parts = _split_message(content)
 
+                _msg_failed = False
                 for part_idx, part_content in enumerate(parts):
                     idem_key = (
                         f"ferry-merge-{msg.id}"
@@ -569,14 +591,32 @@ async def _merge_threads(
                             idempotency_key=idem_key,
                         )
                     except Exception as exc:  # noqa: BLE001
+                        safe_exc = safe_sanitize(config.token_store, str(exc))
                         state.warnings.append(
                             {
                                 "phase": "messages",
                                 "type": "merge_message_failed",
-                                "message": f"Merge message {msg.id} failed: {exc}",
+                                "message": f"Merge message {msg.id} failed: {safe_exc}",
                             }
                         )
+                        # Batch 7 S1: record the failure ONCE per message (a multi-part
+                        # message strands on the first failing part) so it lands in
+                        # failed_messages — recoverable via incremental re-attempt / retry.
+                        if not _msg_failed:
+                            _msg_failed = True
+                            state.failed_messages.append(
+                                FailedMessage(
+                                    discord_msg_id=msg.id,
+                                    stoat_channel_id=parent_stoat_id,
+                                    error=safe_exc,
+                                    content_preview=content[:50] if content else "",
+                                )
+                            )
 
+                # A message that POSTed all parts cleanly drives reconciliation (drop on
+                # success); a failed one is left in failed_messages for the next run.
+                if not _msg_failed:
+                    _succeeded_ids.add(msg.id)
                 _posted += 1
                 await _rate_limit_with_pause(config)
 
@@ -584,6 +624,27 @@ async def _merge_threads(
             # --incremental run skips already-copied messages). Overwrite, like flatten.
             if _thread_max_id:
                 state.channel_high_water[export.channel.id] = str(_thread_max_id)
+
+            # Batch 7 S1: reconcile this parent's previously-failed ids (mirrors the
+            # parallel path :849-867). Drop any that succeeded this run (in _succeeded_ids
+            # — the merge path never writes message_map), and collapse the carried +
+            # fresh-re-fail duplicate to one entry. Scoped to parent_stoat_id + the ids
+            # carried into this thread, so sibling threads' entries are untouched.
+            if config.incremental and _failed_ids_here:
+                _seen: set[str] = set()
+                _reconciled: list[FailedMessage] = []
+                for fm in state.failed_messages:
+                    if (
+                        fm.stoat_channel_id == parent_stoat_id
+                        and fm.discord_msg_id in _failed_ids_here
+                    ):
+                        if fm.discord_msg_id in _succeeded_ids:
+                            continue  # succeeded this run -> drop
+                        if fm.discord_msg_id in _seen:
+                            continue  # carried + re-fail dup -> collapse
+                        _seen.add(fm.discord_msg_id)
+                    _reconciled.append(fm)
+                state.failed_messages = _reconciled
 
             on_event(
                 MigrationEvent(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -808,8 +808,12 @@ async def run_categories(
         # Suppress this transient upsert when no category is genuinely new: it
         # would set empty channels arrays and orphan carried channels until the
         # CHANNELS phase re-PATCHes. run_channels owns the authoritative upsert.
+        # Batch 7 S2: ALSO suppress in incremental mode — even a genuinely-new category
+        # here would full-replace away carried-only categories (built from this run's
+        # partial export). run_channels enumerates the FULL category_map, so it is the
+        # single authoritative (non-destructive) upsert in incremental runs.
         any_new_category = any(cid not in pre_existing_category_ids for cid, _ in unique_categories)
-        if stoat_categories and any_new_category:
+        if stoat_categories and any_new_category and not config.incremental:
             await api_upsert_categories(
                 session,
                 config.stoat_url,

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -17,6 +17,17 @@ if TYPE_CHECKING:
     from discord_ferry.state import MigrationState
 
 
+def _clamp01(value: float) -> float:
+    """Clamp a ratio into [0.0, 1.0].
+
+    Defends against scope-mismatched numerators (Batch 7 S3): in incremental mode the
+    denominator is this-run's partial source total while failed_count is carried
+    cumulatively, so an unclamped ratio could go negative (or >1). A no-op for any ratio
+    already in range.
+    """
+    return max(0.0, min(1.0, value))
+
+
 def compute_fidelity_score(
     total_messages: int,
     failed_count: int,
@@ -54,11 +65,13 @@ def compute_fidelity_score(
         Dict with 'overall', 'messages', 'attachments', 'embeds', 'replies',
         and 'reactions' scores (0-100).
     """
-    msg_ratio = (total_messages - failed_count) / max(total_messages, 1)
-    att_ratio = attachments_uploaded / max(attachments_uploaded + attachments_skipped, 1)
-    embed_ratio = (embeds_total - embeds_dropped) / embeds_total if embeds_total else 1.0
-    reply_ratio = replies_linked / replies_total if replies_total else 1.0
-    reaction_ratio = reactions_applied / max(reactions_total, 1) if reactions_total else 1.0
+    msg_ratio = _clamp01((total_messages - failed_count) / max(total_messages, 1))
+    att_ratio = _clamp01(attachments_uploaded / max(attachments_uploaded + attachments_skipped, 1))
+    embed_ratio = _clamp01((embeds_total - embeds_dropped) / embeds_total) if embeds_total else 1.0
+    reply_ratio = _clamp01(replies_linked / replies_total) if replies_total else 1.0
+    reaction_ratio = (
+        _clamp01(reactions_applied / max(reactions_total, 1)) if reactions_total else 1.0
+    )
     overall = (
         msg_ratio * 0.40
         + att_ratio * 0.25

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -910,3 +910,142 @@ async def test_rebuild_forum_indexes_reports_cumulative_counts(tmp_path: Path) -
     assert "<#stoat-fp1> — 47 messages migrated" not in content, (
         "Index showed delta count, not cumulative"
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch 7 S2 — non-destructive incremental category upsert
+# ---------------------------------------------------------------------------
+
+
+async def test_incremental_run_categories_skips_early_upsert(tmp_path: Path) -> None:
+    """SC-14: incremental run_categories does NOT fire the destructive early upsert.
+
+    This also closes the critique M2 concern: because run_categories never PATCHes in
+    incremental mode, there is no destructive intermediate state for a crash/cancel to
+    land in (carried-only categories stay live until run_channels' authoritative upsert),
+    even in the zero-channel edge where run_channels would skip its own upsert.
+    """
+    exports = [
+        _make_export(
+            channel_id="chNew", channel_name="new", category_id="catNew", category="NewCat"
+        ),
+    ]
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"catOld": "stoat-catOld"},  # carried-only, absent from this export
+        category_names={"catOld": "OldCat"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    patch_bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_categories(config, state, exports, lambda e: None)
+    assert patch_bodies == []  # no destructive early upsert in incremental mode
+    assert "catNew" in state.category_map  # map population still happens
+
+
+async def test_fresh_run_categories_fires_early_upsert(tmp_path: Path) -> None:
+    """SC-15: a fresh (non-incremental) run still fires run_categories' early upsert."""
+    exports = [
+        _make_export(
+            channel_id="chNew", channel_name="new", category_id="catNew", category="NewCat"
+        ),
+    ]
+    state = MigrationState(stoat_server_id="srv1")
+    config = _make_config(tmp_path, incremental=False)
+    patch_bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_categories(config, state, exports, lambda e: None)
+    assert patch_bodies, "fresh run must fire the early upsert (non-regression)"
+
+
+async def test_incremental_final_upsert_includes_carried_and_new(tmp_path: Path) -> None:
+    """SC-16: after run_channels, the authoritative upsert holds carried + new categories."""
+    exports = [
+        _make_export(
+            channel_id="chNew", channel_name="new", category_id="catNew", category="NewCat"
+        ),
+    ]
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"catOld": "stoat-catOld"},  # carried-only
+        channel_map={"chOld": "stoat-chOld"},
+        category_names={"catOld": "OldCat"},
+        channel_categories={"chOld": "catOld"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    patch_bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/channels", payload={"_id": "stoat-chNew"}, repeat=True)
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+    assert patch_bodies, "run_channels must own the authoritative upsert"
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    assert "stoat-catOld" in by_id  # carried-only category survives
+    assert state.category_map["catNew"] in by_id  # new category materialized
+    assert "stoat-chOld" in by_id["stoat-catOld"]["channels"]  # carried channel re-attached
+
+
+async def test_incremental_multiple_carried_only_categories_survive(tmp_path: Path) -> None:
+    """SC-18: multiple simultaneously carried-only categories all survive (no contamination)."""
+    exports = [
+        _make_export(
+            channel_id="chNew", channel_name="new", category_id="catNew", category="NewCat"
+        ),
+    ]
+    state = MigrationState(
+        stoat_server_id="srv1",
+        category_map={"catA": "stoat-catA", "catB": "stoat-catB"},  # two carried-only
+        channel_map={"chA": "stoat-chA", "chB": "stoat-chB"},
+        category_names={"catA": "Alpha", "catB": "Beta"},
+        channel_categories={"chA": "catA", "chB": "catB"},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    patch_bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/channels", payload={"_id": "stoat-chNew"}, repeat=True)
+        m.patch(
+            f"{STOAT_URL}/servers/srv1",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: patch_bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_categories(config, state, exports, lambda e: None)
+        await run_channels(config, state, exports, lambda e: None)
+    categories = patch_bodies[-1].get("categories", [])
+    by_id = {c["id"]: c for c in categories}  # type: ignore[index,union-attr]
+    assert "stoat-catA" in by_id and "stoat-catB" in by_id
+    assert by_id["stoat-catA"]["channels"] == ["stoat-chA"]
+    assert by_id["stoat-catB"]["channels"] == ["stoat-chB"]  # no cross-contamination
+
+
+async def test_incremental_gate_does_not_touch_dry_run(tmp_path: Path) -> None:
+    """SC-19: dry-run still maps categories and makes no HTTP (gate is after the return)."""
+    exports = [
+        _make_export(
+            channel_id="chNew", channel_name="new", category_id="catNew", category="NewCat"
+        ),
+    ]
+    state = MigrationState(stoat_server_id="srv1")
+    config = _make_config(tmp_path, incremental=True, dry_run=True)
+    with aioresponses():  # any HTTP would raise (none registered)
+        await run_categories(config, state, exports, lambda e: None)
+    assert state.category_map["catNew"] == "dry-cat-catNew"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -907,3 +907,81 @@ def test_generate_report_reactions_dropped_lowers_score(tmp_path: Path) -> None:
     state = MigrationState(reactions_applied=3, reactions_dropped=1)  # pending empty
     report = generate_report(config, state, exports)
     assert report["fidelity"]["reactions"] == 75.0  # 3 / (3 + 1)
+
+
+# ---------------------------------------------------------------------------
+# Batch 7 S3 — clamp fidelity ratios to [0, 1]
+# ---------------------------------------------------------------------------
+
+
+def test_fidelity_messages_clamped_when_failed_exceeds_total() -> None:
+    """SC-20: failed_count > total_messages -> messages == 0.0 (not negative)."""
+    score = compute_fidelity_score(
+        total_messages=50, failed_count=80, attachments_uploaded=10, attachments_skipped=0
+    )
+    assert score["messages"] == 0.0
+
+
+def test_fidelity_all_subscores_in_bounds_for_overscope() -> None:
+    """SC-21: all sub-scores + overall stay within [0, 100] for over-scope inputs."""
+    score = compute_fidelity_score(
+        total_messages=50,
+        failed_count=80,
+        attachments_uploaded=10,
+        attachments_skipped=0,
+        embeds_total=5,
+        embeds_dropped=9,
+        replies_total=5,
+        replies_linked=9,
+        reactions_total=5,
+        reactions_applied=9,
+    )
+    for key in ("messages", "attachments", "embeds", "replies", "reactions", "overall"):
+        assert 0.0 <= score[key] <= 100.0
+
+
+def test_fidelity_in_range_is_identity() -> None:
+    """SC-22: a fully in-range vector is unchanged by the clamp (no-op non-regression)."""
+    score = compute_fidelity_score(
+        total_messages=100,
+        failed_count=5,
+        attachments_uploaded=90,
+        attachments_skipped=10,
+        embeds_total=10,
+        embeds_dropped=2,
+        replies_total=10,
+        replies_linked=7,
+        reactions_total=5,
+        reactions_applied=4,
+    )
+    assert score["messages"] == 95.0
+    assert score["attachments"] == 90.0
+    assert score["embeds"] == 80.0
+    assert score["replies"] == 70.0
+    assert score["reactions"] == 80.0
+
+
+def test_fidelity_total_zero_clamps() -> None:
+    """SC-23: total_messages=0 with failures -> messages clamped to 0.0, no error."""
+    score = compute_fidelity_score(
+        total_messages=0, failed_count=3, attachments_uploaded=0, attachments_skipped=0
+    )
+    assert score["messages"] == 0.0
+
+
+def test_fidelity_overall_not_depressed_by_clamped_messages() -> None:
+    """SC-25: a clamped (0) messages term contributes 0, no negative drag on overall."""
+    score = compute_fidelity_score(
+        total_messages=50,
+        failed_count=80,
+        attachments_uploaded=100,
+        attachments_skipped=0,
+        embeds_total=10,
+        embeds_dropped=0,
+        replies_total=10,
+        replies_linked=10,
+        reactions_total=10,
+        reactions_applied=10,
+    )
+    # messages=0 (*0.40); att/embed/reply/reaction = 1.0 -> 0.25+0.15+0.10+0.10 = 0.60
+    assert score["overall"] == 60.0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -489,3 +489,24 @@ def test_summarize_state_capped_reactions_lower_ratio() -> None:
     state = MigrationState(reactions_applied=8, reactions_capped=2)  # pending empty
     summary = summarize_state(state)
     assert summary.fidelity.reactions == 80.0  # 8 / (8 + 2)
+
+
+# ---------------------------------------------------------------------------
+# Batch 7 S3 — clamped fidelity propagates through ferry stats
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_state_messages_fidelity_clamped() -> None:
+    """SC-24: ferry stats shows messages 0.0 when carried failures exceed this-run source.
+
+    Confirms summarize_state delegates to compute_fidelity_score (single clamp fixes both).
+    """
+    from discord_ferry.state import FailedMessage
+
+    state = MigrationState(stoat_server_id="srv1")
+    state.source_messages_total = 50
+    state.failed_messages = [
+        FailedMessage(discord_msg_id=str(i), stoat_channel_id="c", error="boom") for i in range(80)
+    ]
+    summary = summarize_state(state)
+    assert summary.fidelity.messages == 0.0

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core.security import SecureTokenStore
 from discord_ferry.migrator.messages import run_messages
 from discord_ferry.migrator.structure import run_channels
 from discord_ferry.parser.models import (
@@ -16,7 +17,7 @@ from discord_ferry.parser.models import (
     DCEGuild,
     DCEMessage,
 )
-from discord_ferry.state import MigrationState
+from discord_ferry.state import FailedMessage, MigrationState
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -542,3 +543,287 @@ async def test_merge_non_numeric_marker_no_crash(tmp_path: Path) -> None:
     # Threshold normalized to "" -> every message copies (idempotent), no ValueError.
     assert "ferry-merge-10" in keys
     assert "ferry-merge-20" in keys
+
+
+# ---------------------------------------------------------------------------
+# Batch 7 S1 — thread-merge failed-message self-heal (#76 pattern ported)
+# ---------------------------------------------------------------------------
+
+
+def _fail_on(fail_ids: set[str], keys: list[str] | None = None) -> object:
+    """Patch target for api_send_message: raise for merge POSTs whose key maps to a
+    msg.id in fail_ids; else record the idempotency_key + return a fake id.
+
+    Mirrors _capture_keys but injects a per-message send failure.
+    """
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        key = str(kwargs.get("idempotency_key", ""))
+        mid = ""
+        if key.startswith("ferry-merge-"):
+            mid = key[len("ferry-merge-") :].split("_p")[0]
+        if mid and mid in fail_ids:
+            raise RuntimeError(f"simulated send failure for {mid}")
+        if keys is not None:
+            keys.append(key)
+        return {"_id": f"stoat-{key}"}
+
+    return _send
+
+
+async def test_merge_success_records_no_failure(tmp_path: Path) -> None:
+    """SC-1: a fully-successful merge run records zero FailedMessage (non-regression)."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(
+        tmp_path, ["10", "20", "30"], marker=None, incremental=False
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys([])):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert state.failed_messages == []
+    assert state.channel_high_water["200"] == "30"
+
+
+async def test_merge_failure_recorded_plain_mode(tmp_path: Path) -> None:
+    """SC-2: a merge POST failure is recorded as a FailedMessage even in plain mode."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(
+        tmp_path, ["10", "20", "30"], marker=None, incremental=False
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    failed = [fm for fm in state.failed_messages if fm.discord_msg_id == "20"]
+    assert len(failed) == 1
+    assert failed[0].stoat_channel_id == "stoat-ch-100"
+    assert failed[0].content_preview  # non-empty preview from built content
+    assert state.channel_high_water["200"] == "30"  # marker still max(all ids)
+
+
+async def test_merge_incremental_reattempts_prior_failed_id(tmp_path: Path) -> None:
+    """SC-3: a prior-failed id below the marker is re-attempted on --incremental."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert state.channel_high_water["200"] == "30"
+    assert any(fm.discord_msg_id == "20" for fm in state.failed_messages)
+    # run 2: reuse state, all succeed; "20" must be re-attempted despite <= marker.
+    config2, _s2, parent2, thread2 = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    keys2: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys2)):
+        await run_messages(config2, state, [parent2, thread2], lambda e: None)
+    assert "ferry-merge-20" in keys2
+    assert "ferry-merge-10" not in keys2  # already-copied, not failed -> skipped
+
+
+async def test_merge_reattempt_success_drops_entry(tmp_path: Path) -> None:
+    """SC-4: a successful re-attempt drops the entry from failed_messages."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    config2, _s2, parent2, thread2 = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys([])):
+        await run_messages(config2, state, [parent2, thread2], lambda e: None)
+    assert not any(fm.discord_msg_id == "20" for fm in state.failed_messages)
+
+
+async def test_merge_reattempt_refail_collapses_to_one(tmp_path: Path) -> None:
+    """SC-5: a re-failing id stays as exactly one entry (carried+re-fail collapsed)."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    config2, _s2, parent2, thread2 = _merge_setup(tmp_path, ["10", "20", "30"], marker=None)
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config2, state, [parent2, thread2], lambda e: None)
+    assert len([fm for fm in state.failed_messages if fm.discord_msg_id == "20"]) == 1
+
+
+async def test_merge_plain_mode_ignores_marker_no_failrecord_on_success(tmp_path: Path) -> None:
+    """SC-6: plain mode (incremental=False) ignores the marker (no skip), no FailedMessage."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(
+        tmp_path, ["10", "20", "30"], marker="20", incremental=False
+    )
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    # No incremental skip in plain mode: every message is (re-)posted, no FailedMessage.
+    assert {"ferry-merge-10", "ferry-merge-20", "ferry-merge-30"}.issubset(set(keys))
+    assert state.failed_messages == []
+
+
+async def test_merge_multipart_failure_records_one(tmp_path: Path) -> None:
+    """SC-7: a multi-part message with a failing part records exactly one FailedMessage."""
+    from unittest.mock import patch
+
+    long_text = "a" * 5000  # > 2000 -> _split_message yields multiple parts
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=False
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("50", long_text)],
+        message_count=1,
+    )
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        key = str(kwargs.get("idempotency_key", ""))
+        if key == "ferry-merge-50_p2":
+            raise RuntimeError("part 2 fails")
+        return {"_id": f"stoat-{key}"}
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _send):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert len([fm for fm in state.failed_messages if fm.discord_msg_id == "50"]) == 1
+
+
+async def test_merge_cross_thread_sibling_safety(tmp_path: Path) -> None:
+    """SC-8: thread B completion does not drop/mangle thread A's still-failed entry."""
+    from unittest.mock import patch
+
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=True
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    state.channel_high_water["200"] = "30"
+    state.channel_high_water["201"] = "31"
+    state.failed_messages.append(
+        FailedMessage(
+            discord_msg_id="20", stoat_channel_id="stoat-ch-100", error="prior", content_preview="x"
+        )
+    )
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread_a = _make_export(
+        channel_id="200",
+        channel_name="thread-a",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message(m, f"m{m}") for m in ["10", "20", "30"]],
+        message_count=3,
+    )
+    thread_b = _make_export(
+        channel_id="201",
+        channel_name="thread-b",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message(m, f"m{m}") for m in ["11", "21", "31"]],
+        message_count=3,
+    )
+    # B succeeds; A's "20" re-fails -> A keeps exactly one entry, B adds none, none mangled.
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"20"})):
+        await run_messages(config, state, [parent, thread_a, thread_b], lambda e: None)
+    assert len([fm for fm in state.failed_messages if fm.discord_msg_id == "20"]) == 1
+
+
+async def test_merge_fully_failed_message_is_recorded_for_retry(tmp_path: Path) -> None:
+    """SC-9: a fully-failed merge message is recorded so ferry retry can recover it.
+
+    KNOWN LIMITATION (documented, design §S1 I1): the incremental re-attempt path
+    (SC-3/4/5) is the asserted-correct recovery and is idempotency-safe. `ferry retry`
+    recovers a FULLY-failed merge message cleanly, but recovering a PARTIAL-SUCCESS
+    multi-part merge message via `ferry retry` may duplicate already-sent parts (the
+    `ferry-merge-` vs `ferry-` idempotency-namespace mismatch). We do NOT assert the
+    duplicate as desired; this test only asserts the recordable surface.
+    """
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10"], marker=None, incremental=False)
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"10"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    failed = [fm for fm in state.failed_messages if fm.discord_msg_id == "10"]
+    assert len(failed) == 1
+    assert failed[0].stoat_channel_id == "stoat-ch-100"  # retry posts to the parent channel
+
+
+async def test_merge_failure_sanitizes_token(tmp_path: Path) -> None:
+    """SC-10: a token in the exception is absent from FailedMessage.error AND warnings."""
+    from unittest.mock import patch
+
+    token = "SECRET-TOKEN-12345"
+    config = _make_config(
+        tmp_path, thread_strategy="merge", message_rate_limit=0.0, incremental=False
+    )
+    config.token_store = SecureTokenStore({"discord": token})
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    parent = _make_export(channel_id="100", channel_name="general")
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("60", "hi")],
+        message_count=1,
+    )
+
+    async def _send(
+        session: object, stoat_url: object, token_: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        raise RuntimeError(f"boom {token}")
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _send):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert all(token not in (fm.error or "") for fm in state.failed_messages)
+    assert all(token not in str(w.get("message", "")) for w in state.warnings)
+
+
+async def test_merge_empty_thread_no_marker_no_failure(tmp_path: Path) -> None:
+    """SC-11: an empty merge thread writes no marker and records no failure."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, [], marker=None, incremental=False)
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys([])):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert state.failed_messages == []
+    assert "200" not in state.channel_high_water
+
+
+async def test_merge_separator_failure_not_recorded_as_failed(tmp_path: Path) -> None:
+    """SC-12: a separator failure is warn-only, never a FailedMessage."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(tmp_path, ["10", "20"], marker=None)
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        key = str(kwargs.get("idempotency_key", ""))
+        if key.startswith("ferry-thread-sep-"):
+            raise RuntimeError("sep fails")
+        return {"_id": f"stoat-{key}"}
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _send):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert state.failed_messages == []
+    assert any(w.get("type") == "merge_separator_failed" for w in state.warnings)
+
+
+async def test_merge_non_numeric_id_failure_recorded(tmp_path: Path) -> None:
+    """SC-13: a non-numeric merge id that fails is recorded; numeric marker unaffected."""
+    from unittest.mock import patch
+
+    config, state, parent, thread = _merge_setup(
+        tmp_path, ["sys-x", "30"], marker=None, incremental=False
+    )
+    with patch("discord_ferry.migrator.messages.api_send_message", _fail_on({"sys-x"})):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+    assert any(fm.discord_msg_id == "sys-x" for fm in state.failed_messages)
+    assert state.channel_high_water["200"] == "30"  # max over numeric ids only

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.12"
+version = "2.6.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Bug-Hunt Batch 7 — Incremental Edge Cases (v2.6.13)

Seventh batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (§4 Batch 7). Three engine-side incremental-mode fixes; no GUI/CLI/state-schema change.

### S1 / F7a — merge-thread failed-message self-heal (`migrator/messages.py`, MEDIUM, data-integrity)
`thread_strategy="merge"` POST failures were recorded only as warnings while the high-water marker was written regardless, so on a later `--incremental` run the failed id sat below the marker and was skipped forever — permanent silent loss, unrecoverable by `ferry retry`. The shipped #76 self-heal is ported into the merge loop: a POST failure is recorded as a `FailedMessage` (all modes); on `--incremental` a prior-failed id is excluded from the skip gate and re-attempted; a completion reconciliation drops ids that succeeded this run (via a loop-local `_succeeded_ids` — the merge path never writes `message_map`) and collapses a carried + re-fail duplicate to one entry. Marker write unchanged (plain/resume byte-identical). Both merge warnings (separator + message) now `safe_sanitize`'d (never persist a token to `state.json`).

**Known limitation (documented):** the `--incremental` re-attempt is the idempotency-safe primary recovery; recovering a *partial-success multi-part* merge message via `ferry retry` may re-send already-delivered parts (the `ferry-merge-` vs `ferry-` idempotency-namespace difference). A proper fix needs the merge context threaded into the retry engine — out of scope.

### S2 / F7b — non-destructive incremental category upsert (`migrator/structure.py`, LOW, resume)
`run_categories`' early full-replace category PATCH (built from this run's partial export) deleted carried-only categories in incremental mode until `run_channels` re-PATCHed. The early upsert is now skipped in incremental mode; `run_channels`' authoritative full-map enumerate upsert is the single source of truth. Fresh (non-incremental) runs unchanged.

### S3 / F7c — clamp fidelity ratios (`reporter.py`, MEDIUM, data-integrity)
`compute_fidelity_score` could render a negative Messages percentage in incremental mode (carried cumulative `failed_count` > this-run partial `source_messages_total`). All five ratios are clamped to `[0, 1]` via a `_clamp01` helper — a no-op for in-range inputs. The single helper change also fixes `ferry stats` (delegates to the same function).

### Quality gates
- **1246 tests** (24 new: SC-1..SC-25; 0 existing modified — append-only). `ruff check .` + `ruff format --check .` + `mypy src/` clean.
- `/df` pipeline: brief → spec → brainstorm → **critique (fresh opus): ITERATE → PASS** (caught I1 multi-part `ferry retry` duplicate → scoped + documented; I2 raw-`{exc}` warning beside a sanitized error → both now sanitized) → test-scenarios → controller-driven build.
- Code review (fresh opus): **APPROVE** (0 Critical/Important). Mistral second opinion: 10 findings, all false-positive or out-of-scope on source verification.
- Each new guard falsified individually (revert → RED → restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
