### PR TITLE
feat: map every Discord permission Stoat can express — migrated voice channels now work (v2.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-02
+
+### Fixed
+
+- **Migrated voice channels now grant voice permissions.** Nobody could connect, speak or hear in
+  a migrated voice channel, because none of Discord's voice permissions had a mapping — they all
+  translated to zero.
+
+  The permission map covered 17 Discord permissions, reaching 18 Stoat bits out of the **34**
+  Stoat actually defines. Newly mapped: `VIEW_AUDIT_LOG`, `STREAM`, `CONNECT`, `SPEAK`, `MUTE_MEMBERS`,
+  `DEAFEN_MEMBERS`, `MOVE_MEMBERS`, `MODERATE_MEMBERS`, `BYPASS_SLOWMODE`, `MENTION_EVERYONE`, and
+  `AssignRoles` alongside the existing `MANAGE_ROLES` targets.
+
+  `CONNECT` maps to **two** Stoat bits, `Connect` and `Listen`. Stoat gates *joining* a voice
+  channel on `Connect` but gates *receiving* anyone's audio or video on `Listen`, so granting
+  `Connect` alone would still have left members in a silent room.
+
+- **Migrated ADMINISTRATOR roles no longer lose permissions.** The expansion applied to a Discord
+  admin role was a hand-written list covering only the bits that happened to be mapped, so admins
+  arrived without any voice, mention, timeout, audit-log or role-assignment rights. It is now
+  derived from Stoat's full enum, which means extending the map can no longer leave it behind.
+
+### Changed
+
+- **Roles that could mention `@everyone` in Discord can do so in Stoat.** A code comment claimed
+  Stoat had no equivalent permission and that the mapping was intentionally dropped. That was
+  false — `MentionEveryone` is bit 37 and `MentionRoles` is bit 38. This restores what Discord
+  granted at source, but it is a real new capability for those roles: **review which roles hold
+  "Mention @everyone" before migrating a large server.**
+
+- `docs/reference/stoat-api-notes.md` now lists all 34 permission bits and states plainly that the
+  authoritative source is stoatchat's `ChannelPermission` enum, not `developers.stoat.chat`. The
+  page previously reproduced a 13-bit subset from that site, which is where the missing mappings
+  came from in the first place.
+
 ## [2.9.0] - 2026-08-02
 
 ### Added

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -47,7 +47,8 @@ These limitations affect role and permission migration.
 | Per-member channel overrides | Not supported by Stoat; only role-based overrides are migrated | Create a single-user role for each member who had individual overrides, then apply the override to that role |
 | Managed roles (bot roles) | Not migrated — these are auto-created by Discord for each bot integration | None needed — bot integrations do not carry over |
 | Role membership | Roles are recreated, but members are **not** assigned to them — there is no reliable way to map Discord accounts to Stoat accounts | Members re-join via invite and assign roles manually (or with a Stoat bot) |
-| "Mention @everyone" permission | Dropped — Stoat has no equivalent permission | None |
+| "Pin messages" permission | Not migrated on its own — Stoat has no pin-only permission. Pinning lives under `ManageMessages`, which also allows deletion, so Ferry will not grant it from a pin-only Discord role | Grant `ManageMessages` manually to roles that should be able to pin |
+| Discord permissions with no Stoat counterpart | Dropped — threads, events, polls, soundboard, stickers, application commands, server insights, TTS, priority speaker and voice activity detection have no Stoat equivalent to grant | None needed — the underlying features do not exist on Stoat |
 
 ---
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -565,22 +565,12 @@ This applies to masquerade payloads, embed objects, role objects, and permission
 ### Permission Bits
 
 Stoat has **no single ADMINISTRATOR permission**. Every capability must be granted individually.
+Stoat defines **34** permission bits; the complete list lives in one place, in
+[Stoat API Notes → Permission Bits](stoat-api-notes.md#permission-bits).
 
-| Name | Bit | Value | Notes |
-|------|-----|-------|-------|
-| ManageChannel | 0 | 1 | |
-| ManageServer | 1 | 2 | |
-| ManagePermissions | 2 | 4 | |
-| ManageRole | 3 | 8 | Also required for masquerade `colour` |
-| ManageCustomisation | 4 | 16 | Required to create/manage emoji |
-| ViewChannel | 20 | 1,048,576 | |
-| ReadMessageHistory | 21 | 2,097,152 | |
-| SendMessage | 22 | 4,194,304 | |
-| ManageMessages | 23 | 8,388,608 | Required to pin messages |
-| SendEmbeds | 26 | 67,108,864 | |
-| UploadFiles | 27 | 134,217,728 | |
-| Masquerade | 28 | 268,435,456 | Required for masquerade name and avatar |
-| React | 29 | 536,870,912 | |
+This page deliberately does **not** copy that table. It used to, and the copy went stale: it
+carried a 13-bit subset long after Stoat's enum had grown to 34, and the resulting blind spot is
+what let Ferry ship voice channels that granted no voice permissions. One table, one owner.
 
 **Ferry minimum permissions** (bits 3, 4, 20–23, 26–29):
 
@@ -735,22 +725,43 @@ the equivalent Stoat bitfield.
 
 | Discord Permission | Discord Bit | Stoat Permission | Stoat Bit |
 |-------------------|-------------|-----------------|-----------|
+| CREATE_INSTANT_INVITE | 0 | InviteOthers | 25 |
+| KICK_MEMBERS | 1 | KickMembers | 6 |
+| BAN_MEMBERS | 2 | BanMembers | 7 |
 | MANAGE_CHANNELS | 4 | ManageChannel | 0 |
 | MANAGE_GUILD | 5 | ManageServer | 1 |
-| MANAGE_ROLES | 28 | ManagePermissions + ManageRole | 2, 3 |
-| MANAGE_EMOJIS | 30 | ManageCustomisation | 4 |
+| ADD_REACTIONS | 6 | React | 29 |
+| VIEW_AUDIT_LOG | 7 | ViewAuditLogs | 40 |
+| STREAM | 9 | Video | 32 |
 | VIEW_CHANNEL | 10 | ViewChannel | 20 |
-| READ_MESSAGE_HISTORY | 16 | ReadMessageHistory | 21 |
 | SEND_MESSAGES | 11 | SendMessage | 22 |
 | MANAGE_MESSAGES | 13 | ManageMessages | 23 |
 | EMBED_LINKS | 14 | SendEmbeds | 26 |
 | ATTACH_FILES | 15 | UploadFiles | 27 |
-| ADD_REACTIONS | 6 | React | 29 |
+| READ_MESSAGE_HISTORY | 16 | ReadMessageHistory | 21 |
+| MENTION_EVERYONE | 17 | MentionEveryone + MentionRoles | 37, 38 |
+| CONNECT | 20 | Connect + Listen | 30, 36 |
+| SPEAK | 21 | Speak | 31 |
+| MUTE_MEMBERS | 22 | MuteMembers | 33 |
+| DEAFEN_MEMBERS | 23 | DeafenMembers | 34 |
+| MOVE_MEMBERS | 24 | MoveMembers | 35 |
+| CHANGE_NICKNAME | 26 | ChangeNickname | 10 |
+| MANAGE_NICKNAMES | 27 | ManageNicknames | 11 |
+| MANAGE_ROLES | 28 | ManagePermissions + ManageRole + AssignRoles | 2, 3, 9 |
+| MANAGE_WEBHOOKS | 29 | ManageWebhooks | 24 |
+| MANAGE_EMOJIS | 30 | ManageCustomisation | 4 |
+| MODERATE_MEMBERS | 40 | TimeoutMembers | 8 |
+| BYPASS_SLOWMODE | 52 | BypassSlowmode | 39 |
 
 **Special cases**:
 
-- **ADMINISTRATOR** (Discord bit 3): Expands to `ALL_STOAT_PERMISSIONS` — every Stoat bit set
-- **MANAGE_ROLES** maps to **two** Stoat bits (ManagePermissions + ManageRole)
+- **ADMINISTRATOR** (Discord bit 3): Expands to `ALL_STOAT_PERMISSIONS`, derived from
+  `STOAT_PERMISSION_BITS` — every one of the 34 bits Stoat defines, and nothing from its
+  reserved 41–52 free area
+- **CONNECT** maps to **two** bits: Stoat gates joining a voice channel on `Connect` but gates
+  hearing anyone on `Listen`, and Discord's single permission covers both
+- **PIN_MESSAGES** (51) is deliberately unmapped — Stoat has no pin-only bit, and its nearest
+  equivalent (`ManageMessages`) also permits deletion
 - **Unmapped Discord bits**: Silently dropped (no Stoat equivalent)
 - **Managed/bot roles**: Permissions skipped (role still created for mention remapping)
 

--- a/docs/reference/stoat-api-notes.md
+++ b/docs/reference/stoat-api-notes.md
@@ -122,23 +122,62 @@ PATCH. Forgetting to include a channel in any category leaves it uncategorised.
 ## Permission Bits
 
 Stoat has no single ADMINISTRATOR permission. Every capability must be granted individually via
-bitmask. The authoritative list from `developers.stoat.chat`:
+bitmask.
 
-| Name | Bit | Value | Notes |
-|------|-----|-------|-------|
-| ManageChannel | 0 | 1 | |
-| ManageServer | 1 | 2 | |
-| ManagePermissions | 2 | 4 | |
-| ManageRole | 3 | 8 | Also required for masquerade `colour` |
-| ManageCustomisation | 4 | 16 | Required to create/manage emoji |
-| ViewChannel | 20 | 1,048,576 | |
-| ReadMessageHistory | 21 | 2,097,152 | |
-| SendMessage | 22 | 4,194,304 | |
-| ManageMessages | 23 | 8,388,608 | Required to pin messages |
-| SendEmbeds | 26 | 67,108,864 | |
-| UploadFiles | 27 | 134,217,728 | |
-| Masquerade | 28 | 268,435,456 | Required for masquerade name and avatar |
-| React | 29 | 536,870,912 | |
+> **Read the source, not the docs site.** The authoritative list is the `ChannelPermission` enum in
+> `stoatchat/stoatchat` at `crates/core/permissions/src/models/channel.rs`. `developers.stoat.chat`
+> has lagged it, and an earlier revision of this page reproduced a 13-bit subset from that site —
+> which is how Ferry came to drop `MentionEveryone` as "nonexistent" and to ship voice channels that
+> granted no voice permissions. Verified against source 2026-08-02 (commit `502203d3`).
+
+All **34** defined bits:
+
+| Name | Bit | Notes |
+|------|-----|-------|
+| ManageChannel | 0 | |
+| ManageServer | 1 | |
+| ManagePermissions | 2 | |
+| ManageRole | 3 | Also required for masquerade `colour` |
+| ManageCustomisation | 4 | Required to create/manage emoji |
+| KickMembers | 6 | |
+| BanMembers | 7 | |
+| TimeoutMembers | 8 | |
+| AssignRoles | 9 | Split out of `ManageRole` |
+| ChangeNickname | 10 | |
+| ManageNicknames | 11 | |
+| ChangeAvatar | 12 | No Discord analogue |
+| RemoveAvatars | 13 | No Discord analogue |
+| ViewChannel | 20 | |
+| ReadMessageHistory | 21 | |
+| SendMessage | 22 | |
+| ManageMessages | 23 | Required to pin messages — Stoat has no pin-only bit |
+| ManageWebhooks | 24 | |
+| InviteOthers | 25 | |
+| SendEmbeds | 26 | |
+| UploadFiles | 27 | Send attachments and media |
+| Masquerade | 28 | Required for masquerade name and avatar |
+| React | 29 | |
+| Connect | 30 | Join a voice channel |
+| Speak | 31 | Publish microphone |
+| Video | 32 | Publish camera / screen share |
+| MuteMembers | 33 | |
+| DeafenMembers | 34 | |
+| MoveMembers | 35 | |
+| Listen | 36 | **Receive** audio and video — see below |
+| MentionEveryone | 37 | |
+| MentionRoles | 38 | |
+| BypassSlowmode | 39 | |
+| ViewAuditLogs | 40 | |
+
+Bit 5 and bits 14–19 are undefined gaps. Bits **41–52 are a declared "free area"** and 53–64 are
+marked do-not-use, so never derive an "all permissions" value from Stoat's `GrantAllSafe`
+(`0x000F_FFFF_FFFF_FFFF`) — it spans the free area, and Stoat computes it for server owners without
+ever persisting it to a role.
+
+**`Connect` alone does not give you a working voice channel.** Stoat gates *joining* on `Connect`
+(`voice_join.rs:52`) but builds the LiveKit token's `can_subscribe` from `Listen`
+(`voice_client.rs:95`), so a member with `Connect` and `Speak` but no `Listen` joins the call and
+hears nobody. Discord's single `CONNECT` permission covers both, so Ferry maps it to both bits.
 
 **Ferry account minimum permission value:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.9.0"
+version = "2.10.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.9.0"
+__version__ = "2.10.0"

--- a/src/discord_ferry/discord/permissions.py
+++ b/src/discord_ferry/discord/permissions.py
@@ -2,13 +2,17 @@
 
 # Discord permission bit position → Stoat permission bit position(s).
 # Discord bits not in this map have no Stoat equivalent and are dropped.
+#
+# Discord bit numbers verified against discordjs/discord-api-types
+# `payloads/common.ts`; Stoat targets against STOAT_PERMISSION_BITS below.
 DISCORD_TO_STOAT: dict[int, int | list[int]] = {
     0: 25,  # CREATE_INSTANT_INVITE → InviteOthers
     1: 6,  # KICK_MEMBERS → KickMembers
     2: 7,  # BAN_MEMBERS → BanMembers
     4: 0,  # MANAGE_CHANNELS → ManageChannel
     5: 1,  # MANAGE_GUILD → ManageServer
-    28: [2, 3],  # MANAGE_ROLES → ManagePermissions + ManageRole
+    7: 40,  # VIEW_AUDIT_LOG → ViewAuditLogs
+    28: [2, 3, 9],  # MANAGE_ROLES → ManagePermissions + ManageRole + AssignRoles
     30: 4,  # MANAGE_EMOJIS → ManageCustomisation
     10: 20,  # VIEW_CHANNEL → ViewChannel
     16: 21,  # READ_MESSAGE_HISTORY → ReadMessageHistory
@@ -17,34 +21,117 @@ DISCORD_TO_STOAT: dict[int, int | list[int]] = {
     14: 26,  # EMBED_LINKS → SendEmbeds
     15: 27,  # ATTACH_FILES → UploadFiles
     6: 29,  # ADD_REACTIONS → React
-    # NOTE: MENTION_EVERYONE (Discord bit 17) has NO Stoat equivalent — the Stoat
-    # Permission enum has no MentionEveryone — so it is intentionally dropped.
+    17: [37, 38],  # MENTION_EVERYONE → MentionEveryone + MentionRoles
     26: 10,  # CHANGE_NICKNAME → ChangeNickname
     27: 11,  # MANAGE_NICKNAMES → ManageNicknames
     29: 24,  # MANAGE_WEBHOOKS → ManageWebhooks
+    40: 8,  # MODERATE_MEMBERS → TimeoutMembers
+    52: 39,  # BYPASS_SLOWMODE → BypassSlowmode
+    # Voice.
+    9: 32,  # STREAM → Video
+    20: [30, 36],  # CONNECT → Connect + Listen (see below)
+    21: 31,  # SPEAK → Speak
+    22: 33,  # MUTE_MEMBERS → MuteMembers
+    23: 34,  # DEAFEN_MEMBERS → DeafenMembers
+    24: 35,  # MOVE_MEMBERS → MoveMembers
 }
 
-ALL_STOAT_PERMISSIONS = (
-    1
-    | 2
-    | 4
-    | 8
-    | 16  # bits 0-4
-    | 64
-    | 128  # bits 6-7 (KickMembers, BanMembers)
-    | 1_024
-    | 2_048  # bits 10-11 (ChangeNickname, ManageNicknames)
-    | 1_048_576
-    | 2_097_152  # bits 20-21
-    | 4_194_304
-    | 8_388_608  # bits 22-23
-    | 16_777_216
-    | 33_554_432  # bits 24-25 (ManageWebhooks, InviteOthers)
-    | 67_108_864
-    | 134_217_728  # bits 26-27
-    | 268_435_456
-    | 536_870_912  # bits 28-29
+# --- Notes on the non-obvious entries ----------------------------------------
+#
+# CONNECT → Connect + Listen is the one mapping NOT justified by a name match.
+# Stoat gates *joining* a voice channel on Connect (`voice_join.rs:52`) but builds
+# the LiveKit token's `can_subscribe` from Listen (`voice_client.rs:95`). Discord's
+# CONNECT confers the ability to hear, so granting Connect alone drops the user
+# into a room where nobody is audible. Stoat's own DEFAULT_PERMISSION bundles
+# Connect/Speak/Listen/Video together, which corroborates the intent.
+#
+# MENTION_EVERYONE → MentionEveryone + MentionRoles is a name match on both
+# targets: Discord's single bit covers @everyone, @here and role pings alike.
+#
+# Deliberately NOT mapped:
+#
+# * Discord PIN_MESSAGES (51). Stoat has no pin-only bit -- pinning lives under
+#   ManageMessages (23), which also permits deletion. Routing 51 there would hand
+#   deletion rights to someone who only had permission to pin.
+# * Discord CREATE_GUILD_EXPRESSIONS (43), for the same reason against
+#   ManageCustomisation (4).
+# * Everything Stoat has no analogue for: threads, events, polls, soundboard,
+#   stickers, application commands, insights, TTS, priority speaker, VAD.
+#
+# Stoat bits with no Discord analogue, reachable only through the ADMINISTRATOR
+# expansion: 12 ChangeAvatar, 13 RemoveAvatars, 28 Masquerade.
+#
+# AssignRoles (9) is granted at CHANNEL-override scope too, as a side effect of
+# MANAGE_ROLES appearing in a Discord channel overwrite. That is inert rather
+# than an over-grant: Stoat checks it against `calculate_server_permissions`
+# (`member_edit.rs:55,89`), which does not apply channel overrides.
+
+# Every bit position defined by Stoat's `ChannelPermission` enum, mirrored from
+# stoatchat/stoatchat `crates/core/permissions/src/models/channel.rs` (commit
+# 502203d3, read 2026-08-02). Read the SOURCE, not the developer docs site --
+# the docs lagged source, which is how a correct MentionEveryone mapping came to
+# be deleted as "nonexistent" in v2.6.15.
+#
+# Bit 5 and bits 14-19 are undefined gaps. The enum reserves bits 41-52 as a
+# declared "free area" and marks 53-64 do-not-use, so this set must never be
+# widened speculatively.
+STOAT_PERMISSION_BITS: frozenset[int] = frozenset(
+    {
+        0,  # ManageChannel
+        1,  # ManageServer
+        2,  # ManagePermissions
+        3,  # ManageRole
+        4,  # ManageCustomisation
+        6,  # KickMembers
+        7,  # BanMembers
+        8,  # TimeoutMembers
+        9,  # AssignRoles
+        10,  # ChangeNickname
+        11,  # ManageNicknames
+        12,  # ChangeAvatar
+        13,  # RemoveAvatars
+        20,  # ViewChannel
+        21,  # ReadMessageHistory
+        22,  # SendMessage
+        23,  # ManageMessages
+        24,  # ManageWebhooks
+        25,  # InviteOthers
+        26,  # SendEmbeds
+        27,  # UploadFiles
+        28,  # Masquerade
+        29,  # React
+        30,  # Connect
+        31,  # Speak
+        32,  # Video
+        33,  # MuteMembers
+        34,  # DeafenMembers
+        35,  # MoveMembers
+        36,  # Listen
+        37,  # MentionEveryone
+        38,  # MentionRoles
+        39,  # BypassSlowmode
+        40,  # ViewAuditLogs
+    }
 )
+
+
+def _bitfield(bits: frozenset[int]) -> int:
+    """OR together ``1 << bit`` for every bit position in ``bits``."""
+    value = 0
+    for bit in bits:
+        value |= 1 << bit
+    return value
+
+
+# The expansion applied when a Discord role holds ADMINISTRATOR. Derived from the
+# enum above rather than hand-maintained -- the previous hand-rolled OR-chain
+# covered only the bits that happened to be mapped, so migrated admins silently
+# lost every voice, mention and audit-log permission.
+#
+# Deliberately NOT Stoat's `GrantAllSafe` (0x000F_FFFF_FFFF_FFFF): that spans
+# bits 0-51, including the undefined free area, and Stoat computes it for server
+# owners without ever persisting it to a role.
+ALL_STOAT_PERMISSIONS = _bitfield(STOAT_PERMISSION_BITS)
 
 
 def translate_permissions(discord_bits: int, *, is_deny: bool = False) -> int:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,6 +3,7 @@
 from discord_ferry.discord.permissions import (
     ALL_STOAT_PERMISSIONS,
     DISCORD_TO_STOAT,
+    STOAT_PERMISSION_BITS,
     translate_permissions,
 )
 
@@ -21,12 +22,14 @@ def test_single_bit_send_messages() -> None:
     assert translate_permissions(1 << 11) == 1 << 22
 
 
-def test_manage_roles_maps_to_two_bits() -> None:
-    # Discord MANAGE_ROLES = bit 28 → Stoat ManagePermissions (2) + ManageRole (3)
+def test_manage_roles_maps_to_three_bits() -> None:
+    # Discord MANAGE_ROLES = bit 28 → Stoat ManagePermissions (2) + ManageRole (3).
+    # Batch 5 (#109) added AssignRoles (9), which Stoat splits out of ManageRole.
     result = translate_permissions(1 << 28)
     assert result & (1 << 2)  # ManagePermissions set
     assert result & (1 << 3)  # ManageRole set
-    assert result == (1 << 2) | (1 << 3)
+    assert result & (1 << 9)  # AssignRoles set
+    assert result == (1 << 2) | (1 << 3) | (1 << 9)
 
 
 def test_administrator_expands_to_all() -> None:
@@ -63,33 +66,59 @@ def test_all_mapped_bits() -> None:
     assert result & (1 << 1)  # ManageServer
     assert result & (1 << 22)  # SendMessage
     assert result & (1 << 29)  # React
+    # Batch 5 (#109): bits above 29 are now reachable without ADMINISTRATOR.
+    assert result & (1 << 30)  # Connect
+    assert result & (1 << 36)  # Listen
+    assert result & (1 << 37)  # MentionEveryone
+    assert result & (1 << 40)  # ViewAuditLogs
 
 
 def test_all_stoat_permissions_value() -> None:
-    # Verify ALL_STOAT_PERMISSIONS matches the documented sum (incl. the 6
-    # Batch 9 additions: bits 6,7,10,11,24,25).
+    """Pin ALL_STOAT_PERMISSIONS against an independent transcription.
+
+    The constant is derived from STOAT_PERMISSION_BITS, so asserting it against
+    that same set would be circular. This list is transcribed straight from
+    stoatchat's `ChannelPermission` enum in declaration order, and the decimal
+    literal pins the resulting value.
+    """
     expected = (
-        1
-        | 2
-        | 4
-        | 8
-        | 16
-        | 64
-        | 128
-        | 1_024
-        | 2_048
-        | 1_048_576
-        | 2_097_152
-        | 4_194_304
-        | 8_388_608
-        | 16_777_216
-        | 33_554_432
-        | 67_108_864
-        | 134_217_728
-        | 268_435_456
-        | 536_870_912
+        (1 << 0)  # ManageChannel
+        | (1 << 1)  # ManageServer
+        | (1 << 2)  # ManagePermissions
+        | (1 << 3)  # ManageRole
+        | (1 << 4)  # ManageCustomisation
+        | (1 << 6)  # KickMembers
+        | (1 << 7)  # BanMembers
+        | (1 << 8)  # TimeoutMembers
+        | (1 << 9)  # AssignRoles
+        | (1 << 10)  # ChangeNickname
+        | (1 << 11)  # ManageNicknames
+        | (1 << 12)  # ChangeAvatar
+        | (1 << 13)  # RemoveAvatars
+        | (1 << 20)  # ViewChannel
+        | (1 << 21)  # ReadMessageHistory
+        | (1 << 22)  # SendMessage
+        | (1 << 23)  # ManageMessages
+        | (1 << 24)  # ManageWebhooks
+        | (1 << 25)  # InviteOthers
+        | (1 << 26)  # SendEmbeds
+        | (1 << 27)  # UploadFiles
+        | (1 << 28)  # Masquerade
+        | (1 << 29)  # React
+        | (1 << 30)  # Connect
+        | (1 << 31)  # Speak
+        | (1 << 32)  # Video
+        | (1 << 33)  # MuteMembers
+        | (1 << 34)  # DeafenMembers
+        | (1 << 35)  # MoveMembers
+        | (1 << 36)  # Listen
+        | (1 << 37)  # MentionEveryone
+        | (1 << 38)  # MentionRoles
+        | (1 << 39)  # BypassSlowmode
+        | (1 << 40)  # ViewAuditLogs
     )
     assert expected == ALL_STOAT_PERMISSIONS
+    assert ALL_STOAT_PERMISSIONS == 2_199_022_223_327
 
 
 def test_administrator_deny_returns_zero() -> None:
@@ -149,9 +178,11 @@ def test_new_permission_mappings() -> None:
         assert translate_permissions(1 << discord_bit) == 1 << stoat_bit
 
 
-def test_mention_everyone_dropped() -> None:
-    """MENTION_EVERYONE (bit 17) has no Stoat equivalent → dropped."""
-    assert translate_permissions(1 << 17) == 0
+# NOTE: `test_mention_everyone_dropped` lived here. It asserted
+# `translate_permissions(1 << 17) == 0` on the strength of a code comment
+# claiming Stoat has no MentionEveryone. The comment was false (bit 37, with
+# MentionRoles at 38), so the test was pinning a bug. Superseded by
+# `test_mention_everyone_maps_to_both_stoat_bits` below.
 
 
 def test_admin_grants_new_bits() -> None:
@@ -160,3 +191,104 @@ def test_admin_grants_new_bits() -> None:
     assert result == ALL_STOAT_PERMISSIONS
     for bit in (6, 7, 10, 11, 24, 25):
         assert result & (1 << bit)
+
+
+# ---------------------------------------------------------------------------
+# Batch 5 (#109) — permission parity with Stoat's full 34-bit enum
+# ---------------------------------------------------------------------------
+
+
+def test_voice_permissions_map() -> None:
+    """SC-24: the Discord voice bits reach their Stoat counterparts.
+
+    Before this batch every one of these translated to 0, which is why migrated
+    voice channels granted nobody the right to speak or moderate a call.
+    """
+    assert translate_permissions(1 << 21) == 1 << 31  # SPEAK → Speak
+    assert translate_permissions(1 << 22) == 1 << 33  # MUTE_MEMBERS → MuteMembers
+    assert translate_permissions(1 << 23) == 1 << 34  # DEAFEN_MEMBERS → DeafenMembers
+    assert translate_permissions(1 << 24) == 1 << 35  # MOVE_MEMBERS → MoveMembers
+    assert translate_permissions(1 << 9) == 1 << 32  # STREAM → Video
+
+
+def test_connect_also_grants_listen() -> None:
+    """Discord CONNECT means join AND hear; Stoat splits those in two.
+
+    ``voice_join.rs:52`` gates joining on Connect, but ``voice_client.rs:95``
+    sets the LiveKit token's ``can_subscribe`` from Listen. Granting Connect
+    alone puts the user in the room with no audio or video from anyone.
+    """
+    assert translate_permissions(1 << 20) == (1 << 30) | (1 << 36)
+
+
+def test_mention_everyone_maps_to_both_stoat_bits() -> None:
+    """Discord MENTION_EVERYONE covers @everyone, @here AND role pings.
+
+    Supersedes ``test_mention_everyone_dropped``: the comment claiming Stoat has
+    no MentionEveryone was false — it is bit 37, with MentionRoles at 38.
+    """
+    assert translate_permissions(1 << 17) == (1 << 37) | (1 << 38)
+
+
+def test_moderate_members_maps_to_timeout() -> None:
+    assert translate_permissions(1 << 40) == 1 << 8  # MODERATE_MEMBERS → TimeoutMembers
+
+
+def test_view_audit_log_maps() -> None:
+    assert translate_permissions(1 << 7) == 1 << 40  # VIEW_AUDIT_LOG → ViewAuditLogs
+
+
+def test_manage_roles_also_grants_assign_roles() -> None:
+    """MANAGE_ROLES covers assigning roles to members, which Stoat splits out."""
+    assert translate_permissions(1 << 28) == (1 << 2) | (1 << 3) | (1 << 9)
+
+
+def test_bypass_slowmode_maps() -> None:
+    """Discord's explicit BYPASS_SLOWMODE (52) → Stoat BypassSlowmode (39).
+
+    Ferry migrates slowmode, so a moderator exempt at source would otherwise be
+    throttled at destination. Deliberately NOT inferred from MANAGE_MESSAGES:
+    Discord ships a dedicated bit for this, so no derivation is needed.
+    """
+    assert translate_permissions(1 << 52) == 1 << 39
+    # ...and the permissions it is sometimes conflated with stay single-target.
+    assert translate_permissions(1 << 13) == 1 << 23  # MANAGE_MESSAGES
+    assert translate_permissions(1 << 4) == 1 << 0  # MANAGE_CHANNELS
+
+
+def test_admin_expansion_covers_every_defined_bit_and_nothing_else() -> None:
+    """SC-25: all 34 defined bits, and nothing in Stoat's 41-52 free area."""
+    assert len(STOAT_PERMISSION_BITS) == 34
+    for bit in STOAT_PERMISSION_BITS:
+        assert ALL_STOAT_PERMISSIONS & (1 << bit), f"bit {bit} missing from admin expansion"
+    assert ALL_STOAT_PERMISSIONS < (1 << 41)
+    # Explicitly NOT GrantAllSafe: Stoat computes that for owners without ever
+    # persisting it to a role, and it spans the undefined free area.
+    assert ALL_STOAT_PERMISSIONS != 0x000F_FFFF_FFFF_FFFF
+
+
+def test_admin_expansion_stays_inside_stoat_s_own_numeric_bounds() -> None:
+    """The value crossed 2**32 in batch 5 (#109) — pin what it must still fit.
+
+    Stoat stores permissions as i64, and its enum carries the comment "This should
+    be restricted to the lower 52 bits to prevent any potential issues with
+    Javascript". Both bounds are asserted so a future bit addition that breaks
+    either one fails here rather than at a client.
+    """
+    assert ALL_STOAT_PERMISSIONS < 2**63 - 1  # i64
+    assert ALL_STOAT_PERMISSIONS < 2**53  # exactly representable as a JS number
+
+
+def test_every_mapped_target_is_a_defined_stoat_bit() -> None:
+    """A typo'd target would otherwise grant a bit Stoat does not define."""
+    for target in DISCORD_TO_STOAT.values():
+        bits = target if isinstance(target, list) else [target]
+        for bit in bits:
+            assert bit in STOAT_PERMISSION_BITS, f"target bit {bit} is not a Stoat permission"
+
+
+def test_admin_grants_voice_and_mention_bits() -> None:
+    """The old hand-rolled OR-chain omitted every bit above 29."""
+    result = translate_permissions(1 << 3)
+    for bit in (8, 9, 12, 13, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40):
+        assert result & (1 << bit), f"admin expansion missing bit {bit}"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1784,6 +1784,19 @@ async def test_run_roles_applies_permissions(tmp_path: Path) -> None:
     assert perm_bodies[0] == {"permissions": {"allow": 4_194_304, "deny": 0}}
 
 
+def test_ferry_min_permissions_value_pinned() -> None:
+    """SC-27: Ferry's operating floor is deliberately narrow.
+
+    It is what the Ferry account needs to *perform* a migration, not a fidelity
+    surface — so it grants no voice, mention or audit-log bits even though batch 5
+    (#109) made those translatable. Widening it must be a deliberate, reviewed act
+    rather than a side effect of extending the Discord→Stoat map.
+    """
+    assert FERRY_MIN_PERMISSIONS == 1_022_361_624
+    for bit in (30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40):
+        assert not FERRY_MIN_PERMISSIONS & (1 << bit), f"unexpected bit {bit} in Ferry's floor"
+
+
 async def test_run_roles_applies_server_defaults(tmp_path: Path) -> None:
     """ROLES phase applies server default permissions merged with FERRY_MIN_PERMISSIONS."""
     events: list[MigrationEvent] = []

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch 5 of 10 in the upstream-drift programme (#107). Closes #109.

## Migrated voice channels didn't work

Nobody could connect, speak or hear in a migrated voice channel, because **none of Discord's six voice permissions had a mapping** — every one translated to zero. Migrated ADMINISTRATOR roles were similarly hollowed out: the expansion applied to a Discord admin was a hand-written OR-chain covering only the bits that happened to be mapped, so admins arrived with no voice, mention, timeout, audit-log or role-assignment rights.

The map covered 17 Discord permissions, reaching 18 Stoat bits out of the **34** Stoat defines.

## The structural cause, and the structural fix

The old `ALL_STOAT_PERMISSIONS` was maintained by hand *in parallel* with the map, so every past extension of the map silently left the admin expansion behind. It is now **derived** from an explicit `STOAT_PERMISSION_BITS` frozenset mirroring stoatchat's `ChannelPermission` enum, and a test asserts that every mapped target is a bit Stoat actually defines. Adding a mapping can no longer forget the admin path.

Deliberately **not** Stoat's `GrantAllSafe` (`0x000F_FFFF_FFFF_FFFF`): it spans bits 0–51, including the declared 41–52 "free area", and Stoat computes it for server owners without ever persisting it to a role.

## Source-verified, not taken from the issue

Both enums read directly — `stoatchat/stoatchat` `crates/core/permissions/src/models/channel.rs` at commit `502203d3`, and `discordjs/discord-api-types` `payloads/common.ts`. That matters here specifically: **this drift exists because a v2.6.15 ship-review consulted `developers.stoat.chat`, which lagged source**, concluded `MentionEveryone` didn't exist, and deleted a correct mapping — overruling both a bug-hunt finding and a design-stage critique that had it right.

Reading the enums rather than the issue's table changed two decisions:

- **`CONNECT` maps to two bits, `Connect` *and* `Listen`.** Stoat gates *joining* a voice channel on `Connect` (`voice_join.rs:52`) but builds the LiveKit token's `can_subscribe` from `Listen` (`voice_client.rs:95`). Granting `Connect` alone drops members into a room where nobody is audible — the headline claim of this PR would have been false. It is the one mapping here not justified by a name match; Stoat's own `DEFAULT_PERMISSION` bundles `Connect/Speak/Listen/Video`, which corroborates it.
- **Discord has since added an explicit `BYPASS_SLOWMODE` (bit 52).** An earlier draft inferred Stoat's `BypassSlowmode` from `MANAGE_MESSAGES`/`MANAGE_CHANNELS` (Discord's older implicit exemption rule). Diffing the *whole* Discord enum rather than only the bits the issue named turned up the real bit, and the inference was removed. Ferry migrates slowmode, so this is not academic — a moderator exempt at source would otherwise be throttled at destination.

## Deliberately unmapped

- **`PIN_MESSAGES` (51)** and **`CREATE_GUILD_EXPRESSIONS` (43).** Stoat has no pin-only or create-only bit; the nearest equivalents (`ManageMessages`, `ManageCustomisation`) also permit deletion. Mapping them would hand deletion rights to someone who only had permission to pin or create.
- Everything Stoat has no analogue for: threads, events, polls, soundboard, stickers, application commands, insights, TTS, priority speaker, VAD.

## `FERRY_MIN_PERMISSIONS` reviewed and left narrow

`migrator/structure.py`'s floor is the server's **default role** — every member's baseline — not the Ferry account's own grant. Ferry owns the servers it creates, and Stoat short-circuits owners to `GrantAllSafe`, so Ferry needs nothing added. Widening it to cover the new bits would grant `ManageServer` and `BanMembers` to **everyone** in the migrated server. A new test (SC-27) pins its value and asserts it holds no bit ≥ 30, so this batch can't widen it by accident and neither can the next one.

## A capability change, called out rather than buried

Roles that could mention `@everyone` in Discord can now do so in Stoat. That restores what Discord granted at source and is the correct behaviour, but it is a real new capability — **worth reviewing which roles hold it before migrating a large server.** Flagged under `### Changed` in the CHANGELOG, not folded into the fix.

## Verification

- RED first: every new mapping test failed with `assert 0 == ...` against the old code, and `test_all_stoat_permissions_value` showed the admin expansion was `1_072_696_543` where it should be `2_199_022_223_327` — 15 bits missing.
- **Every guard falsified in place** and confirmed to turn its own test red: removing `Listen` from `CONNECT`, reverting `MENTION_EVERYONE` to dropped, removing one bit from the 34-bit mirror, and pointing a mapping at bit 41 (Stoat's free area).
- **The falsification harness had a bug of its own, found and fixed**: two of the edits removed exactly six bytes each and ran inside the same wall-clock second, so CPython's `(mtime-seconds, size)` bytecode cache served the *previous* case's `.pyc` and reported a load-bearing guard as inert.
- One removed test: `test_mention_everyone_dropped` asserted `translate_permissions(1 << 17) == 0` on the strength of the false comment. It was pinning the bug. Its removal is recorded in place rather than silently dropped.
- The admin value crossed 2³² (it is now ~2.2 × 10¹²). Verified empirically that it round-trips through `save_discord_metadata`/`load_discord_metadata` unmangled, fits `i64`, and stays under 2⁵³ — the bound Stoat's own enum comment asks for. Pinned by a test.
- +11 tests; **1392 passing** (baseline 1382). `ruff check .`, `ruff format --check .`, `mypy src/` clean; `uv sync --locked` clean.

## Docs corrected where they stated the opposite of the code

- `stoat-api-notes.md` carried a **13-bit subset copied from the docs site** — the proximate cause of this drift. Now all 34 bits, with the sourcing warning stated plainly, and it is the single owner of that table.
- `architecture.md` held **two** permission tables. Its mapping table was 8 rows and claimed `MANAGE_ROLES` maps to two bits; a *separate* 13-bit table 170 lines above it is now a pointer rather than a third copy. Three copies of one table is how the drift stayed hidden.
- `known-limitations.md` told users "Mention @everyone" could not be migrated. Replaced with accurate rows for pin-only roles and for Discord permissions with no Stoat counterpart.

## Review

Code review found three real issues, all fixed here: the second stale table in `architecture.md`; a **wrong baseline figure in my own CHANGELOG** ("15 Discord bits and 20 Stoat bits" — copied from this issue's body without counting; it is 17 and 18); and an incomplete "no Discord analogue" comment that omitted `Masquerade` (28). Taking an upstream figure on trust is precisely the habit this batch exists to correct, so the correction is recorded rather than quietly patched.

It also raised, unscored, whether `AssignRoles` reaching *channel-override* scope over-grants, since Discord's channel-scoped `MANAGE_ROLES` only ever meant "edit this channel's overwrites". Answered from source: `member_edit.rs:55` computes `calculate_server_permissions` and line 89 checks `AssignRoles` against that, so a channel override cannot confer it. Inert, and now commented in place.

The second-opinion pass produced two findings that were **rejected on evidence**, one of them dangerous. It read `FERRY_MIN_PERMISSIONS` as the Ferry bot's own grant and proposed widening it to `0x1FFFFFFFFF` so the bot could join voice channels — that constant is the server's *default role*, so the change would have handed `ManageServer` and `BanMembers` to every member of every migrated server. It also proposed collapsing multi-target mappings in the deny path to their first bit, which would let a role explicitly denied `@everyone` pings keep the ability to ping `@role`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
