### PR TITLE
security(deps): clear 3 high Dependabot alerts — socketio 5.16.3, engineio 4.13.3 (v2.6.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.6.17] - 2026-06-28
+
+### Security
+
+Cleared 3 high-severity Dependabot alerts — denial-of-service vulnerabilities in transitive
+dependencies pulled by `nicegui[asyncio-client]` (the GUI shell). `uv.lock`-only bump; no
+`pyproject.toml`, source, or API change.
+
+- **`python-socketio` 5.16.1 → 5.16.3** — binary-attachment accumulation DoS
+  (GHSA-5w7q-77mv-v69f, patched 5.16.2).
+- **`python-engineio` 4.13.1 → 4.13.3** — unbound thread allocation DoS
+  (GHSA-cgwc-pv48-fhj5, patched 4.13.2) + maximum payload size sometimes not enforced DoS
+  (GHSA-m9gh-vj53-gvh9, patched 4.13.2).
+
 ## [2.6.16] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.6.16"
+version = "2.6.17"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.6.16"
+__version__ = "2.6.17"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.6.16"
+version = "2.6.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2024,14 +2024,14 @@ wheels = [
 
 [[package]]
 name = "python-engineio"
-version = "4.13.1"
+version = "4.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "simple-websocket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/12/bdef9dbeedbe2cdeba2a2056ad27b1fb081557d34b69a97f574843462cae/python_engineio-4.13.1.tar.gz", hash = "sha256:0a853fcef52f5b345425d8c2b921ac85023a04dfcf75d7b74696c61e940fd066", size = 92348, upload-time = "2026-02-06T23:38:06.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/54/0cce26da03a981f949bb8449c9778537f75f5917c172e1d2992ff25cb57d/python_engineio-4.13.1-py3-none-any.whl", hash = "sha256:f32ad10589859c11053ad7d9bb3c9695cdf862113bfb0d20bc4d890198287399", size = 59847, upload-time = "2026-02-06T23:38:04.861Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
 ]
 
 [[package]]
@@ -2045,15 +2045,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.16.1"
+version = "5.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/81/cf8284f45e32efa18d3848ed82cdd4dcc1b657b082458fbe01ad3e1f2f8d/python_socketio-5.16.1.tar.gz", hash = "sha256:f863f98eacce81ceea2e742f6388e10ca3cdd0764be21d30d5196470edf5ea89", size = 128508, upload-time = "2026-02-06T23:42:07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c7/deb8c5e604404dbf10a3808a858946ca3547692ff6316b698945bb72177e/python_socketio-5.16.1-py3-none-any.whl", hash = "sha256:a3eb1702e92aa2f2b5d3ba00261b61f062cce51f1cfb6900bf3ab4d1934d2d35", size = 82054, upload-time = "2026-02-06T23:42:05.772Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## security(deps): clear 3 high Dependabot alerts

Three **high-severity DoS** vulnerabilities in **transitive** dependencies pulled by `nicegui[asyncio-client]` (the GUI shell) — not direct deps, not in our code. `uv.lock`-only fix; no `pyproject.toml`, source, or API change.

| Alert | Package | Bump | GHSA |
|-------|---------|------|------|
| #41 | `python-socketio` | 5.16.1 → **5.16.3** | GHSA-5w7q-77mv-v69f — binary-attachment accumulation DoS (patched 5.16.2) |
| #40 | `python-engineio` | 4.13.1 → **4.13.3** | GHSA-cgwc-pv48-fhj5 — unbound thread allocation DoS (patched 4.13.2) |
| #39 | `python-engineio` | 4.13.1 → **4.13.3** | GHSA-m9gh-vj53-gvh9 — max payload size sometimes not enforced DoS (patched 4.13.2) |

`nicegui` has no upper-bound constraint on these, so `uv lock --upgrade-package python-socketio --upgrade-package python-engineio` resolves all three cleanly with no override. Both land past the patched thresholds.

### Quality
- `uv.lock`-only + version bump + CHANGELOG (0 non-docs code lines → code-review/Mistral gates N/A).
- Gate: `ruff check .` + `ruff format --check .` + `mypy src/` + `pytest` = **1297 passed** on the patched versions; `uv sync --locked` consistent.

Version: **v2.6.16 → v2.6.17** (patch — security/deps, per the v2.4.1 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
