### PR TITLE
ci: build the packaging path on PRs that touch it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@ on:
   push:
     tags:
       - "v*.*.*"
-  # Manual runs exist so the packaging path can be exercised BEFORE a tag. A
-  # packaging failure discovered on a tag means deleting and re-cutting a published
-  # release; a dispatch run costs nothing.
+  # Exercise the packaging path on PRs that touch it. workflow_dispatch alone could
+  # never do this: GitHub only offers it from the default branch's copy of a workflow,
+  # and auto-tag.yml pushes the tag the instant a version bump lands on main -- so
+  # there is no window between "dispatch available" and "tag created". A packaging
+  # failure found on a tag means deleting and re-cutting a published release.
+  # The release job is tag-gated, so these runs build and verify only.
+  pull_request:
+    paths:
+      - "ferry.spec"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Internal
+
+- **The release workflow now builds on pull requests that touch the packaging path**
+  (`ferry.spec` or `release.yml`). The `workflow_dispatch` trigger added in 2.8.4 could
+  never serve its stated purpose: GitHub only offers it from the default branch's copy of
+  a workflow, and `auto-tag.yml` pushes the tag the instant a version bump lands on main,
+  so there was no window between "dispatch available" and "tag created". A packaging
+  failure would first have surfaced on an already-published tag. The `release` job stays
+  gated on a tag ref, so these runs build and verify only.
+
 ## [2.8.4] - 2026-08-02
 
 ### Fixed

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -94,6 +94,14 @@ def test_release_workflow_can_be_dispatched_manually() -> None:
     workflow = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     triggers = workflow.split("jobs:", 1)[0]
     assert "workflow_dispatch:" in triggers, "release.yml must allow manual dispatch"
+    # workflow_dispatch alone is not enough: GitHub only offers it from the default
+    # branch's copy, and auto-tag.yml pushes the tag the moment a version bump lands on
+    # main, so there is no window between "dispatch available" and "tag created". The
+    # pull_request trigger is what actually exercises packaging before a tag exists.
+    assert "pull_request:" in triggers, (
+        "release.yml must build on PRs that touch the packaging path"
+    )
+    assert "ferry.spec" in triggers, "the PR trigger must watch ferry.spec"
 
 
 def test_ferry_spec_keeps_onefile_off_darwin() -> None:


### PR DESCRIPTION
## Why

The `workflow_dispatch` trigger added in v2.8.4 could never serve its stated purpose:

- GitHub only offers `workflow_dispatch` from the **default branch's** copy of a workflow, so it does not exist until the change is already on `main`.
- `auto-tag.yml` triggers on `push: branches: [main], paths: [pyproject.toml]` and pushes the tag immediately, which fires the tagged release run.

So there is no window between "dispatch is available" and "tag exists". A packaging failure would first surface on an already-published tag — the failure mode the dispatch was added to prevent.

## What

A path-filtered `pull_request` trigger on `ferry.spec` and `release.yml`. The `release` job is already gated on `startsWith(github.ref, 'refs/tags/')`, so these runs build and verify only — they never touch the GitHub Release or PyPI.

Normal PRs are unaffected: the filter means the three platform builds only run when the packaging path itself changes.

**This PR is its own first test** — it touches `release.yml`, so the new trigger fires here and exercises the onedir build, the `ditto` archive, and the artifact-verification step on all three runners before it merges.

CI config only, so no version bump (per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
