### PR TITLE
content: user-facing docs caught up with the code (v2.2.3 → v2.6.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Documentation
+
+- **User-facing docs caught up with the code (v2.2.3 → v2.6.17).** The README, CLI reference,
+  and guides had drifted ~14 releases behind. Highlights: the `ferry probe` command and
+  post-migration invite generation are now documented; the "what gets migrated" tables include
+  the native-fidelity work (role hoist/icons/live discovery, server description & NSFW,
+  category ordering, slowmode, voice user limits); "role icons not migrated" and "slowmode
+  not supported" removed from known limitations (both migrated since v2.5.0); all references
+  to GUI Advanced Options controls that do not exist (reaction mode, min thread messages,
+  checkpoint interval, concurrency, skip avatars, validate after) replaced with an honest
+  "internal defaults, not currently configurable" note; wrong report filename `report.json`
+  corrected to `migration_report.json`; `export-blueprint` options corrected (`--output` is
+  required; `--name` exists); README gained badges and a section on the non-migration
+  commands. Docs-only; no version bump.
+
+### Internal
+
+- **Removed dead `_patch_checksums` test helper** (`tests/test_exporter_manager.py`). It was defined but never called (every `TestVerifyDceChecksum` test inlines its own `patch("importlib.resources.files")`), and was broken anyway — it built a `_Ctx` context manager then ignored it and returned a fresh, unconfigured patcher, papered over with `# type: ignore[return]`. No behavior change; suite stays at 926 passed.
+
 ## [2.6.17] - 2026-06-28
 
 ### Security
@@ -417,12 +438,6 @@ Autumn upload robustness cluster — the first batch from the 2026-06-25 v2.6.6 
 - **Extracted `_stoat_channel_type(int) -> str`** in `migrator/structure.py` as the single source of truth for the Discord-type → Stoat-type mapping (type 2 → Voice, else Text), replacing the inline match in `run_channels`.
 - All three new metadata fields round-trip through `discord_metadata.json` with `.get()`-defaulted decodes, so pre-upgrade metadata files load forward-compatibly and trigger the graceful-skip path. Locked by a deep-equality round-trip test in `tests/test_metadata.py`.
 - The **end-of-run server invite** (S4) originally scoped alongside these features was dropped from this release: `api_create_invite` belongs to the in-progress probe-and-invites feature, so invite generation will ship there rather than be duplicated here.
-
-## [Unreleased]
-
-### Internal
-
-- **Removed dead `_patch_checksums` test helper** (`tests/test_exporter_manager.py`). It was defined but never called (every `TestVerifyDceChecksum` test inlines its own `patch("importlib.resources.files")`), and was broken anyway — it built a `_Ctx` context manager then ignored it and returned a fresh, unconfigured patcher, papered over with `# type: ignore[return]`. No behavior change; suite stays at 926 passed.
 
 ## [2.2.12] - 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Discord Ferry
 
+[![CI](https://github.com/nordscope-fi/Discord-stoat-ferry/actions/workflows/ci.yml/badge.svg)](https://github.com/nordscope-fi/Discord-stoat-ferry/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/nordscope-fi/Discord-stoat-ferry)](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 **Migrate your Discord server to Stoat (formerly Revolt) — messages, channels, roles, emoji, attachments, and all.**
 
 > One-click app for Windows and Mac. Command-line interface for Linux.
@@ -67,16 +72,19 @@ Ferry can **pause and resume** — close it anytime, pick up where you left off.
 | Discord feature | What happens |
 |-----------------|-------------|
 | Text channels | Recreated on Stoat with the same names and topics |
-| Categories | Recreated — channels grouped the same way |
-| Roles | Recreated with colours and Discord permissions translated to Stoat equivalents |
+| Categories | Recreated in the same order as on Discord, with channels grouped the same way |
+| Roles | All server roles recreated — even roles nobody posted with — with colours, hierarchy, hoisting ("display separately"), image icons, and Discord permissions translated to Stoat equivalents |
 | Channel permissions | Per-role and @everyone overrides migrated |
 | NSFW channels | NSFW flag preserved |
+| Server description & NSFW flag | Copied to the new Stoat server |
+| Slowmode | Per-channel slowmode settings preserved |
+| Voice user limits | Per-channel user limits preserved |
 | Messages + authors | Each message shows the original author's name and avatar |
 | File attachments | Uploaded to Stoat's file storage |
-| Custom emoji | Uploaded (up to 100) |
+| Custom emoji | Uploaded (up to 100 — the most-used, uploadable emoji are kept) |
 | Pinned messages | Re-pinned in the correct channels |
 | Replies | Reply links preserved between messages |
-| Reactions | Shown as text summary by default, or applied via API |
+| Reactions | Shown as text summary by default, or applied via API (Stoat allows at most 20 reactions per message) |
 | Embeds | Flattened to Stoat format with thumbnails and images uploaded |
 | Polls | Rendered as formatted text |
 | Threads | Converted to text channels, merged into parent, or archived as markdown — your choice |
@@ -85,6 +93,8 @@ Ferry can **pause and resume** — close it anytime, pick up where you left off.
 | Stickers | Image uploaded, or text fallback for animated/missing |
 | Server banner | Uploaded from Discord API when a Discord token is provided |
 | Original timestamps | Shown at the start of each message (e.g. `*[2024-01-15 12:00 UTC]*`) |
+
+> Some of these need a Discord token to read live server data: role hoisting and icons, roles nobody posted with, server description, category ordering, slowmode, and voice user limits. In offline mode (export folder only), Ferry migrates what the export contains and skips the rest with a warning.
 
 ### Reliability features
 
@@ -95,12 +105,26 @@ Ferry is built to handle large migrations safely:
 - **Incremental migration** — only migrate new messages since the last completed run
 - **Pre-creation review** — summary and confirmation before anything is created on Stoat
 - **Migration report** — human-readable `migration_report.md` with a fidelity score
-- **Dead-letter queue** — failed messages tracked and retryable without re-running
+- **Invite link** — Ferry creates an invite to your new Stoat server when the migration finishes (on by default; turn off with `--no-create-invite`)
+- **Failed-message recovery** — messages that fail to send are tracked and automatically re-sent on the next `--incremental` run
 - **Message splitting** — messages over 2000 characters are split, not truncated
 - **Migration lock** — prevents two Ferry instances from targeting the same server
 - **Circuit breaker** — automatic backoff on API failures, no indefinite blocking
 - **Rollback** — undo a migration with one command (or one click in the GUI) — deletes Ferry-created channels, roles, and emoji from the Stoat server
 - **Post-migration stats** — `ferry stats <output-dir>` prints a console-friendly summary (entity counts, fidelity score, per-channel breakdown, error preview, elapsed time) from a completed migration — useful for support, scripting, and quick sanity checks without re-opening the report
+
+---
+
+## Beyond migration
+
+Ferry ships a few extra commands alongside `migrate`:
+
+- **`ferry validate`** — check an export before migrating: counts, warnings, and a time estimate. No network calls.
+- **`ferry probe`** — diagnose a live Stoat instance (upload size limits, rate limits, voice support, webhooks). Useful for self-hosters.
+- **`ferry build`** — create a fresh Stoat server from a preset template (`gaming`, `community`, or `education`) or a blueprint file.
+- **`ferry export-blueprint`** — turn a Discord export into a reusable server blueprint (structure only, no messages).
+
+See the [CLI reference](docs/guides/cli-reference.md) for all commands and options.
 
 ---
 

--- a/docs/getting-started/first-migration.md
+++ b/docs/getting-started/first-migration.md
@@ -245,15 +245,9 @@ Before creating anything on Stoat, Ferry shows a review summary.
 
 === "GUI (Windows / macOS)"
 
-    When all 12 phases complete, Ferry shows a summary card with:
+    When all phases complete, Ferry shows a completion card with the error count and — when a Discord token was used — a native-fidelity line (slowmode settings, voice user limits, and role icons applied).
 
-    - Total channels created
-    - Total messages migrated
-    - Total attachments uploaded
-    - Error count (click to view details)
-    - **Fidelity score** — a quantified measure of migration quality
-
-    Click **Open Report** to view the full migration report in your browser.
+    Click **Open Report** to view the full migration report, including message counts, attachment counts, and the **fidelity score** — a quantified measure of migration quality.
 
     <!-- screenshot: ferry-complete-screen -->
 
@@ -262,7 +256,7 @@ Before creating anything on Stoat, Ferry shows a review summary.
     Ferry prints a summary table when it finishes, including a **fidelity score** — a quantified measure of migration quality (messages migrated vs. source total, attachment success rate, and other factors). The full report is saved to:
 
     ```
-    ferry-output/report.json
+    ferry-output/migration_report.json
     ```
 
     Other files written to the output directory:
@@ -273,7 +267,7 @@ Before creating anything on Stoat, Ferry shows a review summary.
     | `message_map.json` | Discord message ID → Stoat message ID mapping (used for reply linking and incremental runs) |
     | `discord_metadata.json` | Server structure and permission data fetched from Discord API |
     | `migration_report.md` | Human-readable summary with fidelity score and per-channel stats |
-    | `report.json` | Machine-readable full report including error details |
+    | `migration_report.json` | Machine-readable full report including error details |
 
 ---
 
@@ -318,7 +312,7 @@ After a successful migration:
 
 **Seeing errors in the log?**
 
-Most errors are non-fatal. Ferry logs them and continues. A failed attachment upload or a skipped message does not stop the whole migration. Check `ferry-output/report.json` for a list of everything that was skipped and why.
+Most errors are non-fatal. Ferry logs them and continues. A failed attachment upload or a skipped message does not stop the whole migration. Check `ferry-output/migration_report.json` for a list of everything that was skipped and why.
 
 **Rate limit warnings?**
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -9,7 +9,7 @@ Ferry's command-line interface provides the same migration capability as the GUI
 
 ## Commands
 
-Ferry has six top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, and `stats`.
+Ferry has seven top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, `stats`, and `probe`.
 
 ---
 
@@ -68,6 +68,8 @@ ferry migrate [OPTIONS]
 | `--token TEXT` | `STOAT_TOKEN` | *(required)* | Your Stoat user token (copied from your browser — see [setup guide](../getting-started/setup-stoat.md#2-get-your-stoat-user-token)) |
 | `--server-id TEXT` | | | Migrate into an existing Stoat server by ID |
 | `--server-name TEXT` | | | Name for the new server (defaults to the Discord server name) |
+| `--create-invite` / `--no-create-invite` | | on | Create an invite link to the migrated server when the migration finishes. The invite URL is printed in the completion summary and included in the reports. |
+| `--invite-channel-id TEXT` | | | Discord channel ID to base the invite on. By default Ferry picks the first eligible text channel. |
 | `--skip-messages` | | false | Import structure only — no messages sent |
 | `--skip-emoji` | | false | Do not upload custom emoji |
 | `--skip-reactions` | | false | Do not add reactions |
@@ -108,11 +110,11 @@ STOAT_TOKEN=your_stoat_token_here
 
 ---
 
-### GUI Only Options
+### Internal defaults (not currently configurable)
 
-These options are available in the GUI's Advanced Options panel but are not yet exposed as CLI flags. They will be added as CLI options in a future release:
+These settings exist inside Ferry with the defaults below, but there is currently no CLI flag or GUI control to change them:
 
-| Config Field | Default | Description |
+| Setting | Default | Description |
 |---|---|---|
 | `skip_avatars` | False | Skip avatar pre-flight phase |
 | `validate_after` | False | Run post-migration validation comparing Stoat server against source |
@@ -121,9 +123,6 @@ These options are available in the GUI's Advanced Options panel but are not yet 
 | `reaction_mode` | `"text"` | How reactions are migrated: `"text"` (append to content), `"native"` (API calls), `"skip"` |
 | `min_thread_messages` | 0 | Exclude threads with fewer than this many messages (0 = include all) |
 | `checkpoint_interval` | 50 | How often state is saved during messages (every N messages) |
-
-!!! tip "Using these settings from the CLI"
-    These options are available in the GUI's Advanced Options section today. CLI flags for them are planned for a future release.
 
 ---
 
@@ -273,7 +272,8 @@ ferry export-blueprint [OPTIONS]
 | Flag | Description |
 |------|-------------|
 | `--from PATH` | Path to DCE export directory *(required)* |
-| `--output PATH` | Output path for the blueprint JSON file (default: `blueprint.json`) |
+| `--output PATH` / `-o` | Output path for the blueprint JSON file *(required)* |
+| `--name TEXT` | Override the server name stored in the blueprint |
 
 **Example:**
 
@@ -394,3 +394,52 @@ ferry stats ~/migrations/my-server-2026-05-15/
 
 !!! note "What stats does NOT do"
     `ferry stats` is read-only. It does not write to `state.json`, does not call any API, and does not modify the Stoat server. For a richer Markdown report including the original Discord export context, use the `migration_report.md` file written into the output directory by `ferry migrate` — it includes fields that require the original DCE exports to compute.
+
+---
+
+## `ferry probe`
+
+Check what a live Stoat instance actually supports before you migrate to it. Probe measures upload size limits, checks whether voice channels can be created (Stoat Bug #194), checks webhook availability, and inspects rate-limit behaviour. It is most useful for self-hosted instances, where limits differ from the official service.
+
+```
+ferry probe --test-server-id <id> [OPTIONS]
+```
+
+Probe creates its test entities (channels, uploads) on the server you point it at, and deletes everything it created before exiting. Use a throwaway server, not your production server. It never writes a migration state file.
+
+### Options
+
+| Flag | Environment Variable | Description |
+|------|----------------------|-------------|
+| `--stoat-url TEXT` | `STOAT_URL` | Stoat API base URL *(required)* |
+| `--token TEXT` | `STOAT_TOKEN` | Your Stoat user token *(required)* |
+| `--test-server-id TEXT` | | ID of a throwaway Stoat server to create test entities on *(required)* |
+| `--deep` | | Reserved for a deeper upload-boundary probe — currently reports "not yet implemented" |
+| `--json` | | Print results as machine-readable JSON instead of a table |
+| `--verbose` / `-v` | | Verbose output |
+
+### What it checks
+
+- **Upload size limits** — the limits the instance's file server (Autumn) advertises per upload category, compared against the values Ferry assumes. A mismatch is reported as a warning.
+- **Voice channels** — creates a test voice channel and checks whether the instance actually supports voice (Stoat Bug #194). If not, Discord voice channels will become text channels.
+- **Webhooks** — creates a test channel and checks whether webhooks can be created on the instance.
+- **Rate limiting** — what rate-limit information the instance exposes in its responses.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Probe ran and results were printed |
+| `1` | Missing `--stoat-url` or `--token` |
+
+### Examples
+
+```bash
+# Probe the official hosted service
+ferry probe --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN" \
+  --test-server-id 01ABCDEF234567890ABCDEFGH
+
+# Probe a self-hosted instance and save the results as JSON
+ferry probe --stoat-url https://stoat.example.com --token "$STOAT_TOKEN" \
+  --test-server-id 01ABCDEF234567890ABCDEFGH --json > probe-results.json
+```

--- a/docs/guides/gui-walkthrough.md
+++ b/docs/guides/gui-walkthrough.md
@@ -50,11 +50,9 @@ Click **Advanced Options** to expand the following settings. Defaults are safe f
 | Thread strategy | Flatten | How to handle threads and forum posts. **Flatten** (default) creates a dedicated channel for each thread. **Merge** appends thread messages into the parent channel. **Archive** exports the thread as a markdown attachment in the parent channel. |
 | Dry run | Off | Run all migration phases without actually contacting the Stoat server. Useful for validating your export before committing to a full migration. |
 | Existing server ID | *(empty)* | Paste a Stoat server ID to migrate into a server you have already created, rather than creating a new one. |
-| Checkpoint interval | 50 | How often migration state is saved (every N messages). Lower = safer but more I/O. Minimum 1. |
-| Skip avatars | Off | Skip the avatar pre-flight phase. Avatars will be uploaded on-demand during messages instead. |
-| Reaction mode | Text | How to handle reactions: **Text** (default) appends `[Reactions: emoji count]` to message content — zero extra API calls. **Native** applies reactions via API (slower). **Skip** ignores reactions entirely. |
-| Min thread messages | 0 | Exclude threads with fewer than this many messages. 0 includes all threads. Useful for servers with hundreds of low-activity threads. |
-| Validate after | Off | Run a post-migration validation that compares Stoat server against the migration state. Reports discrepancies. |
+| Server name | *(empty)* | Name for the new Stoat server. Defaults to the Discord server's name. |
+
+A few settings (checkpoint interval, reaction mode, minimum thread messages, and others) are fixed to safe internal defaults and cannot currently be changed from the GUI or CLI — see [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable) in the CLI reference.
 
 !!! tip "Running into 'Too Many Requests' errors?"
     That error (code 429) means Stoat is asking Ferry to slow down. Increase the rate limit slider to 2.0 or 3.0 seconds. This slows the migration but eliminates the errors.
@@ -131,7 +129,7 @@ Ferry runs through three steps automatically:
 
 If Ferry detects cached export files from a previous run, it shows a summary (file count and total size) and offers two choices:
 
-- **Use cached exports** — skip re-exporting and go straight to validation.
+- **Use Cached** — skip re-exporting and go straight to validation.
 - **Re-export** — discard cached files and export fresh.
 
 This is useful when resuming after a crash or when you want to re-run the migration without re-downloading everything.
@@ -240,14 +238,14 @@ Click **Cancel** to stop the migration entirely. Ferry saves its state to disk b
 
 ## Completion Screen
 
-When all phases finish, the Completion screen shows a summary card with final statistics: messages sent, attachments uploaded, errors, elapsed time, and a **fidelity score** — a 0–100 measure of migration quality based on messages, attachments, embeds, replies, and reactions.
+When all phases finish, the Completion screen shows a card with the error count and — when a Discord token was used — a native-fidelity line showing how many slowmode settings, voice user limits, and role icons were applied.
 
 <!-- screenshot: completion screen with summary card -->
 
-Click **Open Report** to open the migration report in your browser. Two report files are saved to the `ferry-output/` folder:
+For the full statistics (message counts, attachments, and the **fidelity score** — a 0–100 measure of migration quality), click **Open Report**. Two report files are saved to the `ferry-output/` folder:
 
 - `migration_report.md` — a human-readable summary you can share with your community
-- `report.json` — a machine-readable report with full error details and ID mappings
+- `migration_report.json` — a machine-readable report with full error details and ID mappings
 
 ### Rollback this migration
 

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -10,14 +10,14 @@ These limitations relate to how channels, threads, and server organization are r
 
 | Discord Feature | What Stoat Gets | Workaround |
 |-----------------|----------------|------------|
-| Threads | Flattened to text channels by default, prefixed with parent channel name (e.g. `general-my-thread`) | Use `--thread-strategy merge` to append thread messages into the parent channel, or `--thread-strategy archive` to export as a markdown attachment. In the GUI, use the **Min thread messages** setting to filter out low-activity threads and reduce channel count. |
+| Threads | Flattened to text channels by default, prefixed with parent channel name (e.g. `general-my-thread`) | Use `--thread-strategy merge` to append thread messages into the parent channel, or `--thread-strategy archive` to export as a markdown attachment. Both are also available in the GUI's thread strategy setting. |
 | Forum posts | Each post becomes a text channel inside a `forum-*` category, with an auto-generated index channel listing all posts | None — this is the closest structural equivalent |
 | Stage Channels | Not migrated (no Stoat equivalent) | None |
 | Scheduled Events | Not migrated | None |
-| Channel ordering | Display order may differ from the original Discord layout | Manually reorder channels in Stoat after migration |
+| Channel ordering | Categories follow the original Discord order (since v2.3.0, requires a Discord token), but channels *inside* a category may appear in a different order | Manually reorder channels within categories in Stoat after migration |
 
 !!! note "Thread handling and channel limits"
-    With the default `flatten` strategy, every thread becomes a channel. A busy Discord server with hundreds of threads can easily exceed Stoat's 200-channel limit. Use `--thread-strategy merge` or `archive` to avoid creating extra channels, set a minimum message count in the GUI's **Min thread messages** setting, or use `--skip-threads` to omit threads entirely. Self-hosted admins can raise the limit — see [Self-Hosted Tips](self-hosted-tips.md).
+    With the default `flatten` strategy, every thread becomes a channel. A busy Discord server with hundreds of threads can easily exceed Stoat's 200-channel limit. Use `--thread-strategy merge` or `archive` to avoid creating extra channels, or use `--skip-threads` to omit threads entirely. Self-hosted admins can raise the limit — see [Self-Hosted Tips](self-hosted-tips.md).
 
 ---
 
@@ -30,7 +30,7 @@ These limitations affect how individual messages and their content appear after 
 | Embeds | Flattened to markdown text; inline fields use `\|` separators | None — Stoat embeds have a different structure and cannot replicate Discord embeds exactly |
 | Polls | Rendered as plain text showing the question and options | None |
 | Stickers | Uploaded as image attachments where the source file is available; Lottie (animated) stickers receive a text fallback | None — Lottie format is not supported by Stoat |
-| Reactions | Text summary appended to the message by default (`reaction_mode="text"`). Shows emoji and count. | In the GUI, set **Reaction mode** to **Native** for per-emoji reactions added via the Stoat API (slower, limited to 20 per message) |
+| Reactions | Text summary appended to the message by default. Shows emoji and count. Stoat allows at most 20 reactions per message; anything beyond that is dropped and counted in the migration report. | None — reaction handling is currently fixed to text mode (see [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable)) |
 | Forwarded messages | Skipped entirely | None — this is a DiscordChatExporter limitation; forwarded messages export as empty content |
 | Long messages (>2000 chars) | Split into sequential parts with `[continued K/N]` markers (e.g. `[continued 2/3]`). Original content is fully preserved across parts. | None needed — splitting is automatic and lossless |
 | Author names >32 chars | Truncated to 29 chars with a `#XXXX` discriminator suffix derived from the author's Discord ID. Ensures uniqueness while fitting the Stoat masquerade name limit. | None — the suffix preserves attributability even after truncation |
@@ -46,6 +46,8 @@ These limitations affect role and permission migration.
 |-----------------|----------------|------------|
 | Per-member channel overrides | Not supported by Stoat; only role-based overrides are migrated | Create a single-user role for each member who had individual overrides, then apply the override to that role |
 | Managed roles (bot roles) | Not migrated — these are auto-created by Discord for each bot integration | None needed — bot integrations do not carry over |
+| Role membership | Roles are recreated, but members are **not** assigned to them — there is no reliable way to map Discord accounts to Stoat accounts | Members re-join via invite and assign roles manually (or with a Stoat bot) |
+| "Mention @everyone" permission | Dropped — Stoat has no equivalent permission | None |
 
 ---
 
@@ -74,20 +76,30 @@ These limitations affect use cases involving large servers or non-standard expor
 
 ---
 
+## Incremental Migration
+
+`--incremental` copies messages that are **new** since the last completed run. Two things to know:
+
+| Limitation | Detail | Workaround |
+|------------|--------|------------|
+| New messages only | Incremental detects messages *added* after the last run. Messages that were **edited or deleted** on Discord in the meantime are not updated on Stoat. | None — full edit/delete sync is out of scope |
+| Failed messages | Messages that failed to send in a previous run are re-sent automatically by the next `--incremental` run. | None needed — this is automatic |
+
+---
+
 ## Platform Features
 
 These limitations relate to platform-level features that either work differently or have no equivalent in Stoat.
 
 | Discord Feature | What Stoat Gets | Workaround |
 |-----------------|----------------|------------|
-| Voice channels | Created, but functionality may be limited due to a known upstream issue (Stoat Bug #194) | Verify channel types in the Stoat web interface after migration; voice requires the Vortex or LiveKit service |
+| Voice channels | Created, but functionality may be limited due to a known upstream issue (Stoat Bug #194) | Verify channel types in the Stoat web interface after migration; voice requires the Vortex or LiveKit service. Run `ferry probe` to check whether your instance supports voice before migrating. |
 | AutoMod | Not supported by Stoat | Configure moderation manually after migration |
 | Welcome Screen | Not migrated | None |
 | Soundboard | Not supported by Stoat | None |
-| Role icons | Not migrated — Stoat roles do not support icons | None |
+| Role icons | Image icons are migrated (since v2.5.0, requires a Discord token). Emoji-only role icons cannot be migrated. | None for emoji icons — Stoat only supports image icons |
 | Animated emoji | Static fallback uploaded where possible; some animated emoji may be skipped | None — Stoat does not support animated emoji |
 | Server boosts | Not applicable — Stoat uses a different model | None |
-| Slowmode | Not supported by Stoat | None |
 
 ---
 

--- a/docs/guides/large-servers.md
+++ b/docs/guides/large-servers.md
@@ -68,10 +68,10 @@ v2.0.0 processes multiple channels concurrently, dramatically reducing migration
 | `max_concurrent_channels` | 3 | Channels processed simultaneously |
 | `max_concurrent_requests` | 5 | Total concurrent API calls across all workers |
 
-These settings interact: with 3 channels and 5 API slots, each channel averages ~1.7 concurrent API calls. For self-hosted instances with generous rate limits, increase both.
+These settings interact: with 3 channels and 5 API slots, each channel averages ~1.7 concurrent API calls.
 
-!!! info "GUI only (for now)"
-    These concurrency settings are available in the GUI's Advanced Options panel. CLI flags are planned for a future release. See the [CLI Reference](cli-reference.md#gui-only-options) for the full list.
+!!! info "Fixed defaults"
+    These concurrency settings are internal defaults and cannot currently be changed from the GUI or CLI. See [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable) in the CLI reference.
 
 ---
 
@@ -160,18 +160,20 @@ If emoji fidelity matters, raise the `server_emoji` limit on a self-hosted insta
 
 ---
 
-## Thread Filtering
+## Keeping Thread Channels Under Control
 
-For servers with hundreds of threads, many may contain only a few messages. Use `min_thread_messages` (default 0) to exclude low-activity threads and stay within Stoat's 200-channel limit:
+With the default `flatten` strategy, every thread becomes its own channel — a busy server with hundreds of threads can blow past Stoat's 200-channel limit. Two options avoid that:
 
-=== "GUI"
-    On the Setup screen, expand **Advanced Options** and set the **Min thread messages** field. Threads with fewer messages than this threshold are skipped.
+- `--thread-strategy merge` appends thread messages into the parent channel instead of creating new channels.
+- `--skip-threads` omits threads entirely.
 
-=== "CLI"
-    Thread filtering is currently available through the GUI only. On the CLI, use `--skip-threads` to exclude all threads, or `--thread-strategy merge` to avoid creating extra channels.
+Both are available in the GUI's Advanced Options too (thread strategy dropdown and skip-threads toggle).
 
-!!! tip "Find the right threshold"
-    Run `ferry validate` first — the counts table shows thread message counts. In the GUI, setting Min thread messages to 5 is a good starting point, skipping threads that are essentially empty.
+!!! tip "Check first"
+    Run `ferry validate` on your export — the counts table shows how many threads it contains, so you can see whether the channel limit is a risk before migrating.
+
+!!! info "Minimum-message filtering is not configurable"
+    Ferry has an internal `min_thread_messages` setting for filtering out low-activity threads, but there is currently no GUI control or CLI flag for it. See [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable).
 
 ---
 
@@ -187,23 +189,11 @@ By default, Ferry uses `reaction_mode='text'`, which appends reaction counts to 
 
 For a 10,000-message server with 20,000 reactions, `text` mode saves roughly 5 hours compared to `native` mode.
 
-=== "GUI"
-    On the Setup screen, expand **Advanced Options** and use the **Reaction mode** dropdown.
-
-=== "CLI"
-    Reaction mode is currently available through the GUI only. On the CLI, use `--skip-reactions` to skip reactions entirely. The default `text` mode is always active otherwise.
+!!! info "Fixed to text mode"
+    Reaction mode is an internal default and cannot currently be changed from the GUI or CLI — Ferry always uses `text` mode. To leave reactions out entirely, use `--skip-reactions` (or the GUI's skip-reactions toggle).
 
 ---
 
-## Checkpoint Tuning
+## Checkpoints
 
-Ferry saves migration state every 50 messages by default (`checkpoint_interval=50`). For very large servers (100,000+ messages), you can increase this to reduce disk I/O overhead.
-
-=== "GUI"
-    On the Setup screen, expand **Advanced Options** and adjust the **Checkpoint interval** field. A value of 200 is a good balance for large migrations.
-
-=== "CLI"
-    Checkpoint interval is currently available through the GUI only. The default of 50 works well for most migrations.
-
-!!! info "Trade-off"
-    A higher checkpoint interval means faster throughput but slightly more re-work if the migration is interrupted — Ferry will replay up to `checkpoint_interval` messages on resume. For most large migrations, 200 is a good balance.
+Ferry saves migration state every 50 messages. If a migration is interrupted, resuming replays at most those 50 messages — nothing else is lost. This interval is an internal default and cannot currently be changed from the GUI or CLI; it works well for migrations of any size.

--- a/docs/guides/pre-flight-checklist.md
+++ b/docs/guides/pre-flight-checklist.md
@@ -76,7 +76,7 @@ Stoat's default limit is **200 channels per server**. Every Discord thread and f
 
 Run `ferry validate` on your export to see the projected channel count before starting.
 
-**Why:** If the total exceeds 200, the migration will fail partway through. In the GUI, use the **Min thread messages** setting to filter low-activity threads, or use `--skip-threads` to omit threads entirely. Self-hosted admins can raise the limit — see [Self-Hosted Tips](self-hosted-tips.md#raising-limits-for-migration).
+**Why:** If the total exceeds 200, the migration will fail partway through. Use `--thread-strategy merge` to avoid creating a channel per thread, or `--skip-threads` to omit threads entirely (both also available in the GUI). Self-hosted admins can raise the limit — see [Self-Hosted Tips](self-hosted-tips.md#raising-limits-for-migration).
 
 ---
 
@@ -127,25 +127,19 @@ Ensure the Stoat account you are using was created at least **72 hours ago**.
 
 Ferry 2.0 adds several options. Decide which apply to your migration before you start:
 
-**Available as CLI flags and in the GUI:**
+**Available as CLI flags** (in the GUI, only the thread strategy has a control):
 
 | Option | Purpose | When to use |
 |--------|---------|-------------|
 | `--thread-strategy flatten\|merge\|archive` | Controls how Discord threads are represented in Stoat | Default is `flatten` (each thread becomes a channel). Use `merge` to append thread messages to the parent channel, or `archive` to create read-only channels |
 | `--incremental` | Migrate only messages posted since the last run | Subsequent runs on a live-but-slowing server; requires a previous completed migration |
 | `--verify-uploads` | After each file upload, compare file sizes | Use when uploads may be silently corrupted (slow connections, large files) |
-| `--cleanup-orphans` | Detect files that were uploaded but never referenced | Run after migration to reclaim storage on self-hosted instances |
+| `--cleanup-orphans` | Detect and report files that were uploaded but never referenced (report-only — nothing is deleted) | Useful on self-hosted instances to find files worth cleaning up manually |
 | `--force` | Override the export freshness check (exports older than 30 days) | Only use if re-running with a known-good old export |
 | `--force-unlock` | Remove the advisory migration lock from the server | Use if a previous migration crashed and left the lock in place |
 | `--skip-dce-verify` | Skip SHA-256 verification of the DCE binary | Not recommended; use only in air-gapped environments where the hash is already verified |
 
-**Available in the GUI only (no CLI flag yet):**
-
-| Option | Purpose | When to use |
-|--------|---------|-------------|
-| Reaction mode | Text summary (default), native API calls, or skip | Use `native` if per-emoji reactions matter; use `skip` for fastest migration |
-| Min thread messages | Exclude threads below a message count | Use when your server has hundreds of low-activity threads |
-| Concurrent channels | Number of channels processed in parallel | Increase on self-hosted instances with relaxed rate limits |
+**Fixed internal defaults** — reaction mode (text summary), minimum thread messages (0), and concurrency (3 channels in parallel) cannot currently be changed from the CLI or GUI. See [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable) in the CLI reference.
 
 **Why:** Choosing the wrong thread strategy or omitting `--incremental` on a second run will duplicate messages or create an unexpected channel structure. Decide before starting — these options cannot be changed mid-migration.
 
@@ -165,7 +159,7 @@ Copy this condensed checklist for quick use:
 - [ ] Per-member overrides planned (single-user roles created)
 - [ ] MongoDB backed up (self-hosted only)
 - [ ] Stoat account is older than 72 hours (official service only)
-- [ ] Migration options reviewed (thread strategy, incremental mode, reaction mode, concurrency)
+- [ ] Migration options reviewed (thread strategy, incremental mode)
 
 ---
 

--- a/docs/guides/self-hosted-tips.md
+++ b/docs/guides/self-hosted-tips.md
@@ -78,23 +78,18 @@ For powerful self-hosted instances, you can increase concurrency to speed up mig
 | `max_concurrent_channels` | 3 | Channels processed in parallel during the message phase |
 | `max_concurrent_requests` | 5 | Total concurrent API calls across all channel workers |
 
-These two settings interact: with 3 channels and 5 API slots, each channel averages ~1.7 concurrent calls. Both can be raised for self-hosted instances with relaxed rate limits.
+These two settings interact: with 3 channels and 5 API slots, each channel averages ~1.7 concurrent calls.
 
-=== "GUI"
-    On the Setup screen, expand **Advanced Options** to find the concurrency settings. Try 6 concurrent channels and 12 concurrent requests for a powerful self-hosted instance.
-
-=== "CLI"
-    These concurrency settings are currently available through the GUI only. CLI flags are planned for a future release. The defaults (3 channels, 5 requests) are safe for most setups.
-
-Monitor your Stoat server load and reduce these values if you encounter frequent 429 errors.
+!!! info "Fixed defaults"
+    These concurrency settings are internal defaults and cannot currently be changed from the GUI or CLI. See [Internal defaults](cli-reference.md#internal-defaults-not-currently-configurable) in the CLI reference. To adjust migration speed, use the `--rate-limit` and `--upload-delay` flags (or the GUI's rate-limit slider) instead.
 
 ---
 
 ## Ferry GUI Storage Secret
 
-The Ferry GUI uses a storage secret to persist session data (such as your API URL and token between page navigations). By default, a random secret is generated each time Ferry starts.
+The Ferry GUI uses a storage secret to persist non-sensitive session settings (such as your Stoat API URL) between page navigations. Tokens are never part of this — they are held in memory only and are never written to disk. By default, a random secret is generated each time Ferry starts.
 
-To persist sessions across restarts, set the `FERRY_STORAGE_SECRET` environment variable:
+To persist settings across restarts, set the `FERRY_STORAGE_SECRET` environment variable:
 
 ```bash
 export FERRY_STORAGE_SECRET="your-random-secret-here"

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,16 +37,19 @@ Ferry can **pause and resume** — close it anytime and pick up where you left o
 | Discord feature | What happens |
 |-----------------|-------------|
 | Text channels | Recreated on Stoat with the same names and topics |
-| Categories | Recreated — channels grouped the same way |
-| Roles | Recreated with colours and Discord permissions translated to Stoat equivalents |
+| Categories | Recreated in the same order as on Discord, with channels grouped the same way |
+| Roles | All server roles recreated — even roles nobody posted with — with colours, hierarchy, hoisting ("display separately"), image icons, and Discord permissions translated to Stoat equivalents |
 | Channel permissions | Per-role and @everyone overrides migrated |
 | NSFW channels | NSFW flag preserved |
+| Server description & NSFW flag | Copied to the new Stoat server |
+| Slowmode | Per-channel slowmode settings preserved |
+| Voice user limits | Per-channel user limits preserved |
 | Messages + authors | Each message shows the original author's name and avatar |
 | File attachments | Uploaded to Stoat's file storage |
-| Custom emoji | Uploaded (up to 100) |
+| Custom emoji | Uploaded (up to 100 — the most-used, uploadable emoji are kept) |
 | Pinned messages | Re-pinned in the correct channels |
 | Replies | Reply links preserved between messages |
-| Reactions | Shown as text summary by default, or applied via API |
+| Reactions | Shown as text summary by default, or applied via API (Stoat allows at most 20 reactions per message) |
 | Embeds | Flattened to Stoat format with thumbnails and images uploaded |
 | Polls | Rendered as formatted text |
 | Threads | Converted to text channels, merged into parent, or archived as markdown — your choice |
@@ -56,6 +59,8 @@ Ferry can **pause and resume** — close it anytime and pick up where you left o
 | Server banner | Uploaded from Discord API when a Discord token is provided |
 | Original timestamps | Shown at the start of each message (e.g. `*[2024-01-15 12:00 UTC]*`) |
 
+> Some of these need a Discord token to read live server data: role hoisting and icons, roles nobody posted with, server description, category ordering, slowmode, and voice user limits. In offline mode (export folder only), Ferry migrates what the export contains and skips the rest with a warning.
+
 ### Reliability Features
 
 Ferry is built to handle large migrations safely:
@@ -63,11 +68,10 @@ Ferry is built to handle large migrations safely:
 - **Pause and resume** — close Ferry anytime, pick up where you left off
 - **Parallel channel sends** — processes multiple channels concurrently (3x–5x faster)
 - **Incremental migration** — only migrate new messages since the last completed run
-- **Thread filtering** — exclude low-activity threads by minimum message count
 - **Pre-creation review** — summary and confirmation before anything is created on Stoat
 - **Migration report** — human-readable `migration_report.md` with a fidelity score
-- **Dead-letter queue** — failed messages tracked and retryable without re-running
-- **Post-migration validation** — verifies Stoat server structure matches the source
+- **Invite link** — Ferry creates an invite to your new Stoat server when the migration finishes (on by default; turn off with `--no-create-invite`)
+- **Failed-message recovery** — messages that fail to send are tracked and automatically re-sent on the next `--incremental` run
 - **Message splitting** — messages over 2000 characters are split, not truncated
 - **Migration lock** — prevents two Ferry instances from targeting the same server
 - **Circuit breaker** — automatic backoff on API failures, no indefinite blocking


### PR DESCRIPTION
## Summary

User-facing docs had drifted ~14 releases behind the code (README and CLI reference last touched at v2.2.3; the repo is at v2.6.17). This PR brings every user-facing doc back in line with the code. Two audit passes verified every claim in the changed files against source at `7fea3c6`.

Docs-only — **no version bump** per project rules.

## False claims fixed

- **known-limitations**: "role icons not migrated" and "slowmode not supported" removed — both migrated since v2.5.0. Channel-ordering row now states the precise truth (categories follow Discord order; within-category order may differ). Added rows: role membership not assigned, "Mention @everyone" permission dropped, 20-reactions-per-message cap, incremental edit/delete-sync limits.
- **Phantom GUI settings**: four guides (gui-walkthrough, large-servers, pre-flight-checklist, self-hosted-tips) told users to change settings in a GUI Advanced Options panel that does not contain them (reaction mode, min thread messages, checkpoint interval, concurrency, skip avatars, validate after). All replaced with an honest "Internal defaults (not currently configurable)" section in the CLI reference, with pointers to it.
- Wrong report filename `report.json` → `migration_report.json` (3 places).
- GUI completion-card description now matches what `gui.py` actually renders (error count + native-fidelity line; full stats live in the report).
- `export-blueprint`: `--output` is required (docs claimed a default); `--name` documented.
- `--cleanup-orphans` described as report-only (it deletes nothing).
- GUI storage-secret section: tokens are memory-only and never written to disk.

## Missing features documented

- **`ferry probe`** — full new section in the CLI reference; command count corrected 6 → 7. `--deep` documented as not yet implemented (verified in `probe.py`).
- **Invite generation** — `--create-invite/--no-create-invite` (default on) and `--invite-channel-id` added to the migrate options; noted the invite URL appears in CLI output and reports (the GUI does not show it).
- **Native fidelity** — README + docs/index "what gets migrated" tables now include role hoist/icons/live role discovery, server description & NSFW, category ordering, slowmode, and voice user limits, with a footnote on which need a Discord token.
- README gained CI/release/Python/MIT badges and a "Beyond migration" section covering `validate` / `probe` / `build` / `export-blueprint`.

## Housekeeping

- CHANGELOG: stray mid-file `[Unreleased]` block moved to the top of the file; Documentation entry added.

## Verification

- Full gate green: ruff, format, mypy, 1297 tests passed.
- `uv run mkdocs build --strict` passes; new anchor links verified in the built HTML.
- Every documented flag/default diffed against live `ferry <cmd> --help` output.
- Grep sweep for the known-stale patterns returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
