### PR TITLE
chore(ci): launch the Windows exe we build, and fix the signing step's shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,70 @@ jobs:
       - name: Build executable
         run: uv run --extra dev pyinstaller ferry.spec
 
+      # Launch what we just built. Nothing else in CI ever executes the frozen
+      # binary -- ci.yml is ubuntu-only and runs the source tree, so a defect that
+      # exists only in the packaged Windows app ships unseen. That is exactly what
+      # happened with issue #123: a fault that killed the export on every platform
+      # survived eleven releases because no test ran the real thing.
+      #
+      # Scope: this proves the exe boots, serves, and writes its log. It cannot
+      # reproduce a missing WebView2 runtime (the runner has Edge installed), so
+      # the blank-window symptom of #123 is out of reach here by design.
+      - name: Smoke-test the built binary
+        shell: pwsh
+        run: |
+          $exe = "dist/Ferry.exe"
+          $log = Join-Path $env:USERPROFILE ".discord-ferry\logs\ferry.log"
+          Remove-Item $log -ErrorAction SilentlyContinue
+
+          $proc = Start-Process $exe -PassThru
+          Write-Host "launched pid $($proc.Id)"
+
+          # Onefile unpacks ~46 MB to a temp dir before Python even starts, so be
+          # generous: a slow runner is not a failure.
+          $served = $false
+          foreach ($i in 1..45) {
+            Start-Sleep -Seconds 2
+            if ($proc.HasExited) { break }
+            try {
+              $r = Invoke-WebRequest "http://127.0.0.1:8765/" -TimeoutSec 3 -UseBasicParsing
+              if ($r.StatusCode -eq 200) { $served = $true; Write-Host "served after ~$($i*2)s"; break }
+            } catch { }
+          }
+
+          # Kill the whole tree: native mode runs the pywebview window in a child.
+          taskkill /T /F /PID $proc.Id 2>&1 | Out-Null
+
+          if (-not $served) {
+            Write-Host "::error::Ferry.exe never served on 127.0.0.1:8765"
+            if ($proc.HasExited) { Write-Host "process exited early, code $($proc.ExitCode)" }
+            if (Test-Path $log) { Write-Host "--- ferry.log ---"; Get-Content $log }
+            exit 1
+          }
+
+          # The log is the diagnostic added in v2.11.1. If it is missing here, the
+          # frozen build cannot report its own failures -- the condition that made
+          # #123 undiagnosable.
+          if (-not (Test-Path $log)) {
+            Write-Host "::error::no ferry.log written to $log"
+            exit 1
+          }
+          Write-Host "smoke test passed: served on :8765, log at $log"
+
       - name: Sign Windows binary
         if: env.HAS_WINDOWS_CERT == 'true'
         env:
           WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        # shell: bash is load-bearing -- windows-latest defaults to pwsh, where
+        # `base64 -d` and `del` are not valid. This step has never run (the cert
+        # secret is unset), so the breakage was latent: it would have failed the
+        # first time signing was actually enabled.
+        shell: bash
         run: |
           echo "$WINDOWS_CERT_PFX" | base64 -d > cert.pfx
           signtool sign /fd SHA256 /f cert.pfx /p "$WINDOWS_CERT_PASSWORD" dist/Ferry.exe
-          del cert.pfx
+          rm -f cert.pfx
 
       - name: Rename artifact
         run: mv dist/Ferry.exe dist/Ferry-windows-x86_64.exe


### PR DESCRIPTION
Follow-up to #124. Closes the last outstanding item from that PR's "not included" list.

## Why

**Nothing in CI has ever executed the frozen Windows binary.** `ci.yml` is ubuntu-only and runs the source tree; `release.yml` builds `Ferry.exe` on `windows-latest` and immediately uploads it without launching it once.

That is how #123 survived eleven releases — a fault that killed the export on every platform, in a code path no automated test ran.

## What

The `build-windows` job now launches what it just built, polls `127.0.0.1:8765` until it serves, and asserts `ferry.log` was written. The process tree is killed afterwards (native mode runs the pywebview window in a child). 90s budget, because onefile unpacks ~46 MB before Python starts.

On failure it prints the exit code and dumps `ferry.log`, so a red build is actionable rather than just red.

**Scope, stated plainly:** this proves the exe boots, serves, and can report its own failures. It **cannot** reproduce a missing WebView2 runtime — the runner has Edge installed — so the blank-window symptom of #123 is out of reach here by design. That remains a v2.12.0 item.

## Also

The signing step lacked `shell: bash`, so `base64 -d` and `del` ran under pwsh, where neither is valid. It has never executed (the cert secret is unset), so the breakage was latent — it would have surfaced the first time signing was switched on. `del` → `rm -f` to match.

## Verification

This PR touches `release.yml`, so it triggers the packaging path and **the smoke test runs on itself**. Watch the `build-windows` job.

No version bump — CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)