### PR TITLE
fix: five upload limits were too permissive, and the check that should have caught them could not fail (v2.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.8.5] - 2026-08-02
+
+### Fixed
+
+- **Five of the six upload size limits were too permissive, so oversized files were uploaded
+  and then rejected by the server** (`uploader/autumn.py`). Autumn's limits are *decimal*
+  megabytes, as written in stoatchat's `Revolt.toml`, but ours were binary:
+
+  | tag | was | now | too big by |
+  |---|---|---|---|
+  | attachments | 20,971,520 | 20,000,000 | 971,520 |
+  | avatars | 4,194,304 | 4,000,000 | 194,304 |
+  | backgrounds | 6,291,456 | 6,000,000 | 291,456 |
+  | banners | 6,291,456 | 6,000,000 | 291,456 |
+  | emojis | 512,000 | 500,000 | 12,000 |
+
+  `TAG_SIZE_LIMITS` is the *pre-upload* guard, so ours being looser than the server's meant a
+  file in the gap band passed our check, was uploaded in full, and came back a 413. Worst for
+  attachments, where the band is ~971 KB wide. Such files are now declined locally with an
+  accurate message instead of costing the bandwidth first. `icons` was already correct — it
+  had been diagnosed and fixed on its own, with a comment naming this exact trap, while the
+  other five were left standing.
+
+- **The probe's Autumn drift detector could not fail** (`migrator/probe.py`). It read a `tags`
+  key from the Autumn root, which returns only `{"autumn": ..., "version": ...}` — so it
+  compared nothing and reported "matches assumptions" on every run. Worse than no check: it
+  asserted the very thing it never tested, and that silence is why the five wrong limits above
+  went unnoticed. It now reads `features.limits.<new_user|default>.file_upload_size_limits`
+  from the Stoat root and reports a per-tier, per-tag diff. When the limits cannot be read at
+  all it says so explicitly rather than passing.
+
+  It also now warns on the two cases it previously counted as clean passes: a tag we assume
+  that the instance never advertises (unverified is not the same as matching — the original
+  sin in miniature), and a bucket the instance advertises that we hold no limit for.
+
+### Security
+
+- **`ferry probe` can no longer be aborted by a malformed instance response**
+  (`migrator/probe.py`). It parses JSON from a server it does not control, and `run_probe`
+  wraps its four checks in `try`/`finally` with no `except` — so a single unexpected type
+  (say `features.limits.default` arriving as a string rather than an object) raised an
+  `AttributeError` that killed every remaining check and propagated to the caller. Truthy
+  non-dicts were the dangerous shape, because the `x or {}` idiom does not catch them. Each
+  hop of the parse is now type-guarded.
+
+### Changed
+
+- **`ferry probe` reports Autumn reachability as its own check** (`autumn_reachable`), separate
+  from the limits diff, so an unreachable file server cannot mask the limits result — and a
+  non-200 from it is now a failure rather than a silent "ok".
+- Size-limit messages are rendered in decimal MB to match the limits themselves. They divided
+  by 1,048,576, which would have described the 20,000,000-byte cap as "limit: 19.1 MB".
+
 ### Internal
 
 - **The release workflow now builds on pull requests that touch the packaging path**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.8.4"
+version = "2.8.5"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.8.4"
+__version__ = "2.8.5"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1478,8 +1478,9 @@ async def _upload_attachments(
         if att.file_size_bytes > 0 and limit > 0 and att.file_size_bytes > limit:
             reason = (
                 f"File too large: {att.file_name} "
-                f"({att.file_size_bytes / 1_048_576:.1f} MB, "
-                f"limit: {limit / 1_048_576:.1f} MB)"
+                # Decimal MB, matching TAG_SIZE_LIMITS (see autumn.py).
+                f"({att.file_size_bytes / 1_000_000:.1f} MB, "
+                f"limit: {limit / 1_000_000:.1f} MB)"
             )
             if channel_result is not None:
                 placeholder = _skip_attachment_to_result(channel_result, att.file_name, reason)

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -16,11 +16,27 @@ from discord_ferry.migrator.api import (
     api_execute_webhook,
     api_fetch_channel,
 )
-from discord_ferry.migrator.connect import _discover_autumn_url
 from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+# Tiers on the Stoat root that may carry upload limits. `global` carries none today; it
+# is listed so that it would be compared rather than missed if it ever gained them.
+_LIMIT_TIERS = ("global", "new_user", "default")
+
+
+def _sub_dict(obj: Any, key: str) -> dict[str, Any]:
+    """``obj[key]`` when both it and ``obj`` are dicts, else ``{}``.
+
+    This module parses JSON from an instance we do not control, and ``run_probe`` wraps
+    its four checks in ``try/finally`` with **no** ``except`` -- so an ``AttributeError``
+    from something like ``limits["new_user"]`` being a string would abort every remaining
+    check and propagate to the caller. Guarding each hop makes the parse total, which is
+    safer than catching afterwards.
+    """
+    value = obj.get(key) if isinstance(obj, dict) else None
+    return value if isinstance(value, dict) else {}
 
 
 @dataclass
@@ -69,24 +85,99 @@ async def run_probe(
 
 
 async def _check_autumn(sess: aiohttp.ClientSession, stoat_url: str, report: ProbeReport) -> None:
+    """Diff our assumed upload limits against the ones this instance advertises.
+
+    The limits live on the **Stoat** root under
+    ``features.limits.<tier>.file_upload_size_limits`` -- not on the Autumn root, which
+    returns only ``{"autumn": ..., "version": ...}``. Until v2.8.5 this read a ``tags``
+    key from the Autumn root; that key does not exist, so the diff list was always empty
+    and the check reported "matches assumptions" unconditionally. That is worse than no
+    check, because it asserted the very thing it never tested -- and it hid five wrong
+    values in ``TAG_SIZE_LIMITS`` for months.
+
+    One GET serves both halves: the limits, and the Autumn URL for the reachability
+    check. Reported as two independent checks so an unreachable Autumn cannot mask the
+    limits result.
+    """
     try:
-        autumn_url = await _discover_autumn_url(sess, stoat_url)
-        # Best-effort: GET the autumn root for advertised per-tag limits.
-        async with sess.get(f"{autumn_url.rstrip('/')}/") as resp:
-            data: dict[str, Any] = await resp.json() if resp.status == 200 else {}
-        advertised = data.get("tags") or {}
-        diffs = [
-            f"{tag}: advertised {advertised.get(tag)} vs assumed {assumed}"
+        async with sess.get(f"{stoat_url.rstrip('/')}/") as resp:
+            root: Any = await resp.json() if resp.status == 200 else {}
+    except Exception as exc:  # noqa: BLE001 — probe must continue
+        detail = f"{type(exc).__name__}: {exc}"
+        report.add("autumn_limits", "fail", detail)
+        report.add("autumn_reachable", "fail", f"Stoat root unreachable: {detail}")
+        return
+
+    features = _sub_dict(root, "features")
+    _report_autumn_limits(features, report)
+    await _report_autumn_reachable(sess, features, report)
+
+
+def _report_autumn_limits(features: dict[str, Any], report: ProbeReport) -> None:
+    """Compare ``TAG_SIZE_LIMITS`` per tier, or say plainly that we could not read them."""
+    limits = _sub_dict(features, "limits")
+    tiers_read: list[str] = []
+    diffs: list[str] = []
+    for tier in _LIMIT_TIERS:
+        advertised = _sub_dict(limits, tier).get("file_upload_size_limits")
+        if not isinstance(advertised, dict) or not advertised:
+            continue
+        tiers_read.append(tier)
+        diffs += [
+            f"{tier}/{tag}: advertised {advertised[tag]} vs assumed {assumed}"
             for tag, assumed in TAG_SIZE_LIMITS.items()
-            if tag in advertised and advertised.get(tag) != assumed
+            if tag in advertised and advertised[tag] != assumed
         ]
+        # A tag we assume but the instance never advertises is UNVERIFIED, not matching.
+        # Counting it as a pass would repeat this check's original sin.
+        diffs += [
+            f"{tier}/{tag}: assumed {assumed} but not advertised"
+            for tag, assumed in TAG_SIZE_LIMITS.items()
+            if tag not in advertised
+        ]
+        # A bucket we have no limit for is drift too -- it may be one we should support.
+        diffs += [
+            f"{tier}/{tag}: advertised {value}, we assume nothing"
+            for tag, value in sorted(advertised.items())
+            if tag not in TAG_SIZE_LIMITS
+        ]
+
+    if not tiers_read:
+        # Never "matches assumptions" here -- we compared nothing.
         report.add(
             "autumn_limits",
-            "warn" if diffs else "ok",
-            "; ".join(diffs) or "matches assumptions",
+            "warn",
+            "could not read advertised limits (features.limits."
+            f"<{'|'.join(_LIMIT_TIERS)}>.file_upload_size_limits absent)",
         )
+        return
+
+    report.add(
+        "autumn_limits",
+        "warn" if diffs else "ok",
+        "; ".join(diffs) or f"matches assumptions for tier(s): {', '.join(tiers_read)}",
+    )
+
+
+async def _report_autumn_reachable(
+    sess: aiohttp.ClientSession, features: dict[str, Any], report: ProbeReport
+) -> None:
+    """Reachability/version signal only -- the Autumn root advertises no limits."""
+    autumn_url = _sub_dict(features, "autumn").get("url") or ""
+    if not isinstance(autumn_url, str) or not autumn_url:
+        report.add("autumn_reachable", "warn", "features.autumn.url absent from the Stoat root")
+        return
+    try:
+        async with sess.get(f"{autumn_url.rstrip('/')}/") as resp:
+            if resp.status != 200:
+                # Reporting a non-200 as "ok" would repeat this check's original sin:
+                # asserting health it never established.
+                report.add("autumn_reachable", "fail", f"{autumn_url}: HTTP {resp.status}")
+                return
+            body: dict[str, Any] = await resp.json(content_type=None)
+        report.add("autumn_reachable", "ok", f"{autumn_url} (version {body.get('version', '?')})")
     except Exception as exc:  # noqa: BLE001 — probe must continue
-        report.add("autumn_limits", "fail", f"{type(exc).__name__}: {exc}")
+        report.add("autumn_reachable", "fail", f"{autumn_url}: {type(exc).__name__}: {exc}")
 
 
 async def _check_voice_bug(

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -21,13 +21,18 @@ _MAX_RETRY_DELAY_MS = 60_000.0  # Mirrors migrator.api._MAX_RETRY_DELAY_SECONDS.
 _DEFAULT_RETRY_DELAY_MS = 1000.0
 _RETRYABLE_STATUSES = {429, 502, 503, 504}
 
+# Autumn's limits are DECIMAL megabytes, as written in stoatchat's Revolt.toml -- never
+# N * 1024 * 1024. Getting that wrong makes our pre-upload guard LOOSER than the server's,
+# so a file in the gap band is uploaded and then rejected with a 413. Verified 2026-08-02
+# against `features.limits.default.file_upload_size_limits` on https://api.stoat.chat/;
+# `ferry probe` re-checks it against whatever instance you point it at.
 TAG_SIZE_LIMITS: dict[str, int] = {
-    "attachments": 20 * 1024 * 1024,
-    "avatars": 4 * 1024 * 1024,
-    "backgrounds": 6 * 1024 * 1024,
-    "icons": 2_500_000,  # Autumn enforces a flat 2.5MB (stoatchat Revolt.toml), not 2560*1024
-    "banners": 6 * 1024 * 1024,
-    "emojis": 500 * 1024,
+    "attachments": 20_000_000,
+    "avatars": 4_000_000,
+    "backgrounds": 6_000_000,
+    "icons": 2_500_000,
+    "banners": 6_000_000,
+    "emojis": 500_000,
 }
 
 # Single-flight registry: coalesces concurrent first-uploads of the same cache key
@@ -125,7 +130,9 @@ async def upload_to_autumn(
 
     Args:
         session: An active aiohttp ClientSession to use for the request.
-        autumn_url: Autumn server base URL (e.g. "https://autumn.stoat.chat").
+        autumn_url: Autumn server base URL (e.g. "https://cdn.stoatusercontent.com" —
+            the old autumn.stoat.chat host 301-redirects there; we discover it at runtime
+            from the Stoat root's features.autumn.url).
         tag: Upload tag determining the bucket (attachments, avatars, icons, banners, emojis, etc.).
         file_path: Local path to the file to upload.
         token: Stoat session token for the x-session-token header.
@@ -212,8 +219,10 @@ async def upload_to_autumn(
                     limit = TAG_SIZE_LIMITS.get(tag, 0)
                     raise AutumnUploadError(
                         f"File too large: {file_path.name} "
-                        f"({file_path.stat().st_size / 1_048_576:.1f} MB, "
-                        f"limit: {limit / 1_048_576:.1f} MB)"
+                        # Decimal MB, matching TAG_SIZE_LIMITS -- dividing by 1_048_576
+                        # would render the 20_000_000 cap as "limit: 19.1 MB".
+                        f"({file_path.stat().st_size / 1_000_000:.1f} MB, "
+                        f"limit: {limit / 1_000_000:.1f} MB)"
                     )
 
                 text = await response.text()

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -176,11 +176,29 @@ async def test_upload_with_cache_miss(tmp_path: Path, mock_aiohttp: aioresponses
     assert cache[str(file)] == "new_file_id"
 
 
-def test_icons_limit_matches_stoat_autumn_config() -> None:
-    """Autumn enforces a flat 2_500_000 for icons (Revolt.toml), not 2560*1024."""
+def test_tag_size_limits_match_the_live_instance() -> None:
+    """Every limit is DECIMAL megabytes, matching what the instance advertises.
+
+    Measured 2026-08-02 from `features.limits.default.file_upload_size_limits` on
+    https://api.stoat.chat/. Autumn's config is written in decimal (20_000_000), so
+    every `N * 1024 * 1024` here was too permissive: files in the gap band passed our
+    pre-upload guard, were uploaded, and were rejected by Autumn with a 413.
+
+    `icons` was already correct — it had been diagnosed and fixed in isolation, with the
+    comment "Autumn enforces a flat 2.5MB (Revolt.toml), not 2560*1024", while the other
+    five were left. This pin covers all six so that cannot recur. `ferry probe` now
+    checks the same thing against a live instance.
+    """
     from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
-    assert TAG_SIZE_LIMITS["icons"] == 2_500_000
+    assert TAG_SIZE_LIMITS == {
+        "attachments": 20_000_000,
+        "avatars": 4_000_000,
+        "backgrounds": 6_000_000,
+        "icons": 2_500_000,
+        "banners": 6_000_000,
+        "emojis": 500_000,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -32,6 +32,7 @@ from discord_ferry.parser.models import (
     DCEReference,
 )
 from discord_ferry.state import FailedMessage, MigrationState
+from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1437,7 +1438,10 @@ async def test_attachment_exactly_at_limit_proceeds(
         id="att1",
         url="exact.bin",
         file_name="exact.bin",
-        file_size_bytes=20 * 1024 * 1024,  # Exactly at limit
+        # Track the constant, not a literal: this test pins `>` vs `>=`, and a hardcoded
+        # 20 * 1024 * 1024 silently stopped being "the limit" when it was corrected to
+        # decimal MB in v2.8.5.
+        file_size_bytes=TAG_SIZE_LIMITS["attachments"],  # Exactly at limit
     )
     msg = _make_message(id="msg1", content="exact limit", attachments=[att])
 

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -4,10 +4,28 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 
-from discord_ferry.migrator.probe import ProbeReport, run_probe
+from discord_ferry.migrator.probe import ProbeReport, _check_autumn, run_probe
+from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
 BASE_URL = "https://api.test"
+AUTUMN_URL = "https://cdn.test"
 TOKEN = "test-token"
+
+
+def _root_payload(limits: dict[str, object] | None) -> dict[str, object]:
+    """A Stoat API root payload, optionally carrying a `features.limits` block."""
+    features: dict[str, object] = {"autumn": {"url": AUTUMN_URL}}
+    if limits is not None:
+        features["limits"] = limits
+    return {"revolt": "0.14.3", "features": features}
+
+
+def _check(report: ProbeReport, name: str) -> str:
+    """Return "status: detail" for a named check, so assertions read as one string."""
+    for c in report.checks:
+        if c.name == name:
+            return f"{c.status}: {c.detail}"
+    raise AssertionError(f"no check named {name!r} in {[c.name for c in report.checks]}")
 
 
 def _noop_event(_evt: object) -> None:
@@ -47,3 +65,180 @@ async def test_probe_voice_teardown_fires_on_getback_failure(mock_aiohttp: aiore
 
     assert delete_called["n"] == 1  # teardown fired despite GET-back failure
     assert isinstance(report, ProbeReport)
+
+
+# ---------------------------------------------------------------------------
+# Autumn limits drift detector
+# ---------------------------------------------------------------------------
+
+
+async def test_autumn_limits_mismatch_warns(mock_aiohttp: aioresponses) -> None:
+    """A deliberately mismatched advertised limit must produce `warn` — proving it can fail.
+
+    Against the pre-fix code this asserts nothing: `_check_autumn` read `tags` from the
+    Autumn root, which no longer returns that key, so the diff list was always empty and
+    the check reported "matches assumptions" unconditionally.
+    """
+    advertised = dict(TAG_SIZE_LIMITS)
+    advertised["icons"] = 1_000_000  # against our assumed 2_500_000
+    mock_aiohttp.get(
+        f"{BASE_URL}/",
+        payload=_root_payload({"default": {"file_upload_size_limits": advertised}}),
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "hi", "version": "0.14.3"})
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    result = _check(report, "autumn_limits")
+    assert result.startswith("warn:")
+    assert "icons" in result
+    assert "1000000" in result.replace(",", "").replace("_", "")
+    assert "2500000" in result.replace(",", "").replace("_", "")
+    assert "default" in result
+
+
+async def test_autumn_limits_matching_reports_ok(mock_aiohttp: aioresponses) -> None:
+    """Limits equal to our assumptions report `ok`, naming the tier(s) actually compared.
+
+    The payload is built FROM TAG_SIZE_LIMITS so this cannot rot when those values change.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/",
+        payload=_root_payload(
+            {
+                "new_user": {"file_upload_size_limits": dict(TAG_SIZE_LIMITS)},
+                "default": {"file_upload_size_limits": dict(TAG_SIZE_LIMITS)},
+            }
+        ),
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "hi", "version": "0.14.3"})
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    result = _check(report, "autumn_limits")
+    assert result.startswith("ok:")
+    assert "new_user" in result and "default" in result
+
+
+async def test_autumn_limits_absent_is_reported_not_silently_passed(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A root without `features.limits` must say so — never "matches assumptions".
+
+    This is the exact failure the old implementation had: nothing to compare, reported
+    as a clean pass.
+    """
+    mock_aiohttp.get(f"{BASE_URL}/", payload=_root_payload(None))
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "hi", "version": "0.14.3"})
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    result = _check(report, "autumn_limits")
+    assert result.startswith("warn:")
+    assert "could not read" in result
+    assert "matches" not in result
+    assert "assumptions" not in result
+
+
+async def test_unreachable_autumn_root_does_not_mask_the_limits_result(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Autumn being down fails only its own check; the limits diff still lands.
+
+    The two are reported separately precisely so one cannot hide the other.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/",
+        payload=_root_payload({"default": {"file_upload_size_limits": dict(TAG_SIZE_LIMITS)}}),
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", status=503)
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    assert _check(report, "autumn_limits").startswith("ok:")
+    reachable = _check(report, "autumn_reachable")
+    assert reachable.startswith("fail:")
+    assert "503" in reachable
+
+
+async def test_malformed_limits_block_does_not_abort_the_probe(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A non-dict where a dict is expected must not raise out of the check.
+
+    `run_probe` wraps its four checks in try/finally with NO except, so an AttributeError
+    escaping here would abort every remaining check and propagate to the caller. Truthy
+    non-dicts are the dangerous shape: `x or {}` does not save them.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/",
+        payload={"features": {"autumn": "not-a-dict", "limits": {"default": "not-a-dict"}}},
+    )
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)  # must not raise
+
+    assert _check(report, "autumn_limits").startswith("warn:")
+    assert _check(report, "autumn_reachable").startswith("warn:")
+
+
+async def test_non_dict_root_does_not_abort_the_probe(mock_aiohttp: aioresponses) -> None:
+    """A 200 whose JSON body is a list, not an object, is survivable."""
+    mock_aiohttp.get(f"{BASE_URL}/", payload=["not", "an", "object"])
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)  # must not raise
+
+    assert _check(report, "autumn_limits").startswith("warn:")
+
+
+async def test_tag_we_assume_but_server_never_advertises_is_not_a_pass(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """An unverified assumption must warn, not report "matches".
+
+    Reporting a tag we never actually compared as passing is exactly the failure this
+    whole check is being fixed for.
+    """
+    partial = {"attachments": TAG_SIZE_LIMITS["attachments"]}  # only 1 of our 6
+    mock_aiohttp.get(
+        f"{BASE_URL}/", payload=_root_payload({"default": {"file_upload_size_limits": partial}})
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "hi", "version": "0.14.3"})
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    result = _check(report, "autumn_limits")
+    assert result.startswith("warn:")
+    assert "not advertised" in result
+    assert "emojis" in result
+
+
+async def test_server_bucket_we_have_no_limit_for_is_reported(mock_aiohttp: aioresponses) -> None:
+    """A bucket the instance advertises that we know nothing about is drift worth seeing."""
+    advertised = dict(TAG_SIZE_LIMITS)
+    advertised["stickers"] = 1_000_000
+    mock_aiohttp.get(
+        f"{BASE_URL}/", payload=_root_payload({"default": {"file_upload_size_limits": advertised}})
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "hi", "version": "0.14.3"})
+
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as session:
+        await _check_autumn(session, BASE_URL, report)
+
+    result = _check(report, "autumn_limits")
+    assert result.startswith("warn:")
+    assert "stickers" in result

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.8.4"
+version = "2.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch 3 of 10 in the upstream-drift programme (#107). Two coupled defects — one was hiding the other.

## The check that could not fail

`probe._check_autumn` compared our assumed upload limits against a `tags` key on the **Autumn** root:

```
GET https://cdn.stoatusercontent.com/
{"autumn": "Hello, I am a file server!", "version": "0.14.3"}
```

There is no `tags` key. So it compared nothing, and reported `ok` / *"matches assumptions"* on every run since it was written. Worse than no check — it asserted precisely what it never tested.

## What that silence was hiding

Autumn's limits are **decimal** megabytes, as written in stoatchat's `Revolt.toml`. Ours were binary:

| tag | was | server | too big by |
|---|---|---|---|
| attachments | 20,971,520 | 20,000,000 | 971,520 |
| avatars | 4,194,304 | 4,000,000 | 194,304 |
| backgrounds | 6,291,456 | 6,000,000 | 291,456 |
| banners | 6,291,456 | 6,000,000 | 291,456 |
| emojis | 512,000 | 500,000 | 12,000 |
| icons | 2,500,000 | 2,500,000 | already correct |

`TAG_SIZE_LIMITS` is the **pre-upload** guard, so ours being *looser* than the server's meant a file in the gap band passed our check, was uploaded in full, and came back a 413. `icons` is the tell — it had been diagnosed and fixed on its own, carrying a comment naming this exact trap, while the other five were left standing and the detector reported success.

Fixing the detector without fixing these was not an option: a working detector would immediately warn on five of our own constants.

## The detector now

Reads `features.limits.<global|new_user|default>.file_upload_size_limits` from the **Stoat** root and reports a per-tier, per-tag diff. It warns on the two cases it previously counted as clean passes:

- a tag we assume that the instance never advertises — *unverified is not the same as matching*, the original sin in miniature;
- a bucket the instance advertises that we hold no limit for.

And when it cannot read the limits at all, it says so instead of passing. Autumn reachability is a separate check now, so a downed file server cannot mask the limits result, and a non-200 is a failure rather than a silent `ok`.

## Hardening found in review

Moving the parse out of `_check_autumn`'s `try` meant one malformed field — `limits.default` arriving as a string — raised an `AttributeError` through `run_probe`'s exceptionless `try`/`finally`, aborting **all four** probe checks. Truthy non-dicts are the dangerous shape; the `x or {}` idiom does not catch them. Every hop of the parse is now type-guarded, so the failure is eliminated rather than trapped.

## Verification

- RED before the detector fix: `'ok: matches assumptions'` against a deliberately wrong `icons`.
- RED before the constants fix: exactly 5 differing, 1 identical.
- **Every guard falsified in place** — reverting the limits read turns 3 tests red; the naive accessor reproduces `AttributeError: 'list' object has no attribute 'get'`.
- Self-caught mid-build: a 503 from Autumn was being reported as `ok (version ?)` — the same sin. Now `fail`.
- +8 tests, none dropped (`test_autumn.py`'s narrow `icons` assertion was widened to pin all six). **1367 passed** (baseline 1359).
- `ruff check .`, `ruff format --check .`, `mypy src/` clean; `uv sync --locked` clean.
- Version base re-read from `origin/main` **and** the one unmerged sibling branch checked for a collision.

Code review returned clean. Mistral found the `AttributeError` regression above and correctly argued the unverified-tag case, both fixed here; its suggestion to document the tightening as a behaviour change is in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)