### PR TITLE
fix: Autumn's rate-limit reset header is milliseconds, and was never read (v2.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.3] - 2026-08-02
+
+### Fixed
+
+- **Autumn retried uploads nine seconds too early after a rate-limit hit**
+  (`uploader/autumn.py`). Autumn sits behind the same rate-limit middleware as the Stoat API and
+  advertises `X-RateLimit-Reset-After: 10000` (**milliseconds**) on a 429 — verified live against
+  `cdn.stoatusercontent.com` — but `_retry_after_ms` never read that header. A real Autumn 429
+  carries no body `retry_after` and no `Retry-After`, so every one of them fell through to the
+  1000 ms default and retried into a bucket that was still shut. With `MAX_RETRIES = 3`, all three
+  attempts could burn inside a single 10-second window and the upload failed outright.
+  This is the mirror image of the 2.8.2 defect: the same header and the same unit, but where
+  `migrator/api.py` read it and over-waited by 6×, `uploader/autumn.py` never read it and
+  under-waited by 10×. Neither client's tests knew the other existed.
+
+### Changed
+
+- **Autumn's 429 backoff is now bounded to [0, 60] seconds** (`uploader/autumn.py`), matching the
+  cap `migrator/api.py` already applied. Flagged rather than shipped quietly because it changes
+  behaviour for inputs no correct server sends: the delay is remote-supplied, and making the header
+  load-bearing is what made that matter. A negative `retry_after` made `asyncio.sleep` return
+  immediately and turned the retry loop hot; an `X-RateLimit-Reset-After` of `3600000` slept a
+  literal hour.
+- **Non-finite and boolean advertised delays are rejected** rather than clamped
+  (`uploader/autumn.py`), falling back to the 1000 ms default. A clamp alone cannot catch `NaN`:
+  every comparison against it is False, so it survives `min`/`max`, and `asyncio.sleep(nan)` then
+  **never returns** — one such response would hang an upload forever. (`time.sleep(nan)` raises
+  `ValueError`; asyncio's silence here is CPython #105331.) It needs no malice to arrive: Python's
+  `json` module parses bare `NaN`/`Infinity` by default, so `{"retry_after": NaN}` from a sloppy
+  server reaches us as a float. Separately, `bool` is a subclass of `int` in Python, so a JSON
+  `true` was accepted as a 1 ms delay — beneath the clamp's floor, and so effectively no backoff.
+
 ### Internal
 
 - `.gitignore` now covers `.worktrees/`. The directory already existed at the repo root but was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.8.2"
+version = "2.8.3"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.8.2"
+__version__ = "2.8.3"

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MAX_RETRIES = 3
+_MAX_RETRY_DELAY_MS = 60_000.0  # Mirrors migrator.api._MAX_RETRY_DELAY_SECONDS.
+_DEFAULT_RETRY_DELAY_MS = 1000.0
 _RETRYABLE_STATUSES = {429, 502, 503, 504}
 
 TAG_SIZE_LIMITS: dict[str, int] = {
@@ -34,22 +37,79 @@ TAG_SIZE_LIMITS: dict[str, int] = {
 _inflight_uploads: dict[str, asyncio.Future[str]] = {}
 
 
-async def _retry_after_ms(response: aiohttp.ClientResponse) -> float:
-    """429 backoff in ms: body ``retry_after`` -> ``Retry-After`` header (int seconds) -> 1000ms."""
+async def _advertised_retry_after_ms(response: aiohttp.ClientResponse) -> float:
+    """The delay Autumn advertises for a 429, in MILLISECONDS, before clamping.
+
+    Precedence, most specific first:
+
+    1. body ``retry_after`` -- milliseconds. Stoat's rate-limit middleware writes the
+       same ``ratelimiter.reset`` value into the body that it puts in the header.
+    2. ``Retry-After`` header -- RFC 9110 delta-SECONDS, hence x1000. Autumn does not
+       send it, but a CDN or proxy in front of Autumn may, and its view of when it will
+       let us back in outranks the origin's.
+    3. ``X-RateLimit-Reset-After`` header -- MILLISECONDS. What Autumn actually sends.
+
+    UNIT HAZARD -- do NOT unify this with ``discord.client._retry_after_seconds``. Autumn
+    sits behind the same middleware as the Stoat API, so its ``X-RateLimit-Reset-After``
+    is milliseconds, matching ``migrator.api._stoat_rate_delay_seconds``; Discord's
+    identically-named header is delta-seconds. See that function's docstring for the full
+    rules and the test pinning the Discord side.
+    """
     try:
         body = await response.json(content_type=None)
     except (aiohttp.ClientError, ValueError):
         body = None
     if isinstance(body, dict):
         ra = body.get("retry_after")
-        if isinstance(ra, (int, float)):
+        # bool is a subclass of int, and a JSON `true` would otherwise become a 1 ms
+        # delay -- under the clamp's floor, so effectively no backoff at all.
+        if isinstance(ra, (int, float)) and not isinstance(ra, bool):
             return float(ra)
+
     header = response.headers.get("Retry-After")
     if header is not None:
         stripped = header.strip()
         if stripped.isascii() and stripped.isdigit():
             return float(int(stripped) * 1000)
-    return 1000.0
+
+    reset_after = response.headers.get("X-RateLimit-Reset-After")
+    if reset_after:
+        try:
+            return float(reset_after)
+        except ValueError:
+            pass  # Unparseable -- fall through to the default.
+
+    return _DEFAULT_RETRY_DELAY_MS
+
+
+async def _retry_after_ms(response: aiohttp.ClientResponse) -> float:
+    """429 backoff in MILLISECONDS, clamped to [0, ``_MAX_RETRY_DELAY_MS``].
+
+    The advertised value is remote-supplied, so it is bounded at both ends: a negative
+    delay would make ``asyncio.sleep`` return immediately and turn the retry loop hot,
+    burning all three attempts inside one closed window, while an unbounded one would
+    present as a hang. Mirrors the cap ``migrator.api._MAX_RETRY_DELAY_SECONDS`` already
+    applies on the Stoat side.
+
+    Non-finite values are rejected outright rather than clamped, because the clamp alone
+    cannot catch NaN: every comparison against it is False, so it survives whichever of
+    ``min``/``max`` receives it first. ``asyncio.sleep(nan)`` then **never returns** --
+    verified, and unlike ``time.sleep(nan)``, which raises ``ValueError`` (CPython
+    #105331) -- so a single such response hangs the upload forever.
+
+    Rejecting is deliberate rather than reordering the clamp to ``max(0.0, min(...))``,
+    which would also contain NaN but resolve it to a 0 ms delay: that is the no-backoff
+    failure this function exists to prevent. Falling back to the default preserves real
+    backoff.
+
+    Reachable from a merely sloppy server, not just a hostile one: Python's ``json``
+    module parses bare ``NaN``/``Infinity`` by default, so a body of
+    ``{"retry_after": NaN}`` arrives here as a float.
+    """
+    advertised = await _advertised_retry_after_ms(response)
+    if not math.isfinite(advertised):
+        return _DEFAULT_RETRY_DELAY_MS
+    return min(max(advertised, 0.0), _MAX_RETRY_DELAY_MS)
 
 
 async def upload_to_autumn(

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -540,3 +540,213 @@ async def test_429_exhausted_raises(
     async with aiohttp.ClientSession() as session:
         with pytest.raises(AutumnUploadError, match="Upload failed after"):
             await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# X-RateLimit-Reset-After (MILLISECONDS) + delay clamp
+# ---------------------------------------------------------------------------
+
+
+async def test_429_x_ratelimit_reset_after_is_milliseconds(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """Autumn's X-RateLimit-Reset-After is MILLISECONDS, not the 1000 ms default.
+
+    Autumn rides the same rate-limit middleware as the Stoat API, so a real Autumn 429
+    advertises ``x-ratelimit-reset-after: 10000`` (verified live against
+    cdn.stoatusercontent.com) with no body and no Retry-After. Falling through to the
+    default made every Autumn 429 retry nine seconds early, into a bucket still shut.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"X-RateLimit-Reset-After": "10000"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 10.0
+
+
+async def test_429_negative_retry_after_floors_at_zero(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A negative advertised delay must not disable backoff.
+
+    asyncio.sleep() of a negative value returns immediately, which would turn the retry
+    loop hot and burn all three attempts against a still-closed bucket.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=429, payload={"retry_after": -5000})
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 0.0
+
+
+async def test_429_absurd_retry_after_is_capped(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """An hour-long advertised delay is capped at 60 s rather than presenting as a hang."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"X-RateLimit-Reset-After": "3600000"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 60.0
+
+
+async def test_429_unparseable_reset_after_falls_back_to_default(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A non-numeric X-RateLimit-Reset-After is ignored, not fatal."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"X-RateLimit-Reset-After": "soon"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0
+
+
+async def test_429_body_retry_after_outranks_reset_after_header(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """The body stays the most specific source when both it and the ms header are present."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        payload={"retry_after": 100},
+        headers={"X-RateLimit-Reset-After": "10000"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 0.1
+
+
+async def test_429_retry_after_header_outranks_reset_after_header(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A proxy's Retry-After (delta-SECONDS) outranks the origin's ms header.
+
+    The two are different units on the same response -- 2 s against 10000 ms. Asserting
+    2.0 rather than 10.0 proves the seconds branch ran, so a future reorder of the
+    precedence chain cannot silently swap the units.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"Retry-After": "2", "X-RateLimit-Reset-After": "10000"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 2.0
+
+
+async def test_429_nan_reset_after_header_falls_back_to_default(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A NaN delay must be rejected, not clamped -- the clamp cannot catch it.
+
+    float("nan") parses fine, and every comparison against NaN is False, so it passes
+    straight through min()/max(). asyncio.sleep(nan) then poisons the event loop's
+    timer heap. Guards the clamp against giving false assurance.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"X-RateLimit-Reset-After": "nan"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0
+
+
+async def test_429_infinite_reset_after_header_falls_back_to_default(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """An infinite delay is treated as garbage, not as "wait the maximum"."""
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments",
+        status=429,
+        body=b"",
+        headers={"X-RateLimit-Reset-After": "inf"},
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0
+
+
+async def test_429_nan_body_retry_after_falls_back_to_default(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """The body route reaches NaN too -- Python's json parses bare NaN by default.
+
+    This is the more reachable of the two NaN paths: it needs only a sloppy server
+    serialising a float, not a hand-written header.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(
+        f"{AUTUMN_URL}/attachments", status=429, payload={"retry_after": float("nan")}
+    )
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0
+
+
+async def test_429_boolean_body_retry_after_is_ignored(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A JSON `true` is not a delay of 1 ms.
+
+    bool is a subclass of int, so an isinstance check accepts it and float(True) gives
+    1.0 ms -- below the clamp's floor, so it would slip past as effectively no backoff.
+    """
+    file = tmp_path / "x.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=429, payload={"retry_after": True})
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", payload={"id": "ok"})
+    async with aiohttp.ClientSession() as session:
+        result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
+    assert result == "ok"
+    assert slept[0] == 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.8.2"
+version = "2.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch 2 of 10 in the upstream-drift programme (#107).

## The bug

`uploader/autumn.py`'s `_retry_after_ms` never read `X-RateLimit-Reset-After`. A real Autumn 429 carries no body `retry_after` and no `Retry-After`, so **every one of them** fell through to the 1000 ms default and retried ~9 s early into a bucket that was still shut. With `MAX_RETRIES = 3`, all three attempts could burn inside a single 10-second window and the upload failed outright.

This is the mirror image of v2.8.2 (#105) — the same header, the same unit, opposite failures:

| Client | Reads the header? | Result |
|---|---|---|
| `migrator/api.py` | yes, as **seconds** | over-waited 60 s where 10 s was advertised (fixed in v2.8.2) |
| `uploader/autumn.py` | **no** | under-waited 1 s where 10 s was advertised (**this PR**) |
| `discord/client.py` | yes, as **seconds** — correct there | untouched |

Neither client's tests knew the other existed. Verified live 2026-08-02: `curl -sD- https://cdn.stoatusercontent.com/` returns `x-ratelimit-reset-after: 10000`.

## The change

`_retry_after_ms` splits into a resolver and a bounding wrapper. Precedence is unchanged at the top and extended at the bottom:

body `retry_after` (ms) → `Retry-After` (RFC 9110 delta-seconds, ×1000) → **`X-RateLimit-Reset-After` (ms)** → 1000 ms default

The call site is untouched and still divides by 1000. All three readers of this header name now carry cross-referencing `UNIT HAZARD` docstrings; unifying any two silently breaks one by 1000×.

## Behaviour changes, called out rather than shipped quietly

Making a remote-supplied number decide how long we sleep is what made bounding it matter:

- **Clamped to [0, 60] s**, matching the cap `api.py` already applied. Uncapped, an `X-RateLimit-Reset-After: 3600000` slept a literal hour.
- **Non-finite values rejected**, not clamped. A clamp *cannot* catch NaN — every comparison against it is False, so it survives `min`/`max` — and `asyncio.sleep(nan)` **never returns**, hanging the upload forever. (`time.sleep(nan)` raises `ValueError`; asyncio's silence is CPython #105331.) It needs no malice: Python's `json` parses bare `NaN` by default, so `{"retry_after": NaN}` from a sloppy server arrives as a float. Rejecting beats the tempting alternative of reordering the clamp to `max(0.0, min(...))`, which contains NaN but resolves it to a **0 ms** delay — the exact no-backoff failure this PR exists to close.
- **`bool` excluded**: it subclasses `int` in Python, so a JSON `true` was accepted as a 1 ms delay, beneath the clamp's floor and so effectively no backoff.

## Verification

- RED observed before the fix: `assert 1.0 == 10.0`.
- **Every guard falsified in place** rather than merely asserted — neutering the header branch, the clamp, the finiteness check or the bool exclusion each turns its own test red. Removing the clamp gave `assert 3600.0 == 60.0`.
- 10 new tests, **none modified**. Suite 1317 → **1327 passed**.
- `ruff check .`, `ruff format --check .`, `mypy src/` clean; `uv sync --locked` clean.

Review found one real gap (the NaN hole above), fixed here. Two suggestions were rejected on the evidence: precedence-divergence warnings (both values derive from the same upstream `ratelimiter.reset`), and a claim that the tests are fragile for asserting on `asyncio.sleep`'s argument (that is the observable behaviour, and it breaking on a dropped `/1000` is the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)