### PR TITLE
fix: macOS users could not open Ferry — Gatekeeper docs, docs rendering, Intel builds (v2.8.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
   build-windows:
     name: Build Windows executable
     runs-on: windows-latest
+    # Only a non-secret boolean is hoisted to job level. A step cannot read its
+    # own step-level `env` from its own `if:`, so the guard has to resolve above
+    # the step — but the certificate itself stays scoped to the signing step so
+    # checkout/build steps never see it.
+    env:
+      HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_CERT_PFX != '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -34,7 +40,7 @@ jobs:
         run: uv run --extra dev pyinstaller ferry.spec
 
       - name: Sign Windows binary
-        if: env.WINDOWS_CERT_PFX != ''
+        if: env.HAS_WINDOWS_CERT == 'true'
         env:
           WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
@@ -54,8 +60,18 @@ jobs:
           retention-days: 1
 
   build-macos:
-    name: Build macOS executable
-    runs-on: macos-14
+    name: Build macOS executable (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            arch: arm64
+          # Last x86_64 image GitHub offers; support ends August 2027, after
+          # which Intel Macs need a universal2 cross-build or get dropped.
+          - runner: macos-15-intel
+            arch: x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -72,21 +88,20 @@ jobs:
       - name: Build executable
         run: uv run --extra dev pyinstaller ferry.spec
 
-      - name: Sign macOS binary
-        if: env.APPLE_IDENTITY != ''
-        env:
-          APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
-        run: |
-          codesign --deep --force --sign "$APPLE_IDENTITY" dist/Ferry.app
-          codesign --verify dist/Ferry.app
+      # Developer ID signing + notarization land here. Until then PyInstaller's
+      # ad-hoc signature is all the bundle carries, so Gatekeeper rejects it on
+      # first launch and users must approve the app via System Settings. See
+      # docs/getting-started/install.md. Notarization additionally requires
+      # `--options runtime` plus an entitlements plist; signing alone does not
+      # clear the warning, which is why no signing step runs here today.
 
       - name: Zip .app bundle
-        run: cd dist && zip -r ../Ferry-macos-arm64.zip Ferry.app
+        run: cd dist && zip -r ../Ferry-macos-${{ matrix.arch }}.zip Ferry.app
 
       - uses: actions/upload-artifact@v6
         with:
-          name: ferry-macos
-          path: Ferry-macos-arm64.zip
+          name: ferry-macos-${{ matrix.arch }}
+          path: Ferry-macos-${{ matrix.arch }}.zip
           retention-days: 1
 
   release:
@@ -109,10 +124,16 @@ jobs:
           name: ferry-windows
           path: release-assets/
 
-      - name: Download macOS artifact
+      - name: Download macOS artifact (Apple Silicon)
         uses: actions/download-artifact@v7
         with:
-          name: ferry-macos
+          name: ferry-macos-arm64
+          path: release-assets/
+
+      - name: Download macOS artifact (Intel)
+        uses: actions/download-artifact@v7
+        with:
+          name: ferry-macos-x86_64
           path: release-assets/
 
       - name: Create GitHub Release
@@ -122,6 +143,7 @@ jobs:
           files: |
             release-assets/Ferry-windows-x86_64.exe
             release-assets/Ferry-macos-arm64.zip
+            release-assets/Ferry-macos-x86_64.zip
 
       - name: Build Python distributions
         run: uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-08-01
+
+### Fixed
+
+- **The documentation site never rendered its own markup.** `mkdocs.yml` carried no
+  `markdown_extensions` block, so `admonition` and `pymdownx.tabbed` were never enabled —
+  Material for MkDocs does not turn them on implicitly. All 87 admonitions across the 15
+  published pages printed as literal `!!! warning "…"` text, and all 27 content tabs printed
+  as literal `=== "macOS"`. On the installation page that meant the per-OS tabs did not
+  exist: Windows, macOS and Linux instructions ran together on one page, so a Mac user read
+  Windows steps first. `toc` and `tables` are listed alongside the new extensions so the full
+  set the docs depend on is visible in one place, though both remain on by default.
+
+- **macOS install instructions told users to do something Apple removed two years ago.**
+  The guide instructed right-click → **Open**; that bypass was removed in **macOS 15
+  Sequoia** (August 2024). Users following it found no such option, and the dialog they were
+  left staring at offers only **Done** and a highlighted **Move to Bin** — the prominent
+  button deletes the app. Rewritten around the System Settings → Privacy & Security →
+  **Open Anyway** flow, with an explicit warning not to click Move to Bin, and a note that
+  the button only appears after a blocked launch and expires after about an hour.
+
+- `xattr -d com.apple.quarantine` → `xattr -dr` in both install and troubleshooting guides.
+  Without `-r` the flag is cleared from the bundle directory only while the executable inside
+  stays quarantined, so the documented command silently did nothing for an `.app`.
+
+- **Neither code-signing step in `release.yml` could ever have run.** Both gated on
+  `if: env.<SECRET> != ''` while defining that variable in the same step's `env:` block; a
+  step cannot read its own step-level `env` from its own `if:`, so the condition was
+  permanently false. The Windows guard now resolves a non-secret boolean at job level while
+  the certificate itself stays scoped to the signing step, so the gate works without widening
+  the secret to checkout and build steps.
+
+- README download table understated the artifact sizes by roughly half (`~25 MB` against a
+  real 48 MB), and pointed Windows users at a filename the release does not publish.
+
+### Added
+
+- **Intel Mac builds.** `release.yml`'s macOS job is now a matrix over `macos-14` (arm64) and
+  `macos-15-intel` (x86_64), publishing `Ferry-macos-x86_64.zip` alongside the existing
+  `Ferry-macos-arm64.zip`. Releases were previously arm64-only, so Intel Macs could not run
+  Ferry at all. `macos-15-intel` is the last x86_64 image GitHub offers and is supported
+  through August 2027.
+
+- Troubleshooting entry for the actual dialog users hit — *"Apple could not verify Ferry is
+  free of malware"* — including an explicit note that the right-click workaround found in
+  older guides no longer works.
+
+### Known limitations
+
+- Ferry is still **not notarized**, so macOS continues to require the one-time Open Anyway
+  approval. Clearing the warning outright requires a Developer ID certificate plus
+  notarization, which needs a paid Apple Developer Program membership. The removed macOS
+  signing step is marked in `release.yml` where that work belongs; note it also needs
+  `--options runtime` and an entitlements plist, as signing alone does not satisfy Gatekeeper.
+
 ## [2.7.1] - 2026-08-01
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@
 
 | Platform | Download | Size |
 |----------|----------|------|
-| **Windows** | [Ferry.exe](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest/download/Ferry-windows-x86_64.exe) | ~25 MB |
-| **macOS** | [Ferry.zip](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest/download/Ferry-macos-arm64.zip) | ~25 MB |
+| **Windows** | [Ferry.exe](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest/download/Ferry-windows-x86_64.exe) | ~48 MB |
+| **macOS** — Apple Silicon (M1–M4) | [Ferry.zip](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest/download/Ferry-macos-arm64.zip) | ~48 MB |
+| **macOS** — Intel | [Ferry.zip](https://github.com/nordscope-fi/Discord-stoat-ferry/releases/latest/download/Ferry-macos-x86_64.zip) | ~48 MB |
 | **Linux / pip** | `pipx install discord-ferry` | ~2 MB |
+
+> **macOS:** the first launch is blocked by Gatekeeper because Ferry is not notarized. Click **Done** — *not* "Move to Bin" — then approve it once under **System Settings → Privacy & Security → Open Anyway**. Full walkthrough in the [installation guide](https://nordscope-fi.github.io/Discord-stoat-ferry/getting-started/install/).
 
 ---
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -9,8 +9,8 @@ Pick your operating system below to get started.
 === "Windows"
 
     1. Go to the [Discord Ferry releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases) on GitHub.
-    2. Under the latest release, click **Ferry.exe** to download it.
-    3. Double-click **Ferry.exe** to run it. Your browser will open automatically.
+    2. Under the latest release, click **Ferry-windows-x86_64.exe** to download it.
+    3. Double-click the downloaded file to run it. Your browser will open automatically.
 
     <!-- screenshot: windows-smartscreen-warning -->
 
@@ -26,22 +26,48 @@ Pick your operating system below to get started.
 
 === "macOS"
 
+    First, check which Mac you have. Click the Apple menu in the top-left corner and choose **About This Mac**:
+
+    | What you see | Download this file |
+    |---|---|
+    | **Chip:** Apple M1 / M2 / M3 / M4 | `Ferry-macos-arm64.zip` |
+    | **Processor:** Intel | `Ferry-macos-x86_64.zip` |
+
+    Then:
+
     1. Go to the [Discord Ferry releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases) on GitHub.
-    2. Under the latest release, click **Ferry-macos-arm64.zip** to download it.
+    2. Under the latest release, click the file that matches your Mac.
     3. Unzip the downloaded file.
     4. Drag the **Ferry.app** icon into your **Applications** folder.
-
-    !!! warning "First launch — do NOT double-click"
-        The first time you open Ferry, you must right-click (or Control-click) the app icon and select **Open**. If you double-click instead, macOS will refuse to run it.
+    5. Double-click **Ferry.app**. macOS blocks it the first time. This is expected — keep reading.
 
     <!-- screenshot: macos-gatekeeper-warning -->
 
-    !!! warning "Gatekeeper warning"
-        macOS may show a dialog saying **"Ferry can't be opened because Apple cannot check it for malicious software."**
+    !!! danger "Click Done, not Move to Bin"
+        macOS shows a dialog reading **"Apple could not verify 'Ferry' is free of malware that may harm your Mac or compromise your privacy."** It offers two buttons: **Done** and **Move to Bin**.
 
-        Click **Open** to proceed. This message appears because Ferry is not notarized through Apple's paid developer program. The source code is publicly available on GitHub.
+        Click **Done**. The highlighted **Move to Bin** button deletes Ferry.
 
-        After the first launch, you can open Ferry normally by double-clicking it.
+    !!! warning "Approving Ferry (once)"
+        Ferry is not notarized through Apple's paid developer program, so macOS asks you to approve it by hand the first time:
+
+        1. Open **System Settings** from the Apple menu.
+        2. Go to **Privacy & Security** and scroll down to the **Security** section.
+        3. You will see **"Ferry" was blocked to protect your Mac**. Click **Open Anyway**.
+        4. Click **Open Anyway** once more to confirm, then enter your Mac password.
+
+        Ferry opens. From now on you can launch it with a normal double-click.
+
+        **Not seeing the button?** It only appears *after* macOS has blocked Ferry, and it disappears again after about an hour. Double-click **Ferry.app** once more, then go straight back to **Privacy & Security**.
+
+    !!! tip "Faster, if you are comfortable with Terminal"
+        This single command clears the download quarantine flag, which stops macOS blocking the app in the first place:
+
+        ```bash
+        xattr -dr com.apple.quarantine /Applications/Ferry.app
+        ```
+
+        Then open Ferry normally. The source code is publicly available on GitHub if you would like to check it first.
 
 === "Linux"
 
@@ -93,10 +119,14 @@ PyInstaller (the packaging tool used to create Ferry's single `.exe` file) can t
 This sometimes happens if macOS quarantined the file during download. Open **Terminal** (search for it in Spotlight) and run:
 
 ```bash
-xattr -d com.apple.quarantine /Applications/Ferry.app
+xattr -dr com.apple.quarantine /Applications/Ferry.app
 ```
 
-Then try opening Ferry again.
+Then try opening Ferry again. The `-r` is important: without it the flag is only cleared from the folder, and the app inside stays blocked.
+
+**macOS says it "could not verify Ferry is free of malware"**
+
+This is the normal first-launch prompt, not a fault. Follow the **Approving Ferry** steps in the macOS tab above. Whatever you do, do not click **Move to Bin** — that deletes the app.
 
 **"Python not found" or "python3: command not found" (Linux)**
 

--- a/docs/guides/gui-walkthrough.md
+++ b/docs/guides/gui-walkthrough.md
@@ -3,7 +3,9 @@
 This guide walks through every screen of the Discord Ferry web interface. Ferry runs a small local web server when you launch it — no data ever leaves your machine.
 
 !!! info "Launching the GUI"
-    Double-click `ferry.exe` (Windows) or `ferry` (macOS/Linux). Your browser will open automatically to `http://localhost:8765`. If it does not, open that URL manually.
+    On **Windows**, double-click the downloaded `Ferry-windows-x86_64.exe`. On **macOS**, open **Ferry.app** — see [Installation](../getting-started/install.md) if macOS blocks it the first time. On **Linux**, run `ferry-gui` in a terminal.
+
+    Your browser will open automatically to `http://localhost:8765`. If it does not, open that URL manually.
 
 ---
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -106,26 +106,33 @@ This page covers the most common problems encountered during migration, their ca
 | **Cause** | Ferry is packaged as a single-file app using PyInstaller (a Python packaging tool). These self-extracting apps are frequently flagged as false positives by antivirus software because the extraction technique resembles some malware behavior. |
 | **Solution** | Add `ferry.exe` to your antivirus exclusion list. If your organization's policy prevents this, use the Python source distribution instead: clone the [GitHub repository](https://github.com/nordscope-fi/Discord-stoat-ferry) and install with `uv pip install .`, then run with `ferry` directly. The source distribution is not affected by this issue. |
 
+### macOS "Apple could not verify Ferry is free of malware"
+
+| | |
+|---|---|
+| **Symptom** | Double-clicking `Ferry.app` shows a dialog reading *"Apple could not verify 'Ferry' is free of malware that may harm your Mac or compromise your privacy."* The only buttons are **Done** and **Move to Bin**. |
+| **Cause** | Ferry is not notarized through Apple's paid developer program, so Gatekeeper blocks the first launch. It is not a fault in the app. |
+| **Solution** | Click **Done** — never **Move to Bin**, which deletes Ferry. Then open **System Settings → Privacy & Security**, scroll to the **Security** section, and click **Open Anyway** next to *"Ferry" was blocked to protect your Mac*. Confirm with **Open Anyway** again and enter your password. See [Installation](../getting-started/install.md) for the illustrated walkthrough. |
+
+!!! warning "The Open Anyway button is time-limited"
+    It appears only after macOS has blocked Ferry, and it disappears again after about an hour. If it is not there, double-click `Ferry.app` again and return to **Privacy & Security**.
+
+!!! failure "Right-clicking no longer works"
+    Older guides tell you to right-click (or Control-click) the app and choose **Open**. Apple removed that shortcut in **macOS 15 Sequoia**. On macOS 15 and later, the System Settings route above is the only way through the dialog.
+
 ### macOS "app is damaged and can't be opened"
 
 | | |
 |---|---|
-| **Symptom** | macOS refuses to open `ferry` with a message that the app is damaged or cannot be opened |
+| **Symptom** | macOS refuses to open `Ferry.app` with a message that the app is damaged or cannot be opened |
 | **Cause** | macOS automatically marks files downloaded from the internet as untrusted. This is a built-in security check called Gatekeeper — it is not an actual problem with Ferry. |
 | **Solution** | Run the following command in Terminal, then try opening Ferry again: |
 
 ```bash
-xattr -d com.apple.quarantine /path/to/ferry
+xattr -dr com.apple.quarantine /Applications/Ferry.app
 ```
 
-Replace `/path/to/ferry` with the actual path to the downloaded binary. If you moved it to `/Applications`, the command would be:
-
-```bash
-xattr -d com.apple.quarantine /Applications/ferry
-```
-
-!!! info "Right-click workaround"
-    Alternatively, right-click (or Control-click) the `ferry` file, choose **Open**, and click **Open** in the dialog that appears. macOS will remember this choice and not prompt again.
+The `-r` flag matters. Without it the quarantine flag is cleared only from the bundle folder, while the executable inside it stays blocked and the app still refuses to open. If you kept Ferry somewhere other than `/Applications`, substitute that path.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,23 @@ exclude_docs: |
   plans/
   superpowers/
   discord-ferry-claude-code-brief.md
+# `toc` and `tables` are on by default and are listed anyway, so the full set
+# the docs depend on is visible in one place. Verified by building with
+# `tables` removed: the tables still rendered, so this key extends the
+# built-in defaults rather than replacing them.
+markdown_extensions:
+  - toc
+  - tables
+  # Without `admonition` and `pymdownx.tabbed`, every `!!! warning` and
+  # `=== "macOS"` in docs/ renders as literal markup on the published site.
+  - admonition
+  - pymdownx.tabbed:
+      alternate_style: true
+  # Supersedes `fenced_code`; required for code fences nested inside tabs
+  # and admonitions, which is where most of ours live.
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
 nav:
   - Home: index.md
   - Getting Started:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.7.1"
+version = "2.8.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.7.1"
+__version__ = "2.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.7.1"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Users could not open the macOS app. Diagnosed against the **actually shipped `v2.7.1` artifact**, not inferred from the workflow file:

```
codesign -dvvv   → Signature=adhoc, TeamIdentifier=not set
codesign --verify --deep --strict → valid on disk        ✅ bundle is sound
spctl -a -t exec → rejected                              ❌ reproduces the dialog
file .../MacOS/Ferry → Mach-O 64-bit executable arm64    ❌ arm64-only
```

The bundle is fine. It fails one gate: no Developer ID, no notarization ticket.

## Three compounding failures

**1. The install guide sent users to a dead end that deletes the app.** It said right-click → **Open**. Apple removed that bypass in **macOS 15 Sequoia** (Aug 2024). Users found no such option and were left at a dialog offering only `Done` and a highlighted **`Move to Bin`**.

Rewritten around **System Settings → Privacy & Security → Open Anyway**, with an explicit warning against Move to Bin and the non-obvious detail that the button only appears *after* a blocked launch and expires after ~1h.

**2. The documentation site never rendered its own markup.** `mkdocs.yml` had no `markdown_extensions` block, so `admonition` and `pymdownx.tabbed` were never enabled — Material for MkDocs does not turn them on implicitly.

| | before | after |
|---|---|---|
| literal `!!!` leaking into HTML | **87** | **0** |
| content tabs rendered | **0** | 13 tab sets |
| tab labels on install page | *(none)* | `[Windows, macOS, Linux]` |
| `<table>` elements | 89 | 91 (no regression) |

On the install page the per-OS tabs did not exist at all: Windows, macOS and Linux instructions ran together on one page, so a Mac user's first instructions were the Windows ones. Fixing this was a prerequisite — a `!!! danger` callout would otherwise have rendered as literal text.

**3. Neither code-signing step could ever have run.** Both gated on `if: env.<SECRET> != ''` while defining that variable in the same step's own `env:` block, which a step cannot read from its own `if:`. The repo has no such secrets anyway. The macOS step also lacked `--options runtime`, so it could not have produced a notarizable app even with a certificate — it is removed, with a comment marking where notarization lands.

## Also

- **Intel Mac builds.** Releases were arm64-only, so Intel Macs could not run Ferry at all. The macOS job is now a matrix over `macos-14` and `macos-15-intel` (the last x86_64 image GitHub offers, supported through Aug 2027).
- `xattr -d` → `xattr -dr` throughout. Tested on the real bundle: the old form left **9 of 10** items quarantined, including the executable. The documented command did nothing.
- README sizes were ~2× off (`~25 MB` vs a real 48 MB) and pointed Windows users at a filename the release does not publish.
- `gui-walkthrough.md` told macOS/Linux users to double-click a bare `ferry` binary — `ferry` is the CLI entry point, macOS ships `Ferry.app`, and Linux has no double-click.

## Verification

- `ruff` + `mypy` clean, **1310 tests passed**, `mkdocs build --strict` exit 0
- `release.yml` parsed as YAML: upload names `ferry-macos-{arm64,x86_64}` match downloads exactly
- Repo-wide programmatic check: no workflow step gates on its own step-level `env`
- Quarantine round-trip executed on the real v2.7.1 bundle

## Known limitation

Ferry remains **un-notarized**, so the one-time Open Anyway approval is still required. Clearing the warning outright needs a Developer ID certificate plus notarization, which requires a paid Apple Developer Program membership — tracked as follow-up. Note it also needs `--options runtime` and an entitlements plist, and `ferry.spec` sets `upx=True`, which can invalidate macOS signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
