### PR TITLE
fix: GUI lifecycle — cached-export choice + memory-only token storage (v2.6.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.14] - 2026-06-28
+
+### Fixed
+
+GUI lifecycle — the eighth batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt
+(`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 8). Two GUI-shell-only fixes in
+`gui.py`; no engine/parser/CLI/state-schema changes. Both close documented residuals of the
+v2.6.1 token-lifecycle rework.
+
+- **The cached-export choice is now honoured** (`gui.py`, S1/F8a). On `/export`, the
+  "Use Cached"/"Re-export" choice card was inert: `background_tasks.create(_run_export())` ran
+  unconditionally on page load, racing the click — re-validating the token, re-downloading DCE,
+  re-running the export and overwriting the cached JSON, then navigating away. The auto-launch is now
+  gated behind `_should_auto_export(cached)` (fires only when no cache exists); "Use Cached" goes
+  straight to `/validate` (and clears the now-unneeded Discord token — no skip-path leak), while
+  "Re-export" launches the export explicitly. The cached fast-path works and the cached JSON is no
+  longer clobbered.
+
+- **Session tokens are never persisted to disk** (`gui.py`, S2/F8b, security). The Stoat and Discord
+  tokens were written to `app.storage.user`, which NiceGUI persists to `.nicegui/storage-user.json`
+  on disk; the only clear ran at the terminal migration screen, so abandoning the flow (or a crash)
+  before migration started stranded a plaintext token on disk — and the setup form even pre-filled
+  the token fields from that on-disk copy. Both token values now live only in NiceGUI's memory-only
+  per-tab store (`app.storage.tab`): never written to disk, dropped when the tab closes, and
+  surviving in-tab navigation so the setup→export→validate→migrate handoff is preserved. This closes
+  the abandonment window in every mode, including a hard crash. The token input fields no longer
+  pre-fill (re-enter each launch — the `security.md`-aligned norm), a setup-load scrub removes any
+  token left on disk by a pre-fix version, and missing-token restart edges bounce cleanly to setup
+  with a "session expired" notice. Engine/shell separation is unchanged (the engine never reads
+  `app.storage`).
+
 ## [2.6.13] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.13"
+version = "2.6.14"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.13"
+__version__ = "2.6.14"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -132,6 +132,18 @@ def _clear_tokens(storage: MutableMapping[str, Any], keys: Iterable[str]) -> Non
         storage.pop(key, None)
 
 
+def _store_session_tokens(store: MutableMapping[str, Any], *, stoat: str, discord: str) -> None:
+    """Write the two session tokens into ``store``.
+
+    Production passes ``app.storage.tab`` (memory-only, never written to disk —
+    see Batch 8 / F8b). The parameter is named ``store`` (not ``storage``) so the
+    security source-inspection guard, which forbids token assignment via the
+    disk-backed ``storage`` alias, cannot false-match this body.
+    """
+    store["token"] = stoat
+    store["discord_token"] = discord
+
+
 def _format_eta(total_messages: int, rate_limit: float) -> str:
     """Format an ETA string from message count and rate limit."""
     seconds = int(total_messages * rate_limit)
@@ -222,6 +234,17 @@ def _detect_cached_exports(export_dir: Path) -> dict[str, int] | None:
     return {"file_count": len(json_files), "total_size": total_size}
 
 
+def _should_auto_export(cached: dict[str, int] | None) -> bool:
+    """True when the /export page should auto-launch DCE on load.
+
+    Only auto-launch when there is no cached export. When a cache exists the
+    cached-export card's buttons drive the decision (Use Cached / Re-export),
+    so the auto-launch must NOT fire (it would race the click and overwrite the
+    cached JSON). See Batch 8 / F8a.
+    """
+    return cached is None
+
+
 def _render_step_indicator(active_step: int) -> None:
     """Render a 4-step visual indicator (1-indexed). Call inside a ui.column."""
     with ui.row().classes("w-full justify-center items-center gap-0 mb-6"):
@@ -257,6 +280,9 @@ def setup_page() -> None:
     """Setup screen — collect connection details and migration options."""
     ui.add_head_html(_HEAD_HTML)
     storage = app.storage.user
+    # Scrub any token a pre-fix version persisted to .nicegui/storage-user.json.
+    # Tokens now live only in memory (app.storage.tab); see Batch 8 / F8b.
+    _clear_tokens(storage, _SESSION_TOKEN_KEYS)
 
     def _rate_label(value: float) -> str:
         return f"{value:.1f}s/msg ({_msgs_per_hour(value):,} msg/hr)"
@@ -347,7 +373,7 @@ def setup_page() -> None:
                         placeholder="Paste your Discord user token",
                         password=True,
                         password_toggle_button=True,
-                        value=str(storage.get("discord_token", "")),
+                        value="",  # never pre-fill a token from disk (Batch 8 / F8b)
                     ).classes("w-full")
 
                     discord_server_input = ui.input(
@@ -432,7 +458,7 @@ def setup_page() -> None:
                     placeholder="Paste your session token here",
                     password=True,
                     password_toggle_button=True,
-                    value=str(storage.get("token", "")),
+                    value="",  # never pre-fill a token from disk (Batch 8 / F8b)
                 ).classes("w-full")
 
                 with ui.column().classes("gap-0 -mt-2"):
@@ -501,7 +527,7 @@ def setup_page() -> None:
 
                 error_label = ui.label("").classes("text-red-500 text-sm")
 
-                def _on_validate_click() -> None:
+                async def _on_validate_click() -> None:
                     mode = mode_toggle.value or "orchestrated"
                     toggle_val = server_toggle.value or "official"
                     stoat_url = _resolve_stoat_url(toggle_val, custom_url_input.value)
@@ -539,9 +565,12 @@ def setup_page() -> None:
                         error_label.set_text(f"Required: {', '.join(missing)}")
                         return
 
-                    # Store values
+                    # Store values. Tokens go to the memory-only tab store (never to
+                    # disk); tab access needs a connected client — the await is a no-op
+                    # during a live click but guarantees access. See Batch 8 / F8b.
+                    await ui.context.client.connected()
+                    _store_session_tokens(app.storage.tab, stoat=token, discord=discord_token)
                     storage["mode"] = mode
-                    storage["discord_token"] = discord_token
                     storage["discord_server_id"] = discord_server
                     if mode == "offline":
                         storage["export_dir"] = export_dir_input.value.strip()
@@ -551,7 +580,6 @@ def setup_page() -> None:
                     storage["stoat_url"] = stoat_url
                     storage["server_toggle"] = toggle_val
                     storage["custom_stoat_url"] = custom_url_input.value.strip()
-                    storage["token"] = token
                     storage["server_id"] = server_id_input.value.strip()
                     storage["server_name"] = server_name_input.value.strip()
                     storage["rate_limit"] = rate_slider.value
@@ -608,15 +636,22 @@ def export_page() -> None:
                     "text-sm text-gray-500 text-center mb-4"
                 )
                 with ui.row().classes("w-full justify-center gap-4 mt-2"):
-                    ui.button(
-                        "Use Cached",
-                        on_click=lambda: ui.navigate.to("/validate"),
-                    ).props("color=green")
+                    # Use Cached: skip export, clear the now-unneeded Discord token
+                    # (mirrors the export finally's discord-only clear — no skip-path
+                    # leak; the Stoat token survives for /validate). The client is
+                    # connected during a click, so the tab-store access is safe.
+                    def _use_cached() -> None:
+                        _clear_tokens(app.storage.tab, ("discord_token",))
+                        ui.navigate.to("/validate")
 
-                    # export_view is defined below; closure is only invoked on click.
+                    ui.button("Use Cached", on_click=_use_cached).props("color=green")
+
+                    # export_view / _run_export are defined below; closures are only
+                    # invoked on click.
                     def _re_export() -> None:
                         cached_view.set_visibility(False)
                         export_view.set_visibility(True)
+                        background_tasks.create(_run_export())
 
                     ui.button("Re-export", on_click=_re_export).props("color=grey")
 
@@ -689,7 +724,16 @@ def export_page() -> None:
             validate_discord_token,
         )
 
-        discord_token = str(storage.get("discord_token", ""))
+        # Tokens live in the memory-only tab store; need a connected client to read.
+        await ui.context.client.connected()
+        if not app.storage.tab.get("discord_token"):
+            # Restart edge: stale non-secret keys on disk but a fresh tab with no
+            # token. Bounce cleanly rather than raising DiscordAuthError("").
+            ui.notify("Session expired — re-enter your token", type="warning")
+            ui.navigate.to("/")
+            return
+
+        discord_token = str(app.storage.tab.get("discord_token", ""))
         discord_server = str(storage.get("discord_server_id", ""))
         export_dir = Path(str(storage["export_dir"]))
 
@@ -737,7 +781,7 @@ def export_page() -> None:
             config = FerryConfig(
                 export_dir=export_dir,
                 stoat_url=str(storage.get("stoat_url", "")),
-                token=str(storage.get("token", "")),
+                token=str(app.storage.tab.get("token", "")),
                 discord_token=discord_token,
                 discord_server_id=discord_server,
                 cancel_event=cancel_event,
@@ -775,14 +819,18 @@ def export_page() -> None:
             ui.notify(f"Export failed: {exc}", type="negative")
         finally:
             # Clear ONLY the Discord token here — export is its sole consumer.
-            # The Stoat token MUST survive: this finally runs synchronously
-            # BEFORE the queued ui.navigate.to("/validate") redirect loads, and
-            # both validate_page and migrate_page guard on storage["token"].
-            # Clearing it here bounces the user back to setup. The Stoat token is
-            # cleared by the terminal migration screen (migrate_page._run).
-            _clear_tokens(storage, ("discord_token",))
+            # The Stoat token MUST survive for /migrate (which reads it from the
+            # tab store). The pre-migration page guards now check export_dir/
+            # stoat_url, and migrate re-checks the tab token after connected(), so
+            # clearing the Discord token here no longer bounces the user. Tokens
+            # live in the memory-only tab store; suppress in case the task is
+            # cancelled before connected() (the tab access would otherwise raise
+            # and mask the original exception).
+            with contextlib.suppress(Exception):
+                _clear_tokens(app.storage.tab, ("discord_token",))
 
-    background_tasks.create(_run_export())
+    if _should_auto_export(cached):
+        background_tasks.create(_run_export())
 
 
 # ---------------------------------------------------------------------------
@@ -796,7 +844,10 @@ def validate_page() -> None:
     ui.add_head_html(_HEAD_HTML)
 
     storage = app.storage.user
-    if not storage.get("export_dir") or not storage.get("stoat_url") or not storage.get("token"):
+    # Guard on the non-secret setup-complete signal (export_dir + stoat_url are
+    # written in the same validate pass as the token). The token itself now lives
+    # in the memory-only tab store and is re-checked at /migrate. See Batch 8 / F8b.
+    if not storage.get("export_dir") or not storage.get("stoat_url"):
         ui.navigate.to("/")
         return
 
@@ -900,12 +951,20 @@ def validate_page() -> None:
 
 
 @ui.page("/migrate")
-def migrate_page() -> None:
+async def migrate_page() -> None:
     """Migration screen — run the engine, show live phase/progress/log."""
     ui.add_head_html(_HEAD_HTML)
 
     storage = app.storage.user
-    if not storage.get("export_dir") or not storage.get("stoat_url") or not storage.get("token"):
+    if not storage.get("export_dir") or not storage.get("stoat_url"):
+        ui.navigate.to("/")
+        return
+
+    # Tokens live in the memory-only tab store; need a connected client to read it.
+    await ui.context.client.connected()
+    if not app.storage.tab.get("token"):
+        # Restart edge: stale non-secret keys on disk but a fresh tab, no token.
+        ui.notify("Session expired — re-enter your token", type="warning")
         ui.navigate.to("/")
         return
 
@@ -956,7 +1015,7 @@ def migrate_page() -> None:
     config = FerryConfig(
         export_dir=Path(storage["export_dir"]),
         stoat_url=storage["stoat_url"],
-        token=storage["token"],
+        token=app.storage.tab["token"],
         server_id=storage.get("server_id") or None,
         server_name=storage.get("server_name") or None,
         dry_run=bool(storage.get("dry_run", False)),
@@ -971,7 +1030,7 @@ def migrate_page() -> None:
         pause_event=pause_event,
         cancel_event=cancel_event,
         skip_export=True,  # Export already done by this point (via /export or offline mode)
-        discord_token=storage.get("discord_token") or None,
+        discord_token=app.storage.tab.get("discord_token") or None,
         discord_server_id=storage.get("discord_server_id") or None,
     )
 
@@ -1407,12 +1466,18 @@ def migrate_page() -> None:
         finally:
             # Terminal owner of session-token cleanup, for BOTH offline and
             # orchestrated modes, on success AND error. (Offline mode never
-            # visits /export, so its finally is the only cleanup point.) Safe
-            # because this runs AFTER run_migration returns: config already holds
-            # its own token copy (a plain str), the engine never reads
-            # app.storage, and the only in-_run storage read (config.resume,
-            # above) has already completed. Do NOT move token reads below this.
-            _clear_tokens(storage, _SESSION_TOKEN_KEYS)
+            # visits /export, so its finally is the only cleanup point.) Tokens
+            # live in the memory-only tab store; clearing here is good hygiene
+            # (immediate, rather than waiting for the tab to close). Safe because
+            # this runs AFTER run_migration returns: config already holds its own
+            # token copy (a plain str), the engine never reads app.storage, and
+            # the only in-_run storage read (config.resume, above) has already
+            # completed. Do NOT move token reads below this. Suppress for parity
+            # with the export finally: if the tab closed during a long migration,
+            # this background task's tab access would otherwise raise on the now-
+            # disconnected client (the token is memory-only — never on disk).
+            with contextlib.suppress(Exception):
+                _clear_tokens(app.storage.tab, _SESSION_TOKEN_KEYS)
 
     background_tasks.create(_run())
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -354,3 +354,184 @@ def test_session_token_keys_pinned() -> None:
     # Constant-pin: the security-critical key list must never silently shrink.
     # This is the load-bearing CI guard against the recurring token-leak vector.
     assert _SESSION_TOKEN_KEYS == ("token", "discord_token")
+
+
+# ---------------------------------------------------------------------------
+# Batch 8 — S1 cached-export gating
+# ---------------------------------------------------------------------------
+
+
+def test_should_auto_export_none_is_true() -> None:
+    """SC-1: no cached export -> auto-launch (orchestrated happy path, non-regression)."""
+    from discord_ferry.gui import _should_auto_export
+
+    assert _should_auto_export(None) is True
+
+
+def test_should_auto_export_with_cache_is_false() -> None:
+    """SC-2: cached export present -> do NOT auto-run (buttons drive; cached JSON preserved)."""
+    from discord_ferry.gui import _should_auto_export
+
+    assert _should_auto_export({"file_count": 3, "total_size": 1_000_000}) is False
+
+
+def test_use_cached_clears_only_discord_token() -> None:
+    """SC-3: 'Use Cached' clears discord_token only (Stoat token survives for /validate).
+
+    Two-part guard: (1) the _clear_tokens semantics the handler relies on, and
+    (2) source-inspection pinning that the _use_cached handler itself clears the
+    discord-only tuple — NOT _SESSION_TOKEN_KEYS, which would wipe the Stoat token
+    and break the /validate handoff.
+    """
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    # (1) the relied-upon semantics
+    store: dict[str, Any] = {"token": "stoat-tok", "discord_token": "disc-tok"}
+    _clear_tokens(store, ("discord_token",))
+    assert "discord_token" not in store
+    assert store["token"] == "stoat-tok"
+
+    # (2) the handler's actual clear-set is pinned — slice the _use_cached body so
+    # this stays specific even after T3 adds the same literal to the export finally.
+    source = inspect.getsource(gui_mod)
+    idx = source.index("def _use_cached() -> None:")
+    use_cached_body = source[idx : idx + 200]
+    assert "_clear_tokens(app.storage.tab" in use_cached_body
+    assert '("discord_token",)' in use_cached_body
+    assert "_SESSION_TOKEN_KEYS" not in use_cached_body
+
+
+def test_export_launch_is_gated() -> None:
+    """SC-4: the /export auto-launch is behind _should_auto_export(cached)."""
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    assert "if _should_auto_export(cached):" in source
+    # The ungated module-level auto-launch (4-space indented) must no longer exist.
+    assert "\n    background_tasks.create(_run_export())\n" not in source
+
+
+def test_reexport_button_launches_export() -> None:
+    """SC-5: 'Re-export' triggers _run_export (exactly one launch per intent)."""
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    # The re-export handler both toggles visibility AND launches the export.
+    assert "def _re_export() -> None:" in source
+    # Exactly two launch sites: the cached-absent gate + the re-export handler.
+    assert source.count("background_tasks.create(_run_export())") == 2
+
+
+# ---------------------------------------------------------------------------
+# Batch 8 — S2 token lifecycle (memory-only app.storage.tab)
+# ---------------------------------------------------------------------------
+
+
+def test_store_session_tokens_writes_exactly_two_keys() -> None:
+    """SC-7: _store_session_tokens writes exactly token + discord_token, nothing else."""
+    from discord_ferry.gui import _store_session_tokens
+
+    d: dict[str, Any] = {}
+    _store_session_tokens(d, stoat="s", discord="dt")
+    assert d == {"token": "s", "discord_token": "dt"}
+
+
+def test_store_session_tokens_roundtrip_then_clear() -> None:
+    """SC-8: written tokens are readable (data-level handoff); terminal clear wipes both."""
+    from discord_ferry.gui import _store_session_tokens
+
+    d: dict[str, Any] = {}
+    _store_session_tokens(d, stoat="s", discord="dt")
+    assert d["token"] == "s"
+    assert d["discord_token"] == "dt"
+    _clear_tokens(d, _SESSION_TOKEN_KEYS)
+    assert "token" not in d
+    assert "discord_token" not in d
+
+
+def test_legacy_scrub_removes_tokens_keeps_nonsecrets() -> None:
+    """SC-9: the setup-load scrub removes on-disk tokens, leaves non-secret keys."""
+    user: dict[str, Any] = {
+        "token": "old",
+        "discord_token": "old",
+        "export_dir": "/p",
+        "stoat_url": "https://x",
+    }
+    _clear_tokens(user, _SESSION_TOKEN_KEYS)  # the setup-load scrub
+    assert "token" not in user
+    assert "discord_token" not in user
+    assert user["export_dir"] == "/p"
+    assert user["stoat_url"] == "https://x"
+
+
+def test_tokens_never_disk_backed() -> None:
+    """SC-10 (load-bearing): tokens go to app.storage.tab, never to app.storage.user.
+
+    Brittle-by-design CI guard against the recurring token-leak vector: if any
+    future refactor reverts a token write to the disk-backed app.storage.user
+    alias, or restores a token pre-fill, this fails loudly.
+    """
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    # (a) token writes target the memory-only tab store
+    assert "_store_session_tokens(app.storage.tab" in source
+    # (b) the disk-backed app.storage.user alias is NEVER a token assignment target
+    assert 'storage["token"] =' not in source
+    assert 'storage["discord_token"] =' not in source
+    # (c) the token input fields do NOT pre-fill from storage (value="" — no disk read)
+    assert 'value=str(storage.get("token"' not in source
+    assert 'value=str(storage.get("discord_token"' not in source
+
+
+def test_token_access_uses_connected_client() -> None:
+    """SC-11: token read/write sites await a connected client (tab access is then valid)."""
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    assert "async def _on_validate_click() -> None:" in source
+    assert "async def migrate_page() -> None:" in source
+    # validate-click, _run_export, migrate_page each await a connected client.
+    assert source.count("await ui.context.client.connected()") >= 3
+    # _run_export restart-bounce on a missing tab discord_token.
+    assert 'app.storage.tab.get("discord_token")' in source
+
+
+def test_page_guards_drop_token_term() -> None:
+    """SC-12: validate/migrate top-guards no longer read storage.get('token')."""
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    # The old 3-term guard (…or not storage.get("token")) must be gone.
+    assert 'or not storage.get("token")' not in source
+    # migrate re-checks the token in the tab store after connected().
+    assert 'if not app.storage.tab.get("token"):' in source
+
+
+def test_export_finally_suppresses_tab_clear() -> None:
+    """SC-13 (M4): the export finally tab clear is exception-suppressed.
+
+    Anchored on the export finally's unique comment and sliced, so it stays
+    specific to THIS site (contextlib.suppress is used at several other places).
+    """
+    import inspect
+
+    import discord_ferry.gui as gui_mod
+
+    source = inspect.getsource(gui_mod)
+    idx = source.index("# and mask the original exception).")
+    region = source[idx : idx + 200]
+    assert "with contextlib.suppress(Exception):" in region
+    assert '_clear_tokens(app.storage.tab, ("discord_token",))' in region

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.13"
+version = "2.6.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Bug-Hunt Batch 8 — GUI Lifecycle (v2.6.14)

Eighth batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (§4 Batch 8). Two GUI-shell-only fixes in `gui.py`; no engine/parser/CLI/state-schema change. Both close documented residuals of the v2.6.1 token-lifecycle rework.

### S1 / F8a — cached-export choice now honoured (`gui.py` export_page, MEDIUM)
The `/export` cached-export card's "Use Cached"/"Re-export" buttons were inert: `background_tasks.create(_run_export())` ran **unconditionally** on page load, racing the user's click — re-validating the token, possibly re-downloading DCE, re-running the export and **overwriting the cached JSON**, then navigating away. The auto-launch is now gated behind a pure helper `_should_auto_export(cached)` (fires only when no cache exists). "Use Cached" goes straight to `/validate` and clears only the Discord token (no skip-path leak; the Stoat token survives for `/validate`); "Re-export" launches the export explicitly. `_run_export`'s body is unchanged — exactly one launch per user intent.

### S2 / F8b — session tokens never persisted to disk (`gui.py` token lifecycle, MEDIUM, security)
The Stoat and Discord tokens were written to `app.storage.user`, which NiceGUI persists to `.nicegui/storage-user.json` **on disk**; the only clear ran at the terminal migration screen, so abandoning the flow (or a crash) before migration started left a plaintext token on disk — and the setup form even pre-filled the token fields from that on-disk copy. Violates `security.md` ("never persist Discord tokens to disk").

Both token values now live only in NiceGUI's **memory-only** per-tab store (`app.storage.tab`): never written to disk, dropped when the tab closes, and surviving in-tab navigation so the setup→export→validate→migrate handoff is preserved. This closes the abandonment window in **every** mode, including a hard crash (Context7-verified `app.storage.tab` semantics). Mechanism chosen by the user over keep-on-disk-and-clear (which `security.md` forbids and which Context7 showed is fragile — `on_disconnect` fires on in-app navigation).

Supporting changes (all in `gui.py`): `_on_validate_click` and `migrate_page` are `async` + `await ui.context.client.connected()` before any tab access; token input fields no longer pre-fill (re-enter each launch — the `security.md`-aligned norm); a setup-load scrub removes any token left on disk by a pre-fix version; the validate/migrate top-guards drop the token term (they check `export_dir`+`stoat_url`, written in the same validate pass) and migrate re-checks the tab token after `connected()`; missing-token restart edges bounce cleanly to setup with a "session expired" notice; the tab clears are `contextlib.suppress`-wrapped. Engine/shell separation is unchanged (the engine never reads `app.storage`).

### Quality gates
- **1258 tests** (12 new: SC-1..SC-5, SC-7..SC-13; 0 existing modified — append-only). `ruff check .` + `ruff format --check .` + `mypy src/` clean.
- The load-bearing **"tab not user"** security property is pinned by an `inspect.getsource` guard (fails loudly if any future refactor reverts a token write to disk-backed storage).
- `/df` pipeline: brief → spec → brainstorm → **critique (fresh opus): ITERATE → PASS** (caught the missing CI security pin + the export restart-bounce + 3 polish items) → test-scenarios → controller-driven build.
- Code review (fresh opus): **APPROVE** (0 Critical/Important; the one Minor parity nit — suppress the terminal tab-clear — applied). Mistral second opinion (Security focus): 10 findings, all false-positive on source verification.
- Each new guard falsified individually (revert → RED → restore).

> **Note:** the live handoff and the on-disk-residue property are not CI-testable without `nicegui.testing` (not wired into the suite — the v2.6.1 precedent); they are covered by the source-inspection security pin + helper-unit tests + a documented manual-smoke protocol (in the change manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
