### PR TITLE
fix: defense-in-depth & misc lows (v2.6.16) — bug-hunt Batch 10 FINAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.16] - 2026-06-28
+
+### Fixed
+
+Defense-in-depth & misc lows — the tenth and FINAL batch from the 2026-06-25 v2.6.6
+whole-codebase bug-hunt (`docs/plans/audits/2026-06-25-bug-hunt.md`, §4 Batch 10), closing the
+hunt. Four latent-gap fixes; no GUI/CLI/state-schema/API change.
+
+- **Engine exception strings are token-redacted everywhere they are emitted or persisted**
+  (`core/engine.py`). A new `_safe(config, text)` helper wraps every raw-exception interpolation in
+  the engine event stream and in persisted `state.warnings` / `RollbackFailure.error` — honoring
+  `safe_sanitize`'s persist-or-emit contract. Previously only two sites were sanitized, leaving a
+  latent path for a future token-in-URL or echoed-4xx-body to leak a credential to the GUI/CLI log
+  or `state.json`. A new `_ensure_token_store` helper wires the token store in **both**
+  `run_migration` and `run_rollback` (the shells call rollback directly and never set it), so the
+  rollback-path redaction is actually effective. No behaviour change when no token store is set.
+- **Concurrent uploads of the same file no longer duplicate** (`uploader/autumn.py`).
+  `upload_with_cache` had a check-then-act race: two parallel channel workers requesting the same
+  physical file (an author's avatar / identical attachment) both missed the cache and both uploaded,
+  wasting the per-tag Autumn budget and orphaning a file. A self-cleaning in-flight `asyncio.Future`
+  registry now coalesces concurrent same-key callers onto a single upload. A failed upload is not
+  cached and does not poison the key (a later run retries); concurrent same-key callers share the
+  originator's outcome.
+- **Avatar checkpoint cadence is now time-based** (`migrator/avatars.py`). The phase saved state only
+  every 10th upload, so a sub-10 tail (and a hard-kill between two saves) lost up to 9 `avatar_cache`
+  entries, re-uploading those avatars as untracked orphans on resume. It now saves on a 5s wall-clock
+  throttle (mirroring `messages.py`), bounding crash loss by time.
+- **Repaired a dead test assertion** (`tests/test_thread_strategy.py`). `test_merge_mode_separator_sent`
+  defined a capture callback that aioresponses never invoked, so the thread separator payload was
+  never actually asserted. Converted to the `_capture_keys` idiom asserting the separator's
+  idempotency key — a broken separator send now fails the test.
+
 ## [2.6.15] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.15"
+version = "2.6.16"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.15"
+__version__ = "2.6.16"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -15,7 +15,7 @@ import aiohttp
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.core.security import safe_sanitize
+from discord_ferry.core.security import SecureTokenStore, safe_sanitize
 from discord_ferry.discord import (
     fetch_and_translate_guild_metadata,
     load_discord_metadata,
@@ -114,6 +114,32 @@ _DEFAULT_PHASES: dict[str, PhaseFunction] = {
 }
 
 
+def _safe(config: FerryConfig, text: str) -> str:
+    """Redact any known token values from *text* before it is emitted or persisted.
+
+    Thin wrapper around :func:`safe_sanitize` (None-safe) so every engine event or
+    warning that interpolates a raw exception ``repr`` honors safe_sanitize's
+    persist-or-emit contract.
+    """
+    return safe_sanitize(config.token_store, text)
+
+
+def _ensure_token_store(config: FerryConfig) -> None:
+    """Populate ``config.token_store`` from the configured tokens if not already set.
+
+    Both :func:`run_migration` and :func:`run_rollback` call this so that every error
+    message emitted/persisted during either flow is token-redacted via :func:`_safe`.
+    ``run_rollback`` is invoked directly by the CLI/GUI shells, which never set the
+    store — without this the rollback-path ``_safe`` calls would be inert.
+    """
+    if config.token_store is not None:
+        return
+    tokens: dict[str, str] = {"stoat": config.token}
+    if config.discord_token:
+        tokens["discord"] = config.discord_token
+    config.token_store = SecureTokenStore(tokens)
+
+
 async def run_migration(
     config: FerryConfig,
     on_event: EventCallback,
@@ -137,13 +163,8 @@ async def run_migration(
     """
     config.output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create token store for sanitizing error messages at output boundaries.
-    from discord_ferry.core.security import SecureTokenStore
-
-    tokens: dict[str, str] = {"stoat": config.token}
-    if config.discord_token:
-        tokens["discord"] = config.discord_token
-    config.token_store = SecureTokenStore(tokens)
+    # Ensure error messages emitted/persisted are token-redacted at output boundaries.
+    _ensure_token_store(config)
 
     if config.resume and config.incremental:
         raise MigrationError("--resume and --incremental are mutually exclusive.")
@@ -327,9 +348,10 @@ async def run_migration(
                     {
                         "phase": "export",
                         "type": "discord_metadata_fetch_failed",
-                        "message": (
+                        "message": _safe(
+                            config,
                             f"Could not fetch Discord metadata: {exc}. "
-                            "Permissions will not be migrated."
+                            "Permissions will not be migrated.",
                         ),
                     }
                 )
@@ -337,7 +359,9 @@ async def run_migration(
                     MigrationEvent(
                         phase="export",
                         status="warning",
-                        message=f"Discord metadata fetch failed: {exc}. Permissions skipped.",
+                        message=_safe(
+                            config, f"Discord metadata fetch failed: {exc}. Permissions skipped."
+                        ),
                     )
                 )
     else:
@@ -578,7 +602,7 @@ async def run_migration(
                 MigrationEvent(
                     phase="validate_migration",
                     status="warning",
-                    message=f"Validation skipped: {exc}",
+                    message=_safe(config, f"Validation skipped: {exc}"),
                 )
             )
         save_state(state, config.output_dir)
@@ -722,7 +746,7 @@ async def _acquire_migration_lock(
             MigrationEvent(
                 phase="connect",
                 status="warning",
-                message=f"Could not fetch server for lock check: {exc}",
+                message=_safe(config, f"Could not fetch server for lock check: {exc}"),
             )
         )
         return False
@@ -789,7 +813,7 @@ async def _acquire_migration_lock(
             MigrationEvent(
                 phase="connect",
                 status="warning",
-                message=f"Could not acquire migration lock: {exc}",
+                message=_safe(config, f"Could not acquire migration lock: {exc}"),
             )
         )
         return False
@@ -833,7 +857,7 @@ async def _release_migration_lock(
             MigrationEvent(
                 phase="connect",
                 status="warning",
-                message=f"Could not release migration lock: {exc}",
+                message=_safe(config, f"Could not release migration lock: {exc}"),
             )
         )
 
@@ -927,14 +951,18 @@ async def _rebuild_forum_indexes(
                     {
                         "phase": "report",
                         "type": "forum_index_rebuild_failed",
-                        "message": f"Failed to rebuild forum index for '{forum_name}': {exc}",
+                        "message": _safe(
+                            config, f"Failed to rebuild forum index for '{forum_name}': {exc}"
+                        ),
                     }
                 )
                 on_event(
                     MigrationEvent(
                         phase="report",
                         status="warning",
-                        message=f"Forum index rebuild for '{forum_name}' failed: {exc}",
+                        message=_safe(
+                            config, f"Forum index rebuild for '{forum_name}' failed: {exc}"
+                        ),
                     )
                 )
 
@@ -1232,13 +1260,13 @@ async def _delete_one_channel(
                 RollbackFailure(
                     entity_type="channel",
                     stoat_id=channel_id,
-                    error=str(exc),
+                    error=_safe(config, str(exc)),
                     http_status=http_status,
                 )
             )
             save_state(state, config.output_dir)
             severity = "error" if http_status == 401 else "warning"
-            msg = f"Failed to delete channel {channel_id}: {exc}"
+            msg = _safe(config, f"Failed to delete channel {channel_id}: {exc}")
             if http_status == 401:
                 msg += " (session token may be invalid)"
             on_event(MigrationEvent(phase="rollback", status=severity, message=msg))
@@ -1280,13 +1308,13 @@ async def _delete_one_role(
             RollbackFailure(
                 entity_type="role",
                 stoat_id=role_id,
-                error=str(exc),
+                error=_safe(config, str(exc)),
                 http_status=http_status,
             )
         )
         save_state(state, config.output_dir)
         severity = "error" if http_status == 401 else "warning"
-        msg = f"Failed to delete role {role_id}: {exc}"
+        msg = _safe(config, f"Failed to delete role {role_id}: {exc}")
         if http_status == 401:
             msg += " (session token may be invalid)"
         on_event(MigrationEvent(phase="rollback", status=severity, message=msg))
@@ -1317,13 +1345,13 @@ async def _delete_one_emoji(
             RollbackFailure(
                 entity_type="emoji",
                 stoat_id=emoji_id,
-                error=str(exc),
+                error=_safe(config, str(exc)),
                 http_status=http_status,
             )
         )
         save_state(state, config.output_dir)
         severity = "error" if http_status == 401 else "warning"
-        msg = f"Failed to delete emoji {emoji_id}: {exc}"
+        msg = _safe(config, f"Failed to delete emoji {emoji_id}: {exc}")
         if http_status == 401:
             msg += " (session token may be invalid)"
         on_event(MigrationEvent(phase="rollback", status=severity, message=msg))
@@ -1364,7 +1392,7 @@ async def _clean_categories(
             RollbackFailure(
                 entity_type="category",
                 stoat_id="<all>",
-                error=f"Could not fetch server for category cleanup: {exc}",
+                error=_safe(config, f"Could not fetch server for category cleanup: {exc}"),
                 http_status=_parse_http_status(str(exc)),
             )
         )
@@ -1373,7 +1401,7 @@ async def _clean_categories(
             MigrationEvent(
                 phase="rollback",
                 status="warning",
-                message=f"Category cleanup skipped: {exc}",
+                message=_safe(config, f"Category cleanup skipped: {exc}"),
             )
         )
         return
@@ -1388,7 +1416,7 @@ async def _clean_categories(
             RollbackFailure(
                 entity_type="category",
                 stoat_id="<all>",
-                error=str(exc),
+                error=_safe(config, str(exc)),
                 http_status=_parse_http_status(str(exc)),
             )
         )
@@ -1397,7 +1425,7 @@ async def _clean_categories(
             MigrationEvent(
                 phase="rollback",
                 status="warning",
-                message=f"Category cleanup PATCH failed: {exc}",
+                message=_safe(config, f"Category cleanup PATCH failed: {exc}"),
             )
         )
         return
@@ -1451,6 +1479,10 @@ async def run_rollback(
             is set, or if the migration lock cannot be acquired (a concurrent
             operation is in progress).
     """
+    # Token-redact error messages emitted/persisted during rollback (the CLI/GUI
+    # shells call run_rollback directly and never set the store).
+    _ensure_token_store(config)
+
     server_id = _validate_rollback_inputs(state, config)
     # Ensure the lock helpers use the resolved server ID.
     config.server_id = server_id
@@ -1493,7 +1525,7 @@ async def run_rollback(
                     MigrationEvent(
                         phase="rollback",
                         status="error",
-                        message=f"Could not fetch server {server_id}: {exc}",
+                        message=_safe(config, f"Could not fetch server {server_id}: {exc}"),
                     )
                 )
                 raise

--- a/src/discord_ferry/migrator/avatars.py
+++ b/src/discord_ferry/migrator/avatars.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -136,6 +137,7 @@ async def run_avatars(
     total = len(to_upload)
     uploaded = 0
     failed = 0
+    _last_save_time = time.monotonic()
 
     # Sort deterministically by author ID.
     sorted_authors = sorted(to_upload.items(), key=lambda item: item[0])
@@ -215,9 +217,13 @@ async def run_avatars(
                 state.referenced_autumn_ids.add(autumn_id)
                 uploaded += 1
 
-                # Periodic state save every 10 avatars for crash recovery.
-                if uploaded % 10 == 0:
+                # Periodic state save on a 5s wall-clock cadence (mirrors messages.py)
+                # so a hard kill loses at most ~5s of avatar_cache work — not up to 9
+                # entries (the old count-gate never checkpointed a sub-10 tail).
+                now = time.monotonic()
+                if now - _last_save_time >= 5.0:
                     save_state(state, config.output_dir)
+                    _last_save_time = now
 
             except Exception as exc:  # noqa: BLE001
                 state.warnings.append(

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -27,6 +27,12 @@ TAG_SIZE_LIMITS: dict[str, int] = {
     "emojis": 500 * 1024,
 }
 
+# Single-flight registry: coalesces concurrent first-uploads of the same cache key
+# (keyed by str(file_path), the same key upload_with_cache caches under) so two
+# parallel channel workers requesting the same physical file upload it only once.
+# Self-cleaning — every entry is popped on completion (success or failure).
+_inflight_uploads: dict[str, asyncio.Future[str]] = {}
+
 
 async def _retry_after_ms(response: aiohttp.ClientResponse) -> float:
     """429 backoff in ms: body ``retry_after`` -> ``Retry-After`` header (int seconds) -> 1000ms."""
@@ -191,14 +197,30 @@ async def upload_with_cache(
     if key in cache:
         return cache[key]
 
-    await asyncio.sleep(delay)
-    file_id = await upload_to_autumn(
-        session,
-        autumn_url,
-        tag,
-        file_path,
-        token,
-        verify_size=verify_size,
-    )
-    cache[key] = file_id
-    return file_id
+    # Coalesce concurrent first-uploads of the same key (check-then-act race): a
+    # second caller awaits the first uploader's result instead of re-uploading.
+    inflight = _inflight_uploads.get(key)
+    if inflight is not None:
+        return await inflight
+
+    future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    _inflight_uploads[key] = future
+    try:
+        await asyncio.sleep(delay)
+        file_id = await upload_to_autumn(
+            session,
+            autumn_url,
+            tag,
+            file_path,
+            token,
+            verify_size=verify_size,
+        )
+        cache[key] = file_id
+        future.set_result(file_id)
+        return file_id
+    except BaseException as exc:
+        future.set_exception(exc)
+        future.exception()  # mark retrieved -> silence "exception never retrieved"
+        raise
+    finally:
+        _inflight_uploads.pop(key, None)

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -184,6 +184,136 @@ def test_icons_limit_matches_stoat_autumn_config() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Batch 10 / S2 — upload_with_cache single-flight concurrency
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_with_cache_coalesces_same_key(tmp_path: Path) -> None:
+    """SC-5: concurrent same-key calls upload exactly once and share the id."""
+    import asyncio
+    from unittest.mock import patch
+
+    f = tmp_path / "a.png"
+    f.write_bytes(b"x" * 10)
+    cache: dict[str, str] = {}
+    calls = 0
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
+        return "id-1"
+
+    with patch("discord_ferry.uploader.autumn.upload_to_autumn", _slow):
+        async with aiohttp.ClientSession() as session:
+            task = asyncio.gather(
+                upload_with_cache(session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0),
+                upload_with_cache(session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0),
+            )
+            await entered.wait()  # leader registered the in-flight future + entered upload
+            await asyncio.sleep(0)  # let the follower reach `await inflight`
+            release.set()
+            results = await task
+
+    assert calls == 1
+    assert results == ["id-1", "id-1"]
+    assert cache[str(f)] == "id-1"
+
+
+async def test_upload_with_cache_distinct_keys_concurrent(tmp_path: Path) -> None:
+    """SC-6: distinct keys upload independently (no global serialization)."""
+    import asyncio
+    from unittest.mock import patch
+
+    f1 = tmp_path / "a.png"
+    f2 = tmp_path / "b.png"
+    f1.write_bytes(b"x" * 10)
+    f2.write_bytes(b"y" * 10)
+    cache: dict[str, str] = {}
+    calls = 0
+
+    async def _up(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        return f"id-{calls}"
+
+    with patch("discord_ferry.uploader.autumn.upload_to_autumn", _up):
+        async with aiohttp.ClientSession() as session:
+            results = await asyncio.gather(
+                upload_with_cache(session, AUTUMN_URL, "avatars", f1, TOKEN, cache, delay=0),
+                upload_with_cache(session, AUTUMN_URL, "avatars", f2, TOKEN, cache, delay=0),
+            )
+
+    assert calls == 2
+    assert len(set(results)) == 2
+
+
+async def test_upload_with_cache_hit_skips_upload_and_inflight(tmp_path: Path) -> None:
+    """SC-7: a cache hit returns without uploading or registering an in-flight future."""
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.uploader.autumn import _inflight_uploads
+
+    f = tmp_path / "a.png"
+    f.write_bytes(b"x" * 10)
+    cache = {str(f): "cached-id"}
+    mock = AsyncMock(return_value="should-not-be-used")
+    with patch("discord_ferry.uploader.autumn.upload_to_autumn", mock):
+        async with aiohttp.ClientSession() as session:
+            result = await upload_with_cache(
+                session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0
+            )
+
+    assert result == "cached-id"
+    assert mock.call_count == 0
+    assert str(f) not in _inflight_uploads
+
+
+async def test_upload_with_cache_failure_does_not_poison_key(tmp_path: Path) -> None:
+    """SC-8: a failed upload pops the key; a later call retries; no stray warning."""
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.uploader.autumn import _inflight_uploads
+
+    f = tmp_path / "a.png"
+    f.write_bytes(b"x" * 10)
+    cache: dict[str, str] = {}
+    mock = AsyncMock(side_effect=[AutumnUploadError("boom"), "id-2"])
+    with patch("discord_ferry.uploader.autumn.upload_to_autumn", mock):
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(AutumnUploadError):
+                await upload_with_cache(session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0)
+            assert str(f) not in _inflight_uploads  # not poisoned
+            result = await upload_with_cache(
+                session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0
+            )
+
+    assert result == "id-2"
+    assert mock.call_count == 2
+
+
+async def test_upload_with_cache_self_cleans_inflight(tmp_path: Path) -> None:
+    """SC-9: the in-flight entry is popped after a successful upload."""
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.uploader.autumn import _inflight_uploads
+
+    f = tmp_path / "a.png"
+    f.write_bytes(b"x" * 10)
+    cache: dict[str, str] = {}
+    mock = AsyncMock(return_value="id-1")
+    with patch("discord_ferry.uploader.autumn.upload_to_autumn", mock):
+        async with aiohttp.ClientSession() as session:
+            await upload_with_cache(session, AUTUMN_URL, "avatars", f, TOKEN, cache, delay=0)
+
+    assert str(f) not in _inflight_uploads
+    assert cache[str(f)] == "id-1"
+
+
+# ---------------------------------------------------------------------------
 # S1 — malformed 200 -> AutumnUploadError
 # ---------------------------------------------------------------------------
 

--- a/tests/test_avatars.py
+++ b/tests/test_avatars.py
@@ -355,3 +355,70 @@ async def test_avatar_upload_tracked_and_referenced(tmp_path: Path) -> None:
     assert state.autumn_uploads["autumn_av1"] == "user1"
     # Avatar is immediately referenced (avatars are always used via masquerade)
     assert "autumn_av1" in state.referenced_autumn_ids
+
+
+# ---------------------------------------------------------------------------
+# Batch 10 / S3 — time-based checkpoint cadence (replaces the %10 count-gate)
+# ---------------------------------------------------------------------------
+
+
+def _three_avatar_export(tmp_path: Path) -> DCEExport:
+    """Three local-avatar authors in a single export (sub-10, exercises the throttle)."""
+    messages = []
+    for i in range(3):
+        f = tmp_path / f"avatar_u{i}.webp"
+        f.write_bytes(b"RIFF\x00\x00\x00\x00WEBP")
+        author = _make_author(f"u{i}", f"User{i}", avatar_url=f"avatar_u{i}.webp")
+        messages.append(_make_message(f"m{i}", author))
+    return _make_export(messages)
+
+
+async def test_avatars_time_throttle_saves_sub_ten_run(tmp_path: Path) -> None:
+    """SC-10: a <10-avatar run checkpoints mid-loop once the monotonic clock crosses 5s."""
+    import itertools
+    from unittest.mock import Mock
+
+    export = _three_avatar_export(tmp_path)
+    config = _make_config(tmp_path)
+    state = _make_state()
+    save_mock = Mock()
+    # Every monotonic reading jumps 100s ahead, so each per-iteration check crosses the
+    # 5s threshold (robust even if other code also reads the clock).
+    monotonic = Mock(side_effect=itertools.count(0, 100))
+
+    with (
+        patch(
+            "discord_ferry.migrator.avatars.upload_with_cache",
+            new=AsyncMock(side_effect=["a0", "a1", "a2"]),
+        ),
+        patch("discord_ferry.migrator.avatars.save_state", save_mock),
+        patch("discord_ferry.migrator.avatars.time.monotonic", monotonic),
+    ):
+        await run_avatars(config, state, [export], lambda e: None)
+
+    assert save_mock.call_count >= 1  # checkpointed mid-loop, not only at engine phase-end
+    assert set(state.avatar_cache.values()) == {"a0", "a1", "a2"}
+
+
+async def test_avatars_time_throttle_no_premature_save(tmp_path: Path) -> None:
+    """SC-11: no mid-loop save while the clock has not advanced past 5s (no write storm)."""
+    from unittest.mock import Mock
+
+    export = _three_avatar_export(tmp_path)
+    config = _make_config(tmp_path)
+    state = _make_state()
+    save_mock = Mock()
+    monotonic = Mock(return_value=1.0)  # constant — never crosses +5.0
+
+    with (
+        patch(
+            "discord_ferry.migrator.avatars.upload_with_cache",
+            new=AsyncMock(side_effect=["a0", "a1", "a2"]),
+        ),
+        patch("discord_ferry.migrator.avatars.save_state", save_mock),
+        patch("discord_ferry.migrator.avatars.time.monotonic", monotonic),
+    ):
+        await run_avatars(config, state, [export], lambda e: None)
+
+    assert save_mock.call_count == 0
+    assert set(state.avatar_cache.values()) == {"a0", "a1", "a2"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1862,3 +1862,150 @@ async def test_run_migration_messages_crash_keeps_phase_for_resume(tmp_path: Pat
 
     saved = load_state(tmp_path)
     assert saved.current_phase == "messages"
+
+
+# ---------------------------------------------------------------------------
+# Batch 10 / S1 — engine exception-sanitization sweep (_safe)
+# ---------------------------------------------------------------------------
+
+
+async def test_rollback_event_message_redacts_token(tmp_path: Path) -> None:
+    """SC-1: an emitted rollback-delete event message redacts a token in the exc."""
+    from discord_ferry.core.engine import _delete_one_channel
+    from discord_ferry.core.security import SecureTokenStore
+    from discord_ferry.errors import MigrationError
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_config(tmp_path, token_store=SecureTokenStore({"stoat": "SEKRET-TOKEN-abcd"}))
+    state = MigrationState()
+    state.rollback_progress = RollbackProgress()
+    events: list[MigrationEvent] = []
+    sem = asyncio.BoundedSemaphore(1)
+
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise MigrationError("HTTP 500 at https://h/x?token=SEKRET-TOKEN-abcd")
+
+    with patch("discord_ferry.core.engine.api_delete_channel", _boom):
+        async with aiohttp.ClientSession() as session:
+            await _delete_one_channel("42", sem, config, state, session, events.append)
+
+    messages = [e.message or "" for e in events]
+    assert not any("SEKRET-TOKEN-abcd" in m for m in messages)
+    assert any("****abcd" in m for m in messages)
+
+
+async def test_rollback_failure_error_redacts_token(tmp_path: Path) -> None:
+    """SC-2: the persisted RollbackFailure.error redacts the token (state.json-bound)."""
+    from discord_ferry.core.engine import _delete_one_channel
+    from discord_ferry.core.security import SecureTokenStore
+    from discord_ferry.errors import MigrationError
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_config(tmp_path, token_store=SecureTokenStore({"stoat": "SEKRET-TOKEN-abcd"}))
+    state = MigrationState()
+    state.rollback_progress = RollbackProgress()
+    sem = asyncio.BoundedSemaphore(1)
+
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise MigrationError("token=SEKRET-TOKEN-abcd")
+
+    with patch("discord_ferry.core.engine.api_delete_channel", _boom):
+        async with aiohttp.ClientSession() as session:
+            await _delete_one_channel("42", sem, config, state, session, lambda e: None)
+
+    assert state.rollback_progress is not None
+    error = state.rollback_progress.failures[0].error
+    assert "SEKRET-TOKEN-abcd" not in error
+    assert "****abcd" in error
+
+
+async def test_rollback_event_message_none_store_unchanged(tmp_path: Path) -> None:
+    """SC-3: with no token store, the message is byte-identical (None-safe no-op)."""
+    from discord_ferry.core.engine import _delete_one_channel
+    from discord_ferry.errors import MigrationError
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_config(tmp_path)  # token_store defaults to None
+    assert config.token_store is None
+    state = MigrationState()
+    state.rollback_progress = RollbackProgress()
+    events: list[MigrationEvent] = []
+    sem = asyncio.BoundedSemaphore(1)
+
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise MigrationError("plain failure detail")
+
+    with patch("discord_ferry.core.engine.api_delete_channel", _boom):
+        async with aiohttp.ClientSession() as session:
+            await _delete_one_channel("42", sem, config, state, session, events.append)
+
+    assert any(e.message == "Failed to delete channel 42: plain failure detail" for e in events)
+
+
+async def test_rollback_success_message_not_sanitized(tmp_path: Path) -> None:
+    """SC-4: a non-exception event message is NOT wrapped (negative control).
+
+    The success-path "Deleted channel {id}" message is deliberately left unwrapped.
+    A token whose value is a substring of that literal must NOT be redacted — proving
+    the sweep did not over-wrap non-exception sites.
+    """
+    from discord_ferry.core.engine import _delete_one_channel
+    from discord_ferry.core.security import SecureTokenStore
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_config(tmp_path, token_store=SecureTokenStore({"x": "Deleted"}))
+    state = MigrationState()
+    state.rollback_progress = RollbackProgress()
+    events: list[MigrationEvent] = []
+    sem = asyncio.BoundedSemaphore(1)
+
+    async def _ok(*args: object, **kwargs: object) -> None:
+        return None
+
+    with patch("discord_ferry.core.engine.api_delete_channel", _ok):
+        async with aiohttp.ClientSession() as session:
+            await _delete_one_channel("42", sem, config, state, session, events.append)
+
+    assert any(e.message == "Deleted channel 42" for e in events)
+
+
+def test_ensure_token_store_populates_and_redacts(tmp_path: Path) -> None:
+    """_ensure_token_store sets a store that redacts the configured token."""
+    from discord_ferry.core.engine import _ensure_token_store
+
+    config = _make_config(tmp_path, token="SEKRET-TOKEN-abcd")
+    assert config.token_store is None
+    _ensure_token_store(config)
+    assert config.token_store is not None
+    assert "SEKRET-TOKEN-abcd" not in config.token_store.sanitize("a SEKRET-TOKEN-abcd b")
+
+
+def test_ensure_token_store_idempotent(tmp_path: Path) -> None:
+    """_ensure_token_store does not replace an already-set store."""
+    from discord_ferry.core.engine import _ensure_token_store
+    from discord_ferry.core.security import SecureTokenStore
+
+    existing = SecureTokenStore({"stoat": "other"})
+    config = _make_config(tmp_path, token="SEKRET", token_store=existing)
+    _ensure_token_store(config)
+    assert config.token_store is existing  # unchanged
+
+
+async def test_run_rollback_initializes_token_store(tmp_path: Path) -> None:
+    """Ship-review fix: run_rollback wires config.token_store so rollback _safe works.
+
+    The store is populated BEFORE input validation, so even an early validation failure
+    leaves a populated store — proving the rollback path is no longer redaction-inert.
+    """
+    from discord_ferry.core.engine import run_rollback
+    from discord_ferry.errors import MigrationError
+
+    config = _make_config(tmp_path, token="SEKRET-TOKEN-abcd")
+    assert config.token_store is None
+    state = MigrationState()  # no stoat_server_id + config has no server_id → validate raises
+
+    with pytest.raises(MigrationError):
+        await run_rollback(config, state, [], lambda e: None)
+
+    assert config.token_store is not None
+    assert "SEKRET-TOKEN-abcd" not in config.token_store.sanitize("x SEKRET-TOKEN-abcd y")

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -198,24 +198,18 @@ async def test_merge_mode_separator_sent(tmp_path: Path) -> None:
         message_count=1,
     )
 
-    sent_payloads: list[dict[str, object]] = []
+    from unittest.mock import patch
 
-    with aioresponses() as m:
-        # Capture all POST calls to the messages endpoint.
-        def capture_send(url: str, **kwargs: object) -> None:
-            sent_payloads.append(kwargs.get("json", {}))  # type: ignore[arg-type]
+    keys: list[str] = []
 
-        # Allow multiple sends to any channel.
-        for _ in range(10):
-            m.post(
-                f"{STOAT_URL}/channels/stoat-ch-100/messages",
-                payload={"_id": "msg-result"},
-                repeat=True,
-            )
-
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
         await run_messages(config, state, [parent, thread], events.append)
 
-    # Verify the separator message was sent (check event messages).
+    # The separator message was actually sent (idempotency_key ferry-thread-sep-{channel_id}).
+    # Pins the separator payload at the send level — a broken separator now fails this test.
+    assert "ferry-thread-sep-200" in keys
+
+    # Existing event-level assertion preserved.
     event_msgs = [e.message for e in events]
     assert any("Merged thread" in msg and "my-thread" in msg for msg in event_msgs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.15"
+version = "2.6.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Bug-Hunt Batch 10 (FINAL) — Defense-in-Depth & Misc Lows

Tenth and **final** batch of the 2026-06-25 v2.6.6 whole-codebase bug-hunt — this **closes the hunt** (44/44 confirmed findings addressed or consciously parked; batches 1–9 shipped v2.6.7–v2.6.15). Four latent-gap fixes. No GUI/CLI/state-schema/API-call change.

### Fixes
- **S1 — engine exception sanitization (`core/engine.py`).** A new `_safe(config, text)` helper routes every raw-exception interpolation — emitted via the event stream **and** persisted to `state.warnings` / `RollbackFailure.error` — through `safe_sanitize`, honoring its persist-or-emit contract (previously only 2 of ~16 sites were sanitized). A new `_ensure_token_store` helper wires the token store in **both** `run_migration` and `run_rollback` (the shells call rollback directly and never set it), so the rollback-path redaction is genuinely effective. No behaviour change when no token store is configured (None-safe).
- **S2 — concurrency-safe Autumn uploads (`uploader/autumn.py`).** `upload_with_cache` had a check-then-act race: two parallel channel workers requesting the same physical file both missed the cache and both uploaded (wasted per-tag budget + orphan files). A self-cleaning in-flight `asyncio.Future` registry now coalesces concurrent same-key callers onto one upload; a failed upload doesn't poison the key.
- **S3 — time-based avatar checkpoint cadence (`migrator/avatars.py`).** Replaced the "every 10th upload" count-gate (which never checkpointed a sub-10 tail → up to 9 `avatar_cache` entries lost on hard-kill, resumed as orphans) with a 5s `time.monotonic()` throttle.
- **S4 — repaired a dead test (`tests/test_thread_strategy.py`).** `test_merge_mode_separator_sent`'s capture callback was never invoked by aioresponses, so the separator payload was never asserted. Converted to the `_capture_keys` idiom asserting the separator's idempotency key.

### Quality
- Full `/df` pipeline. **Critique** ITERATE→PASS (fresh opus; caught a missed persisted site `engine.py:1391`). **Code review** REQUEST CHANGES→APPROVE (caught that the rollback-path redaction was inert because `run_rollback` never set the token store — fixed via `_ensure_token_store`). **Mistral** 9 findings, 0 real on verification.
- 14 new tests (SC-1..SC-13 + 3 token-store-wiring tests). Append-only for test_engine/test_autumn/test_avatars; reviewed carve-out for the test_thread_strategy repair. Each new guard falsified (revert prod → RED → restore).
- Gate: `ruff check .` + `ruff format --check .` + `mypy src/` + `pytest` = **1297 passed**.

Version: **v2.6.15 → v2.6.16** (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
