### PR TITLE
content: advertise the v2.7.0 tunable-performance flags in README + docs landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Documentation
+
+- README and docs landing page gained a "Tunable performance" reliability bullet pointing at
+  the v2.7.0 flags (concurrency, reaction mode, thread filtering, checkpointing). Docs-only;
+  no version bump.
+
 ## [2.7.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Ferry is built to handle large migrations safely:
 
 - **Pause and resume** — close Ferry anytime, pick up where you left off
 - **Parallel channel sends** — processes multiple channels concurrently (3x–5x faster)
+- **Tunable performance** — concurrency, reaction mode, thread filtering, and checkpointing are all adjustable via CLI flags or the GUI's Advanced Options — see the [CLI reference](docs/guides/cli-reference.md#ferry-migrate)
 - **Incremental migration** — only migrate new messages since the last completed run
 - **Pre-creation review** — summary and confirmation before anything is created on Stoat
 - **Migration report** — human-readable `migration_report.md` with a fidelity score

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Ferry is built to handle large migrations safely:
 
 - **Pause and resume** — close Ferry anytime, pick up where you left off
 - **Parallel channel sends** — processes multiple channels concurrently (3x–5x faster)
+- **Tunable performance** — concurrency, reaction mode, thread filtering, and checkpointing are all adjustable via CLI flags or the GUI's Advanced Options — see the [CLI reference](guides/cli-reference.md#ferry-migrate)
 - **Incremental migration** — only migrate new messages since the last completed run
 - **Pre-creation review** — summary and confirmation before anything is created on Stoat
 - **Migration report** — human-readable `migration_report.md` with a fidelity score


### PR DESCRIPTION
Follow-up to #100: the README and docs/index reliability lists gain one **Tunable performance** bullet (concurrency, reaction mode, thread filtering, checkpointing) linking to the CLI reference's migrate section. Anchor verified in the strict mkdocs build. Docs-only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)