### PR TITLE
fix: parser/exporter/sanitize correctness sweep (v2.6.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.15] - 2026-06-28
+
+### Fixed
+
+Parser / exporter / sanitize correctness sweep — the ninth batch from the 2026-06-25 v2.6.6
+whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 9). Ten confirmed
+silent-correctness defects, grouped into five engine-side fixes; no GUI/CLI/state-schema/API change.
+
+- **Bold runs are no longer corrupted by underline stripping** (`parser/transforms.py`). `strip_underline`
+  collapsed every `****` in a message — so two adjacent bold spans (`**a****b**`) lost a delimiter
+  (`**a**b**`), and `****` inside code spans was mangled. It now converts the two nested bold+underline
+  forms explicitly and drops the blind global collapse, leaving pre-existing bold and code spans intact.
+- **Timezone-naive timestamps are read as UTC** (`parser/transforms.py`). `format_original_timestamp`
+  treated an offset-less DCE timestamp as host-local time (shifting the hour) and crashed on a
+  malformed string; it now assumes UTC for naive inputs and falls back to the raw string on a parse
+  error.
+- **Channels are no longer misclassified as threads** (`parser/dce_parser.py`). `_infer_thread_info`
+  treated any `Guild - Channel - Thread`-shaped filename as a thread, so a guild or channel name
+  containing ` - ` mis-tagged a normal channel as a thread (corrupting category placement, merge/
+  skip-threads handling, and forum grouping — and potentially dropping messages). It is now
+  authoritative on the parsed Discord channel type (10/11/12 = thread). The dead `_TWO_SEGMENT_RE`
+  regex was removed.
+- **A huge DCE stderr line no longer crashes the exporter** (`exporter/runner.py`). `_read_stderr`
+  used `async for`, which raised an uncaught `ValueError` on a stderr line over 64 KiB — stopping
+  stderr capture, discarding the fatal line (reported as "Unknown error"), and leaking a
+  "Task exception never retrieved". It now mirrors the stdout drain loop (truncating the over-long
+  line). Cancellation is also checked during a long drain, and over-long lines now count as activity
+  (no false "no new output" heartbeats).
+- **Emoji name de-duplication no longer collides** (`migrator/sanitize.py`). `sanitize_emoji_name`
+  truncated the disambiguating suffix off at the 32-char limit (returning a duplicate) and never
+  registered the generated name (so a later identical name re-collided). It now truncates the base to
+  make room for the suffix, registers the emitted name, and bumps until unique.
+- **Six dropped role permissions are now migrated** (`discord/permissions.py`). `DISCORD_TO_STOAT`
+  omitted Discord permissions that have Stoat equivalents, so migrated roles silently lost
+  invite / kick / ban / manage-webhooks / change-nickname / manage-nicknames authority. Those six are
+  now mapped (and added to the admin-grants-all set). (Discord's `MENTION_EVERYONE` has no Stoat
+  `Permission` equivalent and remains intentionally dropped.)
+
 ## [2.6.14] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.14"
+version = "2.6.15"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.14"
+__version__ = "2.6.15"

--- a/src/discord_ferry/discord/permissions.py
+++ b/src/discord_ferry/discord/permissions.py
@@ -1,8 +1,11 @@
 """Discord → Stoat permission bit translation."""
 
 # Discord permission bit position → Stoat permission bit position(s).
-# Discord bits not in this map are silently dropped (no Stoat equivalent).
+# Discord bits not in this map have no Stoat equivalent and are dropped.
 DISCORD_TO_STOAT: dict[int, int | list[int]] = {
+    0: 25,  # CREATE_INSTANT_INVITE → InviteOthers
+    1: 6,  # KICK_MEMBERS → KickMembers
+    2: 7,  # BAN_MEMBERS → BanMembers
     4: 0,  # MANAGE_CHANNELS → ManageChannel
     5: 1,  # MANAGE_GUILD → ManageServer
     28: [2, 3],  # MANAGE_ROLES → ManagePermissions + ManageRole
@@ -14,6 +17,11 @@ DISCORD_TO_STOAT: dict[int, int | list[int]] = {
     14: 26,  # EMBED_LINKS → SendEmbeds
     15: 27,  # ATTACH_FILES → UploadFiles
     6: 29,  # ADD_REACTIONS → React
+    # NOTE: MENTION_EVERYONE (Discord bit 17) has NO Stoat equivalent — the Stoat
+    # Permission enum has no MentionEveryone — so it is intentionally dropped.
+    26: 10,  # CHANGE_NICKNAME → ChangeNickname
+    27: 11,  # MANAGE_NICKNAMES → ManageNicknames
+    29: 24,  # MANAGE_WEBHOOKS → ManageWebhooks
 }
 
 ALL_STOAT_PERMISSIONS = (
@@ -22,10 +30,16 @@ ALL_STOAT_PERMISSIONS = (
     | 4
     | 8
     | 16  # bits 0-4
+    | 64
+    | 128  # bits 6-7 (KickMembers, BanMembers)
+    | 1_024
+    | 2_048  # bits 10-11 (ChangeNickname, ManageNicknames)
     | 1_048_576
     | 2_097_152  # bits 20-21
     | 4_194_304
     | 8_388_608  # bits 22-23
+    | 16_777_216
+    | 33_554_432  # bits 24-25 (ManageWebhooks, InviteOthers)
     | 67_108_864
     | 134_217_728  # bits 26-27
     | 268_435_456

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -290,7 +290,9 @@ async def _terminate_process(process: asyncio.subprocess.Process) -> None:
         await process.wait()
 
 
-async def _drain_overlong_line(reader: asyncio.StreamReader) -> int:
+async def _drain_overlong_line(
+    reader: asyncio.StreamReader, cancel_event: asyncio.Event | None = None
+) -> int:
     r"""Consume bytes from `reader` until we reach `\n` (or EOF).
 
     Used after `readuntil(b"\n")` raised LimitOverrunError to ensure the
@@ -301,9 +303,13 @@ async def _drain_overlong_line(reader: asyncio.StreamReader) -> int:
       - `readuntil` finds the next `\n` (returns tail, total + len(tail))
       - EOF is hit (IncompleteReadError, total + len(exc.partial))
       - Another LimitOverrunError fires (consume that 64KiB chunk and keep going)
+      - `cancel_event` is set (stop draining promptly so cancellation isn't
+        deferred until a multi-MB line ends)
     """
     total = 0
     while True:
+        if cancel_event is not None and cancel_event.is_set():
+            return total
         try:
             tail = await reader.readuntil(b"\n")
             total += len(tail)
@@ -402,7 +408,19 @@ async def run_dce_export(
 
     async def _read_stderr() -> None:
         assert process.stderr is not None
-        async for raw_line in process.stderr:
+        # Mirror the stdout loop: an explicit readuntil loop so a >64 KiB stderr
+        # line is drained (not crashed via `async for`'s readline → ValueError).
+        while True:
+            try:
+                raw_line = await process.stderr.readuntil(b"\n")
+            except asyncio.IncompleteReadError as exc:
+                raw_line = exc.partial
+                if not raw_line:
+                    break
+            except asyncio.LimitOverrunError:
+                consumed = await _drain_overlong_line(process.stderr)
+                stderr_lines.append(f"<truncated {consumed} bytes; stderr line exceeded 64 KiB>")
+                continue
             line = raw_line.decode("utf-8", errors="replace").strip()
             if line:
                 stderr_lines.append(line)
@@ -414,6 +432,12 @@ async def run_dce_export(
 
     try:
         while True:
+            # Check cancel at the top so a cancel during a long drain (below) or a
+            # huge blocking read isn't deferred until the next full line.
+            if config.cancel_event and config.cancel_event.is_set():
+                await _terminate_process(process)
+                raise asyncio.CancelledError("Export cancelled by user")
+
             try:
                 raw_line = await process.stdout.readuntil(b"\n")
             except asyncio.IncompleteReadError as exc:
@@ -423,7 +447,7 @@ async def run_dce_export(
             except asyncio.LimitOverrunError:
                 # Line longer than 64 KiB -- drain to next \n entirely so the
                 # remainder does not get parsed as a separate "line".
-                consumed = await _drain_overlong_line(process.stdout)
+                consumed = await _drain_overlong_line(process.stdout, config.cancel_event)
                 on_event(
                     MigrationEvent(
                         phase="export",
@@ -431,6 +455,7 @@ async def run_dce_export(
                         message=(f"[dce] <truncated {consumed} bytes; line exceeded 64 KiB>"),
                     )
                 )
+                _record_activity()  # real output flowed — don't let the heartbeat cry "silent"
                 continue
 
             if config.cancel_event and config.cancel_event.is_set():
@@ -444,7 +469,7 @@ async def run_dce_export(
             logger.debug("DCE: %s", line)
             parsed = parse_dce_line(line)
             _emit_for_parsed(parsed, on_event, state)
-            if isinstance(parsed, (PerChannel, Phase, Success, Raw)):
+            if isinstance(parsed, (PerChannel, Phase, Success, Raw, Banner, StatusDot)):
                 _record_activity()
 
         await process.wait()

--- a/src/discord_ferry/migrator/sanitize.py
+++ b/src/discord_ferry/migrator/sanitize.py
@@ -65,9 +65,18 @@ def sanitize_emoji_name(
 
     if used_names is not None:
         if sanitized in used_names:
-            used_names[sanitized] += 1
-            suffixed = f"{sanitized}_{used_names[sanitized]}"
-            sanitized = suffixed[:_DEFAULT_MAX_LENGTH]
+            count = used_names[sanitized] + 1
+            suffix = f"_{count}"
+            candidate = sanitized[: _DEFAULT_MAX_LENGTH - len(suffix)] + suffix
+            # Bump until unique among ALL emitted names (handles a raw name that
+            # equals a previously auto-generated suffixed name).
+            while candidate in used_names:
+                count += 1
+                suffix = f"_{count}"
+                candidate = sanitized[: _DEFAULT_MAX_LENGTH - len(suffix)] + suffix
+            used_names[sanitized] = count  # advance the base counter
+            used_names[candidate] = 1  # register the EMITTED name so it can't re-collide
+            sanitized = candidate
         else:
             used_names[sanitized] = 1
     return sanitized

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 
 _CONTENT_EMOJI_RE = re.compile(r"<a?:[^:]+:(\d+)>")
 _THREE_SEGMENT_RE = re.compile(r"^(.+?) - (.+?) - (.+?) \[(\d+)\]$")
-_TWO_SEGMENT_RE = re.compile(r"^(.+?) - (.+?) \[(\d+)\]$")
+# Discord channel-type codes that are genuinely threads (incl. forum posts = 11).
+# Used to override the filename heuristic so a guild/channel name containing " - "
+# can't misclassify a normal channel as a thread.
+_THREAD_TYPE_CODES = frozenset({10, 11, 12})
 
 # DCE 2.47.1 emits enum-named channel types; pre-2.47 emitted integers.
 # Downstream callers (migrator/structure.py, migrator/messages.py, review.py)
@@ -105,7 +108,7 @@ def parse_single_export(json_path: Path, *, metadata_only: bool = False) -> DCEE
         messages = [_parse_message(m) for m in raw["messages"]]
         messages.sort(key=lambda m: m.timestamp)
 
-    is_thread, parent_channel_name = _infer_thread_info(json_path.stem)
+    is_thread, parent_channel_name = _infer_thread_info(json_path.stem, channel.type)
 
     return DCEExport(
         guild=guild,
@@ -304,17 +307,25 @@ def validate_export(
     return warnings
 
 
-def _infer_thread_info(filename: str) -> tuple[bool, str]:
+def _infer_thread_info(filename: str, channel_type: int | None = None) -> tuple[bool, str]:
     """Infer whether a filename represents a thread and return its parent channel name.
 
     Args:
         filename: The stem (without extension) of the DCE export file.
+        channel_type: The parsed Discord channel-type code. When known, it is
+            authoritative: a non-thread type is never a thread, regardless of
+            " - " in the guild/channel name. When ``None`` (e.g. filename-only
+            callers), the 3-segment filename heuristic alone is used.
 
     Returns:
         Tuple of (is_thread, parent_channel_name).
         For regular channels: (False, "").
         For threads/forum posts: (True, "<parent channel name>").
     """
+    # Type is authoritative when known: a non-thread Discord type is never a
+    # thread, even if the guild/channel name contains " - ".
+    if channel_type is not None and channel_type not in _THREAD_TYPE_CODES:
+        return False, ""
     match = _THREE_SEGMENT_RE.match(filename)
     if match:
         parent_channel_name = match.group(2)

--- a/src/discord_ferry/parser/transforms.py
+++ b/src/discord_ferry/parser/transforms.py
@@ -45,6 +45,10 @@ _DISCORD_INVITE_RE = re.compile(
 
 _SPOILER_RE = re.compile(r"\|\|(.+?)\|\|", re.DOTALL)
 _UNDERLINE_RE = re.compile(r"__([^_]+?)__")
+# Nested bold+underline: collapse to a single bold directly (before the general
+# underline sub) so a pre-existing adjacent-bold run (**a****b**) is never touched.
+_BOLD_WRAPS_UNDERLINE_RE = re.compile(r"\*\*__([^_]+?)__\*\*")
+_UNDERLINE_WRAPS_BOLD_RE = re.compile(r"__\*\*([^_]+?)\*\*__")
 _USER_MENTION_RE = re.compile(r"<@!?(\d+)>")
 _CHANNEL_MENTION_RE = re.compile(r"<#(\d+)>")
 _ROLE_MENTION_RE = re.compile(r"<@&(\d+)>")
@@ -329,7 +333,12 @@ def format_original_timestamp(iso_timestamp: str) -> str:
     Returns:
         Formatted string like ``*[2024-01-15 12:00 UTC]*``.
     """
-    dt = datetime.fromisoformat(iso_timestamp)
+    try:
+        dt = datetime.fromisoformat(iso_timestamp)
+    except ValueError:
+        return iso_timestamp  # malformed → raw fallback, never abort the message
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)  # naive DCE timestamp → UTC (no host-TZ shift)
     utc_dt = dt.astimezone(UTC)
     return f"*[{utc_dt.strftime('%Y-%m-%d %H:%M')} UTC]*"
 
@@ -377,6 +386,12 @@ def strip_underline(content: str) -> str:
     Returns:
         Content with underline syntax converted to bold outside code spans.
     """
-    result = _transform_outside_code(content, lambda s: _UNDERLINE_RE.sub(r"**\1**", s))
-    # Collapse **** sequences that arise when underline wraps bold: **__text__** → ****text****
-    return result.replace("****", "**")
+
+    def _underline_to_bold(s: str) -> str:
+        # Collapse nested bold+underline directly (Stoat has no underline), BEFORE the
+        # general sub, so a pre-existing **a****b** is never blindly collapsed.
+        s = _BOLD_WRAPS_UNDERLINE_RE.sub(r"**\1**", s)  # **__x__** → **x**
+        s = _UNDERLINE_WRAPS_BOLD_RE.sub(r"**\1**", s)  # __**x**__ → **x**
+        return _UNDERLINE_RE.sub(r"**\1**", s)  # standalone __x__ → **x**
+
+    return _transform_outside_code(content, _underline_to_bold)

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -20,7 +20,7 @@ from discord_ferry.exporter.runner import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from discord_ferry.core.events import MigrationEvent
@@ -39,12 +39,22 @@ def _make_config(tmp_path: Path) -> FerryConfig:
     )
 
 
-async def _empty_stderr_iter() -> AsyncGenerator[bytes, None]:
-    for _ in ():
-        yield b""
+def _make_stream_reader(lines: list[bytes]) -> asyncio.StreamReader:
+    """A real StreamReader pre-loaded with lines (supports readuntil + EOF).
+
+    An empty list yields an EOF reader: readuntil() raises
+    IncompleteReadError(partial=b"") → _read_stderr breaks cleanly.
+    """
+    reader = asyncio.StreamReader()
+    for line in lines:
+        reader.feed_data(line)
+    reader.feed_eof()
+    return reader
 
 
-def _make_process(stdout_lines: list[bytes], returncode: int = 0) -> MagicMock:
+def _make_process(
+    stdout_lines: list[bytes], returncode: int = 0, stderr_lines: list[bytes] | None = None
+) -> MagicMock:
     """Build a MagicMock subprocess that yields stdout_lines via readuntil()."""
     process = MagicMock()
     queue: list[bytes] = list(stdout_lines)
@@ -57,7 +67,7 @@ def _make_process(stdout_lines: list[bytes], returncode: int = 0) -> MagicMock:
     stdout = MagicMock()
     stdout.readuntil = _readuntil
     process.stdout = stdout
-    process.stderr = _empty_stderr_iter()
+    process.stderr = _make_stream_reader(stderr_lines or [])
     process.wait = AsyncMock(return_value=returncode)
     process.returncode = returncode
     process.terminate = MagicMock()
@@ -759,3 +769,92 @@ class TestHeartbeat:
         assert heartbeats, "no heartbeat events emitted"
         for e in heartbeats:
             assert e.phase == "export", f"expected phase='export', got {e.phase!r}"
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S3 symmetric stderr drain + cancel + activity
+# ---------------------------------------------------------------------------
+
+
+class TestStderrOverlongLine:
+    @pytest.mark.asyncio
+    async def test_overlong_stderr_line_captured_not_crashed(self, tmp_path: Path) -> None:
+        """SC-19: a >64 KiB stderr line is captured (truncated marker), not a ValueError crash."""
+        from discord_ferry.errors import ExportError
+
+        process = _make_process([], returncode=1)
+        stderr = asyncio.StreamReader(limit=64)
+        stderr.feed_data(b"x" * 200)  # one >64-byte line, no newline
+        stderr.feed_eof()
+        process.stderr = stderr
+        cfg = _make_config(tmp_path)
+
+        with (
+            patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+            pytest.raises(ExportError, match="exceeded 64 KiB"),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+    @pytest.mark.asyncio
+    async def test_normal_stderr_accumulates(self, tmp_path: Path) -> None:
+        """SC-22: normal stderr lines accumulate (surfaced in the ExportError)."""
+        from discord_ferry.errors import ExportError
+
+        process = _make_process([], returncode=1, stderr_lines=[b"a real error\n"])
+        cfg = _make_config(tmp_path)
+
+        with (
+            patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+            pytest.raises(ExportError, match="a real error"),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+
+class TestDrainCancel:
+    @pytest.mark.asyncio
+    async def test_drain_overlong_line_respects_cancel(self) -> None:
+        """SC-20: _drain_overlong_line returns promptly when cancel_event is already set."""
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"x" * 1000)  # many 64-byte chunks
+        reader.feed_eof()
+        with pytest.raises(asyncio.LimitOverrunError):
+            await reader.readuntil(b"\n")
+
+        cancel = asyncio.Event()
+        cancel.set()
+        # With cancel pre-set, the drain must break early rather than consume to EOF.
+        consumed = await _drain_overlong_line(reader, cancel)
+        assert consumed >= 0
+        assert not reader.at_eof()  # did NOT drain everything
+
+
+class TestOverlongStdoutActivity:
+    @pytest.mark.asyncio
+    async def test_overlong_stdout_emits_truncation_event(self, tmp_path: Path) -> None:
+        """SC-21: an overlong stdout line emits a truncation event and the run completes.
+
+        Proves the overlong-stdout branch (which now also records activity) executes
+        through to its emit + continue without crashing.
+        """
+        stdout = asyncio.StreamReader(limit=64)
+        stdout.feed_data(b"y" * 200)  # overlong line (no newline before 64 KiB)
+        stdout.feed_data(b"general: 50%\n")  # a normal line after the drain
+        stdout.feed_eof()
+        process = _make_process([])
+        process.stdout = stdout
+        cfg = _make_config(tmp_path)
+
+        events: list[MigrationEvent] = []
+        with patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", events.append)
+
+        assert any("truncated" in (e.message or "") for e in events)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -715,3 +715,33 @@ def test_validate_export_counts_expired_urls(tmp_path: Path) -> None:
     assert len(expired_warnings) == 1
     assert "2" in expired_warnings[0]["message"]
     assert "--media" in expired_warnings[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S2 type-aware thread classification
+# ---------------------------------------------------------------------------
+
+
+def test_infer_thread_type_overrides_dash_guild() -> None:
+    """SC-12: a dash-guild text channel (type 0) is NOT a thread."""
+    assert _infer_thread_info("Acme - Community - general [123]", channel_type=0) == (False, "")
+
+
+def test_infer_thread_real_thread_type() -> None:
+    """SC-13: a real thread (type 11) is a thread with the right parent."""
+    assert _infer_thread_info("Guild - Channel - Thread [123]", channel_type=11) == (
+        True,
+        "Channel",
+    )
+
+
+def test_infer_thread_plain_channel_type() -> None:
+    """SC-14: a plain 2-segment channel (type 0) is not a thread."""
+    assert _infer_thread_info("Guild - general [123]", channel_type=0) == (False, "")
+
+
+def test_two_segment_re_removed() -> None:
+    """SC-17: the dead _TWO_SEGMENT_RE is gone (no compiled-but-unused regex)."""
+    import discord_ferry.parser.dce_parser as p
+
+    assert not hasattr(p, "_TWO_SEGMENT_RE")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -41,8 +41,9 @@ def test_administrator_with_other_bits() -> None:
 
 
 def test_unmapped_bits_dropped() -> None:
-    # Discord KICK_MEMBERS = bit 1, no Stoat equivalent → dropped
-    assert translate_permissions(1 << 1) == 0
+    # Discord USE_EXTERNAL_EMOJIS = bit 12, no Stoat equivalent → dropped
+    # (KICK_MEMBERS bit 1 is now mapped as of Batch 9; use a still-unmapped bit.)
+    assert translate_permissions(1 << 12) == 0
 
 
 def test_multiple_mapped_bits() -> None:
@@ -65,17 +66,24 @@ def test_all_mapped_bits() -> None:
 
 
 def test_all_stoat_permissions_value() -> None:
-    # Verify ALL_STOAT_PERMISSIONS matches the documented sum
+    # Verify ALL_STOAT_PERMISSIONS matches the documented sum (incl. the 6
+    # Batch 9 additions: bits 6,7,10,11,24,25).
     expected = (
         1
         | 2
         | 4
         | 8
         | 16
+        | 64
+        | 128
+        | 1_024
+        | 2_048
         | 1_048_576
         | 2_097_152
         | 4_194_304
         | 8_388_608
+        | 16_777_216
+        | 33_554_432
         | 67_108_864
         | 134_217_728
         | 268_435_456
@@ -111,7 +119,8 @@ def test_deny_multiple_bits() -> None:
 
 def test_deny_unmapped_bits_dropped() -> None:
     """Unmapped Discord bits in deny context are silently dropped."""
-    assert translate_permissions(1 << 1, is_deny=True) == 0
+    # bit 12 (USE_EXTERNAL_EMOJIS) has no Stoat equivalent (bit 1 is now mapped).
+    assert translate_permissions(1 << 12, is_deny=True) == 0
 
 
 def test_deny_administrator_with_other_bits_preserves_others() -> None:
@@ -119,3 +128,35 @@ def test_deny_administrator_with_other_bits_preserves_others() -> None:
     discord_bits = (1 << 3) | (1 << 10)  # ADMINISTRATOR + VIEW_CHANNEL
     result = translate_permissions(discord_bits, is_deny=True)
     assert result == 1 << 20  # Only ViewChannel deny, ADMIN stripped
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S5 perm-map fidelity (7 newly-mapped Discord permissions)
+# ---------------------------------------------------------------------------
+
+
+def test_new_permission_mappings() -> None:
+    """SC-29: each newly-added Discord→Stoat permission maps correctly."""
+    pairs = [
+        (0, 25),  # CREATE_INSTANT_INVITE → InviteOthers
+        (1, 6),  # KICK_MEMBERS → KickMembers
+        (2, 7),  # BAN_MEMBERS → BanMembers
+        (26, 10),  # CHANGE_NICKNAME → ChangeNickname
+        (27, 11),  # MANAGE_NICKNAMES → ManageNicknames
+        (29, 24),  # MANAGE_WEBHOOKS → ManageWebhooks
+    ]
+    for discord_bit, stoat_bit in pairs:
+        assert translate_permissions(1 << discord_bit) == 1 << stoat_bit
+
+
+def test_mention_everyone_dropped() -> None:
+    """MENTION_EVERYONE (bit 17) has no Stoat equivalent → dropped."""
+    assert translate_permissions(1 << 17) == 0
+
+
+def test_admin_grants_new_bits() -> None:
+    """SC-30: the ADMIN short-circuit now includes the 7 new bits."""
+    result = translate_permissions(1 << 3)
+    assert result == ALL_STOAT_PERMISSIONS
+    for bit in (6, 7, 10, 11, 24, 25):
+        assert result & (1 << bit)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -148,3 +148,43 @@ def test_emoji_name_collision_suffix_truncated() -> None:
     second = sanitize_emoji_name(long_name, used)
     assert first == "a" * 32
     assert len(second) <= 32
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S4 collision-correct emoji de-dup
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_emoji_registers_emitted_name() -> None:
+    """SC-23: two 'fire' → fire, fire_2; both registered in used_names."""
+    used: dict[str, int] = {}
+    a = sanitize_emoji_name("fire", used)
+    b = sanitize_emoji_name("fire", used)
+    assert (a, b) == ("fire", "fire_2")
+    assert "fire" in used and "fire_2" in used
+
+
+def test_sanitize_emoji_emitted_recollision() -> None:
+    """SC-24: a third emoji whose raw name sanitizes to 'fire_2' becomes a distinct fire_2_2."""
+    used: dict[str, int] = {}
+    sanitize_emoji_name("fire", used)
+    sanitize_emoji_name("fire", used)  # → fire_2
+    third = sanitize_emoji_name("fire_2", used)  # collides with the emitted fire_2
+    assert third not in ("fire", "fire_2")
+    assert third == "fire_2_2"
+
+
+def test_sanitize_emoji_near_limit_keeps_suffix() -> None:
+    """SC-25: two 32-char-identical names → distinct (suffix preserved, base truncated, ≤32)."""
+    used: dict[str, int] = {}
+    name = "a" * 40  # sanitizes/truncates to 32 'a'
+    a = sanitize_emoji_name(name, used)
+    b = sanitize_emoji_name(name, used)
+    assert a != b
+    assert len(a) <= 32 and len(b) <= 32
+
+
+def test_sanitize_emoji_non_colliding_unchanged() -> None:
+    """SC-26: a non-colliding name is unchanged."""
+    used: dict[str, int] = {}
+    assert sanitize_emoji_name("unique", used) == "unique"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -749,3 +749,67 @@ def test_multiple_links() -> None:
     assert "<#stoat_ch1>" in result
     assert "<#stoat_ch2>" in result
     assert "[Discord invite — no longer valid]" in result
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S1a bold-safe underline strip
+# ---------------------------------------------------------------------------
+
+
+def test_strip_underline_preserves_adjacent_bold() -> None:
+    """SC-1: pre-existing **a****b** (no underscores) is untouched."""
+    assert strip_underline("**a****b**") == "**a****b**"
+
+
+def test_strip_underline_preserves_literal_stars() -> None:
+    """SC-2: ****literal**** and a **** b unchanged (no underscores)."""
+    assert strip_underline("****literal****") == "****literal****"
+    assert strip_underline("a **** b") == "a **** b"
+
+
+def test_strip_underline_nested_collapses() -> None:
+    """SC-3: nested bold+underline → single bold."""
+    assert strip_underline("**__x__**") == "**x**"
+    assert strip_underline("__**x**__") == "**x**"
+
+
+def test_strip_underline_standalone() -> None:
+    """SC-4: __u__ → **u**."""
+    assert strip_underline("__u__") == "**u**"
+
+
+def test_strip_underline_compound_preserves_existing_seam() -> None:
+    """SC-5: convert underline AND preserve a pre-existing **** elsewhere."""
+    assert strip_underline("__u__ **a****b**") == "**u** **a****b**"
+
+
+def test_strip_underline_abutting_new_contract() -> None:
+    """SC-6: non-nested abutting __a__**b** → **a****b** (both bold preserved; NEW contract)."""
+    assert strip_underline("__a__**b**") == "**a****b**"
+
+
+def test_strip_underline_protects_code_spans() -> None:
+    """SC-7: **** inside a code span is not collapsed."""
+    assert strip_underline("`**a****b**`") == "`**a****b**`"
+
+
+# ---------------------------------------------------------------------------
+# Batch 9 — S1b tz-safe timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_format_timestamp_offset_unchanged() -> None:
+    """SC-9: offset-bearing timestamps convert as today."""
+    assert format_original_timestamp("2024-01-15T12:00:00+00:00") == "*[2024-01-15 12:00 UTC]*"
+    assert format_original_timestamp("2024-01-15T12:00:00+05:30") == "*[2024-01-15 06:30 UTC]*"
+
+
+def test_format_timestamp_naive_is_utc() -> None:
+    """SC-10: a tz-naive timestamp is treated as UTC (no host-TZ shift)."""
+    # Host-TZ-independent: naive 12:00 must render 12:00 UTC, never shifted.
+    assert format_original_timestamp("2024-01-15T12:00:00") == "*[2024-01-15 12:00 UTC]*"
+
+
+def test_format_timestamp_malformed_returns_raw() -> None:
+    """SC-11: a non-ISO string returns the raw input (no raise)."""
+    assert format_original_timestamp("not-a-date") == "not-a-date"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.14"
+version = "2.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Bug-Hunt Batch 9 — Parser / Exporter / Sanitize Correctness Sweep (v2.6.15)

Ninth batch from the 2026-06-25 v2.6.6 whole-codebase bug-hunt (§4 Batch 9). Ten confirmed **silent-correctness** defects, grouped into five surgical engine-side fixes. No GUI/CLI/engine-orchestration/state-schema/API-call change.

### S1 — `parser/transforms.py` (MEDIUM + LOW)
`strip_underline` collapsed **every** `****` in a message, so two adjacent bold spans (`**a****b**`) lost a delimiter (`**a**b**`) and `****` inside code spans was mangled. It now converts the two nested bold+underline forms explicitly and drops the blind global collapse (code-span-safe; pre-existing bold preserved). `format_original_timestamp` now reads tz-naive timestamps as UTC (no host-TZ shift) and falls back to the raw string on a malformed input.

### S2 — `parser/dce_parser.py` (MEDIUM + LOW)
`_infer_thread_info` treated any 3-segment filename as a thread, so a guild/channel name containing ` - ` mis-tagged a normal channel as a thread — corrupting category placement, merge/skip-threads handling, and forum grouping, and potentially **dropping messages**. It is now authoritative on the parsed Discord channel type (`{10,11,12}` = thread); the dead `_TWO_SEGMENT_RE` was removed. A backward-compatible optional param keeps the existing filename-only unit tests valid.

### S3 — `exporter/runner.py` (MEDIUM + LOW×2)
`_read_stderr` used `async for`, which raised an uncaught `ValueError` on a stderr line over 64 KiB — stopping stderr capture, discarding the fatal line (surfaced as "Unknown error"), and leaking a "Task exception never retrieved". It now mirrors the stdout `readuntil` drain loop (truncating the over-long line). Cancellation is checked during a long drain, and over-long lines now count as activity (no false "no new output" heartbeats).

### S4 — `migrator/sanitize.py` (MEDIUM×2)
`sanitize_emoji_name` truncated the disambiguating suffix off at the 32-char limit (returning a duplicate) and never registered the generated name (so a later identical name re-collided). It now truncates the **base** to make room for the suffix, registers the emitted name, and bumps until unique.

### S5 — `discord/permissions.py` (LOW, data-integrity)
`DISCORD_TO_STOAT` dropped Discord permissions that have Stoat equivalents, so migrated roles silently lost invite / kick / ban / manage-webhooks / change-nickname / manage-nicknames authority. Those **6** are now mapped (and added to the admin-grants-all set). _(Discord's `MENTION_EVERYONE` has no Stoat `Permission` equivalent — the ship-stage code review caught an erroneously-proposed 7th mapping against the live Stoat permission docs — so it remains intentionally dropped.)_

### Quality gates
- **1283 tests** (24 new). `ruff check .` + `ruff format --check .` + `mypy src/` clean.
- Two test-edit modes: append-only (`transforms`/`parser`/`sanitize`) + reviewed carve-out (`exporter_runner` mock upgrade, `permissions` tests that pin the map/constant under fix). No unrelated assertion clobbered.
- `/df` pipeline: brief → spec → brainstorm → **critique (fresh opus): ITERATE → PASS** → test-scenarios → controller-driven build.
- Code review (fresh opus): **REQUEST CHANGES → APPROVE** (caught the wrong `MentionEveryone` bit via the live Stoat docs; corrected to 6 mappings, re-verified). Mistral second opinion: 10 findings — 1 real (the same bit), 9 false on source verification.
- Each new guard falsified individually (revert → RED → restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
