### PR TITLE
content: tell users which earlier migrations lost content silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **New guide: "Was my earlier migration affected?"** (`docs/guides/earlier-migrations.md`) — a
+  disclosure covering the five silent bugs fixed between v2.8.2 and v2.10.0.
+
+  Every one of them failed without an error: discarded forwarded messages, sticker- and embed-only
+  replies dropped alongside them, attachments rejected by the server because Ferry's own size check
+  used binary megabytes where Stoat uses decimal, uploads abandoned during rate limiting, and voice
+  channels that granted nobody the right to connect, speak or hear. A migration could report
+  complete success and still be missing content, which is why nobody reported them.
+
+  The guide gives the exact `migration_report.json` searches that identify each one, and is explicit
+  about the limits of recovery: **`--resume`, `--incremental` and `ferry retry` will not backfill
+  any of it** — the affected content was recorded as warnings, never as failures, and sits below the
+  high-water mark those modes skip. Permissions can be fixed in place; missing content currently
+  cannot, short of migrating the export again into a fresh server. The planned repair tool is
+  described honestly, including what it will not be able to do.
+
 ## [2.10.0] - 2026-08-02
 
 ### Fixed

--- a/docs/guides/earlier-migrations.md
+++ b/docs/guides/earlier-migrations.md
@@ -1,0 +1,173 @@
+# Was my earlier migration affected?
+
+Between v2.8.2 and v2.10.0, Ferry fixed five bugs that had one thing in common: **they failed
+silently.** No error, no red text, nothing in the failed-message list. A migration could report
+complete success and still be missing content.
+
+If you migrated with an earlier version, this page tells you what to look for and what your options
+are. It does not sugar-coat them: **for the content that was lost, there is currently no way to
+repair a migrated server in place.** Permissions are the one thing you can fix where it stands.
+
+!!! info "Nothing here requires a re-export"
+    Everything below is a Ferry bug, not an export bug. Your existing
+    DiscordChatExporter output is fine and still contains the missing data — with one exception,
+    noted under [Forwarded messages](#1-forwarded-messages-were-discarded).
+
+## Quick check
+
+| If you migrated with | Then look for |
+|----------------------|---------------|
+| anything before **2.9.0** | Missing forwarded messages, and missing replies whose whole content was a sticker or an embed |
+| anything before **2.8.5** | Missing attachments just over a round size — e.g. a 20.4 MB file |
+| anything before **2.8.3** | Missing attachments, clustered in channels with lots of media |
+| anything before **2.10.0** | Voice channels nobody can use, and roles missing permissions they had in Discord |
+| anything before **2.8.2** | Nothing missing — migrations were just slower than they needed to be |
+
+Your migration report is the fastest way to check the first three. It is written to your output
+directory as `migration_report.json` (and `migration_report.md`).
+
+!!! tip "No terminal? Open the Markdown report instead"
+    Every search below has an equivalent in `migration_report.md`, which lists each warning on its
+    own line with the type in square brackets:
+
+    ```
+    - [forwarded_message] Forwarded message 1506019526855360593 skipped (DCE limitation).
+    - [attachment_upload_failed] Attachment 'clip.mp4' upload failed: File too large
+    ```
+
+    Open it in any text editor and search for the name in brackets.
+
+---
+
+## 1. Forwarded messages were discarded
+
+**Fixed in v2.9.0.** Affects every earlier version.
+
+Ferry skipped every forwarded message and recorded it as a DiscordChatExporter limitation. That was
+true when the code was written and stopped being true in **February 2026**, when DCE 2.47 began
+exporting the full forwarded payload. Ferry has pinned DCE 2.47.1 since **v2.0.2 (21 April 2026)**,
+so if Ferry produced your export, the data was there and was thrown away.
+
+**How to check.** Search your report for `forwarded_message`:
+
+```bash
+grep -c '"type": "forwarded_message"' migration_report.json
+```
+
+Every hit is one message that was dropped.
+
+**The same check covers a second bug.** The detector keyed on *empty content*, which is not unique
+to a forward — a reply whose entire payload was a sticker, or an embed, matched it exactly and was
+discarded too. Those also appear under `forwarded_message`, so the count above includes them.
+
+!!! warning "The one case that needs a re-export"
+    If you exported with DiscordChatExporter **older than 2.47** — for example by pointing Ferry at
+    an export you made yourself, some time ago — then the forwarded content was never written to
+    disk. Re-exporting is the only way to recover it.
+
+## 2. Some attachments were rejected by the server
+
+**Fixed in v2.8.5.** Affects every earlier version.
+
+Ferry checks a file's size before uploading it, to avoid wasting a round trip. Five of the six size
+limits were written as **binary** megabytes (`20 × 1024 × 1024`) where Stoat's media server uses
+**decimal** ones (`20,000,000`). Files landing in the gap passed Ferry's check, were uploaded, and
+were then rejected by the server.
+
+| Upload type | Ferry allowed | Server accepts | Files in this range were lost |
+|---|---|---|---|
+| Attachments | 20,971,520 | 20,000,000 | 20.00 – 20.97 MB |
+| Avatars | 4,194,304 | 4,000,000 | 4.00 – 4.19 MB |
+| Backgrounds | 6,291,456 | 6,000,000 | 6.00 – 6.29 MB |
+| Banners | 6,291,456 | 6,000,000 | 6.00 – 6.29 MB |
+| Emoji | 512,000 | 500,000 | 500 – 512 KB |
+| Icons | 2,500,000 | 2,500,000 | — already correct |
+
+**How to check.** Search your report for `attachment_upload_failed`:
+
+```bash
+grep '"type": "attachment_upload_failed"' migration_report.json
+```
+
+!!! danger "These leave no trace in the migrated message"
+    When Ferry's own size check catches a file, it leaves a visible marker in the message, like
+    `[File too large: clip.mp4 (24.1 MB, limit: 20.0 MB)]`. When the **server** rejects an upload,
+    it does not — the message arrives with the file simply absent, and the only record is the
+    warning in your report. So a visual skim of the migrated server will not find these.
+
+## 3. Uploads could fail during rate limiting
+
+**Fixed in v2.8.3.** Affects every earlier version.
+
+Stoat tells a client how long to wait after a rate limit, in milliseconds. Ferry's media uploader
+never read that header and fell back to waiting one second — roughly nine seconds too short. All
+three retry attempts could therefore be spent inside a single closed window, and the upload would
+give up.
+
+This is most likely to have bitten large, media-heavy channels, which is exactly where it is hardest
+to notice by eye.
+
+**How to check.** The same search as above — a failed upload is recorded as
+`attachment_upload_failed` whatever the cause. The message text will mention the status code.
+
+## 4. Voice channels and role permissions
+
+**Fixed in v2.10.0.** Affects every earlier version.
+
+None of Discord's voice permissions had a Stoat equivalent recorded, so they all translated to
+nothing. **Migrated voice channels granted nobody the right to connect, speak or hear.** Roles that
+held ADMINISTRATOR in Discord were affected more broadly — they arrived without voice, mention,
+timeout, audit-log or role-assignment rights.
+
+**How to check.** There is no warning to search for; this one is silent by construction. Look at the
+server instead:
+
+- Ask a member who is not the server owner to join a migrated voice channel and speak.
+- Compare a migrated moderator role's permissions against the same role in Discord.
+
+The server owner will not reproduce it — Stoat grants owners everything regardless.
+
+## 5. Migrations were slower than they needed to be
+
+**Fixed in v2.8.2.** Affects every earlier version. **No content was lost.**
+
+Ferry read Stoat's rate-limit header as seconds when it is milliseconds, so every rate-limit pause
+waited the full one-minute cap instead of the ten seconds actually required. Listed here only so the
+record is complete.
+
+---
+
+## What you can do
+
+Be aware of what does **not** work, because both look like they should:
+
+- **`--resume` will not backfill any of this.** It continues an interrupted run from where it
+  stopped; it does not revisit messages it has already passed.
+- **`--incremental` will not backfill it either.** It skips everything below the high-water mark it
+  recorded for each channel, and all of the content above sits below that mark.
+- **`ferry retry` cannot find it.** These were recorded as *warnings*, not as failed messages.
+  Nothing was ever added to the retry queue.
+
+That leaves:
+
+| What was affected | Your options today |
+|---|---|
+| Forwarded messages, sticker- or embed-only replies | Migrate the same export again with v2.9.0 or later, into a **new, empty Stoat server**. This produces a complete second copy — it does not merge into the existing one. |
+| Missing attachments | The same. The message text is already in your server; only the file is missing, and there is no supported way to attach it after the fact. |
+| Voice and role permissions | Fixable in place, by hand — no content is involved. Grant the permissions on the affected roles in Stoat, or re-run the ROLES and CHANNELS phases into a fresh server. |
+
+## What we are building
+
+A repair tool is planned. It will re-verify an already-migrated server against its original export
+and fix what it safely can — including permissions and messages that were dropped rather than
+failed. It is tracked as part of the ongoing upstream-drift work in
+[issue #107](https://github.com/nordscope-fi/Discord-stoat-ferry/issues/107).
+
+It will not be able to do everything. Ferry only keeps a record of what it sent for some
+combinations of settings, and where that record is absent the tool will decline to touch messages
+rather than risk duplicating a server's entire history. Permissions repair is the part that will
+work everywhere.
+
+If you think you were affected and the checks above do not settle it, please
+[open an issue](https://github.com/nordscope-fi/Discord-stoat-ferry/issues/new) with your
+`migration_report.json` attached — with any tokens removed.

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -2,6 +2,12 @@
 
 Every migration involves trade-offs. Discord and Stoat are different platforms with different capabilities, and some Discord features have no direct equivalent in Stoat. This page documents what changes, what gets lost, and what workarounds are available.
 
+!!! warning "Already migrated with an older version?"
+    Everything on this page is a deliberate limitation. Ferry also had five **bugs** that lost
+    content silently, fixed between v2.8.2 and v2.10.0 — missing forwarded messages, missing
+    attachments, and voice channels nobody could use. If you migrated before v2.10.0, see
+    [Was my earlier migration affected?](earlier-migrations.md).
+
 ---
 
 ## Structural

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -38,6 +38,11 @@ This page covers the most common problems encountered during migration, their ca
 
 ## Export and File Problems
 
+!!! warning "Content missing from a migration you already ran?"
+    If the migration finished cleanly and content is missing anyway, the cause may be a Ferry bug
+    rather than anything in this page — five silent ones were fixed between v2.8.2 and v2.10.0.
+    See [Was my earlier migration affected?](earlier-migrations.md).
+
 ### Attachment file missing
 
 | | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ Ferry is built to handle large migrations safely:
 - [Troubleshooting](guides/troubleshooting.md) — common issues and solutions
 - [Pre-Flight Checklist](guides/pre-flight-checklist.md) — verify your setup before migrating
 - [Known Limitations](guides/known-limitations.md) — platform constraints and unsupported features
+- [Was My Earlier Migration Affected?](guides/earlier-migrations.md) — five bugs fixed in v2.8.2–v2.10.0 that lost content **silently**; how to check a migration you already ran
 
 ## Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Self-Hosted Tips: guides/self-hosted-tips.md
     - Timestamp Preservation: guides/timestamps.md
     - Known Limitations: guides/known-limitations.md
+    - Was My Earlier Migration Affected?: guides/earlier-migrations.md
     - Pre-Flight Checklist: guides/pre-flight-checklist.md
     - Troubleshooting: guides/troubleshooting.md
   - Reference:


### PR DESCRIPTION
The disclosure step of the upstream-drift programme (#107). Documentation only — **no version bump**.

## Why this exists

Five bugs were fixed between v2.8.2 and v2.10.0. They share one property: **they failed without an error.** No red text, no entry in the failed-message list, nothing added to the retry queue. A migration could report complete success and still be missing content.

That is also why none of them was ever reported. Anyone who already migrated has no way to find out, and a CHANGELOG entry does not reach them.

## What it covers

| Fixed in | What was silently wrong |
|---|---|
| **2.9.0** | Forwarded messages discarded entirely; replies whose whole payload was a sticker or an embed discarded with them |
| **2.8.5** | Attachments rejected by the server — our own size check used binary megabytes where Stoat uses decimal, so files in the gap band passed the check and were then refused |
| **2.8.3** | Uploads abandoned during rate limiting — the media uploader never read Stoat's millisecond header and waited ~1 s instead of ~10 s, so all three retries could burn inside one closed window |
| **2.10.0** | Voice channels granted nobody the right to connect, speak or hear; ADMINISTRATOR roles arrived without voice, mention, timeout, audit-log or role-assignment rights |
| **2.8.2** | Nothing lost — migrations were just slower than necessary. Listed so the record is complete |

## Where it lives

A new guide, `docs/guides/earlier-migrations.md`, linked from the three places someone with a suspect migration actually lands: the docs landing page, **Known Limitations** (which otherwise reads as "everything missing here is deliberate" — it wasn't), and **Troubleshooting**.

The plan for this step called for a CHANGELOG plus a Known Limitations edit. I expanded it to a page because neither of those is reachable by the audience that needs it — someone who migrated three months ago and is wondering where their attachments went.

## The checks are real, not illustrative

Each bug gets the exact search that finds it, e.g.:

```bash
grep -c '"type": "forwarded_message"' migration_report.json
```

Both grep commands in the guide were **run against a real `json.dumps(..., indent=2)` report** rather than written from memory — the spacing in `"type": "..."` matters and would have been easy to get wrong. Markdown equivalents are given for people without a terminal, since GUI users may never open a shell.

The per-tag size bands are listed explicitly (attachments 20.00–20.97 MB, emoji 500–512 KB, and so on) so a user can check a specific file rather than guess.

## It does not overstate what can be recovered

This is the part I most want reviewed, because the honest answer is unflattering. Three things look like they should repair this and do not:

- **`--resume`** continues an interrupted run from where it stopped; it never revisits.
- **`--incremental`** skips everything below each channel's recorded high-water mark — and all of the affected content sits below it.
- **`ferry retry`** cannot see any of it. These were recorded as *warnings*, never as failed messages, so nothing ever entered the retry queue.

Verified in code rather than assumed (`messages.py:808-826` for the high-water gate, `messages.py:1642-1660` for the warning-not-failure path).

So the guide says plainly: permissions are fixable in place by hand; missing content currently is not, short of migrating the same export again into a **new, empty server** — which produces a complete second copy rather than merging into the existing one. The planned repair tool is described including what it will *not* manage, since it must decline to touch messages wherever Ferry's record of what it sent is incomplete.

## One detail that earned its own warning

When Ferry's own size check catches a file, it leaves a visible marker in the migrated message: `[File too large: clip.mp4 (24.1 MB, limit: 20.0 MB)]`. When the **server** rejects the upload, nothing is left behind — the message arrives with the file simply absent, and the only record is a line in the report. A visual skim of the destination server will not find those, so the guide says so directly.

That asymmetry is arguably a defect in its own right; noted on #107 as a follow-up rather than changed in a docs PR.

## Verification

`mkdocs build --strict` clean — it caught one real problem first: `CHANGELOG.md` is symlinked into the site as `changelog.md`, so a `docs/guides/...` relative link resolves correctly on GitHub but breaks on the docs site, while a bare `guides/...` link does the reverse. That reference is now plain text. Full suite re-run despite no code changing; `ruff check .` and `ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
