### PR TITLE
fix: checkpoint the merge path so a crash stops duplicating threads (v2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-08-02
+
+### Fixed
+
+- **A crash during `--thread-strategy merge` no longer duplicates thread messages on the next run.**
+
+  The merge path wrote nothing to disk until the entire MESSAGES phase finished — not a single
+  checkpoint across every thread. A crash, a force-quit or a lost connection partway through
+  therefore discarded the record of everything already delivered into the parent channel, and the
+  recovery run delivered it all again.
+
+  Merging now checkpoints inside each thread (on the same interval-and-time cadence the default
+  `flatten` strategy has always used) and again when a thread completes. `--resume` reads the
+  resulting marker, which it previously ignored for merged threads, so a resumed run continues from
+  where the crash landed instead of restarting the thread. The thread separator is no longer
+  re-posted either.
+
+  The larger the server, the worse this was: the window between "first message delivered" and "phase
+  finished" is the entire merge.
+
+  A message that *failed* to send also advances the checkpoint, so a resumed merge can skip past a
+  failure — exactly as the default `flatten` strategy already did. That message is not lost: it stays
+  in `failed_messages`, is reported as a failure, and an `--incremental` run re-attempts it.
+  `--resume` deliberately does not, because re-sending could duplicate a message that actually landed
+  before its response was lost.
+
+### Changed
+
+- **`docs/reference/stoat-api-notes.md` no longer claims Stoat's `Idempotency-Key` protects a
+  re-run.** It said a repeated key makes the server return the existing message, "which makes the
+  MESSAGES phase safe to re-run". Both halves are false, and the claim was load-bearing — it was the
+  stated reason resume was considered safe.
+
+  Stoat's store is a 1000-entry, in-memory, process-local LRU with no TTL, emptied on restart, and a
+  repeat returns **HTTP 409**, not the original message. A thousand entries is seconds of migration
+  traffic. What actually prevents duplicates is entirely client-side, and the page now says which
+  mechanism covers which strategy — including that `merge` never writes `message_map` and so relies
+  wholly on the markers above.
+
 ### Documentation
 
 - **New guide: "Was my earlier migration affected?"** (`docs/guides/earlier-migrations.md`) — a
@@ -18,9 +57,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   complete success and still be missing content, which is why nobody reported them.
 
   The guide gives the exact `migration_report.json` searches that identify each one, and is explicit
-  about the limits of recovery: **`--resume`, `--incremental` and `ferry retry` will not backfill
-  any of it** — the affected content was recorded as warnings, never as failures, and sits below the
-  high-water mark those modes skip. Permissions can be fixed in place; missing content currently
+  about the limits of recovery: **neither `--resume`, `--incremental`, nor the retry machinery will
+  backfill any of it** — the affected content was recorded as warnings, never as failures, and sits
+  below the high-water mark those modes skip. (The guide also notes that retry has no command-line
+  surface today, so "just run `ferry retry`" was never an option either.) Permissions can be fixed in place; missing content currently
   cannot, short of migrating the export again into a fresh server. The planned repair tool is
   described honestly, including what it will not be able to do.
 

--- a/docs/guides/earlier-migrations.md
+++ b/docs/guides/earlier-migrations.md
@@ -145,8 +145,10 @@ Be aware of what does **not** work, because both look like they should:
   stopped; it does not revisit messages it has already passed.
 - **`--incremental` will not backfill it either.** It skips everything below the high-water mark it
   recorded for each channel, and all of the content above sits below that mark.
-- **`ferry retry` cannot find it.** These were recorded as *warnings*, not as failed messages.
-  Nothing was ever added to the retry queue.
+- **The retry machinery cannot find it either.** These were recorded as *warnings*, not as failed
+  messages, so nothing ever entered the retry queue. (There is also no `ferry retry` command today —
+  the retry code exists inside the engine but has no command-line surface yet. Exposing it is part of
+  the same planned work as the repair tool.)
 
 That leaves:
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -820,8 +820,13 @@ subsequent messages reuse the cached file ID from `state.avatar_cache`.
 ### Idempotency-Key Deduplication
 
 Every message send includes an `Idempotency-Key` HTTP header set to `ferry-{discord_msg_id}`.
-If the same key is submitted twice (e.g. after resume), Stoat returns the existing message
-rather than creating a duplicate. This makes the MESSAGES phase safe to re-run.
+
+**It does not make the MESSAGES phase safe to re-run**, and an earlier revision of this page said
+it did. Stoat's store is a 1000-entry, in-memory, process-local LRU with no TTL that is emptied on
+restart, and a repeated key returns **HTTP 409**, not the original message. Treat it as a guard
+against an immediate double-send inside one run and nothing more — see
+[Stoat API Notes → Message Deduplication](stoat-api-notes.md#message-deduplication-with-idempotency-key)
+for the source-verified contract and for which client-side marker actually covers each strategy.
 
 ### Reply Reference Resolution
 
@@ -873,8 +878,13 @@ The MESSAGES phase has finer granularity (v2.0.0+):
 
 - `state.completed_channel_ids`: set of Discord channel IDs whose messages were fully sent
 - `state.channel_message_offsets`: maps a partially-processed channel ID to the last Discord
-  message ID successfully sent — the phase resumes within that channel from that offset
-- Messages already sent are additionally deduplicated by `Idempotency-Key` header
+  message ID **checkpointed** — the phase resumes within that channel from that offset. Note
+  "checkpointed", not "successfully sent": the counter advances on a failed send too, so a
+  failure can sit below the offset. Such a message stays in `state.failed_messages` and is
+  re-attempted by `--incremental` (not by `--resume`, which is a pure continuation)
+- Under `--thread-strategy merge` the same pair of markers is kept per *thread*, keyed by the
+  thread's own channel ID (batch 6, #107) — that path writes no `message_map`, so the markers
+  are the only protection against a re-run duplicating the thread into its parent
 
 **v1→v2 automatic migration**: On `--resume` with a v1 state file, Ferry detects the old
 `last_completed_channel` / `last_completed_message` fields, converts them to the new set/dict
@@ -1105,8 +1115,11 @@ call `stream_messages()` when `metadata_only=True`).
 Stoat has no bulk message import API. Every message must be sent individually via the Ferry
 account. Masquerade makes each message display the original Discord author's name and avatar,
 preserving conversation readability. The `Idempotency-Key` header (`ferry-{discord_msg_id}`)
-prevents duplicate messages on resume — Stoat returns the existing message if the same key
-was already used.
+guards against an immediate double-send within a single run. It does **not** protect a resume:
+Stoat's cache holds 1000 entries in memory, is cleared on restart, and returns HTTP 409 rather
+than the original message. Resume safety comes from Ferry's own markers — `state.message_map` and
+`completed_channel_ids` under `flatten`, `channel_high_water` and `channel_message_offsets` under
+`merge`.
 
 ### Why Separate discord_metadata.json?
 

--- a/docs/reference/stoat-api-notes.md
+++ b/docs/reference/stoat-api-notes.md
@@ -273,9 +273,34 @@ await api_send_message(
 )
 ```
 
-If the same idempotency key is submitted twice (e.g. after an interrupted migration resumes), Stoat
-returns the existing message rather than creating a duplicate. This makes the MESSAGES phase safe to
-re-run.
+!!! danger "This does NOT make the MESSAGES phase safe to re-run"
+    An earlier revision of this page claimed that submitting the same key twice makes Stoat return
+    the existing message instead of creating a duplicate. **Both halves of that are wrong**, and the
+    claim mattered — it was the stated reason resume was considered safe.
+
+    Verified against `crates/core/database/src/util/idempotency.rs` (2026-08-02):
+
+    - The store is `Lazy<Mutex<lru::LruCache<String, ()>>>` with a capacity of **1000 entries**. It
+      is **in-memory, process-local, has no TTL, and is emptied whenever the server restarts.**
+    - A key that is still cached returns **HTTP 409 `DuplicateNonce`** (`Status::Conflict`). It does
+      **not** return the original message, so there is nothing to reconcile against.
+    - Keys longer than **64 characters** are rejected. Ferry's are ~25–31 (`ferry-{id}`,
+      `ferry-merge-{id}`, `_p{n}` suffix), so this is not currently a constraint.
+
+    A 1000-entry window is a handful of seconds of migration traffic. By the time any resume, retry
+    or repair runs, every relevant key is long gone — and after a server restart, immediately.
+
+**What actually prevents duplicates is entirely client-side**, and each strategy has its own
+mechanism:
+
+| Path | What stops a re-run duplicating | Where |
+|---|---|---|
+| `flatten` | `state.message_map` (source id → Stoat id), plus `completed_channel_ids` and the transient `channel_message_offsets` | `messages.py` |
+| `merge` | `channel_high_water` per thread (durable) and `channel_message_offsets` (transient, mid-thread). **`merge` never writes `message_map`** | `messages.py` |
+| `--incremental` | the durable `channel_high_water` marker, with previously-failed ids deliberately re-attempted | `messages.py` |
+
+Treat the idempotency key as a cheap guard against an immediate double-send within one run — a
+retried request, a duplicated task — and nothing more.
 
 !!! note "Deprecated: nonce body field"
     The old `nonce` body field on message sends is deprecated. Use the `Idempotency-Key` HTTP header

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.10.0"
+version = "2.11.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.10.0"
+__version__ = "2.11.0"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -498,9 +498,35 @@ async def _merge_threads(
                 )
                 continue
 
-            _thread_skip_below = (
-                state.channel_high_water.get(export.channel.id, "") if config.incremental else ""
-            )
+            # These two markers are the ONLY thing preventing a re-run from
+            # duplicating this thread into the parent channel. The Idempotency-Key
+            # header does not help: Stoat's store is a 1000-entry in-memory LRU with
+            # no TTL, cleared on restart, and a hit returns 409 rather than the
+            # original message. And unlike flatten, the merge path never writes
+            # `message_map`, so there is no second line of defence here.
+            #
+            # Batch 6 (#107): mirrors the flatten read at :808-826.
+            # --resume reads the TRANSIENT per-thread offset, which is where a crashed
+            # run stopped inside this thread and is cleared once the thread completes.
+            # --incremental reads the DURABLE high-water mark, taking the transient
+            # offset too in case a crash left it ahead. Plain runs skip nothing.
+            if config.resume:
+                _thread_skip_below = state.channel_message_offsets.get(export.channel.id, "")
+            elif config.incremental:
+                _thread_skip_below = max(
+                    (
+                        v
+                        for v in (
+                            state.channel_high_water.get(export.channel.id, ""),
+                            state.channel_message_offsets.get(export.channel.id, ""),
+                        )
+                        if v and v.isdigit()
+                    ),
+                    key=int,
+                    default="",
+                )
+            else:
+                _thread_skip_below = ""
             # #77 parity: a non-numeric marker (only reachable via a hand-edited
             # state.json) degrades to "no threshold" rather than crashing int().
             if _thread_skip_below and not _thread_skip_below.isdigit():
@@ -509,6 +535,14 @@ async def _merge_threads(
             # sit below the high-water mark; on incremental, exclude them from the skip so
             # the merge re-POSTs them. Empty unless incremental, so --resume is unaffected.
             # Scoped to parent_stoat_id (mirrors the parallel path's stoat_channel_id filter).
+            #
+            # Batch 6 (#107) note: `_posted` advances on a FAILED message as well as a sent
+            # one, so the checkpoint below can persist the id of a message that never
+            # landed, and --resume now skips past it. That matches flatten exactly and is
+            # the contract SC-7 pins (`test_resume_does_not_reattempt_failed_id`): resume
+            # is a pure continuation. The message is not lost -- it stays in
+            # `state.failed_messages`, is reported as a failure, and an --incremental run
+            # self-heals it. See `test_resume_keeps_a_failed_merge_message_recoverable`.
             _failed_ids_here = (
                 {
                     fm.discord_msg_id
@@ -521,10 +555,17 @@ async def _merge_threads(
             _succeeded_ids: set[str] = set()
             _thread_max_id = 0
             _posted = 0
+            _checkpoint_interval = max(config.checkpoint_interval, 1)
+            _last_save_time = time.monotonic()
 
-            # Send separator message (skip on incremental when the thread already
-            # has a durable marker \u2014 the separator was posted on the first run).
-            if not (config.incremental and export.channel.id in state.channel_high_water):
+            # Send separator message. Skipped when a prior run already posted it:
+            # on incremental that is signalled by the durable marker, and on resume
+            # by the transient offset a crashed run left behind (batch 6, #107) --
+            # otherwise every crash would add another separator to the parent.
+            _already_started = export.channel.id in state.channel_high_water or (
+                export.channel.id in state.channel_message_offsets
+            )
+            if not ((config.incremental or config.resume) and _already_started):
                 separator = (
                     f"\u2500\u2500 Thread: {export.channel.name} "
                     f"({export.message_count} messages) \u2500\u2500"
@@ -628,6 +669,25 @@ async def _merge_threads(
                 if not _msg_failed:
                     _succeeded_ids.add(msg.id)
                 _posted += 1
+
+                # Batch 6 (#107): checkpoint inside the thread. Without this a crash
+                # loses the record of everything sent since the phase began, and the
+                # re-run re-delivers it -- the merge path has no message_map to fall
+                # back on. Interval AND a 5s floor, mirroring :885-895.
+                #
+                # No save_lock: _merge_threads is awaited at :446, strictly after the
+                # parallel gather has finished and been reconciled, so nothing else
+                # touches `state` here. Do NOT add one "for symmetry".
+                if _posted % _checkpoint_interval == 0:
+                    now = time.monotonic()
+                    if now - _last_save_time >= 5.0:
+                        # #77 parity: only persist numeric ids, so a non-numeric id can
+                        # never poison the offset the resume path reads back.
+                        if msg.id.isdigit():
+                            state.channel_message_offsets[export.channel.id] = msg.id
+                        save_state(state, config.output_dir)
+                        _last_save_time = now
+
                 await _rate_limit_with_pause(config)
 
             # Durable high-water mark for this thread (written every run so a later
@@ -640,6 +700,11 @@ async def _merge_threads(
             # — the merge path never writes message_map), and collapse the carried +
             # fresh-re-fail duplicate to one entry. Scoped to parent_stoat_id + the ids
             # carried into this thread, so sibling threads' entries are untouched.
+            #
+            # Batch 6 (#107): this gate MUST match the one building _failed_ids_here
+            # above. Re-attempting under a mode that does not reconcile would leave a
+            # succeeded message still recorded as failed — an inaccurate durable
+            # record, and a duplicate send the next time it is re-attempted.
             if config.incremental and _failed_ids_here:
                 _seen: set[str] = set()
                 _reconciled: list[FailedMessage] = []
@@ -655,6 +720,12 @@ async def _merge_threads(
                         _seen.add(fm.discord_msg_id)
                     _reconciled.append(fm)
                 state.failed_messages = _reconciled
+
+            # Thread complete — the durable marker above now covers everything sent,
+            # so the transient offset has nothing left to say. Clearing it is what
+            # makes the separator gate distinguish "mid-flight" from "finished".
+            state.channel_message_offsets.pop(export.channel.id, None)
+            save_state(state, config.output_dir)
 
             on_event(
                 MigrationEvent(
@@ -832,6 +903,14 @@ async def _process_single_channel(
         # #76: ids that failed to POST on a prior run sit below the high-water mark;
         # on incremental, exclude them from the skip so the phase re-POSTs them
         # (self-heal). Empty unless incremental, so --resume is unaffected.
+        #
+        # Deliberate, and pinned by SC-7 (`test_resume_does_not_reattempt_failed_id`):
+        # --resume is a pure continuation, so it does not re-send anything it has a
+        # marker for -- including a failure sitting below that marker. The message is
+        # not lost: it stays in `state.failed_messages` and is reported as a failure,
+        # and an --incremental run self-heals it. Re-sending under resume would risk
+        # duplicating a message that actually landed before the response was lost,
+        # which is a trade-off only the opt-in delta mode makes.
         if config.incremental:
             _failed_ids_here = {
                 fm.discord_msg_id
@@ -923,6 +1002,8 @@ async def _process_single_channel(
             # succeeded this run (now in message_map), and collapse the carried +
             # fresh-re-fail duplicate to a single entry. Scoped to this channel so
             # other channels' and brand-new failures are untouched.
+            #
+            # This gate MUST match the one building _failed_ids_here above.
             if config.incremental and _failed_ids_here:
                 _seen: set[str] = set()
                 _reconciled: list[FailedMessage] = []

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -906,3 +906,222 @@ async def test_archive_strategy_writes_forwarded_content(tmp_path: Path) -> None
 
     md = (tmp_path / "threads" / "general" / "my-thread.md").read_text()
     assert "recovered thread text" in md
+
+
+# ---------------------------------------------------------------------------
+# Batch 6 (#107) — merge-path durability
+# ---------------------------------------------------------------------------
+
+
+class _Crash(BaseException):
+    """Simulates the process dying mid-merge.
+
+    Deliberately a BaseException: the merge loop catches ``Exception`` per message
+    and records a failure, which is the opposite of the scenario under test. Only
+    something outside that net models "the process went away".
+    """
+
+
+def _crash_on_nth(keys: list[str], n: int) -> object:
+    """api_send_message stand-in that records keys and dies on the nth call."""
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        key = str(kwargs.get("idempotency_key", ""))
+        if len(keys) >= n:
+            raise _Crash(f"process died before sending {key}")
+        keys.append(key)
+        return {"_id": f"stoat-{key}"}
+
+    return _send
+
+
+def _two_thread_setup(
+    tmp_path: Path,
+    *,
+    resume: bool = False,
+    incremental: bool = False,
+    checkpoint_interval: int = 50,
+) -> tuple[FerryConfig, MigrationState, list[DCEExport]]:
+    """Parent (ch 100) plus two threads (ch 200, ch 300), four messages each."""
+    config = _make_config(
+        tmp_path,
+        thread_strategy="merge",
+        message_rate_limit=0.0,
+        resume=resume,
+        incremental=incremental,
+        checkpoint_interval=checkpoint_interval,
+    )
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    parent = _make_export(channel_id="100", channel_name="general")
+    threads = [
+        _make_export(
+            channel_id=cid,
+            channel_name=f"thread-{cid}",
+            is_thread=True,
+            parent_channel_name="general",
+            messages=[_make_message(mid, f"msg {mid}") for mid in ids],
+            message_count=len(ids),
+        )
+        for cid, ids in (("200", ["10", "20", "30", "40"]), ("300", ["50", "60", "70", "80"]))
+    ]
+    return config, state, [parent, *threads]
+
+
+async def test_crash_mid_merge_leaves_durable_record(tmp_path: Path) -> None:
+    """SC-35: what reached the parent channel before the crash is on DISK afterwards.
+
+    Asserts against state.json rather than the in-memory state — the whole point
+    is what survives the process going away.
+    """
+    import json
+    from unittest.mock import patch
+
+    import pytest
+
+    # checkpoint_interval=2 plus a clock that always clears the 5s floor, so the
+    # transient offset is genuinely written mid-thread. With the default interval
+    # of 50 and four messages per thread it never would be, and the "offset was
+    # cleared" assertion below would pass whether or not anything cleared it.
+    config, state, exports = _two_thread_setup(tmp_path, checkpoint_interval=2)
+    keys: list[str] = []
+    ticks = iter(range(0, 10_000, 100))
+    # Thread 200: separator + 4 messages = 5 sends, so it completes. Die on the
+    # 6th — thread 300's separator — BEFORE any later checkpoint could persist
+    # thread 200's completion as a side effect. That isolates the completion save.
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", _crash_on_nth(keys, 5)),
+        patch("discord_ferry.migrator.messages.time.monotonic", lambda: next(ticks)),
+        pytest.raises(_Crash),
+    ):
+        await run_messages(config, state, exports, lambda e: None)
+
+    saved = json.loads((tmp_path / "state.json").read_text())
+    # Thread 200 ran to completion: its durable marker survives...
+    assert saved["channel_high_water"].get("200") == "40"
+    # ...and the transient offset the checkpoints wrote was cleared, because there
+    # is nothing left to resume inside it. Left behind, it would suppress the
+    # separator of a thread that had in fact finished.
+    assert "200" not in saved.get("channel_message_offsets", {})
+    # Thread 300 never started and must not claim otherwise.
+    assert "300" not in saved.get("channel_high_water", {})
+
+
+async def test_merge_checkpoints_periodically_inside_a_long_thread(tmp_path: Path) -> None:
+    """SC-36: mid-thread progress is persisted, not just per-thread completion.
+
+    Drives the interval-and-time gate with a clock that always reports the floor
+    as satisfied, so the assertion is about the interval rather than wall time.
+    """
+    import json
+    from unittest.mock import patch
+
+    import pytest
+
+    config, state, exports = _two_thread_setup(tmp_path, checkpoint_interval=2)
+    keys: list[str] = []
+    ticks = iter(range(0, 10_000, 100))
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", _crash_on_nth(keys, 4)),
+        patch("discord_ferry.migrator.messages.time.monotonic", lambda: next(ticks)),
+        pytest.raises(_Crash),
+    ):
+        await run_messages(config, state, exports, lambda e: None)
+
+    saved = json.loads((tmp_path / "state.json").read_text())
+    # Separator + msgs 10, 20 landed; the crash hit msg 30. A checkpoint must have
+    # recorded progress inside thread 200, which never completed.
+    assert saved.get("channel_message_offsets", {}).get("200") == "20"
+    assert "200" not in saved.get("channel_high_water", {})
+
+
+async def test_resume_does_not_remerge_already_sent_thread_messages(tmp_path: Path) -> None:
+    """A resumed merge must not re-deliver what the crashed run already sent."""
+    from unittest.mock import patch
+
+    config, state, exports = _two_thread_setup(tmp_path, resume=True)
+    # Stand-in for the state a crashed run left behind: thread 200 got as far as 20.
+    state.channel_message_offsets["200"] = "20"
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, exports, lambda e: None)
+
+    thread_200 = [k for k in keys if k in ("ferry-merge-10", "ferry-merge-20")]
+    assert thread_200 == [], "re-sent messages the crashed run had already delivered"
+    assert "ferry-merge-30" in keys
+    assert "ferry-merge-40" in keys
+
+
+async def test_resume_does_not_repost_the_thread_separator(tmp_path: Path) -> None:
+    """The separator is posted once per thread, not once per crash."""
+    from unittest.mock import patch
+
+    config, state, exports = _two_thread_setup(tmp_path, resume=True)
+    state.channel_message_offsets["200"] = "20"
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, exports, lambda e: None)
+
+    assert "ferry-thread-sep-200" not in keys
+    # A thread the crashed run never reached still gets its separator.
+    assert "ferry-thread-sep-300" in keys
+
+
+async def test_resume_keeps_a_failed_merge_message_recoverable(tmp_path: Path) -> None:
+    """`_posted` advances on a FAILED send too, so the checkpoint can name a message
+    that never landed — and --resume now skips past it.
+
+    That is deliberate and matches flatten: SC-7
+    (`test_resume_does_not_reattempt_failed_id`) pins resume as a pure continuation,
+    because re-sending could duplicate a message that actually landed before the
+    response was lost. What must hold is that the message stays RECOVERABLE: the
+    failure record survives, so the report shows it and an --incremental run
+    self-heals it.
+    """
+    from unittest.mock import patch
+
+    config, state, exports = _two_thread_setup(tmp_path, resume=True)
+    state.channel_message_offsets["200"] = "30"
+    state.failed_messages.append(
+        FailedMessage(
+            discord_msg_id="20",
+            stoat_channel_id="stoat-ch-100",
+            error="boom",
+            content_preview="msg 20",
+        )
+    )
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, exports, lambda e: None)
+
+    # Not re-attempted under resume — same contract as flatten.
+    assert "ferry-merge-20" not in keys
+    # ...but still on the books, so it is neither silent nor permanent.
+    assert [fm.discord_msg_id for fm in state.failed_messages] == ["20"]
+    # Everything above the marker is still sent.
+    assert "ferry-merge-40" in keys
+
+
+async def test_incremental_still_reattempts_a_failed_merge_message(tmp_path: Path) -> None:
+    """The opt-in delta mode is where the self-heal lives — unchanged by batch 6."""
+    from unittest.mock import patch
+
+    config, state, exports = _two_thread_setup(tmp_path, incremental=True)
+    state.channel_high_water["200"] = "30"
+    state.failed_messages.append(
+        FailedMessage(
+            discord_msg_id="20",
+            stoat_channel_id="stoat-ch-100",
+            error="boom",
+            content_preview="msg 20",
+        )
+    )
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, exports, lambda e: None)
+
+    assert "ferry-merge-20" in keys, "incremental must still self-heal"
+    # Re-sent successfully, so the stale failure record is reconciled away.
+    assert [fm.discord_msg_id for fm in state.failed_messages] == []

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.10.0"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch 6 of 10 in the upstream-drift programme (#107).

## A crash mid-merge duplicated the entire thread set on the next run

`_merge_threads` — the `--thread-strategy merge` path — mutated `state` throughout (warnings, `failed_messages`, `channel_high_water`) and called `save_state` **zero times**. Nothing reached disk until the whole MESSAGES phase finished, so a crash, a force-quit or a dropped connection partway through discarded the record of everything already delivered into the parent channel.

The larger the server, the worse it was: the window between "first message delivered" and "phase complete" *is* the entire merge.

## The half that would have made the fix inert

Checkpointing alone fixes nothing here, and this is the part worth reviewing.

`--resume` re-runs the whole MESSAGES phase. `flatten` channels skip what they already did, via `completed_channel_ids` and `channel_message_offsets`. **The merge path consulted its marker only under `--incremental`** (`messages.py:501-503`). So even with a durable record written, a resumed run would re-merge every thread from the top and re-deliver every message the crashed run had already sent.

Both halves ship together:

- a periodic checkpoint **inside** each thread, on the same interval-and-time cadence `flatten` has always used (`messages.py:885-895`);
- a save when a thread **completes**, which also clears the transient marker;
- `--resume` now reads that transient marker, and `--incremental` keeps reading the durable high-water mark (taking the transient one if a crash left it ahead);
- the thread separator is no longer re-posted by a resumed run.

**No new state fields.** This reuses `flatten`'s existing two-marker model, and a thread export carries its own `channel.id`, distinct from any parent's:

| Marker | Lifetime | Read by |
|---|---|---|
| `channel_message_offsets[thread_id]` | transient — popped on thread completion | `--resume` |
| `channel_high_water[thread_id]` | durable — survives completion | `--incremental` |

**No `save_lock`.** `_merge_threads` is awaited at `messages.py:446`, strictly after the `asyncio.gather` over parent channels has completed and been reconciled, so nothing else touches `state`. There is a comment saying so, because adding one "for symmetry" is the obvious wrong move and it would deadlock.

## A detour worth recording: what I did NOT change, and why

`_posted` advances on a **failed** message as well as a sent one, so the checkpoint can persist the id of a message that never landed — and resume now skips past it.

I read that as a loss this fix had introduced, and extended the `#76` self-heal to `--resume`. The second-opinion pass then found the matching reconciliation gate was still incremental-only, so I extended that as well. Code review then found the same asymmetry on the flatten path, so I extended it there too.

**All of that was wrong.** `tests/test_messages.py:2632` already pins the contract:

> **SC-7**: `--resume` must NOT consult `failed_messages` (no self-heal on resume).

That is a deliberate decision from the earlier `#76` work. Resume is a pure continuation; re-sending could duplicate a message that actually landed before its response was lost — a trade-off only the opt-in `--incremental` delta mode makes. And the message is neither silently nor permanently lost: it stays in `state.failed_messages`, is reported as a failure, and `--incremental` self-heals it.

So both gates on both paths stay `config.incremental` — which is what "mirror the flatten path exactly" meant in the first place. Two tests now pin the real contract rather than my invented one: `test_resume_keeps_a_failed_merge_message_recoverable` and `test_incremental_still_reattempts_a_failed_merge_message`.

Three passes reasoned about this gate — mine, a second opinion, and a code review — and none of us checked for an existing test asserting the current behaviour. Worth remembering for batch 7, which touches the same reconciliation.

## Review findings

Code review raised one Important finding: that flatten's self-heal was not extended to match merge's. Investigating it is what surfaced SC-7 and reversed the change in the other direction — so the finding was valuable even though its recommendation was the opposite of correct. Its characterisation of the flatten behaviour as "permanently, silently skipped" was overstated: the message is recorded in `failed_messages` and surfaced in the migration report.

Two Minor findings were real and are fixed:

- **`ferry retry` does not exist.** `CHANGELOG.md` and `docs/guides/earlier-migrations.md` both referred to it as a runnable command. The CLI exposes `migrate`, `validate`, `build`, `export-blueprint`, `stats`, `rollback` and `probe` — the retry code lives in the engine with no command-line surface. Both references now say so.
- **`architecture.md` described `channel_message_offsets` as "the last message ID successfully sent"** — it is the last id *checkpointed*, which can be a failed one. Corrected, with the consequence spelled out.

The second opinion's other two findings were rejected on evidence: a claimed ordering hazard between the failure record and the checkpoint (ruled out by program order — the `FailedMessage` is appended before `_posted += 1`, and `save_state` serialises `failed_messages` in the same write), and a claimed skip caused by `_thread_max_id` being tracked above the `_SKIP_TYPES` continue (ruled out because `channel_high_water` is only written after the loop completes, and `--resume` reads the transient offset instead).

## The docs claim this batch depended on was false

`stoat-api-notes.md` stated that a repeated `Idempotency-Key` makes Stoat return the existing message, "which makes the MESSAGES phase safe to re-run". That was load-bearing — it was the stated reason resume was considered safe, and it is wrong in both halves.

Re-read from source (`crates/core/database/src/util/idempotency.rs`, 2026-08-02) rather than from notes:

- `Lazy<Mutex<lru::LruCache<String, ()>>>` at `NonZeroUsize::new(1000)` — **in-memory, process-local, no TTL, emptied on restart**.
- a cached key returns `Status::Conflict` + `DuplicateNonce` — **HTTP 409**, not the original message, so there is nothing to reconcile against.
- keys over **64 characters** are rejected (Ferry's are ~25–31, so not currently a constraint).

A thousand entries is seconds of migration traffic. The page now says what actually prevents duplicates — client-side markers — and which mechanism covers which strategy, including that `merge` never writes `message_map` and so relies wholly on the two markers above. The merge gate carries the same note in code.

**`architecture.md` repeated the same false claim in two further places** (`:823`, `:1108`), found by this batch's own manifest audit target — the same duplicated-reference pattern that hid the permission drift in batch 5. Both corrected and pointed at `stoat-api-notes.md` as the single owner.

## Verification

- RED first: all five original tests failed against the old code, including `assert 'ferry-thread-sep-200' not in [...]` showing the separator being re-posted.
- **All five guards falsified in place** — removing the completion save, the transient-marker pop, the periodic checkpoint, the resume read of the transient offset, or the separator gate each turns its own test red, and everything restores green.
- **Falsification caught a vacuous assertion in a draft of my own test**: `assert "200" not in channel_message_offsets` passed whether or not the `.pop()` existed, because with the default `checkpoint_interval=50` and four messages per thread the key was never written in the first place. Then, once fixed, it caught the *completion* save being masked by the next thread's periodic save — so the crash point moved to isolate each guard.
- +6 tests; **1399 passing** (baseline 1393). `ruff check .`, `ruff format --check .`, `mypy src/` clean; `uv sync --locked` clean; `mkdocs build --strict` clean.

## Deferred, with reason

**SC-37** (flatten's failed-message reconcile fooled by a thread's copy of the same source id, `messages.py:925`) is listed under this batch in the scenarios file but belongs with batch 7. The reconcile keys on the global `state.message_map`, which carries no channel information, so making it precise needs a per-channel, per-run success set accumulated across checkpoints — and the collision it guards against **cannot occur before DCE 2.47.3**, since 2.47.1 gives the thread starter a distinct placeholder id. Batch 7 owns the merge duplicate guard that gates that bump. Recorded on #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
