### PR TITLE
fix: stop shipping the release binaries inside the PyPI sdist (v2.8.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 dist/
 build/
 *.whl
+release-assets/
 
 # Virtual environments
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-08-02
+
+### Fixed
+
+- **Every published sdist since at least v2.6.17 has shipped the release binaries inside it.**
+  `release.yml` downloads the built artifacts into `release-assets/` and only afterwards runs
+  `uv build`, and with no `[tool.hatch.build.targets.sdist]` config hatchling swept that
+  directory into the source distribution. The result on PyPI: a **91.5 MB** `.tar.gz` against
+  a **0.2 MB** wheel, for 2.6.17, 2.7.0 and 2.7.1 alike.
+
+  Adding the third (Intel) artifact in v2.8.0 pushed the sdist past PyPI's 100 MB per-project
+  limit, so the upload failed with `400 File too large` — which is how a long-standing bug
+  finally surfaced. The v2.8.0 GitHub Release itself published normally; only the PyPI step
+  failed, so **v2.8.0 exists on GitHub but not on PyPI**.
+
+  Fixed by excluding `release-assets` from the sdist target and gitignoring the directory.
+  The wheel was never affected — it is scoped to `src/discord_ferry` — so `pip install
+  discord-ferry` always resolved to the 0.2 MB wheel on any normal platform. Verified by
+  planting 137 MB of incompressible data in `release-assets/` and rebuilding: 0 members
+  leak, sdist stays at 0.7 MB.
+
 ## [2.8.0] - 2026-08-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.8.0"
+version = "2.8.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"
@@ -64,6 +64,14 @@ docs = [
 # part of the installable package. See docs/plans/designs/2026-05-16-issue-35-*.md.
 [tool.hatch.build.targets.wheel]
 packages = ["src/discord_ferry"]
+
+[tool.hatch.build.targets.sdist]
+# release.yml downloads the built binaries into release-assets/ and only then
+# runs `uv build`, so an unconfigured sdist swept them in: every published sdist
+# was ~91.5 MB against a 0.2 MB wheel. Adding the third (Intel) artifact in
+# v2.8.0 pushed it past PyPI's 100 MB project limit and the upload started
+# failing. The wheel was never affected — it is scoped to src/ above.
+exclude = ["release-assets"]
 
 [tool.ruff]
 line-length = 100

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.8.0"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

The v2.8.0 release run failed at the **Publish to PyPI** step:

```
400 File too large. Limit for project 'discord-ferry' is 100 MB.
```

This is a long-standing bug, not a v2.8.0 regression. `release.yml` downloads the built
artifacts into `release-assets/` and only *afterwards* runs `uv build`. With no
`[tool.hatch.build.targets.sdist]` config, hatchling swept that directory into the source
distribution.

What has actually been on PyPI:

| version | wheel | sdist |
|---|---|---|
| 2.6.17 | 0.2 MB | **91.5 MB** |
| 2.7.0 | 0.2 MB | **91.5 MB** |
| 2.7.1 | 0.2 MB | **91.5 MB** |

Every sdist has been carrying the Windows `.exe` and the macOS `.zip` inside it. Adding the
third (Intel) artifact in v2.8.0 tipped it past PyPI's 100 MB per-project limit, which is the
only reason it finally surfaced.

## Impact

Limited but real. The **wheel was never affected** — it is scoped to `src/discord_ferry` by
`[tool.hatch.build.targets.wheel]` — so `pip install discord-ferry` resolved to the 0.2 MB
wheel on any normal platform. Only sdist consumers (no-binary installs, some distro
packagers) paid 91.5 MB.

**v2.8.0 is on GitHub but not on PyPI.** The GitHub Release step runs before the PyPI step and
completed normally, so all three binaries published. Since the `v2.8.0` tag cannot pick up
this fix retroactively, the correct move is a patch release rather than moving the tag.

## Fix

```toml
[tool.hatch.build.targets.sdist]
exclude = ["release-assets"]
```

Plus `release-assets/` in `.gitignore`, so a stray local copy cannot be committed either.

## Verification

Reproduced and then falsified the fix by planting **137 MB of incompressible data** (mirroring
the real v2.8.0 assets) in `release-assets/` and rebuilding:

| | before fix | after fix |
|---|---|---|
| `release-assets` members in sdist | present | **0** |
| sdist size | >100 MB in CI | **0.7 MB** |
| wheel size | 0.2 MB | 0.2 MB |

The first attempt at this test used `/dev/zero`, which compressed to nothing and masked the
size impact — the incompressible rerun is what actually reproduces CI.

`ruff` + `mypy` clean, **1310 tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
