### PR TITLE
chore: gitignore .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ CLAUDE.md
 claude_log/
 .mcp.json
 
+# Git worktrees — an unignored worktree dir commits an entire second checkout
+.worktrees/
+
 # Internal design docs (kept locally, not in public repo)
 docs/plans/
 docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Internal
+
+- `.gitignore` now covers `.worktrees/`. The directory already existed at the repo root but was
+  untracked *and* unignored, so anyone creating a git worktree there would have committed an entire
+  second checkout into the repository.
+
 ## [2.8.2] - 2026-08-02
 
 ### Fixed


### PR DESCRIPTION
`.worktrees/` already existed at the repo root but was neither tracked nor ignored. Anyone creating a git worktree there — which the superpowers worktree skill does by default when no native tool is available — would have committed an entire second checkout into the repository.

Surfaced while setting up an isolated workspace for the v2.8.2 rate-limit fix (#105); the native worktree tool placed it under the already-ignored `.claude/` instead, so nothing was committed.

Config-only, no version bump (cf. `2946c66`). Logged under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)