### PR TITLE
fix: Stoat's rate-limit reset header is milliseconds, not seconds (v2.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-08-02
+
+### Fixed
+
+- **Stoat rate-limit recovery waited 60 seconds instead of ~10** (`migrator/api.py`). Stoat sends
+  `X-RateLimit-Reset-After` in **milliseconds** — documented at
+  [developers.stoat.chat](https://developers.stoat.chat/developers/api/ratelimits) as "Milliseconds
+  left until calls are replenished" — on every response including 429s. Ferry read it as seconds, so
+  `min(10000, 60)` clamped to the 60-second cap on every rate-limit hit. Worst in the message phase,
+  which hits Stoat's 10-per-10s bucket hardest. The correct body-`retry_after` path (already divided
+  by 1000, and carrying the same value) had become unreachable because the header is checked first.
+  This was a regression caused by upstream: the code was correct when written, before Stoat began
+  exposing these headers.
+- **A test was locking the bug in.** `test_429_x_ratelimit_reset_after` asserted that a header value
+  of `"1.5"` meant 1.5 seconds, so the wrong unit had test coverage — anyone who suspected the defect
+  would have hit a red test and backed off. Corrected to `"1500"` -> 1.5s, preserving the test's
+  original intent (header honoured even when the 429 body is unparseable HTML).
+
+- **A negative advertised delay no longer disables backoff.** A negative header or body value parses
+  cleanly as a float, and `asyncio.sleep()` of a negative number returns immediately — so a hostile
+  or buggy value would have turned the retry loop hot. Both delay paths are now floored at 0
+  alongside the existing 60-second ceiling.
+
+### Internal
+
+- The Stoat-side parser is renamed `_stoat_rate_delay_seconds` and documents its unit contract.
+  `discord/client.py` contains a function that was identical in name, signature and body but whose
+  header genuinely *is* delta-seconds; the two were indistinguishable on sight, and merging them
+  would silently break one side by a factor of 1000. Discord's semantics are now pinned by
+  `test_discord_reset_after_header_is_seconds_not_milliseconds`, which fails if that merge is ever
+  attempted. `Retry-After` remains delta-seconds on both, for proxies in front of Stoat.
+
 ## [2.8.1] - 2026-08-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.8.1"
+version = "2.8.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.8.1"
+__version__ = "2.8.2"

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -144,31 +144,57 @@ async def _api_request(
     )
 
 
-def _retry_after_seconds(headers: Mapping[str, str]) -> float | None:
-    """Parse a rate-limit delay (seconds) from standard headers; None if absent/non-numeric.
+def _stoat_rate_delay_seconds(headers: Mapping[str, str]) -> float | None:
+    """Resolve a 429 delay from Stoat's rate-limit headers, returned in SECONDS.
 
-    ``Retry-After`` may be an HTTP-date rather than delta-seconds — a non-numeric value is
-    ignored (returns None) so the caller falls back to the body / default delay.
+    UNIT HAZARD — do NOT merge this with ``discord.client._retry_after_seconds``.
+    The two look like duplicates and are not. Stoat documents
+    ``X-RateLimit-Reset-After`` as MILLISECONDS ("Milliseconds left until calls are
+    replenished", developers.stoat.chat/developers/api/ratelimits), while Discord
+    sends the identically-named header as delta-seconds. Unifying them silently
+    breaks one side by a factor of 1000.
+    ``tests/test_discord_client.py::test_discord_reset_after_header_is_seconds_not_milliseconds``
+    pins the Discord side against exactly that refactor.
+
+    ``Retry-After`` (RFC 9110 delta-seconds) is honoured first: Stoat itself does not
+    send it, but a proxy or CDN in front of Stoat may. A non-numeric value (an
+    HTTP-date form) is ignored so the caller falls back to the body.
+
+    Returns None when no usable header is present.
     """
-    for name in ("Retry-After", "X-RateLimit-Reset-After"):
-        raw = headers.get(name)
-        if raw:
-            try:
-                return float(raw)
-            except ValueError:
-                continue
+    raw_retry_after = headers.get("Retry-After")
+    if raw_retry_after:
+        try:
+            return float(raw_retry_after)
+        except ValueError:
+            pass  # HTTP-date form — fall through to the Stoat header, then the body.
+
+    raw_reset_after = headers.get("X-RateLimit-Reset-After")
+    if raw_reset_after:
+        try:
+            return float(raw_reset_after) / 1000
+        except ValueError:
+            pass
+
     return None
 
 
 async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
-    """Resolve the 429 sleep in seconds: header → body ``retry_after`` (Stoat ms) → 1s; capped.
+    """Resolve the 429 sleep in seconds: headers → body ``retry_after`` (ms) → 1s; capped.
+
+    Every Stoat-side source is millisecond-based except ``Retry-After``; see
+    :func:`_stoat_rate_delay_seconds` for the unit rules and why this must stay
+    separate from the Discord client's same-named parser.
 
     The body parse is content-type-guarded so a non-JSON 429 (proxy HTML) can't raise
     ``ContentTypeError`` into the network-error path and prime the circuit breaker.
     """
-    header_s = _retry_after_seconds(resp.headers)
+    header_s = _stoat_rate_delay_seconds(resp.headers)
     if header_s is not None:
-        return min(header_s, _MAX_RETRY_DELAY_SECONDS)
+        # Floor at 0: a negative advertised delay parses fine as a float and would
+        # otherwise disable backoff entirely (asyncio.sleep of a negative value
+        # returns immediately, so we would retry in a hot loop).
+        return max(0.0, min(header_s, _MAX_RETRY_DELAY_SECONDS))
     try:
         body = await resp.json(content_type=None)
     except (json.JSONDecodeError, ValueError):
@@ -178,7 +204,7 @@ async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
         retry_ms = float(raw)  # type: ignore[arg-type]  # None/non-numeric → fallback below
     except (TypeError, ValueError):
         retry_ms = 1000.0
-    return min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS)
+    return max(0.0, min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS))
 
 
 async def _api_request_inner(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1154,12 +1154,19 @@ async def test_429_header_beats_body(mock_aiohttp: aioresponses) -> None:  # SC-
 
 
 async def test_429_x_ratelimit_reset_after(mock_aiohttp: aioresponses) -> None:  # SC-4
+    """A non-JSON 429 still honours the header rather than the default delay.
+
+    The advertised value is MILLISECONDS (1500 -> 1.5s). This test previously sent
+    "1.5" and asserted 1.5s, which codified the unit bug fixed in v2.7.2 — the
+    header was being read as seconds. Value corrected; the test's original intent
+    (header honoured even when the body is unparseable HTML) is unchanged.
+    """
     mock_aiohttp.get(
         f"{BASE_URL}/servers/srv1",
         status=429,
         body="<html>",
         content_type="text/html",
-        headers={"X-RateLimit-Reset-After": "1.5"},
+        headers={"X-RateLimit-Reset-After": "1500"},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
     calls, sleep = _sleep_capture()
@@ -1302,3 +1309,156 @@ async def test_429_null_retry_after_falls_back(
             await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
     assert _circuit_state.consecutive_failures == 0
     assert calls[0] == pytest.approx(1.0, abs=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit header units (batch 1)
+#
+# Stoat documents X-RateLimit-Reset-After as MILLISECONDS:
+#   developers.stoat.chat/developers/api/ratelimits
+#   "Milliseconds left until calls are replenished"
+# Discord's identically-named header is delta-SECONDS. Before batch 1 both were
+# parsed by same-named, same-bodied functions in migrator/api.py and
+# discord/client.py — one correct, one not.
+#
+# The header branch was not merely untested: test_429_x_ratelimit_reset_after
+# above ASSERTED the wrong unit ("1.5" -> 1.5s), so the suite actively locked the
+# bug in. Anyone who suspected it would have seen a red test and backed off. That
+# test's value is corrected to milliseconds; the cases below pin the semantics
+# that actually distinguish the two services.
+# ---------------------------------------------------------------------------
+
+
+async def test_429_reset_after_header_is_milliseconds(mock_aiohttp: aioresponses) -> None:
+    """SC-1: X-RateLimit-Reset-After is MILLISECONDS — 10000 means 10s, not 10000s.
+
+    Read as seconds it becomes 10000, which the 60s cap clamps to a full minute:
+    a 6x over-sleep on every rate-limit hit, worst in the message phase.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"X-RateLimit-Reset-After": "10000"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1", "name": "OK"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            result = await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert result["name"] == "OK"
+    assert calls[0] == pytest.approx(10.0, abs=0.05)
+
+
+async def test_429_retry_after_header_is_seconds(mock_aiohttp: aioresponses) -> None:
+    """SC-2: Retry-After is RFC 9110 delta-seconds even in front of Stoat.
+
+    Stoat itself never sends it, but a proxy or CDN in front of Stoat may.
+    """
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", status=429, headers={"Retry-After": "5"})
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == pytest.approx(5.0, abs=0.05)
+
+
+async def test_429_header_takes_precedence_over_body(mock_aiohttp: aioresponses) -> None:
+    """SC-4: the header wins over the body, and is still converted from ms."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"X-RateLimit-Reset-After": "10000"},
+        payload={"retry_after": 250},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == pytest.approx(10.0, abs=0.05)
+
+
+async def test_429_retry_after_beats_reset_after(mock_aiohttp: aioresponses) -> None:
+    """SC-2b: with BOTH headers present, Retry-After wins — and keeps its own unit.
+
+    Pins the precedence inside _stoat_rate_delay_seconds: a proxy's delta-seconds
+    Retry-After is authoritative over Stoat's millisecond header, and must not be
+    divided by 1000 on the way out.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"Retry-After": "3", "X-RateLimit-Reset-After": "10000"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == pytest.approx(3.0, abs=0.05)
+
+
+async def test_429_http_date_retry_after_falls_through(mock_aiohttp: aioresponses) -> None:
+    """SC-5: a non-numeric Retry-After (HTTP-date) is ignored, not crashed on."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"Retry-After": "Wed, 01 Aug 2026 12:00:00 GMT"},
+        payload={"retry_after": 300},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == pytest.approx(0.3, abs=0.05)
+
+
+async def test_429_negative_advertised_delay_is_floored(mock_aiohttp: aioresponses) -> None:
+    """SC-6b: a negative advertised delay is floored at 0, never passed through.
+
+    A negative value parses fine as a float, and asyncio.sleep() of a negative
+    number returns immediately — so without the floor a hostile or buggy header
+    would disable backoff and turn the retry loop hot.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"X-RateLimit-Reset-After": "-5000"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == 0.0
+
+
+async def test_429_reset_after_is_capped(mock_aiohttp: aioresponses) -> None:
+    """SC-6: an absurd advertised delay is still clamped to the 60s cap."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        headers={"X-RateLimit-Reset-After": "999999999"},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert calls[0] == pytest.approx(60.0, abs=0.05)

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -606,3 +606,34 @@ async def test_discord_429_null_retry_after_falls_back(
         async with aiohttp.ClientSession() as session:
             await fetch_guild_roles(session, TOKEN, GUILD_ID)
     assert calls[0] == pytest.approx(1.0, abs=0.05)
+
+
+async def test_discord_reset_after_header_is_seconds_not_milliseconds(
+    mock_discord: aioresponses,
+) -> None:
+    """UNIT PIN: Discord's ``X-RateLimit-Reset-After`` is delta-SECONDS.
+
+    Stoat's identically-named header is MILLISECONDS, and is parsed by a
+    deliberately differently-named function (``migrator.api._stoat_rate_delay_seconds``).
+    The two parsers look like duplicates and MUST NOT be merged: unifying them
+    silently breaks one side by a factor of 1000. This test fails if the Discord
+    side is ever "tidied up" to divide by 1000.
+
+    The sibling test ``test_discord_get_429_html_honors_header`` covers
+    ``Retry-After``, which is seconds on both services and so cannot detect the
+    hazard; only this header distinguishes them.
+    """
+    from unittest.mock import patch
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    mock_discord.get(url, status=429, headers={"X-RateLimit-Reset-After": "5"})
+    mock_discord.get(url, payload=[])
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.discord.client.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            roles = await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+    assert roles == []
+    assert calls[0] == pytest.approx(5.0, abs=0.05), (
+        "Discord's X-RateLimit-Reset-After is delta-seconds: 5 must mean 5s, not 0.005s"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.8.1"
+version = "2.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## The bug

Every Stoat 429 slept the full **60-second cap** instead of the ~10 seconds the server actually asks for.

Stoat sends `X-RateLimit-Reset-After` in **milliseconds** on every response including 429s — [documented](https://developers.stoat.chat/developers/api/ratelimits) as *"Milliseconds left until calls are replenished"*. We parsed it as seconds, so `min(10000, 60)` clamped to the cap on every rate-limit hit. Worst in the message phase, which hits Stoat's 10-per-10s bucket hardest.

The correct body-`retry_after` path (already `/1000`, carrying the same value) had become **unreachable**, because headers are checked first.

**This was a regression caused by upstream, not by us.** The code was correct when written — before Stoat began exposing these headers.

## Why it survived this long

The header branch wasn't merely untested. `test_429_x_ratelimit_reset_after` asserted that a header of `"1.5"` meant 1.5 seconds — **the suite had coverage that locked the bug in**. Anyone who suspected the defect would have hit a red test and concluded they were wrong.

Corrected to `"1500"` → 1.5s, preserving its original intent (header honoured when the 429 body is unparseable HTML).

## Why the rename is load-bearing

`discord/client.py` contains a function that was identical in **name, signature and body** — but Discord's identically-named header genuinely *is* delta-seconds. The two were indistinguishable on sight, and an obvious-looking DRY cleanup would have silently broken one side by a factor of 1000.

The Stoat-side function is now `_stoat_rate_delay_seconds` and documents its unit contract. Discord's semantics are pinned by `test_discord_reset_after_header_is_seconds_not_milliseconds`, which fails if that merge is ever attempted. `Retry-After` remains delta-seconds on both, for proxies in front of Stoat.

## Also hardened

Both delay paths are floored at 0. A negative advertised value parses cleanly as a float, and `asyncio.sleep()` of a negative number returns immediately — so a hostile or buggy value would have turned the retry loop hot. (Note: `asyncio.sleep(-1)` does *not* raise, unlike `time.sleep(-1)`.)

## Verification

- **RED observed before the fix**: `assert 60 == 10.0 ± 0.05`
- **1317 tests pass** (baseline 1309, +8)
- `ruff check .`, `ruff format --check .`, `mypy src/` all clean
- Code review: no Critical or Important findings
- Second opinion (Mistral, API/rate-limit focus): 0 Critical; its 3 "Important" items rested on the claim that `asyncio.sleep(-1)` may raise — verified false — and on a precedence this diff does not change. The one genuine residual (negative values disabling backoff) is fixed above.

## Provenance

`/df-brief` → `/df-spec` → `/df-brainstorm` → `/df-critique` (PASS at round 6; rounds 1–5 each caught a real defect) → `/df-test-scenarios` (48 scenarios) → `writing-plans`.

Batch 1 of 10 in the upstream-drift programme. Next: Autumn's reset header (opposite bug shape — it ignores the header and *under*-waits at 1 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
