### PR TITLE
fix: the one-click GUI export never started, on any platform, since v2.6.14 (#123)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ site/
 # PyInstaller (keep ferry.spec — our build config)
 *.spec
 !ferry.spec
+
+# NiceGUI runtime storage (see .claude/rules/security.md — user-scoped GUI settings,
+# never tokens, but it is runtime state and must not be committed).
+.nicegui/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-08-06
+
+### Fixed
+
+- **The one-click GUI migration could never start an export.** On the Export screen it showed
+  "Preparing…" with an empty log panel and no CPU, disk or network activity, indefinitely.
+  DiscordChatExporter was never launched.
+
+  **Every release from v2.6.14 to v2.11.0 is affected, on every platform.** If you used the
+  one-click (orchestrated) path in the GUI during that window and the export never started,
+  this is why. The "I already have exports" path and the CLI were never affected.
+
+  The export ran in a background task, and its first statement asked NiceGUI for the current
+  client. NiceGUI tracks that per asyncio task rather than through a context variable, so a
+  background task starts with nothing attached and the lookup raised immediately — before a
+  single line reached the log panel. Nothing surfaced the error, because the GUI binary is
+  built without a console and no log file existed to catch it.
+
+  The page now resolves the client and the session tokens before starting the task, and the
+  task re-enters the client's context for the UI calls it makes. The same fault silently
+  suppressed the "Migration complete!" and "Rollback complete!" confirmations and aborted the
+  rollback task early; all four background tasks are fixed together.
+
+- **Waiting for the browser to connect is now bounded.** These waits had no timeout, so a
+  client that never completed its handshake would hang the page forever with no message. They
+  now time out and say so, naming the log file.
+
+- **A missing export directory now reports an error instead of vanishing.** It previously
+  raised outside the error handler, so the screen simply stopped.
+
+- **Re-export is guarded.** Repeated clicks no longer stack concurrent exports writing into the
+  same directory, and a retry after the session token is cleared now returns you to setup
+  rather than exporting with a stale token.
+
+### Added
+
+- **A log file, always on, at `~/.discord-ferry/logs/ferry.log`** (2 MB, 3 rotations). The GUI
+  is packaged without a console, so until now nothing that failed in the background left any
+  trace anywhere — which is why the bug above survived eleven releases. Attach this file to bug
+  reports.
+
+  Tokens are masked before anything is written — including values passed as deferred log
+  arguments, and anything inside a traceback (exception messages routinely quote the token
+  that caused the failure).
+
 ## [2.11.0] - 2026-08-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.11.0"
+version = "2.11.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.11.0"
+__version__ = "2.11.1"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -23,6 +23,8 @@ from rich.table import Table
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
+from discord_ferry.core.logging_setup import configure_logging
+from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError, StateError
 from discord_ferry.migrator.api import (
     api_create_channel,
@@ -606,6 +608,12 @@ def _build_config(kwargs: dict[str, Any]) -> FerryConfig:
             "--discord-token and --discord-server (orchestrated mode)"
         )
 
+    # Register before the config exists, so anything logged between here and the
+    # engine's _ensure_token_store is already redacted.
+    register_secret("stoat", kwargs.get("token") or "")
+    if discord_token:
+        register_secret("discord", discord_token)
+
     return FerryConfig(
         export_dir=export_dir,
         stoat_url=kwargs["stoat_url"],
@@ -651,6 +659,7 @@ def _build_config(kwargs: dict[str, Any]) -> FerryConfig:
 def main(ctx: click.Context) -> None:
     """Migrate a Discord server export to Stoat."""
     load_dotenv()
+    configure_logging()
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
 
@@ -1284,6 +1293,12 @@ def probe_cmd(
     if not token:
         console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
         sys.exit(1)
+
+    # probe never builds a FerryConfig or a SecureTokenStore, so the engine's
+    # _ensure_token_store hook never fires here. Without this line the Stoat
+    # token has no redaction coverage at all for the whole command -- and the
+    # regex backstop deliberately cannot match Stoat tokens (opaque base64url).
+    register_secret("stoat", token)
 
     from discord_ferry.migrator.probe import run_probe
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -15,7 +15,7 @@ import aiohttp
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.core.security import SecureTokenStore, safe_sanitize
+from discord_ferry.core.security import SecureTokenStore, register_secret, safe_sanitize
 from discord_ferry.discord import (
     fetch_and_translate_guild_metadata,
     load_discord_metadata,
@@ -138,6 +138,11 @@ def _ensure_token_store(config: FerryConfig) -> None:
     if config.discord_token:
         tokens["discord"] = config.discord_token
     config.token_store = SecureTokenStore(tokens)
+    # Also register process-wide so the log redaction filter can mask these.
+    # The filter is installed in main(), long before any config exists, so it
+    # has no way to reach this per-config store. See core/logging_setup.py.
+    for name, value in tokens.items():
+        register_secret(name, value)
 
 
 async def run_migration(

--- a/src/discord_ferry/core/logging_setup.py
+++ b/src/discord_ferry/core/logging_setup.py
@@ -1,0 +1,140 @@
+"""Always-on file logging with token redaction.
+
+Ferry ships its GUI as a windowed PyInstaller binary (``ferry.spec`` sets
+``console=False``), which means ``sys.stdout`` and ``sys.stderr`` are ``None``.
+Nothing in ``src/`` ever attached a logging handler, so the 13 module loggers --
+and, worse, NiceGUI's own uncaught-background-task handler -- wrote to
+``logging.lastResort``, whose ``emit`` no-ops when ``sys.stderr`` is ``None``.
+
+That is why issue #123 was undiagnosable: a ``RuntimeError`` killed the export
+task on every run for eleven releases and the traceback went nowhere. This
+module exists so the next failure of that class leaves evidence.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from discord_ferry.core.security import sanitize_secrets
+
+__all__ = ["configure_logging", "reset_logging"]
+
+_LOG_DIR_NAME = ".discord-ferry"
+_LOG_FILE_NAME = "ferry.log"
+_MAX_BYTES = 2 * 1024 * 1024
+_BACKUP_COUNT = 3
+_HANDLER_NAME = "ferry-file"
+
+# Discord tokens have a recognisable three-part shape. This is a *floor*, not the
+# main defence: it covers the window between process start and the first
+# register_secret() call. It deliberately does NOT try to match Stoat tokens --
+# those are opaque base64url and any pattern wide enough to catch one would also
+# redact ordinary Ulids and channel IDs.
+_DISCORD_TOKEN_RE = re.compile(r"\b(?:mfa\.[\w-]{20,}|[\w-]{23,28}\.[\w-]{6,7}\.[\w-]{27,})\b")
+
+
+def _redact(text: str) -> str:
+    """Mask registered secrets, then Discord-shaped tokens, in *text*."""
+    return _DISCORD_TOKEN_RE.sub("****", sanitize_secrets(text))
+
+
+class _RedactingFormatter(logging.Formatter):
+    """Sanitise the fully-formatted record, tracebacks included.
+
+    Redaction MUST happen here rather than in a ``logging.Filter``, for two
+    reasons that a filter-based implementation gets wrong:
+
+    1. **Tracebacks.** ``record.exc_text`` is ``None`` while filters run -- it is
+       populated by ``Formatter.format()`` afterwards. A filter that sanitises
+       ``exc_text`` is therefore a no-op on the first handler to see the record,
+       and the raw traceback lands in the file. (This bites hard here: exception
+       *messages* routinely carry the token that caused the failure. It also
+       hides under pytest, whose logging plugin formats the record first and
+       pre-populates the field -- so a filter-based version passes its own test
+       while leaking in production.)
+    2. **Shared records.** A filter has to mutate ``record.msg`` / ``record.args``
+       to catch deferred ``%s`` arguments, and that mutation is visible to every
+       other handler on the logger. Formatting is per-handler and mutates
+       nothing.
+
+    ``format()`` renders message, args, ``exc_text`` and ``stack_info`` into one
+    string, so sanitising its return value covers all of them at once.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        return _redact(super().format(record))
+
+
+def _log_path() -> Path:
+    """Return the log file path. Sits under the same root as the DCE cache."""
+    return Path.home() / _LOG_DIR_NAME / "logs" / _LOG_FILE_NAME
+
+
+def _existing_handler() -> logging.Handler | None:
+    return next(
+        (h for h in logging.getLogger().handlers if h.get_name() == _HANDLER_NAME),
+        None,
+    )
+
+
+def configure_logging(*, path: Path | None = None) -> Path | None:
+    """Attach a rotating file handler to the root logger.
+
+    Idempotent: a second call returns the existing path rather than stacking a
+    handler. That matters because ``cli.main()`` is a Click *group* callback, so
+    it runs on every ``CliRunner().invoke(main, ...)``.
+
+    Deliberately attaches no ``StreamHandler``: Rich and ``click.echo`` own the
+    console, and a second stream would double every line the CLI prints.
+
+    Args:
+        path: Override the log location. Tests pass a tmp path; production
+            never does.
+
+    Returns:
+        The resolved log path, or ``None`` when the file could not be opened.
+        Logging is a diagnostic aid, never a startup dependency -- an
+        unwritable home directory must not stop Ferry from running.
+    """
+    existing = _existing_handler()
+    if existing is not None:
+        return Path(existing.baseFilename) if isinstance(existing, RotatingFileHandler) else None
+
+    target = path or _log_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(
+            target,
+            maxBytes=_MAX_BYTES,
+            backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+    except OSError:
+        return None
+
+    handler.set_name(_HANDLER_NAME)
+    handler.setFormatter(_RedactingFormatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s"))
+
+    root = logging.getLogger()
+    root.addHandler(handler)
+    # INFO, not DEBUG: migrator/messages.py logs per message, which would bury
+    # the signal and blow through rotation on a large migration.
+    if root.level == logging.NOTSET or root.level > logging.INFO:
+        root.setLevel(logging.INFO)
+
+    return target
+
+
+def reset_logging() -> None:
+    """Detach the file handler. For tests only.
+
+    Mirrors ``migrator.api._reset_circuit_state``. Without this, the handler
+    installed by one test stays attached for the whole pytest session.
+    """
+    handler = _existing_handler()
+    if handler is not None:
+        logging.getLogger().removeHandler(handler)
+        handler.close()

--- a/src/discord_ferry/core/security.py
+++ b/src/discord_ferry/core/security.py
@@ -26,6 +26,18 @@ class SecureTokenStore:
         """
         return self._tokens[name]
 
+    def register(self, name: str, value: str) -> None:
+        """Add or replace a token value.
+
+        Used by the process-wide registry below, which is populated as tokens
+        arrive rather than all at once in ``__init__``.
+        """
+        self._tokens[name] = value
+
+    def clear(self) -> None:
+        """Drop every stored token."""
+        self._tokens.clear()
+
     def masked(self, name: str) -> str:
         """Return a masked representation of the token for display.
 
@@ -73,3 +85,53 @@ def safe_sanitize(token_store: SecureTokenStore | None, text: str) -> str:
     if token_store is None:
         return text
     return token_store.sanitize(text)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide secret registry
+# ---------------------------------------------------------------------------
+#
+# The log handler is installed in ``main()``, long before any token exists:
+# ``FerryConfig.token_store`` is only built inside the engine
+# (``core/engine.py::_ensure_token_store``), and the GUI keeps its tokens in
+# NiceGUI's per-tab store. A redaction filter therefore cannot reach any
+# per-config store, so it consults this module-level one instead, and every
+# entry point registers its tokens here as they arrive.
+#
+# Module-level mutable state is an established pattern in this codebase --
+# ``migrator/api.py`` holds ``_circuit_state`` the same way, with
+# ``_reset_circuit_state()`` for tests. ``reset_secret_registry()`` is the
+# counterpart here and MUST be wired into the test fixtures: without it,
+# secrets registered by one test leak into the whole pytest session.
+
+_secret_registry: SecureTokenStore = SecureTokenStore({})
+
+
+def register_secret(name: str, value: str) -> None:
+    """Record *value* so the logging redaction filter can mask it.
+
+    Empty values are ignored -- ``SecureTokenStore.sanitize`` skips them anyway,
+    but rejecting them here keeps the registry meaningful.
+
+    Safe to call repeatedly with the same name; the last value wins.
+    """
+    if not value:
+        return
+    _secret_registry.register(name, value)
+
+
+def sanitize_secrets(text: str) -> str:
+    """Mask every registered secret in *text*.
+
+    Returns *text* unchanged when nothing is registered yet -- callers that need
+    a floor for that window must apply their own pattern-based redaction.
+    """
+    return _secret_registry.sanitize(text)
+
+
+def reset_secret_registry() -> None:
+    """Drop every registered secret. For tests only.
+
+    Mirrors ``migrator.api._reset_circuit_state``.
+    """
+    _secret_registry.clear()

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -16,9 +16,11 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from nicegui import app, background_tasks, ui
+from nicegui.client import ClientConnectionTimeout
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
+from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.errors import MigrationError
 from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
 from discord_ferry.state import load_state
@@ -138,6 +140,13 @@ def _clear_tokens(storage: MutableMapping[str, Any], keys: Iterable[str]) -> Non
 
 
 _EXPOSED_REACTION_MODES = ("text", "native", "skip")
+
+# NiceGUI 3.x defaults `Client.connected()` to `timeout=None`, i.e. wait forever.
+# A browser on the same machine connects in well under a second, so this only
+# bites on a genuinely dead client -- but it must be bounded, or a client that
+# never handshakes hangs the page silently (a second flavour of issue #123).
+# Comfortably longer than the reconnect_timeout=10.0 passed to ui.run().
+_CLIENT_CONNECT_TIMEOUT = 30.0
 
 
 def _coerce_advanced_settings(storage: Mapping[str, Any]) -> dict[str, Any]:
@@ -282,6 +291,18 @@ def _should_auto_export(cached: dict[str, int] | None) -> bool:
     cached JSON). See Batch 8 / F8a.
     """
     return cached is None
+
+
+def _log_path_hint() -> None:
+    """Show where the log file lives, for a user who has just hit a dead end.
+
+    This is the only place the path surfaces in the GUI, and deliberately so:
+    a persistent footer would be a new feature, which a patch release should
+    not add. Here it appears exactly where someone needs it.
+    """
+    path = configure_logging()
+    if path is not None:
+        ui.label(f"Details in {path}").classes("text-xs text-gray-500")
 
 
 def _render_step_indicator(active_step: int) -> None:
@@ -653,7 +674,7 @@ def setup_page() -> None:
                     # Store values. Tokens go to the memory-only tab store (never to
                     # disk); tab access needs a connected client — the await is a no-op
                     # during a live click but guarantees access. See Batch 8 / F8b.
-                    await ui.context.client.connected()
+                    await ui.context.client.connected(timeout=_CLIENT_CONNECT_TIMEOUT)
                     _store_session_tokens(app.storage.tab, stoat=token, discord=discord_token)
                     storage["mode"] = mode
                     storage["discord_server_id"] = discord_server
@@ -712,8 +733,16 @@ def setup_page() -> None:
 
 
 @ui.page("/export")
-def export_page() -> None:
-    """Export screen — run DCE subprocess, show per-channel progress."""
+async def export_page() -> None:
+    """Export screen — run DCE subprocess, show per-channel progress.
+
+    ``async def`` deliberately, mirroring :func:`migrate_page`. The client and the
+    tab-store tokens MUST be resolved here in the page builder, never inside the
+    ``background_tasks.create`` coroutine below: NiceGUI keys its slot stack by
+    ``id(asyncio.current_task())``, so a child task starts with an empty stack and
+    every ``ui.context`` lookup raises ``RuntimeError``. That is issue #123 — it
+    made this screen hang forever, silently, from v2.6.14 to v2.11.0.
+    """
     from discord_ferry.core.events import MigrationEvent as _MigrationEvent
 
     ui.add_head_html(_HEAD_HTML)
@@ -721,6 +750,23 @@ def export_page() -> None:
     storage = app.storage.user
     if storage.get("mode") != "orchestrated":
         ui.navigate.to("/validate")
+        return
+
+    # Resolve the client once, in the builder where the slot stack is live. Every
+    # background task below re-enters it with `with client:` so its UI calls work.
+    client = ui.context.client
+    try:
+        await client.connected(timeout=_CLIENT_CONNECT_TIMEOUT)
+    except ClientConnectionTimeout:
+        ui.label("Browser did not connect — reload this page.").classes("m-8 text-red-600")
+        _log_path_hint()
+        return
+
+    # Session-expired bounce lives HERE, not in the task: it needs tab access, and
+    # bouncing from the builder is what /migrate already does (see migrate_page).
+    if not app.storage.tab.get("discord_token"):
+        ui.notify("Session expired — re-enter your token", type="warning")
+        ui.navigate.to("/")
         return
 
     # Check for cached exports
@@ -754,11 +800,23 @@ def export_page() -> None:
                     # export_view / _run_export are defined below; closures are only
                     # invoked on click.
                     def _re_export() -> None:
+                        # Re-read the token at CLICK time, not from a value captured
+                        # in the builder. A previous run's `finally` clears it, so a
+                        # captured value would be stale on a second Re-export and we
+                        # would silently export with a dead token instead of bouncing.
+                        token_now = str(app.storage.tab.get("discord_token", ""))
+                        if not token_now:
+                            ui.notify("Session expired — re-enter your token", type="warning")
+                            ui.navigate.to("/")
+                            return
+                        # S8: one export at a time. Without this, repeated clicks stack
+                        # concurrent tasks writing into the same export directory.
+                        reexport_btn.disable()
                         cached_view.set_visibility(False)
                         export_view.set_visibility(True)
-                        background_tasks.create(_run_export())
+                        background_tasks.create(_run_export(token_now))
 
-                    ui.button("Re-export", on_click=_re_export).props("color=grey")
+                    reexport_btn = ui.button("Re-export", on_click=_re_export).props("color=grey")
 
     # --- Normal export UI ---
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10") as export_view:
@@ -819,7 +877,14 @@ def export_page() -> None:
                 # and should not be perturbed by liveness pings).
                 pass  # log_display.push() already happened above
 
-    async def _run_export() -> None:
+    async def _run_export(discord_token: str) -> None:
+        """Run the export. Receives the token as a plain value.
+
+        The whole body runs inside ``with client:`` so ``ui.notify`` and
+        ``ui.navigate.to`` resolve, and inside a single ``try`` so nothing can
+        fail before the first event reaches the log panel — the failure mode that
+        made #123 invisible.
+        """
         from discord_ferry.errors import DiscordAuthError, DotNetMissingError
         from discord_ferry.exporter import (
             detect_dotnet,
@@ -829,113 +894,108 @@ def export_page() -> None:
             validate_discord_token,
         )
 
-        # Tokens live in the memory-only tab store; need a connected client to read.
-        await ui.context.client.connected()
-        if not app.storage.tab.get("discord_token"):
-            # Restart edge: stale non-secret keys on disk but a fresh tab with no
-            # token. Bounce cleanly rather than raising DiscordAuthError("").
-            ui.notify("Session expired — re-enter your token", type="warning")
-            ui.navigate.to("/")
-            return
+        with client:
+            try:
+                # Inside the try: a missing export_dir used to raise KeyError out
+                # here, above the handler, and vanish without a trace.
+                discord_server = str(storage.get("discord_server_id", ""))
+                export_dir = Path(str(storage.get("export_dir", "")))
+                if not str(export_dir):
+                    raise MigrationError("No export directory configured — restart setup.")
 
-        discord_token = str(app.storage.tab.get("discord_token", ""))
-        discord_server = str(storage.get("discord_server_id", ""))
-        export_dir = Path(str(storage["export_dir"]))
-
-        try:
-            on_export_event(
-                _MigrationEvent(
-                    phase="export",
-                    status="started",
-                    message="Validating Discord token...",
+                on_export_event(
+                    _MigrationEvent(
+                        phase="export",
+                        status="started",
+                        message="Validating Discord token...",
+                    )
                 )
-            )
-            await validate_discord_token(discord_token)
+                await validate_discord_token(discord_token)
 
-            on_export_event(
-                _MigrationEvent(
-                    phase="export",
-                    status="progress",
-                    message="Checking for DCE binary...",
-                )
-            )
-            dce_path = get_dce_path()
-            if dce_path is None:
                 on_export_event(
                     _MigrationEvent(
                         phase="export",
                         status="progress",
-                        message="Downloading DCE...",
+                        message="Checking for DCE binary...",
                     )
                 )
-                dce_path = await download_dce(on_export_event)
+                dce_path = get_dce_path()
+                if dce_path is None:
+                    on_export_event(
+                        _MigrationEvent(
+                            phase="export",
+                            status="progress",
+                            message="Downloading DCE...",
+                        )
+                    )
+                    dce_path = await download_dce(on_export_event)
 
-            on_export_event(
-                _MigrationEvent(
-                    phase="export",
-                    status="progress",
-                    message="Verifying .NET 8 runtime...",
+                on_export_event(
+                    _MigrationEvent(
+                        phase="export",
+                        status="progress",
+                        message="Verifying .NET 8 runtime...",
+                    )
                 )
-            )
-            if not detect_dotnet():
-                raise DotNetMissingError(
-                    "DCE requires .NET 8 runtime. "
-                    "Install from https://dotnet.microsoft.com/download/dotnet/8.0"
+                if not detect_dotnet():
+                    raise DotNetMissingError(
+                        "DCE requires .NET 8 runtime. "
+                        "Install from https://dotnet.microsoft.com/download/dotnet/8.0"
+                    )
+
+                config = FerryConfig(
+                    export_dir=export_dir,
+                    stoat_url=str(storage.get("stoat_url", "")),
+                    token=str(app.storage.tab.get("token", "")),
+                    discord_token=discord_token,
+                    discord_server_id=discord_server,
+                    cancel_event=cancel_event,
                 )
 
-            config = FerryConfig(
-                export_dir=export_dir,
-                stoat_url=str(storage.get("stoat_url", "")),
-                token=str(app.storage.tab.get("token", "")),
-                discord_token=discord_token,
-                discord_server_id=discord_server,
-                cancel_event=cancel_event,
-            )
-
-            on_export_event(
-                _MigrationEvent(
-                    phase="export",
-                    status="progress",
-                    message="Launching DiscordChatExporter...",
+                on_export_event(
+                    _MigrationEvent(
+                        phase="export",
+                        status="progress",
+                        message="Launching DiscordChatExporter...",
+                    )
                 )
-            )
-            await run_dce_export(config, dce_path, on_export_event)
+                await run_dce_export(config, dce_path, on_export_event)
 
-            on_export_event(
-                _MigrationEvent(
-                    phase="export",
-                    status="completed",
-                    message="Export complete!",
+                on_export_event(
+                    _MigrationEvent(
+                        phase="export",
+                        status="completed",
+                        message="Export complete!",
+                    )
                 )
-            )
 
-            # Auto-navigate to validate
-            await asyncio.sleep(1)
-            ui.navigate.to("/validate")
+                # Auto-navigate to validate
+                await asyncio.sleep(1)
+                ui.navigate.to("/validate")
 
-        except DiscordAuthError as exc:
-            on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
-            ui.notify(f"Discord auth failed: {exc}", type="negative")
-        except DotNetMissingError as exc:
-            on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
-            ui.notify(str(exc), type="negative")
-        except Exception as exc:
-            on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
-            ui.notify(f"Export failed: {exc}", type="negative")
-        finally:
-            # Clear ONLY the Discord token here — export is its sole consumer.
-            # The Stoat token MUST survive for /migrate (which reads it from the
-            # tab store). The pre-migration page guards now check export_dir/
-            # stoat_url, and migrate re-checks the tab token after connected(), so
-            # clearing the Discord token here no longer bounces the user. Tokens
-            # live in the memory-only tab store; suppress in case the task is
-            # cancelled before connected() (the tab access would otherwise raise
-            # and mask the original exception).
-            with contextlib.suppress(Exception):
-                _clear_tokens(app.storage.tab, ("discord_token",))
+            except DiscordAuthError as exc:
+                on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
+                ui.notify(f"Discord auth failed: {exc}", type="negative")
+            except DotNetMissingError as exc:
+                on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
+                ui.notify(str(exc), type="negative")
+            except Exception as exc:
+                on_export_event(_MigrationEvent(phase="export", status="error", message=str(exc)))
+                ui.notify(f"Export failed: {exc}", type="negative")
+            finally:
+                # Clear ONLY the Discord token here — export is its sole consumer.
+                # The Stoat token MUST survive for /migrate (which reads it from the
+                # tab store). The pre-migration page guards now check export_dir/
+                # stoat_url, and migrate re-checks the tab token after connected(), so
+                # clearing the Discord token here no longer bounces the user. Tokens
+                # live in the memory-only tab store; suppress in case the task is
+                # cancelled before connected() (the tab access would otherwise raise
+                # and mask the original exception).
+                with contextlib.suppress(Exception):
+                    _clear_tokens(app.storage.tab, ("discord_token",))
 
     if _should_auto_export(cached):
-        background_tasks.create(_run_export())
+        background_tasks.create(_run_export(str(app.storage.tab.get("discord_token", ""))))
 
 
 # ---------------------------------------------------------------------------
@@ -1066,7 +1126,10 @@ async def migrate_page() -> None:
         return
 
     # Tokens live in the memory-only tab store; need a connected client to read it.
-    await ui.context.client.connected()
+    # `client` is captured here so the background tasks below can re-enter its slot;
+    # they cannot resolve `ui.context` themselves (issue #123).
+    client = ui.context.client
+    await client.connected(timeout=_CLIENT_CONNECT_TIMEOUT)
     if not app.storage.tab.get("token"):
         # Restart edge: stale non-secret keys on disk but a fresh tab, no token.
         ui.notify("Session expired — re-enter your token", type="warning")
@@ -1534,18 +1597,21 @@ async def migrate_page() -> None:
         rollback_btn.disable()
 
         async def _run() -> None:
-            try:
-                state = load_state(config.output_dir)
-                await run_rollback(config, state, exports=[], on_event=on_event)
-                ui.notify("Rollback complete!", type="positive")
-            except MigrationError as exc:
-                log_display.push(f"[ERROR] Rollback failed: {exc}")
-                ui.notify(f"Rollback failed: {exc}", type="negative")
-            except Exception as exc:
-                log_display.push(f"[ERROR] Unexpected error: {exc}")
-                ui.notify(f"Unexpected error: {exc}", type="negative")
-            finally:
-                rollback_btn.enable()
+            with client:
+                # Re-enter the client's slot: ui.notify below needs it, and a
+                # background task starts with an empty slot stack (issue #123).
+                try:
+                    state = load_state(config.output_dir)
+                    await run_rollback(config, state, exports=[], on_event=on_event)
+                    ui.notify("Rollback complete!", type="positive")
+                except MigrationError as exc:
+                    log_display.push(f"[ERROR] Rollback failed: {exc}")
+                    ui.notify(f"Rollback failed: {exc}", type="negative")
+                except Exception as exc:
+                    log_display.push(f"[ERROR] Unexpected error: {exc}")
+                    ui.notify(f"Unexpected error: {exc}", type="negative")
+                finally:
+                    rollback_btn.enable()
 
         background_tasks.create(_run())
 
@@ -1557,33 +1623,36 @@ async def migrate_page() -> None:
         # Wait for the user to choose Resume or Start Fresh before starting.
         await resume_choice_made.wait()
 
-        # Rebuild config with the final resume choice.
-        config.resume = bool(storage.get("resume", False))
+        with client:
+            # Same slot re-entry as the rollback task above: ui.notify is
+            # unreachable from a bare background task (issue #123).
+            # Rebuild config with the final resume choice.
+            config.resume = bool(storage.get("resume", False))
 
-        try:
-            await run_migration(config, on_event=on_event)
-        except MigrationError as exc:
-            log_display.push(f"[ERROR] Migration failed: {exc}")
-            errors_label.set_text(f"Errors: {error_count} (FAILED)")
-            ui.notify(f"Migration failed: {exc}", type="negative")
-        except Exception as exc:
-            log_display.push(f"[ERROR] Unexpected error: {exc}")
-            ui.notify(f"Unexpected error: {exc}", type="negative")
-        finally:
-            # Terminal owner of session-token cleanup, for BOTH offline and
-            # orchestrated modes, on success AND error. (Offline mode never
-            # visits /export, so its finally is the only cleanup point.) Tokens
-            # live in the memory-only tab store; clearing here is good hygiene
-            # (immediate, rather than waiting for the tab to close). Safe because
-            # this runs AFTER run_migration returns: config already holds its own
-            # token copy (a plain str), the engine never reads app.storage, and
-            # the only in-_run storage read (config.resume, above) has already
-            # completed. Do NOT move token reads below this. Suppress for parity
-            # with the export finally: if the tab closed during a long migration,
-            # this background task's tab access would otherwise raise on the now-
-            # disconnected client (the token is memory-only — never on disk).
-            with contextlib.suppress(Exception):
-                _clear_tokens(app.storage.tab, _SESSION_TOKEN_KEYS)
+            try:
+                await run_migration(config, on_event=on_event)
+            except MigrationError as exc:
+                log_display.push(f"[ERROR] Migration failed: {exc}")
+                errors_label.set_text(f"Errors: {error_count} (FAILED)")
+                ui.notify(f"Migration failed: {exc}", type="negative")
+            except Exception as exc:
+                log_display.push(f"[ERROR] Unexpected error: {exc}")
+                ui.notify(f"Unexpected error: {exc}", type="negative")
+            finally:
+                # Terminal owner of session-token cleanup, for BOTH offline and
+                # orchestrated modes, on success AND error. (Offline mode never
+                # visits /export, so its finally is the only cleanup point.) Tokens
+                # live in the memory-only tab store; clearing here is good hygiene
+                # (immediate, rather than waiting for the tab to close). Safe because
+                # this runs AFTER run_migration returns: config already holds its own
+                # token copy (a plain str), the engine never reads app.storage, and
+                # the only in-_run storage read (config.resume, above) has already
+                # completed. Do NOT move token reads below this. Suppress for parity
+                # with the export finally: if the tab closed during a long migration,
+                # this background task's tab access would otherwise raise on the now-
+                # disconnected client (the token is memory-only — never on disk).
+                with contextlib.suppress(Exception):
+                    _clear_tokens(app.storage.tab, _SESSION_TOKEN_KEYS)
 
     background_tasks.create(_run())
 
@@ -1771,6 +1840,15 @@ def main() -> None:
     # called, and NiceGUI only calls it deep inside ui.run(). Without this, the frozen
     # window child re-runs everything above ui.run() before diverting.
     multiprocessing.freeze_support()
+
+    # AFTER freeze_support(), never before. In the FROZEN build the PyInstaller
+    # bootloader re-runs this entry script for the native-window child process, so
+    # main() executes from the top and freeze_support() is what exits early -- put
+    # configure_logging() above it and both processes open the same
+    # RotatingFileHandler, which on Windows is a file lock. (In a non-frozen run the
+    # spawn child never reaches main() at all, so the ordering is merely inert
+    # there, not wrong.)
+    configure_logging()
 
     try:
         _run_gui()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
 from aiohttp.client_reqrep import ClientResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from discord_ferry.core import logging_setup
+from discord_ferry.core.security import reset_secret_registry
 
 # --- aioresponses / aiohttp 3.14 compatibility shim ---------------------------
 # aiohttp 3.14 made ``stream_writer`` a *required* keyword-only argument of
@@ -37,8 +43,38 @@ if "stream_writer" in inspect.signature(ClientResponse.__init__).parameters:
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+# NiceGUI's `user` fixture, for tests that must execute page code against a live
+# client. Register the NARROW plugin, never `nicegui.testing.plugin`: the
+# umbrella pulls in `screen_plugin`, which does `from selenium import webdriver`
+# at module level. Selenium is not a dependency of this project, so the umbrella
+# raises ModuleNotFoundError at collection time and aborts the ENTIRE suite.
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
 
 @pytest.fixture
 def fixtures_dir() -> Path:
     """Return the path to the test fixtures directory."""
     return FIXTURES_DIR
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ferry_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep `configure_logging()` away from the developer's real home directory.
+
+    `cli.main()` is a Click *group* callback, so Click runs it on EVERY
+    `CliRunner().invoke(main, ...)` regardless of subcommand -- and this suite
+    does that dozens of times. Without this fixture each of those invocations
+    would attach a real RotatingFileHandler under ~/.discord-ferry/logs/, and
+    they would stack for the whole session.
+
+    Autouse and unconditional: a test that opts out by accident is a test that
+    silently writes to the real filesystem.
+    """
+    monkeypatch.setattr(logging_setup, "_log_path", lambda: tmp_path / "ferry.log")
+    logging_setup.reset_logging()
+    reset_secret_registry()
+    try:
+        yield
+    finally:
+        logging_setup.reset_logging()
+        reset_secret_registry()

--- a/tests/nicegui_app.py
+++ b/tests/nicegui_app.py
@@ -1,0 +1,29 @@
+"""Test-only NiceGUI entry point for the `user` fixture.
+
+`nicegui_reset_globals()` clears `Client.page_routes`, so Ferry's `@ui.page`
+decorators must run again *inside* the simulation. NiceGUI's mechanism for that
+is to `runpy` a main file, which this is.
+
+Pointing the marker at the real `src/discord_ferry/gui.py` was rejected: runpy
+would also execute `main()` -> `_run_gui()` -> `finally: _teardown_native_window()`,
+which fires in CI (`uv sync --extra native`) but not on a dev machine without
+pywebview. A test harness whose behaviour depends on an optional extra is a
+harness that lies.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from nicegui import ui
+
+import discord_ferry.gui
+
+# Re-import for its side effect: the @ui.page decorators re-register the routes
+# that nicegui_reset_globals() just cleared.
+importlib.reload(discord_ferry.gui)
+
+# A no-op under simulation (nicegui/ui_run.py short-circuits on
+# helpers.is_user_simulation()), so this never starts a real server -- but it
+# still installs the storage secret, without which app.storage.user raises.
+ui.run(storage_secret="simulated-secret")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -403,36 +403,6 @@ def test_use_cached_clears_only_discord_token() -> None:
     assert "_SESSION_TOKEN_KEYS" not in use_cached_body
 
 
-def test_export_launch_is_gated() -> None:
-    """SC-4: the /export auto-launch is behind _should_auto_export(cached)."""
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    assert "if _should_auto_export(cached):" in source
-    # The ungated module-level auto-launch (4-space indented) must no longer exist.
-    assert "\n    background_tasks.create(_run_export())\n" not in source
-
-
-def test_reexport_button_launches_export() -> None:
-    """SC-5: 'Re-export' triggers _run_export (exactly one launch per intent)."""
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    # The re-export handler both toggles visibility AND launches the export.
-    assert "def _re_export() -> None:" in source
-    # Exactly two launch sites: the cached-absent gate + the re-export handler.
-    assert source.count("background_tasks.create(_run_export())") == 2
-
-
-# ---------------------------------------------------------------------------
-# Batch 8 — S2 token lifecycle (memory-only app.storage.tab)
-# ---------------------------------------------------------------------------
-
-
 def test_store_session_tokens_writes_exactly_two_keys() -> None:
     """SC-7: _store_session_tokens writes exactly token + discord_token, nothing else."""
     from discord_ferry.gui import _store_session_tokens
@@ -490,21 +460,6 @@ def test_tokens_never_disk_backed() -> None:
     # (c) the token input fields do NOT pre-fill from storage (value="" — no disk read)
     assert 'value=str(storage.get("token"' not in source
     assert 'value=str(storage.get("discord_token"' not in source
-
-
-def test_token_access_uses_connected_client() -> None:
-    """SC-11: token read/write sites await a connected client (tab access is then valid)."""
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    assert "async def _on_validate_click() -> None:" in source
-    assert "async def migrate_page() -> None:" in source
-    # validate-click, _run_export, migrate_page each await a connected client.
-    assert source.count("await ui.context.client.connected()") >= 3
-    # _run_export restart-bounce on a missing tab discord_token.
-    assert 'app.storage.tab.get("discord_token")' in source
 
 
 def test_page_guards_drop_token_term() -> None:

--- a/tests/test_gui_export_task.py
+++ b/tests/test_gui_export_task.py
@@ -1,0 +1,156 @@
+"""The issue #123 regression: the /export page must actually start exporting.
+
+For eleven releases (v2.6.14 -> v2.11.0) this screen showed "Preparing..." with an
+empty log panel forever, on every platform, because `_run_export` died on its
+first statement inside a `background_tasks.create` coroutine and the traceback
+went to a logger with no handler.
+
+Why these tests use the `user` fixture rather than a hand-rolled double:
+`user_simulation()` enters `core.app.router.lifespan_context`, which sets
+`app.is_started = True`. That matters because `Context.slot_stack` fabricates a
+pseudo-client whenever `not core.app.is_started` -- so under an ordinary pytest
+run `ui.context` *succeeds* and the defect is invisible. The fixture is the only
+harness here that reproduces the running server.
+
+It also fails any test carrying an ERROR log record, and NiceGUI routes uncaught
+background-task exceptions to exactly that -- so a regression surfaces even
+without an explicit assertion.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nicegui.testing import User
+
+pytestmark = pytest.mark.nicegui_main_file("tests/nicegui_app.py")
+
+# Assembled at runtime, never stored as a literal: a Discord-shaped string in a
+# committed file trips GitHub secret-scanning push protection (it did, on the
+# first push of this branch). The joined value still exercises the redaction
+# regex exactly as a real token would.
+DISCORD_TOKEN = ".".join(("MTIzNDU2Nzg5MDEyMzQ1Njc4", "GhIjKl", "abcdefghijklmnopqrstuvwxyz123"))
+STOAT_TOKEN = "SEKRET-stoat-token-abcd"  # noqa: S105
+
+
+@pytest.fixture
+def user_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """A writable stand-in for `app.storage.user`.
+
+    The real property is request-scoped (it reads a contextvar and a session
+    cookie), so a test body cannot seed it from outside a request. The page code
+    under test only ever treats it as a mapping.
+    """
+    store: dict[str, object] = {}
+    monkeypatch.setattr("nicegui.storage.Storage.user", property(lambda self: store), raising=False)
+    return store
+
+
+@pytest.fixture
+def tab_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """A writable stand-in for `app.storage.tab`.
+
+    The real property raises unless a connected client is resolvable from the
+    current task's slot stack -- which a test body does not have. That is the
+    very constraint this fix exists to respect, so the page code must still see
+    a plain mapping.
+    """
+    store: dict[str, object] = {}
+    monkeypatch.setattr("nicegui.storage.Storage.tab", property(lambda self: store), raising=False)
+    return store
+
+
+def _seed_orchestrated_session(store: dict[str, object], export_dir: Path) -> None:
+    """Put the user store into the state /export expects."""
+    store.update(
+        {
+            "mode": "orchestrated",
+            "export_dir": str(export_dir),
+            "discord_server_id": "123456789012345678",
+            "stoat_url": "https://example.invalid",
+        }
+    )
+
+
+async def test_export_page_reaches_the_first_progress_event(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-123-1: the #123 regression.
+
+    Pre-fix this hangs on "Preparing..." forever with an empty log panel. The
+    assertion is that the export actually *starts* -- i.e. `_run_export` got past
+    `ui.context.client`, which is the line that used to raise.
+    """
+    export_dir = tmp_path / "dce_cache"
+    export_dir.mkdir()
+    _seed_orchestrated_session(user_store, export_dir)
+
+    tab_store["discord_token"] = DISCORD_TOKEN
+    tab_store["token"] = STOAT_TOKEN
+
+    with (
+        patch("discord_ferry.exporter.validate_discord_token", new=AsyncMock()),
+        patch("discord_ferry.exporter.get_dce_path", return_value=tmp_path / "dce"),
+        patch("discord_ferry.exporter.detect_dotnet", return_value=True),
+        patch("discord_ferry.exporter.run_dce_export", new=AsyncMock()) as run_dce,
+    ):
+        await user.open("/export")
+        # should_see loops on asyncio.sleep, which is what actually hands the
+        # event loop to the background task. Asserting straight after open()
+        # would pass vacuously -- _on_handshake never suspends in the test path,
+        # so the task is merely *scheduled*, never run.
+        await user.should_see("Exporting from Discord")
+        # THE assertion. This string is emitted by the first on_export_event call
+        # inside _run_export. Pre-fix the task raised before reaching it, so the
+        # log panel stayed empty forever -- which is exactly issue #123.
+        await user.should_see("Validating Discord token")
+
+    assert run_dce.await_count == 1, (
+        "_run_export never reached run_dce_export — it died before launching DCE"
+    )
+
+
+async def test_export_page_bounces_when_the_tab_token_is_gone(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-123-4: the session-expired check must fire from the BUILDER.
+
+    It used to live inside `_run_export`; leaving it there while moving the token
+    reads would silently change when a stale-session user gets bounced.
+    """
+    export_dir = tmp_path / "dce_cache"
+    export_dir.mkdir()
+    _seed_orchestrated_session(user_store, export_dir)
+
+    tab_store.pop("discord_token", None)
+
+    await user.open("/export")
+    await user.should_not_see("Exporting from Discord")
+
+
+async def test_non_orchestrated_mode_redirects(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-123-7: guards the sync -> async page conversion.
+
+    An async page builder returns its response at a different point than a sync
+    one, so the early-return redirect is worth pinning.
+    """
+    user_store.update({"mode": "offline", "export_dir": str(tmp_path)})
+    await user.open("/export")
+    await user.should_not_see("Exporting from Discord")

--- a/tests/test_gui_task_slot_safety.py
+++ b/tests/test_gui_task_slot_safety.py
@@ -1,0 +1,291 @@
+"""Slot safety for NiceGUI background tasks (issue #123).
+
+NiceGUI keeps its "current slot" stack in ``Slot.stacks``, a plain dict keyed by
+``id(asyncio.current_task())`` -- **not** a ``contextvar``. Child tasks therefore
+do not inherit it, and ``background_tasks.create`` is just ``loop.create_task``.
+Every API that resolves ``ui.context.client`` (``ui.notify``, ``ui.navigate.to``,
+``app.storage.tab``) raises ``RuntimeError`` inside such a task.
+
+That killed the one-click GUI export on every platform from v2.6.14 to v2.11.0,
+silently, because the exception went to a logger with no handler.
+
+These tests are deliberately fixture-free. NiceGUI's ``user`` fixture replaces
+``ui.notify`` with ``UserNotify`` (which appends to a list) and ``ui.navigate``
+with ``UserNavigate`` (which reads ``Client.page_routes``); **neither touches
+``context.client``**, so the fixture cannot prove anything here. Using it would
+reproduce the original sin of this bug: a test that passes without exercising
+what it claims to.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from nicegui import context, core, ui
+from nicegui.client import Client
+from nicegui.slot import Slot, get_task_id
+
+from discord_ferry import gui
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def script_mode_off() -> Iterator[None]:
+    """Disable the pseudo-client hatch, then put it back.
+
+    ``Context.slot_stack`` fabricates a pseudo-client when
+    ``not core.app.is_started`` -- which is true under pytest -- so ``ui.context``
+    *succeeds* in a bare test and the defect is invisible. Forcing
+    ``core.script_mode`` short-circuits that same ``if``, reproducing the running
+    server's behaviour.
+
+    The reset is mandatory: ``nicegui_reset_globals()`` calls ``core.reset()``
+    only on ENTRY, never in its ``finally``, and this test does not use it at
+    all. A leaked ``script_mode = True`` makes ``app.storage.user`` return a
+    throwaway ``PseudoPersistentDict`` for the rest of the worker, silently
+    corrupting every later GUI test.
+    """
+    previous = core.script_mode
+    core.script_mode = True
+    try:
+        yield
+    finally:
+        core.script_mode = previous
+
+
+async def test_bare_background_task_cannot_resolve_the_client(
+    script_mode_off: None,
+) -> None:
+    """SC-123-8a: this is the #123 mechanism, reproduced.
+
+    A child task starts with an empty slot stack, so ``ui.context.client`` raises.
+    """
+    outcome: dict[str, object] = {}
+
+    async def child() -> None:
+        outcome["stack"] = list(Slot.get_stack())
+        try:
+            outcome["client"] = context.client
+        except RuntimeError as exc:
+            outcome["error"] = str(exc)
+
+    Slot.stacks[get_task_id()] = ["<page slot>"]
+    try:
+        await asyncio.get_running_loop().create_task(child())
+    finally:
+        Slot.stacks.pop(get_task_id(), None)
+
+    assert outcome["stack"] == [], "child task unexpectedly inherited a slot stack"
+    assert "error" in outcome, "expected RuntimeError; the defect did not reproduce"
+    assert "slot stack for this task is empty" in str(outcome["error"])
+
+
+async def test_with_client_restores_the_slot_in_a_background_task(
+    script_mode_off: None,
+) -> None:
+    """SC-123-8b: ``with client:`` is what makes the fix work.
+
+    Same child task as above, but re-entering the client's slot: ``context.client``
+    now resolves, and to the *same* client object.
+    """
+    client = Client(ui.page("/_slot_safety_probe"))
+    resolved: dict[str, object] = {}
+
+    async def child() -> None:
+        with client:
+            resolved["client"] = context.client
+        resolved["after"] = list(Slot.get_stack())
+
+    await asyncio.get_running_loop().create_task(child())
+
+    assert resolved["client"] is client
+    assert resolved["after"] == [], "slot stack must be popped on exit"
+
+
+async def test_slot_stack_is_pruned_when_the_task_is_cancelled(
+    script_mode_off: None,
+) -> None:
+    """SC-123-8c: a cancelled task must not leave its stack behind.
+
+    ``Slot.stacks`` is keyed by task id and ids are reused, so a leaked entry
+    would silently hand a later task somebody else's client.
+    """
+    client = Client(ui.page("/_slot_safety_probe_cancel"))
+    started = asyncio.Event()
+    task_ids: list[int] = []
+
+    async def child() -> None:
+        with client:
+            task_ids.append(get_task_id())
+            started.set()
+            await asyncio.sleep(60)
+
+    task = asyncio.get_running_loop().create_task(child())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task_ids, "child never entered the slot"
+    assert task_ids[0] not in Slot.stacks, "cancelled task leaked its slot stack"
+
+
+# ---------------------------------------------------------------------------
+# S6 — structural guard against reintroduction
+# ---------------------------------------------------------------------------
+
+
+class _BackgroundTaskAudit(ast.NodeVisitor):
+    """Find client-scoped lookups inside ``background_tasks.create`` targets.
+
+    Resolution is by SCOPE, not by name. ``gui.py`` contains two distinct
+    ``async def _run()`` closures -- one inside ``_start_rollback``, one directly
+    in ``migrate_page`` -- so a name-keyed walker would misattribute a violation
+    or silently skip one of them.
+    """
+
+    FORBIDDEN = ("context", "tab")
+
+    def __init__(self) -> None:
+        self.scopes: list[dict[str, ast.AsyncFunctionDef]] = [{}]
+        self.launched: set[ast.AsyncFunctionDef] = set()
+        self.violations: list[tuple[str, int]] = []
+
+    def _lookup(self, name: str) -> ast.AsyncFunctionDef | None:
+        for scope in reversed(self.scopes):
+            if name in scope:
+                return scope[name]
+        return None
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self.scopes[-1][node.name] = node
+        self.scopes.append({})
+        self.generic_visit(node)
+        self.scopes.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self.scopes.append({})
+        self.generic_visit(node)
+        self.scopes.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "create"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "background_tasks"
+            and node.args
+            and isinstance(node.args[0], ast.Call)
+            and isinstance(node.args[0].func, ast.Name)
+        ):
+            target = self._lookup(node.args[0].func.id)
+            if target is not None:
+                self.launched.add(target)
+        self.generic_visit(node)
+
+
+def _unguarded_client_lookups(fn: ast.AsyncFunctionDef) -> list[tuple[str, int]]:
+    """Return client-scoped lookups in *fn* that are not inside ``with client:``."""
+    guarded: set[int] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.With):
+            for item in node.items:
+                if isinstance(item.context_expr, ast.Name) and item.context_expr.id == "client":
+                    guarded.update(id(child) for child in ast.walk(node))
+
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Attribute) or id(node) in guarded:
+            continue
+        # ui.context.* and app.storage.tab
+        if node.attr in _BackgroundTaskAudit.FORBIDDEN and isinstance(
+            node.value, ast.Name | ast.Attribute
+        ):
+            found.append((fn.name, node.lineno))
+    return found
+
+
+def test_no_background_task_resolves_the_client_outside_with_client() -> None:
+    """SC-123-31: the structural guard, run against the real gui.py."""
+    tree = ast.parse(inspect.getsource(gui))
+    audit = _BackgroundTaskAudit()
+    audit.visit(tree)
+
+    assert audit.launched, "found no background_tasks.create targets — the audit is broken"
+
+    violations = [v for fn in audit.launched for v in _unguarded_client_lookups(fn)]
+    assert not violations, (
+        "client-scoped lookup inside a background task without `with client:` — "
+        f"this is issue #123: {violations}"
+    )
+
+
+def test_audit_resolves_the_two_colliding_run_closures() -> None:
+    """SC-123-33: scope-stack regression case.
+
+    ``gui.py`` has two separate ``async def _run()``. Both must be discovered as
+    distinct nodes; a name-keyed walker would collapse them into one.
+    """
+    tree = ast.parse(inspect.getsource(gui))
+    audit = _BackgroundTaskAudit()
+    audit.visit(tree)
+
+    runs = [fn for fn in audit.launched if fn.name == "_run"]
+    assert len(runs) == 2, f"expected two distinct `_run` closures, found {len(runs)}"
+    assert runs[0].lineno != runs[1].lineno
+
+
+def test_audit_flags_a_synthetic_violation() -> None:
+    """SC-123-32: the guard actually fails when it should.
+
+    Without this, a guard that silently matches nothing would pass forever — the
+    exact failure mode of the `inspect.getsource()` assertions it replaces.
+    """
+    source = (
+        "async def page():\n"
+        "    async def _task():\n"
+        "        await ui.context.client.connected()\n"
+        "    background_tasks.create(_task())\n"
+    )
+    audit = _BackgroundTaskAudit()
+    audit.visit(ast.parse(source))
+
+    assert len(audit.launched) == 1
+    violations = [v for fn in audit.launched for v in _unguarded_client_lookups(fn)]
+    assert violations, "guard failed to flag an obvious violation"
+    assert violations[0][0] == "_task"
+
+
+def test_narrow_nicegui_test_plugin_is_registered() -> None:
+    """SC-123-27: never register the umbrella plugin.
+
+    ``nicegui.testing.plugin`` imports ``screen_plugin``, which does
+    ``from selenium import webdriver`` at module level. Selenium is not a
+    dependency, so the umbrella aborts collection for the WHOLE suite.
+    """
+    # Read the ASSIGNED value, not the file text: conftest.py names the umbrella
+    # in a comment explaining why it must not be used, and a substring check would
+    # match that comment.
+    tree = ast.parse((Path(__file__).parent / "conftest.py").read_text(encoding="utf-8"))
+    assigned: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "pytest_plugins" for t in node.targets
+        ):
+            assigned = [
+                elt.value
+                for elt in getattr(node.value, "elts", [])
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+            ]
+
+    assert assigned == ["nicegui.testing.user_plugin"], (
+        f"pytest_plugins must register only the narrow plugin, got {assigned}"
+    )

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,227 @@
+"""Always-on file logging and token redaction.
+
+Ferry's GUI binary is built with ``console=False``, so ``sys.stderr`` is ``None``
+and ``logging.lastResort`` silently discards everything. That is why issue #123
+was undiagnosable for eleven releases. These tests cover the replacement.
+
+The redaction tests matter more than they look: this log file is the artifact we
+will ask users to attach to bug reports, so a leak here publishes tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from discord_ferry.core import logging_setup
+from discord_ferry.core.security import register_secret, reset_secret_registry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+STOAT_TOKEN = "SEKRET-stoat-token-abcd"  # noqa: S105 - test fixture, not a real credential
+# Assembled at runtime, never stored as a literal: a Discord-shaped string in a
+# committed file trips GitHub secret-scanning push protection (it did, on the
+# first push of this branch). The joined value still exercises the redaction
+# regex exactly as a real token would.
+DISCORD_TOKEN = ".".join(("MTIzNDU2Nzg5MDEyMzQ1Njc4", "GhIjKl", "abcdefghijklmnopqrstuvwxyz123"))
+
+
+@pytest.fixture
+def log_file(tmp_path: Path) -> Path:
+    """A configured log file. The autouse conftest fixture handles teardown."""
+    path = logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    assert path is not None
+    return path
+
+
+def _read(path: Path) -> str:
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring
+# ---------------------------------------------------------------------------
+
+
+def test_configure_logging_creates_the_file(log_file: Path) -> None:
+    """SC-123-14."""
+    logging.getLogger("discord_ferry.test").info("hello")
+    assert "hello" in _read(log_file)
+
+
+def test_configure_logging_adds_only_a_file_handler(tmp_path: Path) -> None:
+    """SC-123-15: Rich and click.echo own the console.
+
+    A StreamHandler here would double every line the CLI prints. Measured as a
+    DELTA -- pytest attaches its own stream handlers to the root logger, so an
+    absolute check would fail for reasons that have nothing to do with Ferry.
+    """
+    root = logging.getLogger()
+    before = list(root.handlers)
+    logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    added = [h for h in root.handlers if h not in before]
+
+    assert len(added) == 1, f"expected exactly one new handler, got {added}"
+    assert isinstance(added[0], logging.FileHandler)
+
+
+def test_configure_logging_is_idempotent(tmp_path: Path) -> None:
+    """SC-123-23: repeated calls must not stack handlers.
+
+    `cli.main()` is a Click GROUP callback, so it runs on every
+    `CliRunner().invoke(main, ...)` — dozens of times per session.
+    """
+    logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    before = len(logging.getLogger().handlers)
+    logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    assert len(logging.getLogger().handlers) == before
+
+
+def test_unwritable_path_degrades_gracefully(tmp_path: Path) -> None:
+    """SC-123-22: logging is a diagnostic aid, never a startup dependency."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    assert logging_setup.configure_logging(path=blocker / "sub" / "ferry.log") is None
+
+
+def test_reset_detaches_the_handler(tmp_path: Path) -> None:
+    """SC-123-24: mirrors api._reset_circuit_state."""
+    logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    logging_setup.reset_logging()
+    assert not [h for h in logging.getLogger().handlers if h.get_name() == "ferry-file"]
+
+
+def test_debug_records_do_not_reach_the_file(log_file: Path) -> None:
+    """SC-123-26: messages.py logs per message at DEBUG.
+
+    Letting those through would bury the signal and burn through rotation on a
+    large migration.
+    """
+    logging.getLogger("discord_ferry.migrator.messages").debug("per-message noise")
+    assert "per-message noise" not in _read(log_file)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_registered_token_is_masked(log_file: Path) -> None:
+    """SC-123-17: the registry layer."""
+    register_secret("stoat", STOAT_TOKEN)
+    logging.getLogger("discord_ferry.test").warning("connecting with %s" % STOAT_TOKEN)  # noqa: UP031
+    body = _read(log_file)
+    assert STOAT_TOKEN not in body
+    assert "****abcd" in body
+
+
+def test_token_in_deferred_arg_is_masked(log_file: Path) -> None:
+    """SC-123-18: the round-1 Critical.
+
+    A `logging.Filter` sees `record.msg` (the template) and `record.args`
+    separately — the final string is only built later by `record.getMessage()`.
+    A filter that sanitises `record.msg` alone leaks anything passed as `%s`.
+
+    This is not hypothetical: `exporter/runner.py` does
+    `logger.debug("DCE: %s", line)` with raw DCE stdout, and DCE is invoked with
+    the Discord token on its command line.
+    """
+    register_secret("stoat", STOAT_TOKEN)
+    logging.getLogger("discord_ferry.test").warning("DCE: %s", STOAT_TOKEN)
+
+    body = _read(log_file)
+    assert STOAT_TOKEN not in body, "token leaked via record.args — filter used record.msg only"
+    assert "****abcd" in body
+
+
+def test_unregistered_discord_token_is_caught_by_the_pattern(log_file: Path) -> None:
+    """SC-123-19: the regex floor covers records emitted before registration.
+
+    The registry cannot help before `register_secret` runs, and there IS such a
+    window — `configure_logging()` is called in `main()`, long before any token
+    exists.
+    """
+    reset_secret_registry()
+    logging.getLogger("discord_ferry.test").warning("auth header: %s", DISCORD_TOKEN)
+    assert DISCORD_TOKEN not in _read(log_file)
+
+
+def test_traceback_is_redacted(log_file: Path) -> None:
+    """A token inside an exception message must not survive into the file.
+
+    NiceGUI routes uncaught background-task exceptions to logging, so this is
+    exactly the path #123-class failures now travel — and exception messages
+    routinely quote the token that caused the failure.
+
+    `propagate = False` is load-bearing. `record.exc_text` is None while filters
+    run and is only populated by `Formatter.format()`. Under pytest, the logging
+    plugin's own handler formats the record FIRST, pre-populating that field —
+    so a filter-based redactor passes this test while leaking in production.
+    Isolating the logger means only Ferry's handler ever sees the record, which
+    is what production looks like.
+    """
+    register_secret("stoat", STOAT_TOKEN)
+    logger = logging.getLogger("discord_ferry.isolated_traceback_probe")
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    for handler in logging.getLogger().handlers:
+        if handler.get_name() == "ferry-file":
+            logger.addHandler(handler)
+
+    try:
+        try:
+            raise ValueError(f"bad token {STOAT_TOKEN} in message")
+        except ValueError:
+            logger.exception("boom")
+        body = _read(log_file)
+    finally:
+        logger.handlers.clear()
+        logger.propagate = True
+
+    assert "Traceback" in body, "no traceback was written — the test proves nothing"
+    assert STOAT_TOKEN not in body, "raw token leaked via the traceback"
+    assert "****abcd" in body
+
+
+def test_registry_reset_clears_secrets(log_file: Path) -> None:
+    """Registry state must not leak between tests."""
+    register_secret("stoat", STOAT_TOKEN)
+    reset_secret_registry()
+    logging.getLogger("discord_ferry.test").warning("value is %s", STOAT_TOKEN)
+    # Nothing registered and not Discord-shaped, so it passes through unmasked —
+    # this asserts the reset actually happened, not that leaking is acceptable.
+    assert STOAT_TOKEN in _read(log_file)
+
+
+# ---------------------------------------------------------------------------
+# Entry-point wiring
+# ---------------------------------------------------------------------------
+
+
+def test_probe_command_registers_its_token() -> None:
+    """SC-123-20: `run_probe` builds no FerryConfig and no SecureTokenStore.
+
+    Without an explicit hook in `probe_cmd`, the Stoat token passed to
+    `ferry probe` has ZERO redaction coverage — and the regex floor deliberately
+    cannot match Stoat tokens (opaque base64url).
+    """
+    import inspect
+
+    from discord_ferry import cli
+
+    source = inspect.getsource(cli.probe_cmd.callback)
+    assert "register_secret" in source, "probe_cmd must register its token"
+
+
+def test_cli_group_configures_logging() -> None:
+    """SC-123-25 companion: the wiring exists at the group callback."""
+    import inspect
+
+    from discord_ferry import cli
+
+    assert "configure_logging()" in inspect.getsource(cli.main.callback)

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.11.0"
+version = "2.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #123.

## What was broken

The one-click GUI export showed **"Preparing…"** with an empty log panel and no CPU, disk or network activity, indefinitely. DiscordChatExporter was never launched.

**Every release from v2.6.14 (2026-06-28) through v2.11.0 is affected, on every platform** — eleven releases, six weeks. The "I already have exports" path and the CLI were never affected.

## Root cause

`_run_export` runs in a `background_tasks.create` coroutine, and its first statement was `await ui.context.client.connected()`.

NiceGUI keeps its current-slot stack in `Slot.stacks`, a dict keyed by `id(asyncio.current_task())` — **not** a `contextvar`. Child tasks therefore don't inherit it, so a background task starts with an empty stack and `Context.slot` raises `RuntimeError` immediately.

It was silent because the exception routes to `logging.getLogger('nicegui')`, Ferry configured no logging handler anywhere, and the GUI binary is built with `console=False` so `sys.stderr is None` and `logging.lastResort` no-ops. **The traceback was written nowhere.**

Introduced by `acbaf9b` (v2.6.14), which moved session tokens into `app.storage.tab`.

## Why CI never caught it

`Context.slot_stack` fabricates a pseudo-client whenever `not core.app.is_started` — which is true under pytest. The same code therefore *succeeds* in a test and fails in a running server.

Compounding that, `tests/test_gui.py` "covered" this path with assertions on `inspect.getsource()` text:

```python
assert source.count("await ui.context.client.connected()") >= 3
```

Those passed for eleven releases against code that could not run.

## The fix

Page builders resolve the client and the tab tokens; each background task wraps its body in `with client:`, which re-enters `client.content`'s slot. One idiom, all four tasks — mirroring `migrate_page`, which already worked.

The same fault silently suppressed the "Migration complete!" / "Rollback complete!" toasts and aborted the rollback task before its success path. All four are fixed together.

Also fixed:
- **Unbounded client waits.** NiceGUI 3.x defaults `connected()` to `timeout=None`. Now bounded, with the log path named in the timeout message.
- **A missing export directory** raised outside the error handler and vanished silently.
- **Re-export** stacked concurrent exports into one directory, and a retry after the session token was cleared exported with a stale value instead of bouncing.

## Added: an always-on log file

`~/.discord-ferry/logs/ferry.log` (2 MB × 3 rotations). Nothing that failed in the background left a trace anywhere before this — which is the reason the bug survived eleven releases.

Tokens are masked before anything is written, including deferred `%s` arguments and text inside tracebacks. Redaction lives in the **Formatter**, not a Filter: `record.exc_text` is `None` while filters run and is only populated by `Formatter.format()` afterwards, so a filter-based redactor leaks the traceback — and passes its own test under pytest, whose logging plugin populates the field first. That was caught at the ship gate and is covered by a regression test that isolates its logger.

## Verification

- `ruff check` · `ruff format --check .` · `mypy --strict` — clean
- **1420 tests pass**
- **Every new test was confirmed failing against pre-fix code before being accepted.** Verified in a `git worktree` at `main`: they fail with the exact `RuntimeError: The current slot cannot be determined…`. The AST guard reports 6 violations on pre-fix `gui.py` and 0 after.
- **Manual end-to-end run in a browser.** With a deliberately invalid token the export screen now shows `[started] Validating Discord token...` followed by the auth error, instead of hanging on "Preparing…". Neither token appeared in the log file.

## Process

Full design pipeline: brief → spec (rev 3, 35 scenarios) → brainstorm → critique → test-scenarios → plan → build → ship. Three fresh-context critique rounds found **5 Critical and 10 Important** issues before any code was written; the ship-gate review found one more (the traceback leak above).

## Not included

Deferred to v2.12.0, tracked separately: the native-window fallback for a dead WebView2 renderer, frozen-exe argv dispatch, documentation corrections (several pages still claim the browser opens automatically — it does not), and the bug-report template.

A Windows `.exe` smoke test is still outstanding — #123 was reported against the Windows binary, and packaging is only exercised on tags, `workflow_dispatch`, or PRs touching `ferry.spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
