### PR TITLE
security(deps): clear the last 2 medium Dependabot alerts — pymdown-extensions 11.0.1 (v2.7.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ferry-output/
 
 # Claude Code (all internal tooling)
 .claude/
+.claude-session-lock
 CLAUDE.md
 claude_log/
 .mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-08-01
+
+### Security
+
+- **Cleared the two open medium Dependabot alerts (#42, #43) — `uv.lock`-only, no source change.**
+  `setuptools` 82.0.1 → 83.0.0 (MANIFEST.in exclusion bypass in sdist via NFC/NFD Unicode
+  normalization collision on macOS APFS/HFS+; transitive via `pyinstaller` +
+  `pyinstaller-hooks-contrib`, `dev` extra) and `pymdown-extensions` 10.21.3 → 11.0.1 (path
+  traversal in the `b64` extension letting `<img src>` read files outside `base_path`;
+  transitive via `mkdocs-material`, `docs` extra). Neither package ships in the installed
+  wheel or the PyInstaller binary — exposure was limited to the CI/build host — but both are
+  now off the alert board. The `pymdown-extensions` fix is a major bump that Dependabot would
+  not raise automatically; `mkdocs-material` 9.7.6 accepts the v11 line, so no dependency
+  override was needed.
+
 ### Documentation
 
 - README and docs landing page gained a "Tunable performance" reliability bullet pointing at
-  the v2.7.0 flags (concurrency, reaction mode, thread filtering, checkpointing). Docs-only;
-  no version bump.
+  the v2.7.0 flags (concurrency, reaction mode, thread filtering, checkpointing).
+
+### Internal
+
+- `.gitignore` now covers `.claude-session-lock`, which sat untracked next to the already-ignored
+  `.claude/` directory and showed up in every `git status`.
 
 ## [2.7.0] - 2026-07-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.7.0"
+version = "2.7.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1863,15 +1863,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the last two open medium Dependabot alerts. Lockfile-only — no source logic change; the only `src/` edit is the version string.

## Alerts closed

| Alert | Package | Severity | Issue | Fix |
|---|---|---|---|---|
| #43 | `pymdown-extensions` | medium | Path traversal in the `b64` extension — `<img src>` can read files outside `base_path` | 10.21.3 → **11.0.1** |
| #42 | `setuptools` | medium | `MANIFEST.in` exclusion bypass in sdist via NFC/NFD Unicode normalization collision on macOS APFS/HFS+ | 82.0.1 → **83.0.0** (landed in #102) |

Dependabot never raised a PR for #43 on its own because the fix is a **major** bump on a transitive dep. `mkdocs-material` 9.7.6 accepts the v11 line, so `uv lock --upgrade-package pymdown-extensions` resolved cleanly with no dependency override — same shape as the v2.6.17 socketio/engineio clear (#97).

## Exposure

Neither package ships in the installed wheel or the PyInstaller binary:

- `pymdown-extensions` ← `mkdocs-material` (`docs` extra, Deploy Docs job only)
- `setuptools` ← `pyinstaller` + `pyinstaller-hooks-contrib` (`dev` extra, build-time)

Dependabot labels both `scope: runtime` because it reads the resolved `uv.lock` graph rather than extra membership. Real exposure was limited to the CI/build host — worth clearing for a clean board, not an emergency.

## Verification

`.github/workflows/docs.yml` triggers only on `docs/**` and `mkdocs.yml`, so **CI will not exercise the docs build for this PR** — which is the one thing a pymdown major bump could plausibly break. Verified locally instead:

```
uv run mkdocs build --strict     -> exit 0, built in 0.87s
```

Full gate, all green:

```
uv run ruff check .              -> All checks passed
uv run ruff format --check .     -> 93 files already formatted
uv run mypy src/                 -> no issues, 42 source files
uv run pytest                    -> 1310 passed in 188s
uv sync --locked --extra dev --extra native  -> clean
```

1310 tests matches the v2.7.0 baseline exactly — no test delta expected for a lockfile change, and none observed.

## Also

Adds `.claude-session-lock` to `.gitignore`. It sat untracked beside the already-ignored `.claude/` directory and appeared in every `git status`.

## Version

Patch bump **2.7.0 → 2.7.1**, following the #97 precedent that a dependency security clear gets a patch release. `pyproject.toml`, `src/discord_ferry/__init__.py`, and the `uv.lock` workspace entry are all in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
