### PR TITLE
ci: exclude DCE contract test from the version matrix (kill the 403 flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,12 @@ jobs:
         run: uv run mypy src/
 
       - name: Tests
-        run: uv run pytest
+        # Exclude the DCE contract test from the version matrix: it downloads the
+        # real DCE binary from GitHub's unauthenticated API, so running it across
+        # 3 Python versions concurrently trips the API rate limit (intermittent
+        # 403 flake). The dedicated cached `contract-test` job below is its sole
+        # owner; the matrix only needs the pure-Python suite.
+        run: uv run pytest --ignore=tests/test_dce_contract.py
 
   contract-test:
     name: Contract test (DCE binary)


### PR DESCRIPTION
## Kill the recurring DCE 403 CI flake

The `lint-and-test` matrix (Python 3.11/3.12/3.13) ran the full `uv run pytest`, which includes `tests/test_dce_contract.py` — the only test that downloads the **real** DCE binary from GitHub's **unauthenticated** API. Running it across all three versions concurrently trips GitHub's API rate limit → intermittent `DCENotFoundError: GitHub API returned 403` on whichever matrix job loses the race (most recently the 3.12 job on the v2.6.14 post-merge run).

**Fix:** `--ignore=tests/test_dce_contract.py` in the matrix step. The dedicated `contract-test` job already owns this test and runs it against a **cached** DCE binary (`actions/cache` on `~/.discord-ferry/bin/dce/2.47.1`), so no coverage is lost — the matrix simply stops re-downloading the binary 3× in parallel. The DCE-binary contract is Python-version-independent, so single-version coverage in the cached job is sufficient.

Pure CI-config change — no version bump, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
