### PR TITLE
fix: the Mac app could be force-quit as "not responding", leaving a zombie window (v2.8.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Manual runs exist so the packaging path can be exercised BEFORE a tag. A
+  # packaging failure discovered on a tag means deleting and re-cutting a published
+  # release; a dispatch run costs nothing.
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -95,8 +99,44 @@ jobs:
       # `--options runtime` plus an entitlements plist; signing alone does not
       # clear the warning, which is why no signing step runs here today.
 
-      - name: Zip .app bundle
-        run: cd dist && zip -r ../Ferry-macos-${{ matrix.arch }}.zip Ferry.app
+      - name: Archive .app bundle
+        # ditto, not zip: the onedir bundle is a symlink farm (~119 links). Info-ZIP
+        # follows symlinks by default, which doubles the artifact (measured 91 MB vs
+        # 45 MB) and breaks the code-signature seal on extraction. Name Ferry.app
+        # explicitly -- COLLECT also emits dist/Ferry/, which must not ship.
+        run: cd dist && ditto -c -k --sequesterRsrc --keepParent Ferry.app ../Ferry-macos-${{ matrix.arch }}.zip
+
+      - name: Verify the archived artifact
+        # Assertions run on the EXTRACTED tree, mirroring what Archive Utility does on
+        # a user's Mac. `codesign --verify` against dist/Ferry.app cannot see a
+        # dereferenced archive, so symlink count and size are the real detectors.
+        run: |
+          set -euo pipefail
+          mkdir -p _verify
+          ditto -x -k "Ferry-macos-${{ matrix.arch }}.zip" _verify
+          APP="_verify/Ferry.app"
+          LINKS=$(find "$APP" -type l | wc -l | tr -d ' ')
+          echo "symlinks in extracted bundle: $LINKS"
+          if [ "$LINKS" -eq 0 ]; then
+            echo "::error::archive lost its symlinks - the signature seal is broken"
+            exit 1
+          fi
+          ON_DISK=$(du -sk dist/Ferry.app | cut -f1)
+          EXTRACTED=$(du -sk "$APP" | cut -f1)
+          echo "on-disk ${ON_DISK}K vs extracted ${EXTRACTED}K"
+          python3 -c "import sys; sys.exit(0 if abs($ON_DISK-$EXTRACTED) <= 0.10*$ON_DISK else 1)" || {
+            echo "::error::extracted size differs from the built bundle by more than 10%"
+            exit 1
+          }
+          codesign --verify --deep --strict "$APP"
+          find "$APP" -name dce_checksums.json | grep -q . || {
+            echo "::error::dce_checksums.json missing from the bundle"
+            exit 1
+          }
+          find "$APP" -path "*discord_ferry/templates/*.json" | grep -q . || {
+            echo "::error::template JSON missing from the bundle"
+            exit 1
+          }
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,11 +129,13 @@ jobs:
             exit 1
           }
           codesign --verify --deep --strict "$APP"
-          find "$APP" -name dce_checksums.json | grep -q . || {
+          # -print -quit rather than `| grep -q .`: under pipefail a SIGPIPE'd find
+          # would surface as a bogus "missing" failure.
+          test -n "$(find "$APP" -name dce_checksums.json -print -quit)" || {
             echo "::error::dce_checksums.json missing from the bundle"
             exit 1
           }
-          find "$APP" -path "*discord_ferry/templates/*.json" | grep -q . || {
+          test -n "$(find "$APP" -path '*discord_ferry/templates/*.json' -print -quit)" || {
             echo "::error::template JSON missing from the bundle"
             exit 1
           }
@@ -147,6 +149,11 @@ jobs:
   release:
     name: Create release and publish
     needs: [build-windows, build-macos]
+    # Tag runs only. On a workflow_dispatch, github.ref is a branch ref and
+    # softprops/action-gh-release hard-fails ("GitHub Releases requires a tag"), so
+    # without this guard every manual run goes red at the publish step -- which looks
+    # exactly like the packaging failure the dispatch exists to detect.
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.4] - 2026-08-02
+
+### Fixed
+
+- **The macOS app could be force-quit as "not responding", leaving a window that said
+  "Connection lost. Trying to reconnect…" forever.** Two defects compounded.
+
+  `ferry.spec` built *onefile*, so the process macOS registered with LaunchServices was
+  the PyInstaller bootloader — which unpacks ~200 MB to a temp directory (measured **18
+  seconds** from double-click to window) and then waits in `usleep()`. macOS wrote a hang
+  report against v2.7.1 (`Event: hang`, `Duration: 99.18s`, `Unresponsive for 97
+  seconds`), the Dock offered Force Quit, and `launchd` logged `exited due to SIGTERM`.
+  macOS builds are now *onedir*: one process, and the window is serving in **~2 seconds**.
+
+  Separately, NiceGUI's native mode runs the pywebview window as a `daemon=True`
+  multiprocessing child. SIGTERM kills Python without running `atexit`, so
+  `multiprocessing._exit_function` — the only thing that terminates daemon children —
+  never ran, and the window outlived its server. Ferry now runs a bounded, idempotent
+  teardown ladder (`destroy` → `terminate` → `kill`) from both the shutdown hook and a
+  `finally:` around the server, so no window can outlive the process that feeds it. This
+  matters beyond tidiness: a surviving child would otherwise hang the interpreter in
+  multiprocessing's *unbounded* atexit join while still holding port 8765.
+
+- **The macOS release archive would have shipped a broken bundle.** The onedir `.app`
+  contains 119 symlinks; `zip -r` follows them, producing a 91 MB archive instead of
+  45 MB and extracting real files where the code signature recorded links — which
+  Gatekeeper reports as "Ferry.app is damaged". The release workflow now archives with
+  `ditto` and verifies the *extracted* artifact (symlink count, size, `codesign`, bundled
+  data files). It also gained `workflow_dispatch`, so packaging can be exercised before a
+  tag exists rather than on one.
+
+- **The GUI's folder picker had never worked in the packaged app.** It called
+  `webview.windows[0]` in the server process, but the window is created in a different
+  process, so that list is always empty and every click raised `IndexError` into a
+  "requires native mode" toast. It now goes through `app.native.main_window`, which
+  marshals the dialog across the process boundary.
+
+- The socket.io heartbeat now tolerates a 12-second stall instead of 6
+  (`reconnect_timeout=10.0`), so a brief hiccup no longer flashes the reconnect banner,
+  and uvicorn's graceful-shutdown wait is bounded at 1 second rather than unbounded.
+  Interrupting Ferry with Ctrl-C shuts it down cleanly, leaving no stray processes and
+  no traceback.
+
 ## [2.8.3] - 2026-08-02
 
 ### Fixed

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -136,6 +136,30 @@ The `-r` flag matters. Without it the quarantine flag is cleared only from the b
 
 ---
 
+## The Window Stops Responding
+
+### "Connection lost. Trying to reconnect..."
+
+|  |  |
+|---|---|
+| **Symptom** | A grey box appears over the Ferry window reading **"Connection lost. Trying to reconnect..."**, and it never goes away |
+| **Cause** | Ferry's window is a viewer for a small server that runs inside the app. This message means that server stopped, so the window has nothing left to talk to and will keep retrying forever. On versions before 2.8.3 this happened after force-quitting Ferry: the window survived the quit. |
+| **Solution** | Close the Ferry window, then reopen Ferry. |
+
+If the window will not close, or Ferry does not start again, quit the leftovers by hand:
+
+1. Open **Activity Monitor** (press ⌘ Space, type "Activity Monitor", press Return).
+2. Type `Ferry` in the search box.
+3. Select each result and click the **⊗** button in the toolbar, then **Force Quit**.
+4. Open Ferry again.
+
+!!! tip "You will not lose a migration in progress"
+    Ferry saves a checkpoint as it works. Start it again and choose **Resume** — it
+    picks up from the last completed step rather than starting over. Messages already
+    copied are not copied twice.
+
+---
+
 ## Migration Locks
 
 ### Another migration is in progress

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -143,7 +143,7 @@ The `-r` flag matters. Without it the quarantine flag is cleared only from the b
 |  |  |
 |---|---|
 | **Symptom** | A grey box appears over the Ferry window reading **"Connection lost. Trying to reconnect..."**, and it never goes away |
-| **Cause** | Ferry's window is a viewer for a small server that runs inside the app. This message means that server stopped, so the window has nothing left to talk to and will keep retrying forever. On versions before 2.8.3 this happened after force-quitting Ferry: the window survived the quit. |
+| **Cause** | Ferry's window is a viewer for a small server that runs inside the app. This message means that server stopped, so the window has nothing left to talk to and will keep retrying forever. On versions before 2.8.4 this happened after force-quitting Ferry: the window survived the quit. |
 | **Solution** | Close the Ferry window, then reopen Ferry. |
 
 If the window will not close, or Ferry does not start again, quit the leftovers by hand:

--- a/ferry.spec
+++ b/ferry.spec
@@ -98,19 +98,27 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    a.binaries,
-    a.datas,
-    [],
+# ---------------------------------------------------------------------------
+# Packaging
+#
+# macOS builds ONEDIR. Onefile would put a PyInstaller bootloader in front of
+# Python, and that bootloader -- not the app -- is what LaunchServices registers
+# as "Ferry". It spends its life in usleep() waiting for the child, so macOS
+# flags the app as unresponsive (v2.7.1 produced a 99-second hang report), the
+# user force-quits it, and the SIGTERM orphans the pywebview window, which then
+# shows "Connection lost. Trying to reconnect..." forever. Onedir also cuts
+# launch from ~18s to ~2s because there is no unpack step.
+#
+# Windows stays ONEFILE so the release keeps shipping a single .exe.
+# ---------------------------------------------------------------------------
+
+_EXE_COMMON = dict(
     name="Ferry",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
     upx_exclude=[],
-    runtime_tmpdir=None,
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -120,10 +128,27 @@ exe = EXE(
     icon=icon,
 )
 
-# macOS .app bundle (only when building on macOS)
 if sys.platform == "darwin":
-    app = BUNDLE(
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        **_EXE_COMMON,
+    )
+
+    coll = COLLECT(
         exe,
+        a.binaries,
+        a.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name="Ferry",
+    )
+
+    app = BUNDLE(
+        coll,
         name="Ferry.app",
         icon=icon_mac,
         bundle_identifier="com.discord-ferry.Ferry",
@@ -131,4 +156,14 @@ if sys.platform == "darwin":
             "NSHighResolutionCapable": True,
             "CFBundleShortVersionString": VERSION,
         },
+    )
+else:
+    exe = EXE(
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.datas,
+        [],
+        runtime_tmpdir=None,
+        **_EXE_COMMON,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.8.3"
+version = "2.8.4"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.8.3"
+__version__ = "2.8.4"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
+import multiprocessing
 import os
 import secrets
 import subprocess
@@ -29,8 +31,10 @@ try:
 except ImportError:
     pass
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, MutableMapping
+    from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
     from discord_ferry.core.events import MigrationEvent
     from discord_ferry.parser.models import DCEExport
@@ -1585,6 +1589,90 @@ async def migrate_page() -> None:
                 _clear_tokens(app.storage.tab, _SESSION_TOKEN_KEYS)
 
     background_tasks.create(_run())
+
+
+# ---------------------------------------------------------------------------
+# Native window lifecycle
+# ---------------------------------------------------------------------------
+
+# Each rung of the teardown ladder waits at most this long. A healthy teardown was
+# measured at ~16ms; this budget only bites when a child is wedged, and it must stay
+# small because macOS escalates a force-quit SIGTERM to SIGKILL within seconds.
+_TEARDOWN_JOIN_TIMEOUT = 0.5
+
+
+def _terminate_children(
+    children: Sequence[Any],
+    window: Any | None,
+    join_timeout: float = _TEARDOWN_JOIN_TIMEOUT,
+) -> None:
+    """Tear down the native window child: destroy -> terminate -> kill, all bounded.
+
+    Idempotent: returns immediately when no child is alive, *without touching the
+    window proxy*. That precondition matters because NiceGUI's ``check_shutdown``
+    thread closes the proxy's method queues as soon as the server stops, so an
+    unconditional ``destroy()`` would raise on every healthy shutdown.
+
+    ``children`` and ``window`` are injected so the ladder is testable without a real
+    window; :func:`_teardown_native_window` supplies the production values.
+    """
+    alive = [child for child in children if child.is_alive()]
+    if not alive:
+        return
+
+    # Rung 1: the supported path. NiceGUI's own app.shutdown() closes the window this
+    # way, and the child's method-executor thread keeps polling every 16ms even while
+    # its Cocoa main thread is parked.
+    if window is not None:
+        try:
+            window.destroy()
+        except Exception:  # noqa: BLE001 - a closed queue must not abort the ladder
+            logger.debug("native window destroy() failed", exc_info=True)
+        for child in alive:
+            child.join(timeout=join_timeout)
+        alive = [child for child in alive if child.is_alive()]
+        if not alive:
+            return
+
+    # Rung 2: SIGTERM, which is sufficient in practice (measured: child gone in 16ms).
+    for child in alive:
+        try:
+            child.terminate()
+        except Exception:  # noqa: BLE001 - best effort; rung 3 is the backstop
+            logger.debug("terminate() failed for pid %s", child.pid, exc_info=True)
+    for child in alive:
+        child.join(timeout=join_timeout)
+    alive = [child for child in alive if child.is_alive()]
+    if not alive:
+        return
+
+    # Rung 3: SIGKILL. A belt rather than a measured necessity -- but a child that
+    # outlives this ladder would hang the interpreter in multiprocessing's atexit
+    # join, which has no timeout at all.
+    for child in alive:
+        try:
+            child.kill()
+        except Exception:  # noqa: BLE001 - nothing left to escalate to
+            logger.debug("kill() failed for pid %s", child.pid, exc_info=True)
+    for child in alive:
+        child.join(timeout=join_timeout)
+
+    survivors = [child.pid for child in alive if child.is_alive()]
+    if survivors:
+        logger.warning("native window child(ren) survived teardown: %s", survivors)
+
+
+def _teardown_native_window() -> None:
+    """Synchronous teardown against the live process table. Safe to call anywhere."""
+    _terminate_children(
+        multiprocessing.active_children(),
+        getattr(app.native, "main_window", None),
+    )
+
+
+async def _teardown_native_window_async() -> None:
+    """Async wrapper for ``app.on_shutdown``, so the joins never block the event loop."""
+    await asyncio.to_thread(_teardown_native_window)
 
 
 # ---------------------------------------------------------------------------

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -327,19 +327,16 @@ def setup_page() -> None:
         return f"{value:.1f}s/msg ({_msgs_per_hour(value):,} msg/hr)"
 
     async def _on_browse() -> None:
-        if not _HAS_WEBVIEW:
-            ui.notify("Folder picker requires pywebview — install it with: pip install pywebview")
-            return
-        try:
-            loop = asyncio.get_running_loop()
-            result = await loop.run_in_executor(
-                None,
-                lambda: webview.windows[0].create_file_dialog(webview.FOLDER_DIALOG),
-            )
-            if result and result[0]:
-                export_dir_input.set_value(result[0])
-        except Exception:
+        # app.native.main_window is NiceGUI's proxy to the window process; it is None
+        # in browser mode. Do not reach for webview.windows here -- the window lives
+        # in another process, so that list is always empty on this side.
+        window = getattr(app.native, "main_window", None)
+        if window is None:
             ui.notify("Folder picker requires native mode (pywebview window)")
+            return
+        folder = await _pick_folder(window)
+        if folder:
+            export_dir_input.set_value(folder)
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         # Step indicator
@@ -1673,6 +1670,39 @@ def _teardown_native_window() -> None:
 async def _teardown_native_window_async() -> None:
     """Async wrapper for ``app.on_shutdown``, so the joins never block the event loop."""
     await asyncio.to_thread(_teardown_native_window)
+
+
+def _folder_dialog_type() -> int:
+    """Resolve pywebview's folder-dialog constant.
+
+    Resolved lazily, never at import time: ``webview`` is an unbound name when the
+    optional dependency is missing. Prefers ``FileDialog.FOLDER``; falls back to the
+    deprecated ``FOLDER_DIALOG`` because pyproject floors pywebview at >=5.0.
+    """
+    file_dialog = getattr(webview, "FileDialog", None)
+    if file_dialog is not None:
+        return int(file_dialog.FOLDER)
+    return int(webview.FOLDER_DIALOG)
+
+
+async def _pick_folder(window: Any | None) -> str | None:
+    """Ask the native window for a folder; None when unavailable or cancelled.
+
+    Must go through NiceGUI's ``WindowProxy`` (``app.native.main_window``), which
+    marshals the call to the child over the method queue. ``webview.windows`` is always
+    empty in this process -- the window is created in another one -- so the previous
+    ``webview.windows[0]`` could only ever raise IndexError.
+    """
+    if window is None:
+        return None
+    try:
+        result = await window.create_file_dialog(_folder_dialog_type())
+    except Exception:  # noqa: BLE001 - a dead window must not break the page
+        logger.debug("native folder dialog failed", exc_info=True)
+        return None
+    if not result:
+        return None
+    return str(result[0])
 
 
 # ---------------------------------------------------------------------------

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1660,11 +1660,22 @@ def _terminate_children(
 
 
 def _teardown_native_window() -> None:
-    """Synchronous teardown against the live process table. Safe to call anywhere."""
-    _terminate_children(
-        multiprocessing.active_children(),
-        getattr(app.native, "main_window", None),
-    )
+    """Synchronous teardown against the live process table. Safe to call anywhere.
+
+    Never raises. Both call sites are shutdown paths -- ``app.on_shutdown`` (where an
+    exception would propagate into uvicorn's lifespan shutdown and skip NiceGUI's
+    remaining handlers) and the ``finally:`` in :func:`_run_gui` (where it would mask
+    whatever exception was already unwinding). The inner ladder guards the calls it
+    makes on the window and the children; this guards everything else, including
+    ``active_children()``, ``is_alive()`` and ``join()``.
+    """
+    try:
+        _terminate_children(
+            multiprocessing.active_children(),
+            getattr(app.native, "main_window", None),
+        )
+    except Exception:  # noqa: BLE001 - a shutdown path must not raise
+        logger.warning("native window teardown failed", exc_info=True)
 
 
 async def _teardown_native_window_async() -> None:

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1660,7 +1660,13 @@ def _terminate_children(
 
 
 def _teardown_native_window() -> None:
-    """Synchronous teardown against the live process table. Safe to call anywhere.
+    """Tear down everything alive at shutdown -- today, only the native window child.
+
+    ``active_children()`` is deliberately broad: NiceGUI's native mode creates exactly one
+    ``mp.Process`` (the window), and ``nicegui.run``'s process pool spawns workers only on
+    the first ``run.cpu_bound`` call, which Ferry never makes. If that ever changes, this
+    must filter, or pool workers will be killed ahead of NiceGUI's own ``run.tear_down()``.
+
 
     Never raises. Both call sites are shutdown paths -- ``app.on_shutdown`` (where an
     exception would propagate into uvicorn's lifespan shutdown and skip NiceGUI's
@@ -1769,9 +1775,12 @@ def main() -> None:
     try:
         _run_gui()
     except KeyboardInterrupt:
-        # The interrupt can arrive after uvicorn restores the default SIGINT handler,
-        # or from NiceGUI's check_shutdown thread calling _thread.interrupt_main().
-        # Exit with the conventional SIGINT status rather than a silent 0.
+        # Two routine sources, not just a stray Ctrl-C: uvicorn re-raises a captured
+        # SIGINT after restoring the default handler, and NiceGUI's check_shutdown thread
+        # calls _thread.interrupt_main() ~0-100ms after the window closes -- so even a
+        # clean window close can land here. Measured behaviour today is that neither
+        # surfaces as a KeyboardInterrupt (the app exits 0); this is the defensive path
+        # for when one does, and 130 is the conventional SIGINT status.
         raise SystemExit(130) from None
 
 

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1680,24 +1680,58 @@ async def _teardown_native_window_async() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _run_gui() -> None:
+    """Start the UI and guarantee the native window child dies with the server."""
+    native = _HAS_WEBVIEW
+
+    if native:
+        # Fires on every path that reaches the ASGI lifespan shutdown: window close,
+        # Cmd-Q, Dock quit, force quit (SIGTERM) and a single Ctrl-C.
+        app.on_shutdown(_teardown_native_window_async)
+
+    try:
+        ui.run(
+            title="Discord Ferry",
+            host="127.0.0.1",
+            port=8765,
+            native=native,
+            reload=False,
+            storage_secret=os.environ.get("FERRY_STORAGE_SECRET", secrets.token_hex(32)),
+            # NiceGUI derives ping_interval = max(rt * 0.8, 4) and
+            # ping_timeout = max(rt * 0.4, 2) from this, so the 3.0 default leaves the
+            # browser only ~6s of tolerance before it shows "Connection lost".
+            # 10.0 -> 8s/4s = 12s, still prompt about a genuinely dead server.
+            reconnect_timeout=10.0,
+            # uvicorn's graceful drain is unbounded by default and runs BEFORE the
+            # shutdown hook. The only connection is the local websocket, which closes
+            # immediately, so keep this short: a force-quit SIGKILL landing mid-drain
+            # would orphan the window, which is the whole failure this prevents.
+            timeout_graceful_shutdown=1,
+        )
+    finally:
+        # Covers what the lifespan hook cannot: uvicorn's force_exit path (double
+        # Ctrl-C) and a failure during startup. Without it a surviving daemon child
+        # would hang the interpreter in multiprocessing's atexit join, which has no
+        # timeout -- a hung Ferry still holding port 8765, worse than an orphan.
+        if native:
+            _teardown_native_window()
+
+
 def main() -> None:
     """Launch the NiceGUI local web UI."""
-    native = False
+    # MUST be the first statement. PyInstaller's rthook only rebinds
+    # multiprocessing.freeze_support(); the diversion to spawn_main happens when it is
+    # called, and NiceGUI only calls it deep inside ui.run(). Without this, the frozen
+    # window child re-runs everything above ui.run() before diverting.
+    multiprocessing.freeze_support()
+
     try:
-        import webview  # noqa: F401
-
-        native = True
-    except ImportError:
-        pass
-
-    ui.run(
-        title="Discord Ferry",
-        host="127.0.0.1",
-        port=8765,
-        native=native,
-        reload=False,
-        storage_secret=os.environ.get("FERRY_STORAGE_SECRET", secrets.token_hex(32)),
-    )
+        _run_gui()
+    except KeyboardInterrupt:
+        # The interrupt can arrive after uvicorn restores the default SIGINT handler,
+        # or from NiceGUI's check_shutdown thread calling _thread.interrupt_main().
+        # Exit with the conventional SIGINT status rather than a silent 0.
+        raise SystemExit(130) from None
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -241,3 +241,55 @@ class TestMainLifecycle:
         gui._run_gui()
         assert captured["reconnect_timeout"] == 10.0
         assert captured["timeout_graceful_shutdown"] == 1
+
+
+class TestFolderPicker:
+    """The picker has never worked in the packaged app.
+
+    gui.py called ``webview.windows[0]`` in the SERVER process, but
+    ``webview.create_window()`` only ever runs in the child (native_mode._open_window),
+    so the list is permanently empty and every click raised IndexError straight into
+    the "requires native mode" toast.
+    """
+
+    async def test_returns_the_chosen_path(self) -> None:
+        class Window:
+            async def create_file_dialog(self, _dialog_type: int) -> tuple[str, ...]:
+                return ("/Users/pete/export",)
+
+        assert await gui._pick_folder(Window()) == "/Users/pete/export"
+
+    async def test_cancelled_dialog_returns_none(self) -> None:
+        class Window:
+            async def create_file_dialog(self, _dialog_type: int) -> tuple[str, ...] | None:
+                return None
+
+        assert await gui._pick_folder(Window()) is None
+
+    async def test_empty_tuple_returns_none(self) -> None:
+        """Guards an IndexError regression of exactly the kind being fixed."""
+
+        class Window:
+            async def create_file_dialog(self, _dialog_type: int) -> tuple[str, ...]:
+                return ()
+
+        assert await gui._pick_folder(Window()) is None
+
+    async def test_raising_window_returns_none(self) -> None:
+        class Window:
+            async def create_file_dialog(self, _dialog_type: int) -> tuple[str, ...]:
+                raise RuntimeError("window is gone")
+
+        assert await gui._pick_folder(Window()) is None
+
+    async def test_browser_mode_returns_none(self) -> None:
+        assert await gui._pick_folder(None) is None
+
+    def test_dialog_type_prefers_the_modern_enum(self) -> None:
+        """FOLDER_DIALOG still resolves to 20 on pywebview 6.2.1 but emits a
+        DeprecationWarning; FileDialog.FOLDER is the supported spelling."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert gui._folder_dialog_type() == 20

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -153,6 +153,24 @@ class TestTeardownLadder:
         monkeypatch.setattr(gui.multiprocessing, "active_children", lambda: [ExplodingChild()])
         gui._teardown_native_window()  # must not raise
 
+    def test_production_wiring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pins WHAT the production entry point feeds the ladder.
+
+        The ladder takes its collaborators as arguments for testability, which means a
+        mis-wired call site would leave every ladder test green while the real teardown
+        operated on the wrong objects.
+        """
+        seen: dict[str, Any] = {}
+        monkeypatch.setattr(gui.multiprocessing, "active_children", lambda: ["child"])
+        monkeypatch.setattr(gui.app.native, "main_window", "window")
+        monkeypatch.setattr(
+            gui,
+            "_terminate_children",
+            lambda children, window: seen.update(children=children, window=window),
+        )
+        gui._teardown_native_window()
+        assert seen == {"children": ["child"], "window": "window"}
+
 
 class TestMainLifecycle:
     def test_freeze_support_is_the_first_statement_of_main(self) -> None:

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -134,6 +134,25 @@ class TestTeardownLadder:
         _terminate_children([child], None)
         assert child.terminate_calls == 1
 
+    def test_teardown_never_raises_into_the_shutdown_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both call sites are shutdown paths, so nothing may escape.
+
+        On ``app.on_shutdown`` an exception would propagate into uvicorn's lifespan
+        shutdown and skip NiceGUI's remaining handlers; in ``_run_gui``'s ``finally:``
+        it would mask whatever exception was already unwinding. The inner ladder only
+        guards the calls it makes ON the child -- is_alive()/join()/active_children()
+        are guarded here.
+        """
+
+        class ExplodingChild(FakeChild):
+            def is_alive(self) -> bool:
+                raise OSError("process table went away")
+
+        monkeypatch.setattr(gui.multiprocessing, "active_children", lambda: [ExplodingChild()])
+        gui._teardown_native_window()  # must not raise
+
 
 class TestMainLifecycle:
     def test_freeze_support_is_the_first_statement_of_main(self) -> None:

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -11,8 +11,14 @@ process while it still holds port 8765.
 
 from __future__ import annotations
 
+import ast
+import inspect
 from typing import Any
+from unittest.mock import MagicMock
 
+import pytest
+
+from discord_ferry import gui
 from discord_ferry.gui import _terminate_children
 
 
@@ -127,3 +133,111 @@ class TestTeardownLadder:
         child = FakeChild(alive_sequence=[True, True, False])
         _terminate_children([child], None)
         assert child.terminate_calls == 1
+
+
+class TestMainLifecycle:
+    def test_freeze_support_is_the_first_statement_of_main(self) -> None:
+        """PyInstaller's rthook only REBINDS multiprocessing.freeze_support; the
+        diversion to spawn_main happens when it is CALLED, and NiceGUI calls it deep
+        inside native_mode.activate(). So in the frozen app the spawned window child
+        runs every statement of main() above ui.run(). Calling freeze_support first
+        makes the child divert immediately.
+
+        No source test can prove the child actually diverts -- that rides on the
+        built-bundle check. This pins placement only.
+        """
+        tree = ast.parse(inspect.getsource(gui.main))
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        body = [
+            node
+            for node in func.body
+            if not (isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant))
+        ]
+        first = body[0]
+        assert isinstance(first, ast.Expr), "first statement of main() must be a call"
+        call = first.value
+        assert isinstance(call, ast.Call)
+        assert ast.unparse(call.func) == "multiprocessing.freeze_support"
+
+    def test_finally_runs_the_sync_teardown_on_normal_return(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The anti-inertness test.
+
+        An un-awaited coroutine in that finally: would be a silent no-op on the one
+        path where nothing else cleans up (uvicorn's force_exit, or a boot failure).
+        """
+        calls: list[str] = []
+        monkeypatch.setattr(gui, "_HAS_WEBVIEW", True)
+        monkeypatch.setattr(gui.ui, "run", lambda **_kwargs: calls.append("ran"))
+        monkeypatch.setattr(gui, "_teardown_native_window", lambda: calls.append("torn down"))
+        monkeypatch.setattr(gui.app, "on_shutdown", MagicMock())
+        gui._run_gui()
+        assert calls == ["ran", "torn down"]
+
+    def test_finally_runs_the_sync_teardown_when_ui_run_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        def _boom(**_kwargs: object) -> None:
+            raise RuntimeError("server exploded during startup")
+
+        monkeypatch.setattr(gui, "_HAS_WEBVIEW", True)
+        monkeypatch.setattr(gui.ui, "run", _boom)
+        monkeypatch.setattr(gui, "_teardown_native_window", lambda: calls.append("torn down"))
+        monkeypatch.setattr(gui.app, "on_shutdown", MagicMock())
+        with pytest.raises(RuntimeError):
+            gui._run_gui()
+        assert calls == ["torn down"]
+
+    def test_shutdown_handler_registered_in_native_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        on_shutdown = MagicMock()
+        monkeypatch.setattr(gui, "_HAS_WEBVIEW", True)
+        monkeypatch.setattr(gui.ui, "run", lambda **_kwargs: None)
+        monkeypatch.setattr(gui, "_teardown_native_window", lambda: None)
+        monkeypatch.setattr(gui.app, "on_shutdown", on_shutdown)
+        gui._run_gui()
+        on_shutdown.assert_called_once_with(gui._teardown_native_window_async)
+
+    def test_no_handler_and_no_teardown_in_browser_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        on_shutdown = MagicMock()
+        calls: list[str] = []
+        monkeypatch.setattr(gui, "_HAS_WEBVIEW", False)
+        monkeypatch.setattr(gui.ui, "run", lambda **_kwargs: None)
+        monkeypatch.setattr(gui, "_teardown_native_window", lambda: calls.append("torn down"))
+        monkeypatch.setattr(gui.app, "on_shutdown", on_shutdown)
+        gui._run_gui()
+        on_shutdown.assert_not_called()
+        assert calls == []
+
+    def test_keyboard_interrupt_exits_130(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returning 0 on Ctrl-C would lie to a supervisor or a shell script."""
+
+        def _interrupt() -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(gui, "_run_gui", _interrupt)
+        with pytest.raises(SystemExit) as excinfo:
+            gui.main()
+        assert excinfo.value.code == 130
+
+    def test_normal_return_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gui, "_run_gui", lambda: None)
+        gui.main()
+
+    def test_ui_run_is_called_with_tuned_timings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NiceGUI derives the socket.io heartbeat from reconnect_timeout; its 3.0
+        default gives the browser only ~6s before the "Connection lost" banner."""
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(gui, "_HAS_WEBVIEW", False)
+        monkeypatch.setattr(gui.ui, "run", lambda **kwargs: captured.update(kwargs))
+        monkeypatch.setattr(gui, "_teardown_native_window", lambda: None)
+        gui._run_gui()
+        assert captured["reconnect_timeout"] == 10.0
+        assert captured["timeout_graceful_shutdown"] == 1

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -1,0 +1,129 @@
+"""Tests for the native-window lifecycle in src/discord_ferry/gui.py.
+
+Background: NiceGUI's native mode runs pywebview in a ``daemon=True`` multiprocessing
+child. SIGTERM kills Python without running ``atexit``, so multiprocessing's
+``_exit_function`` -- the only thing that terminates daemon children -- never runs and
+the window is orphaned, showing "Connection lost. Trying to reconnect..." against a
+server that no longer exists. Worse, if a child ever outlives the interpreter's exit,
+``_exit_function`` joins it with NO timeout (multiprocessing/util.py:360), hanging the
+process while it still holds port 8765.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from discord_ferry.gui import _terminate_children
+
+
+class FakeChild:
+    """A ``multiprocessing.Process`` stand-in with a scripted liveness sequence.
+
+    ``is_alive`` pops one entry per call until a single entry remains, which then
+    sticks -- so ``[True]`` models an unkillable child and ``[True, False]`` a child
+    that dies at the first rung.
+    """
+
+    def __init__(self, pid: int = 1234, alive_sequence: list[bool] | None = None) -> None:
+        self.pid = pid
+        self.daemon = True
+        self._alive = list(alive_sequence or [True])
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_timeouts: list[float | None] = []
+
+    def is_alive(self) -> bool:
+        return self._alive[0] if len(self._alive) == 1 else self._alive.pop(0)
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(timeout)
+
+
+class FakeWindow:
+    """Records every attribute access, so "was it touched at all" is assertable."""
+
+    def __init__(self, raises: bool = False) -> None:
+        self.touched: list[str] = []
+        self._raises = raises
+
+    def __getattr__(self, name: str) -> Any:
+        self.touched.append(name)
+
+        def _call(*_args: Any, **_kwargs: Any) -> None:
+            if self._raises:
+                raise RuntimeError("method_queue is closed")
+
+        return _call
+
+
+class TestTeardownLadder:
+    def test_destroy_alone_is_enough(self) -> None:
+        child = FakeChild(alive_sequence=[True, False])
+        window = FakeWindow()
+        _terminate_children([child], window)
+        assert window.touched == ["destroy"]
+        assert child.terminate_calls == 0
+        assert child.kill_calls == 0
+
+    def test_escalates_to_terminate(self) -> None:
+        child = FakeChild(alive_sequence=[True, True, False])
+        _terminate_children([child], FakeWindow())
+        assert child.terminate_calls == 1
+        assert child.kill_calls == 0
+
+    def test_escalates_to_kill(self) -> None:
+        child = FakeChild(alive_sequence=[True, True, True, False])
+        _terminate_children([child], FakeWindow())
+        assert child.terminate_calls == 1
+        assert child.kill_calls == 1
+
+    def test_unkillable_child_does_not_hang(self) -> None:
+        """A child that outlives the ladder must not turn into an unbounded wait."""
+        child = FakeChild(alive_sequence=[True])
+        _terminate_children([child], FakeWindow())
+        assert child.kill_calls == 1
+        assert child.join_timeouts
+        assert all(t is not None for t in child.join_timeouts), "every join must be bounded"
+
+    def test_no_children_leaves_the_window_untouched(self) -> None:
+        """The precondition.
+
+        NiceGUI's check_shutdown closes the proxy's method queues as soon as the server
+        stops, so an unconditional destroy() would raise -- and log a traceback -- on
+        every healthy shutdown.
+        """
+        window = FakeWindow()
+        _terminate_children([FakeChild(alive_sequence=[False])], window)
+        assert window.touched == []
+
+    def test_second_invocation_is_a_no_op(self) -> None:
+        child = FakeChild(alive_sequence=[True, False])
+        window = FakeWindow()
+        _terminate_children([child], window)
+        window.touched.clear()
+        _terminate_children([child], window)
+        assert window.touched == []
+        assert child.terminate_calls == 0
+
+    def test_raising_window_does_not_abort_the_ladder(self) -> None:
+        child = FakeChild(alive_sequence=[True, True, False])
+        _terminate_children([child], FakeWindow(raises=True))
+        assert child.terminate_calls == 1
+
+    def test_joins_are_bounded(self) -> None:
+        child = FakeChild(alive_sequence=[True, True, True, False])
+        _terminate_children([child], FakeWindow(), join_timeout=0.25)
+        assert child.join_timeouts
+        assert all(t == 0.25 for t in child.join_timeouts)
+
+    def test_window_is_optional(self) -> None:
+        """Browser mode has no window proxy; the ladder still tears children down."""
+        child = FakeChild(alive_sequence=[True, True, False])
+        _terminate_children([child], None)
+        assert child.terminate_calls == 1

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -217,7 +217,15 @@ class TestMainLifecycle:
         assert calls == []
 
     def test_keyboard_interrupt_exits_130(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returning 0 on Ctrl-C would lie to a supervisor or a shell script."""
+        """main()'s contract: an escaping KeyboardInterrupt becomes exit 130.
+
+        This is a defensive path, NOT the observed end-to-end behaviour. Measured on
+        both a source run and the built bundle: a real SIGINT is consumed by uvicorn's
+        handle_exit, the graceful shutdown runs, and the re-raised signal never surfaces
+        as a KeyboardInterrupt here -- the process exits 0, cleanly, with no orphans and
+        no traceback. The handler still matters for an interrupt during the boot window,
+        before uvicorn installs its handlers.
+        """
 
         def _interrupt() -> None:
             raise KeyboardInterrupt

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -59,6 +59,12 @@ def test_ferry_spec_builds_onedir_on_darwin() -> None:
     assert "BUNDLE(" in body and "coll," in body, "BUNDLE must wrap the COLLECT output"
 
 
+def test_troubleshooting_covers_the_connection_lost_banner() -> None:
+    """Users search for the exact banner text when the window goes dead."""
+    guide = (_REPO_ROOT / "docs" / "guides" / "troubleshooting.md").read_text(encoding="utf-8")
+    assert "Connection lost" in guide
+
+
 def test_release_workflow_archives_macos_bundle_with_ditto() -> None:
     """The macOS artifact must be archived with a symlink-preserving tool.
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -13,6 +13,12 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
+# Anchored to column 0 on purpose: ferry.spec also contains an indented
+# `elif sys.platform == "darwin":` in the icon-selection block, and an unanchored
+# split matches THAT first -- which made an earlier draft of these tests inspect
+# icon code and pass vacuously.
+_DARWIN_BRANCH = '\nif sys.platform == "darwin":'
+
 
 def test_ferry_spec_bundles_dce_checksums() -> None:
     """ferry.spec must bundle dce_checksums.json into the frozen binary.
@@ -33,3 +39,31 @@ def test_ferry_spec_bundles_dce_checksums() -> None:
         "ferry.spec must map dce_checksums.json -> the 'discord_ferry' package dir in "
         "all_datas, else the frozen binary skips DCE checksum verification."
     )
+
+
+def test_ferry_spec_builds_onedir_on_darwin() -> None:
+    """macOS must build onedir, not onefile.
+
+    Onefile puts a PyInstaller bootloader in front of Python; that bootloader is the
+    process macOS registers with LaunchServices, and it waits in usleep() while the
+    real app runs. macOS flags it unresponsive (a 99s hang report was recorded against
+    v2.7.1), users force-quit it, and the SIGTERM orphans the pywebview window child,
+    which then shows "Connection lost. Trying to reconnect..." forever.
+    """
+    spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")
+    parts = spec_text.split(_DARWIN_BRANCH, 1)
+    assert len(parts) == 2, "ferry.spec must branch packaging on sys.platform"
+    body = parts[1]
+    assert "exclude_binaries=True" in body, "darwin EXE must exclude binaries (onedir)"
+    assert "COLLECT(" in body, "darwin build must COLLECT into a directory"
+    assert "BUNDLE(" in body and "coll," in body, "BUNDLE must wrap the COLLECT output"
+
+
+def test_ferry_spec_keeps_onefile_off_darwin() -> None:
+    """Windows must keep shipping a single Ferry-windows-x86_64.exe."""
+    spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")
+    non_darwin = spec_text.split(_DARWIN_BRANCH, 1)[1].split("\nelse:", 1)
+    assert len(non_darwin) == 2, "ferry.spec must keep an else: branch for other platforms"
+    body = non_darwin[1]
+    assert "runtime_tmpdir=None" in body, "non-darwin build must stay onefile"
+    assert "exclude_binaries" not in body, "non-darwin build must not become onedir"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -59,6 +59,36 @@ def test_ferry_spec_builds_onedir_on_darwin() -> None:
     assert "BUNDLE(" in body and "coll," in body, "BUNDLE must wrap the COLLECT output"
 
 
+def test_release_workflow_archives_macos_bundle_with_ditto() -> None:
+    """The macOS artifact must be archived with a symlink-preserving tool.
+
+    The onedir bundle contains ~119 symlinks cross-linking Contents/MacOS,
+    Contents/Frameworks and Contents/Resources. `zip -r` follows them: measured
+    91 MB instead of 45 MB, and the extracted tree has real files where
+    Contents/_CodeSignature/CodeResources recorded symlinks -- an invalid seal,
+    which for a quarantined ad-hoc-signed app is the "Ferry.app is damaged"
+    dialog rather than the Gatekeeper flow documented in install.md.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    macos_job = workflow.split("build-macos:", 1)[1].split("\n  release:", 1)[0]
+    assert "ditto -c -k --sequesterRsrc --keepParent Ferry.app" in macos_job, (
+        "macOS archive step must use ditto (symlink-preserving), naming Ferry.app "
+        "explicitly so COLLECT's dist/Ferry/ directory is not swept in"
+    )
+    assert "zip -r" not in macos_job, "zip -r dereferences the bundle's symlinks"
+
+
+def test_release_workflow_can_be_dispatched_manually() -> None:
+    """The packaging path must be runnable before a tag exists.
+
+    release.yml otherwise triggers only on tag push, so a packaging failure would
+    first surface on an already-published tag.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    triggers = workflow.split("jobs:", 1)[0]
+    assert "workflow_dispatch:" in triggers, "release.yml must allow manual dispatch"
+
+
 def test_ferry_spec_keeps_onefile_off_darwin() -> None:
     """Windows must keep shipping a single Ferry-windows-x86_64.exe."""
     spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -13,10 +13,11 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Anchored to column 0 on purpose: ferry.spec also contains an indented
-# `elif sys.platform == "darwin":` in the icon-selection block, and an unanchored
-# split matches THAT first -- which made an earlier draft of these tests inspect
-# icon code and pass vacuously.
+# Anchored with a leading newline on purpose. ferry.spec's icon block contains
+# `elif sys.platform == "darwin":`, whose text CONTAINS `if sys.platform == "darwin":`
+# as a substring, so an unanchored split matches there first -- which made an earlier
+# draft of these tests inspect icon code and pass vacuously. The `\n` cannot match
+# inside `elif` because the character before `if` is `l`, not a newline.
 _DARWIN_BRANCH = '\nif sys.platform == "darwin":'
 
 
@@ -103,3 +104,47 @@ def test_ferry_spec_keeps_onefile_off_darwin() -> None:
     body = non_darwin[1]
     assert "runtime_tmpdir=None" in body, "non-darwin build must stay onefile"
     assert "exclude_binaries" not in body, "non-darwin build must not become onedir"
+    # Without these the branch still "looks onefile" while shipping an executable with
+    # no bundled assets at all.
+    assert "a.binaries" in body and "a.datas" in body, (
+        "the onefile EXE must still receive the collected binaries and data files"
+    )
+
+
+def test_exe_common_carries_every_shared_argument() -> None:
+    """Both branches build their EXE from _EXE_COMMON, which the branch-body tests
+    never see -- so a silently dropped argument (icon, console, codesign_identity...)
+    would change the shipped binary with a green suite."""
+    spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")
+    common = spec_text.split("_EXE_COMMON = dict(", 1)[1].split("\n)", 1)[0]
+    for arg in (
+        "name=",
+        "debug=",
+        "bootloader_ignore_signals=",
+        "strip=",
+        "upx=",
+        "upx_exclude=",
+        "console=",
+        "disable_windowed_traceback=",
+        "argv_emulation=",
+        "target_arch=",
+        "codesign_identity=",
+        "entitlements_file=",
+        "icon=",
+    ):
+        assert arg in common, f"{arg} dropped from the shared EXE arguments"
+
+
+def test_release_job_only_publishes_on_a_tag() -> None:
+    """workflow_dispatch runs must not reach the publish step.
+
+    On a dispatch, github.ref is a branch ref and softprops/action-gh-release hard-fails
+    ("GitHub Releases requires a tag"), which would make every manual run go red at the
+    publish step -- indistinguishable at a glance from the packaging failure the dispatch
+    exists to detect.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_job = workflow.split("\n  release:", 1)[1].split("steps:", 1)[0]
+    assert "startsWith(github.ref, 'refs/tags/')" in release_job, (
+        "the release job must be gated on a tag ref"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.8.3"
+version = "2.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What broke

A user on the shipped `Ferry.app` v2.7.1 saw **"Connection lost. Trying to reconnect…"** on an idle window. The banner was truthful — the server was gone — and the window was a zombie that could never reconnect.

Two defects compounded:

**1. macOS flagged the app as not responding.** `ferry.spec` built *onefile*, so the process macOS registers with LaunchServices is the PyInstaller bootloader, which unpacks ~200 MB (measured **18 seconds** from double-click to window) and then waits in `usleep()`. macOS wrote a hang report against v2.7.1 — `Event: hang`, `Duration: 99.18s`, `Unresponsive for 97 seconds`, main thread `→ usleep → __semwait_signal` at an 8 MB footprint. The Dock offered Force Quit; `launchd` logged `exited due to SIGTERM | ran for 107546ms`.

**2. The force quit orphaned the window.** NiceGUI's native mode runs pywebview as a `daemon=True` multiprocessing child. SIGTERM kills Python without running `atexit`, so `multiprocessing._exit_function` — the only thing that terminates daemon children — never ran. The window survived at PPID 1 with nothing listening on 8765.

## What changed

- **macOS builds onedir** (`exclude_binaries` + `COLLECT` + `BUNDLE(coll)`); Windows keeps its single `.exe`. No bootloader, so nothing for macOS to flag.
- **A bounded, idempotent teardown ladder** (`destroy` → `terminate` → `kill`, every join timed) runs from **both** `app.on_shutdown` and a `finally:` around `ui.run()`. The second site is load-bearing: `multiprocessing.util._exit_function` joins daemon children with *no timeout*, so a survivor would hang the interpreter while holding port 8765 — worse than an orphan.
- **`multiprocessing.freeze_support()` is now the first statement of `main()`.** PyInstaller's rthook only *rebinds* it; the diversion to `spawn_main` happens when it's *called*, and NiceGUI only calls it inside `ui.run()` — so the frozen window child was re-running everything above that line.
- **The release archive would have shipped a broken bundle.** The onedir `.app` has 119 symlinks; `zip -r` follows them (91 MB vs 45 MB) and extracts real files where the signature recorded links — Gatekeeper's "Ferry.app is damaged". Now `ditto`, with the *extracted* artifact verified in CI.
- **The folder picker never worked in the packaged app** — it called `webview.windows[0]` in the server process, where that list is permanently empty. Now `app.native.main_window`.
- Heartbeat tolerance 6 s → 12 s (`reconnect_timeout=10.0`); uvicorn's graceful wait bounded at 1 s.

## Measured

| | before | after |
|---|---|---|
| Time to serving | 18 s | **2 s** |
| Processes | 4 | **3** |
| Main thread of the registered app | `usleep` | `uvloop … run_forever` |
| SIGTERM / window-close / SIGINT ×1 / ×2 / boot-window | orphaned window | **0 survivors**, port released, no traceback |
| Archive | 91 MB, symlinks lost | **45 MB**, 119 symlinks, `codesign --verify --deep --strict` clean |

Tests: **1360 pass** (+31). ruff · ruff format · mypy strict clean. `mkdocs build --strict` clean.

## Known limits, stated

- **Ctrl-C exits 0, not 130.** uvicorn consumes SIGINT and its re-raised signal never surfaces as a `KeyboardInterrupt`. Everything that matters holds (no orphans, no traceback); the handler is kept as defence and the test docstring says it covers `main()`'s contract, not observed behaviour.
- **The "leaked semaphore objects" warning on SIGTERM is pre-existing and inherent** — the parent never finalises its own `mp.Queue` semaphores because SIGTERM skips `atexit`.
- **Windows and Intel are CI-build-only**; no machine available to exercise either at runtime.
- **The tagged release run is the first CI exercise of the new packaging path.** `workflow_dispatch` is only offered from the default branch, and `auto-tag.yml` fires the moment `pyproject.toml` lands on main, so there is no window between the two. Every assertion in the new verify step was dry-run locally against the real bundle first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
