### PR TITLE
feat: the packaged binary now accepts command-line arguments (#123)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
         env:
           WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-        # shell: bash is load-bearing -- windows-latest defaults to pwsh, where
+        # shell: bash is required here -- windows-latest defaults to pwsh, where
         # `base64 -d` and `del` are not valid. This step has never run (the cert
         # secret is unset), so the breakage was latent: it would have failed the
         # first time signing was actually enabled.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,36 @@ jobs:
           }
           Write-Host "--version OK ($expected)"
 
+          # --- AttachConsole path (issue #123 symptom 3, no redirection) ---
+          # This check must not use Invoke-Ferry. Invoke-Ferry redirects
+          # stdout and stderr, which gives the process a real inherited
+          # stdout handle. That handle satisfies step 1 of the console
+          # ladder (_stdout_is_usable), so AttachConsole is never called and
+          # the --help and --version checks above never exercise it.
+          #
+          # With no redirection, step 1 fails and acquire_console() must
+          # call _attach_parent_console(). If AttachConsole succeeds, Click
+          # runs and exits 0. If it fails, acquire_console() returns False,
+          # should_run_cli() returns False, and gui.main() runs instead.
+          # gui.main() does not exit. A bounded wait that returns exit code
+          # 0 shows the attach path ran and worked. A timeout shows it did
+          # not.
+          #
+          # Keep this check separate from Invoke-Ferry. Adding redirection
+          # here would remove the only coverage of the attach path.
+          $attachTimeoutMs = 30000
+          $attachProc = Start-Process -FilePath $exe -ArgumentList '--help' -PassThru
+          if (-not $attachProc.WaitForExit($attachTimeoutMs)) {
+            taskkill /T /F /PID $attachProc.Id 2>&1 | Out-Null
+            Write-Host "::error::Ferry.exe --help with no redirection did not exit within $attachTimeoutMs ms. AttachConsole may have failed and the GUI may have launched instead."
+            exit 1
+          }
+          if ($attachProc.ExitCode -ne 0) {
+            Write-Host "::error::Ferry.exe --help with no redirection exited $($attachProc.ExitCode)"
+            exit 1
+          }
+          Write-Host "AttachConsole path OK: no redirection, exited 0"
+
       - name: Sign Windows binary
         if: env.HAS_WINDOWS_CERT == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,56 @@ jobs:
           }
           Write-Host "smoke test passed: served on :8765, log at $log"
 
+          # --- CLI dispatch (issue #123 symptom 3) ---
+          # System.Diagnostics.Process, NOT Start-Process: this needs captured
+          # stdout AND a bounded wait. Redirected stdout is also what satisfies
+          # step 1 of the console ladder. Without it the GUI fallback fires and
+          # this check proves nothing.
+          function Invoke-Ferry([string[]]$FerryArgs, [int]$TimeoutMs = 30000) {
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName = (Resolve-Path $exe).Path
+            $psi.Arguments = $FerryArgs -join ' '
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.UseShellExecute = $false
+            $p = [System.Diagnostics.Process]::Start($psi)
+            # Start BOTH reads before waiting, and read them asynchronously.
+            # Microsoft documents two separate deadlocks here. Calling
+            # WaitForExit before reading deadlocks once the child fills a pipe
+            # buffer. Calling ReadToEnd on stdout and then ReadToEnd on stderr
+            # deadlocks the same way if the child fills the stream that is not
+            # being read yet. ReadToEndAsync on both avoids both cases.
+            $outTask = $p.StandardOutput.ReadToEndAsync()
+            $errTask = $p.StandardError.ReadToEndAsync()
+            if (-not $p.WaitForExit($TimeoutMs)) {
+              $p.Kill($true)
+              throw "Ferry.exe $($FerryArgs -join ' ') did not exit within $TimeoutMs ms"
+            }
+            return @{ Out = $outTask.Result; Err = $errTask.Result; Code = $p.ExitCode }
+          }
+
+          $help = Invoke-Ferry @('--help')
+          if ($help.Code -ne 0) {
+            Write-Host "::error::--help exited $($help.Code)"
+            Write-Host $help.Out; Write-Host $help.Err
+            exit 1
+          }
+          if ($help.Out -notmatch 'Usage') {
+            Write-Host "::error::--help printed no usage text"
+            Write-Host "stdout: [$($help.Out)]"; Write-Host "stderr: [$($help.Err)]"
+            exit 1
+          }
+          Write-Host "--help OK"
+
+          $expected = (Select-String -Path pyproject.toml -Pattern '^version = "(.+)"').Matches[0].Groups[1].Value
+          $ver = Invoke-Ferry @('--version')
+          if ($ver.Code -ne 0 -or $ver.Out -notmatch [regex]::Escape($expected)) {
+            Write-Host "::error::--version did not report $expected"
+            Write-Host "stdout: [$($ver.Out)] exit: $($ver.Code)"
+            exit 1
+          }
+          Write-Host "--version OK ($expected)"
+
       - name: Sign Windows binary
         if: env.HAS_WINDOWS_CERT == 'true'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-08-06
+
+### Added
+
+- **The packaged app now accepts command-line arguments.** `Ferry.exe --help`,
+  `--version`, and every existing command (`migrate`, `rollback`, `probe`,
+  `stats`, `export-blueprint`) work from PowerShell. Previously the binary
+  ignored every argument and opened the GUI with no output (issue #123).
+
+  On Windows the `.exe` is the only artifact, and `pipx install discord-ferry`
+  was the only alternative route to the CLI.
+
+  Because the app is windowed, output arrives after your shell has already
+  printed its next prompt. When launched with no console at all, such as from
+  a service, a scheduled task, or a file dropped onto the icon, it opens the
+  GUI instead of running the command, so arguments never fail without any
+  output.
+
+- **Added `ferry --version`.**
+
 ## [2.11.1] - 2026-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - **The packaged app now accepts command-line arguments.** `Ferry.exe --help`,
-  `--version`, and every existing command (`migrate`, `rollback`, `probe`,
-  `stats`, `export-blueprint`) work from PowerShell. Previously the binary
-  ignored every argument and opened the GUI with no output (issue #123).
+  `--version`, and every existing command (`migrate`, `validate`, `build`,
+  `export-blueprint`, `stats`, `rollback`, `probe`) work from PowerShell.
+  Previously the binary ignored every argument and opened the GUI with no
+  output (issue #123).
 
   On Windows the `.exe` is the only artifact, and `pipx install discord-ferry`
   was the only alternative route to the CLI.
@@ -21,8 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Because the app is windowed, output arrives after your shell has already
   printed its next prompt. When launched with no console at all, such as from
   a service, a scheduled task, or a file dropped onto the icon, it opens the
-  GUI instead of running the command, so arguments never fail without any
-  output.
+  GUI instead of running the command; the arguments passed to it are not
+  acted on when that happens.
 
 - **Added `ferry --version`.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.11.1"
+version = "2.12.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.11.1"
+__version__ = "2.12.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -21,6 +21,7 @@ from rich.markup import escape
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 from rich.table import Table
 
+from discord_ferry import __version__
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.core.logging_setup import configure_logging
@@ -655,6 +656,7 @@ def _build_config(kwargs: dict[str, Any]) -> FerryConfig:
 
 
 @click.group(invoke_without_command=True)
+@click.version_option(__version__, "--version", prog_name="ferry")
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """Migrate a Discord server export to Stoat."""

--- a/src/discord_ferry/core/entry.py
+++ b/src/discord_ferry/core/entry.py
@@ -1,0 +1,114 @@
+"""Entry-point dispatch and console acquisition for the frozen binary.
+
+PyInstaller's entry script is gui.py, whose main() never read sys.argv, so the
+packaged Ferry.exe discarded every argument including --help (issue #123). It is
+also built with console=False, which means that on Windows sys.stdout and
+sys.stderr are None and no console is attached, so dispatching alone would still
+produce no output. Both concerns live here to keep ctypes out of the UI module.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["acquire_console", "run_cli", "should_run_cli"]
+
+_MP_FORK_FLAG = "--multiprocessing-fork"
+
+
+def _stdout_is_usable() -> bool:
+    """Whether sys.stdout can actually be written to.
+
+    In a PyInstaller `console=False` build sys.stdout is None, unless the parent
+    supplied a handle. That happens under redirection, pipes, and CI.
+    """
+    stream = sys.stdout
+    return stream is not None and hasattr(stream, "write")
+
+
+def _attach_parent_console() -> bool:
+    """Attach to the launching shell's console and rebind the std streams.
+
+    Windows only. Returns False when there is no parent console to attach to,
+    such as a file dropped on the exe or a launch from Explorer.
+
+    CONIN$ matters as much as CONOUT$: full delegation exposes `migrate` and
+    `rollback`, and both prompt through click.confirm. Without stdin they would
+    hang on a prompt the user cannot see, which is worse than the current
+    behaviour of producing no output at all.
+    """
+    import ctypes
+
+    attach_parent_process = -1
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]  # win32-only attribute
+    if not kernel32.AttachConsole(attach_parent_process):
+        return False
+
+    try:
+        sys.stdout = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
+        sys.stderr = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
+        sys.stdin = open("CONIN$", encoding="utf-8")  # noqa: SIM115
+    except OSError:
+        return False
+    return True
+
+
+def acquire_console() -> bool:
+    """Ensure this process can print, returning False when it cannot.
+
+    Three steps, in this order:
+
+    1. sys.stdout already usable, so use it (redirection, pipes, CI)
+    2. Windows: AttachConsole, then reopen CONOUT$ and CONIN$
+    3. otherwise, no console is available
+
+    Step 1 must precede step 2. Attaching to a parent console when the caller
+    redirected our output would overwrite that redirection.
+    """
+    if _stdout_is_usable():
+        return True
+    if sys.platform != "win32":
+        # A POSIX binary launched from a shell inherits working streams. If it
+        # did not, there is nothing platform-specific left to try.
+        return True
+    return _attach_parent_console()
+
+
+def should_run_cli(argv: Sequence[str]) -> bool:
+    """Whether this process should hand off to the Click CLI.
+
+    Four conditions, all required:
+
+    1. Arguments were actually passed.
+    2. The process is FROZEN. gui.main() is also the entry point for the
+       `ferry-gui` and `ferry-desktop` console scripts, and for pytest, where
+       sys.argv routinely carries unrelated arguments.
+    3. The argv is not the pywebview spawn child's. freeze_support() exits
+       first in production, so this is belt and braces.
+    4. A console is available. See acquire_console(). Running a CLI whose output
+       goes nowhere is the defect being fixed, not the fix.
+    """
+    if len(argv) <= 1:
+        return False
+    if not getattr(sys, "frozen", False):
+        return False
+    if _MP_FORK_FLAG in argv:
+        return False
+    return acquire_console()
+
+
+def run_cli() -> NoReturn:
+    """Hand off to the Click CLI and exit the process.
+
+    Delegates to the bound `cli_main.main()`, not `cli_main()`: only
+    `Command.main()` carries Click's NoReturn overload, `Command.__call__` is
+    typed `-> Any`. The import is local so a non-frozen GUI launch never pulls
+    in the CLI's dependency surface.
+    """
+    from discord_ferry.cli import main as cli_main
+
+    cli_main.main()

--- a/src/discord_ferry/core/entry.py
+++ b/src/discord_ferry/core/entry.py
@@ -30,18 +30,6 @@ def _stdout_is_usable() -> bool:
     return stream is not None and hasattr(stream, "write")
 
 
-def _stdin_is_usable() -> bool:
-    """Whether sys.stdin can actually be read from.
-
-    Same reasoning and same shape as _stdout_is_usable(). Checked alongside it
-    in acquire_console() because `migrate` and `rollback` prompt through
-    click.confirm(): a usable stdout with an unusable stdin still hangs on a
-    prompt the user cannot answer.
-    """
-    stream = sys.stdin
-    return stream is not None and hasattr(stream, "read")
-
-
 def _attach_parent_console() -> bool:
     """Attach to the launching shell's console and rebind the std streams.
 
@@ -81,21 +69,27 @@ def acquire_console() -> bool:
 
     Three steps, in this order:
 
-    1. sys.stdout AND sys.stdin already usable, so use them (redirection,
-       pipes, CI)
+    1. sys.stdout already usable, so use it (redirection, pipes, CI)
     2. Windows: AttachConsole, then reopen CONOUT$ and CONIN$
     3. otherwise, no console is available
 
     Step 1 must precede step 2. Attaching to a parent console when the caller
     redirected our output would overwrite that redirection.
 
-    Step 1 also checks stdin. `migrate` and `rollback` prompt through
-    click.confirm(), which reads stdin. If stdout works but stdin does not,
-    the prompt hangs and the user cannot see or answer it. A caller may
-    redirect stdout without redirecting stdin, so this function checks stdin
-    explicitly.
+    Step 1 deliberately checks stdout only, not stdin. A caller who redirects
+    output to a file and runs a command meant it, and a scheduled task or
+    service has no keyboard to offer. Requiring stdin here would send that
+    caller to the GUI, which never exits, so the job would hang with the
+    command ignored and nothing written to the log they set up.
+
+    Commands that ask a question handle a missing stdin on their own:
+    click.confirm() aborts with an error, and that error lands in whatever the
+    caller redirected output to. An error in the log beats a hung GUI.
+
+    Step 2 still reopens CONIN$ alongside CONOUT$. When this process attaches
+    a console for itself, it owns both streams and should set up both.
     """
-    if _stdout_is_usable() and _stdin_is_usable():
+    if _stdout_is_usable():
         return True
     if sys.platform != "win32":
         # A POSIX binary launched from a shell inherits working streams. If it

--- a/src/discord_ferry/core/entry.py
+++ b/src/discord_ferry/core/entry.py
@@ -30,6 +30,18 @@ def _stdout_is_usable() -> bool:
     return stream is not None and hasattr(stream, "write")
 
 
+def _stdin_is_usable() -> bool:
+    """Whether sys.stdin can actually be read from.
+
+    Same reasoning and same shape as _stdout_is_usable(). Checked alongside it
+    in acquire_console() because `migrate` and `rollback` prompt through
+    click.confirm(): a usable stdout with an unusable stdin still hangs on a
+    prompt the user cannot answer.
+    """
+    stream = sys.stdin
+    return stream is not None and hasattr(stream, "read")
+
+
 def _attach_parent_console() -> bool:
     """Attach to the launching shell's console and rebind the std streams.
 
@@ -40,6 +52,11 @@ def _attach_parent_console() -> bool:
     `rollback`, and both prompt through click.confirm. Without stdin they would
     hang on a prompt the user cannot see, which is worse than the current
     behaviour of producing no output at all.
+
+    The three opens below share one try/except. If an early open succeeds and
+    a later one raises, the streams it already reassigned are put back before
+    returning False, so a caller that falls back to gui.main() on failure
+    never runs with sys.stdout pointed at a half-open console handle.
     """
     import ctypes
 
@@ -48,11 +65,13 @@ def _attach_parent_console() -> bool:
     if not kernel32.AttachConsole(attach_parent_process):
         return False
 
+    original_stdout, original_stderr, original_stdin = sys.stdout, sys.stderr, sys.stdin
     try:
         sys.stdout = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
         sys.stderr = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
         sys.stdin = open("CONIN$", encoding="utf-8")  # noqa: SIM115
     except OSError:
+        sys.stdout, sys.stderr, sys.stdin = original_stdout, original_stderr, original_stdin
         return False
     return True
 
@@ -62,14 +81,21 @@ def acquire_console() -> bool:
 
     Three steps, in this order:
 
-    1. sys.stdout already usable, so use it (redirection, pipes, CI)
+    1. sys.stdout AND sys.stdin already usable, so use them (redirection,
+       pipes, CI)
     2. Windows: AttachConsole, then reopen CONOUT$ and CONIN$
     3. otherwise, no console is available
 
     Step 1 must precede step 2. Attaching to a parent console when the caller
     redirected our output would overwrite that redirection.
+
+    Step 1 also checks stdin. `migrate` and `rollback` prompt through
+    click.confirm(), which reads stdin. If stdout works but stdin does not,
+    the prompt hangs and the user cannot see or answer it. A caller may
+    redirect stdout without redirecting stdin, so this function checks stdin
+    explicitly.
     """
-    if _stdout_is_usable():
+    if _stdout_is_usable() and _stdin_is_usable():
         return True
     if sys.platform != "win32":
         # A POSIX binary launched from a shell inherits working streams. If it

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -19,6 +19,7 @@ from nicegui import app, background_tasks, ui
 from nicegui.client import ClientConnectionTimeout
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core import entry
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.errors import MigrationError
@@ -1840,6 +1841,12 @@ def main() -> None:
     # called, and NiceGUI only calls it deep inside ui.run(). Without this, the frozen
     # window child re-runs everything above ui.run() before diverting.
     multiprocessing.freeze_support()
+
+    # Immediately after freeze_support(), which has already diverted the pywebview
+    # spawn child. Arguments reach the CLI only when this process is frozen AND a
+    # console is available. See core/entry.py for why both.
+    if entry.should_run_cli(sys.argv):
+        entry.run_cli()  # never returns
 
     # AFTER freeze_support(), never before. In the FROZEN build the PyInstaller
     # bootloader re-runs this entry script for the native-window child process, so

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1430,3 +1430,20 @@ def test_state_roundtrip_excludes_exposed_settings(tmp_path: Path) -> None:
     raw = json.loads((tmp_path / "state.json").read_text())
     for key in _EXPOSED_FIELDS:
         assert key not in raw
+
+
+def test_version_flag_matches_package_version() -> None:
+    """--version must not drift from __init__.py.
+
+    ferry.spec regex-reads that file at build time, so it is the single source
+    of truth. Package metadata is unreliable inside a PyInstaller bundle.
+    """
+    from click.testing import CliRunner
+
+    from discord_ferry import __version__
+    from discord_ferry.cli import main
+
+    result = CliRunner().invoke(main, ["--version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.output

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -69,19 +69,23 @@ def test_usable_stdout_needs_no_attach(monkeypatch: pytest.MonkeyPatch) -> None:
     assert attach_calls == [], "must not attach when stdout already works"
 
 
-def test_usable_stdout_but_unusable_stdin_attaches(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Step 1 requires stdin too, not stdout alone.
+def test_redirected_output_without_stdin_still_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller with somewhere to write gets their command run, keyboard or not.
 
-    A caller could redirect stdout without redirecting stdin. click.confirm()
-    reads stdin, so a usable stdout with no usable stdin still needs the
-    CONIN$ reopen from step 2, exactly like a fully unusable console.
+    This is the scheduled-task and service case: `Ferry.exe migrate --yes >
+    log.txt` has an output file and no keyboard. Requiring stdin here would
+    send that caller to the GUI, which never exits, so the job would hang with
+    the command ignored and nothing in the log they set up.
+
+    Commands that ask a question handle the missing stdin themselves.
+    click.confirm() aborts and the error lands in the redirect.
     """
     monkeypatch.setattr("sys.platform", "win32")
     monkeypatch.setattr("sys.stdin", None)
     attach_calls: list[int] = []
     monkeypatch.setattr(entry, "_attach_parent_console", lambda: attach_calls.append(1) or True)
     assert entry.acquire_console() is True
-    assert attach_calls == [1], "must attach when stdin is unusable even if stdout works"
+    assert attach_calls == [], "a usable stdout is enough; must not attach or fall back"
 
 
 def test_non_windows_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -92,3 +92,22 @@ def test_windows_attach_failure_reports_no_console(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("sys.stdout", None)
     monkeypatch.setattr(entry, "_attach_parent_console", lambda: False)
     assert entry.acquire_console() is False
+
+
+def test_run_cli_never_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Click exits the process itself, so there is no status to return.
+
+    Command.main() is typed -> NoReturn in standalone mode and every path ends
+    in sys.exit(). Asserting `== 0` here would assert on a value that is never
+    produced.
+
+    Uses --help, not --version: Task 3 adds --version and has not landed on
+    this branch yet, so that option does not exist here and would raise
+    SystemExit(2) with "No such option". --help is a Click built-in present
+    on every Command. It exercises the same exit-0 path through the bound
+    main().
+    """
+    monkeypatch.setattr("sys.argv", ["Ferry.exe", "--help"])
+    with pytest.raises(SystemExit) as excinfo:
+        entry.run_cli()
+    assert excinfo.value.code == 0

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ctypes
+import sys
+
 import pytest
 
 from discord_ferry.core import entry
@@ -66,6 +69,21 @@ def test_usable_stdout_needs_no_attach(monkeypatch: pytest.MonkeyPatch) -> None:
     assert attach_calls == [], "must not attach when stdout already works"
 
 
+def test_usable_stdout_but_unusable_stdin_attaches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Step 1 requires stdin too, not stdout alone.
+
+    A caller could redirect stdout without redirecting stdin. click.confirm()
+    reads stdin, so a usable stdout with no usable stdin still needs the
+    CONIN$ reopen from step 2, exactly like a fully unusable console.
+    """
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdin", None)
+    attach_calls: list[int] = []
+    monkeypatch.setattr(entry, "_attach_parent_console", lambda: attach_calls.append(1) or True)
+    assert entry.acquire_console() is True
+    assert attach_calls == [1], "must attach when stdin is unusable even if stdout works"
+
+
 def test_non_windows_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:
     """Even without a usable stdout, a non-Windows platform returns True.
 
@@ -92,6 +110,56 @@ def test_windows_attach_failure_reports_no_console(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("sys.stdout", None)
     monkeypatch.setattr(entry, "_attach_parent_console", lambda: False)
     assert entry.acquire_console() is False
+
+
+def test_attach_partial_open_failure_restores_original_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure partway through the three CONOUT$/CONIN$ opens must not leave
+    sys.stdout, sys.stderr, or sys.stdin reassigned.
+
+    Regression test: the three opens used to share one try/except with no
+    rollback. If the first open (stdout) succeeded and the second (stderr)
+    raised OSError, the function returned False but sys.stdout was left
+    pointing at the console handle from the first open. A caller that falls
+    back to gui.main() on a False return would then run with sys.stdout
+    mutated. This forces AttachConsole to report success so the open() calls
+    are reached, then fails the second open to reproduce that sequence.
+    """
+
+    class _FakeKernel32:
+        @staticmethod
+        def AttachConsole(_pid: int) -> bool:  # noqa: N802 -- mirrors the real Win32 API name
+            return True
+
+    class _FakeWinDLL:
+        kernel32 = _FakeKernel32()
+
+    monkeypatch.setattr(ctypes, "windll", _FakeWinDLL(), raising=False)
+
+    original_stdout = object()
+    original_stderr = object()
+    original_stdin = object()
+    monkeypatch.setattr("sys.stdout", original_stdout)
+    monkeypatch.setattr("sys.stderr", original_stderr)
+    monkeypatch.setattr("sys.stdin", original_stdin)
+
+    open_calls = 0
+
+    def fake_open(*args: object, **kwargs: object) -> object:
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls == 1:
+            return object()
+        raise OSError("simulated failure opening CONOUT$/CONIN$")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    assert entry._attach_parent_console() is False
+    assert open_calls == 2, "must fail on the second open to match the scenario under test"
+    assert sys.stdout is original_stdout
+    assert sys.stderr is original_stderr
+    assert sys.stdin is original_stdin
 
 
 def test_run_cli_never_returns(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -67,8 +67,15 @@ def test_usable_stdout_needs_no_attach(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_non_windows_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A binary launched from a POSIX shell already has working streams."""
+    """Even without a usable stdout, a non-Windows platform returns True.
+
+    sys.stdout is forced to None so the first branch of acquire_console()
+    cannot short-circuit the result. That isolates the platform check this
+    test is meant to cover: there is nothing left to try on POSIX, so the
+    function returns True.
+    """
     monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("sys.stdout", None)
     assert entry.acquire_console() is True
 
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -95,17 +95,24 @@ def test_windows_attach_failure_reports_no_console(monkeypatch: pytest.MonkeyPat
 
 
 def test_run_cli_never_returns(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Click exits the process itself, so there is no status to return.
+    """run_cli() exits the process. It never returns, and it never raises
+    anything other than SystemExit.
 
     Command.main() is typed -> NoReturn in standalone mode and every path ends
     in sys.exit(). Asserting `== 0` here would assert on a value that is never
     produced.
 
+    This does not prove run_cli() calls the bound cli_main.main(). Click's
+    BaseCommand.__call__ just forwards to self.main(), so both raise
+    SystemExit(0) identically at runtime. No test built on
+    pytest.raises(SystemExit) can tell a bound call apart from a bare
+    cli_main() call. That distinction is enforced by mypy's --warn-no-return,
+    not by this test.
+
     Uses --help, not --version: Task 3 adds --version and has not landed on
     this branch yet, so that option does not exist here and would raise
     SystemExit(2) with "No such option". --help is a Click built-in present
-    on every Command. It exercises the same exit-0 path through the bound
-    main().
+    on every Command and gives the same exit-0 path.
     """
     monkeypatch.setattr("sys.argv", ["Ferry.exe", "--help"])
     with pytest.raises(SystemExit) as excinfo:

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,87 @@
+"""Entry-point dispatch for the frozen binary (issue #123, symptom 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from discord_ferry.core import entry
+
+
+def test_no_args_never_runs_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Double-clicking the exe must still open the GUI."""
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    assert entry.should_run_cli(["Ferry.exe"]) is False
+
+
+def test_frozen_with_args_runs_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(entry, "acquire_console", lambda: True)
+    assert entry.should_run_cli(["Ferry.exe", "--help"]) is True
+
+
+def test_non_frozen_never_runs_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`gui.main()` is also the `ferry-gui` console-script entry point.
+
+    Under `uv run pytest --ignore=...` sys.argv[1:] is non-empty for the whole
+    process. Without the frozen gate that would route two existing tests in
+    test_gui_native_lifecycle.py into Click instead of _run_gui().
+    """
+    monkeypatch.delattr("sys.frozen", raising=False)
+    monkeypatch.setattr(entry, "acquire_console", lambda: True)
+    assert entry.should_run_cli(["ferry-gui", "--ignore=tests/x.py"]) is False
+
+
+def test_multiprocessing_fork_never_runs_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defence in depth for the pywebview spawn child.
+
+    freeze_support() exits before this is reached in production, so the guard is
+    unreachable there. But the ordering has no unit-level backstop, and a future
+    refactor that moves statements would route the window child into the CLI and
+    break native mode.
+    """
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(entry, "acquire_console", lambda: True)
+    argv = ["Ferry.exe", "--multiprocessing-fork", "parent_pid=123"]
+    assert entry.should_run_cli(argv) is False
+
+
+def test_no_console_falls_back_to_gui(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A CLI whose output goes nowhere is the bug being fixed, not the fix."""
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(entry, "acquire_console", lambda: False)
+    assert entry.should_run_cli(["Ferry.exe", "--help"]) is False
+
+
+def test_usable_stdout_needs_no_attach(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Step 1 of the ladder, and it must come FIRST.
+
+    Redirection (`Ferry.exe --help > out.txt`), pipes, and CI harnesses all
+    supply real handles. Reaching for AttachConsole before checking would be
+    wrong in exactly the environment the CI verification depends on.
+    """
+    monkeypatch.setattr("sys.platform", "win32")
+    attach_calls: list[int] = []
+    monkeypatch.setattr(entry, "_attach_parent_console", lambda: attach_calls.append(1) or True)
+    assert entry.acquire_console() is True
+    assert attach_calls == [], "must not attach when stdout already works"
+
+
+def test_non_windows_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A binary launched from a POSIX shell already has working streams."""
+    monkeypatch.setattr("sys.platform", "darwin")
+    assert entry.acquire_console() is True
+
+
+def test_windows_without_stdout_attaches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdout", None)
+    monkeypatch.setattr(entry, "_attach_parent_console", lambda: True)
+    assert entry.acquire_console() is True
+
+
+def test_windows_attach_failure_reports_no_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dragging a folder onto the exe: Explorer gives neither stdout nor a console."""
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdout", None)
+    monkeypatch.setattr(entry, "_attach_parent_console", lambda: False)
+    assert entry.acquire_console() is False

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -294,6 +294,34 @@ class TestMainLifecycle:
 
         assert called == ["gui"], "non-frozen main() must go to the GUI"
 
+    def test_frozen_main_with_args_dispatches_to_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The positive path: what this task exists to build.
+
+        Every other case in this class either never sets sys.frozen, or sets it
+        without giving main() any args, so none of them ever reach the dispatch
+        block. This is the one test that sets sys.frozen AND supplies argv AND
+        checks that entry.run_cli() runs, and that configure_logging()/_run_gui()
+        do not run.
+        """
+        monkeypatch.setattr("sys.frozen", True, raising=False)
+        monkeypatch.setattr("sys.argv", ["Ferry.exe", "--help"])
+        monkeypatch.setattr(gui.entry, "acquire_console", lambda: True)
+        calls: list[str] = []
+
+        def _run_cli() -> None:
+            calls.append("cli")
+            raise SystemExit(0)
+
+        monkeypatch.setattr(gui.entry, "run_cli", _run_cli)
+        monkeypatch.setattr(gui, "_run_gui", lambda: calls.append("gui"))
+        monkeypatch.setattr(gui, "configure_logging", lambda: calls.append("logging"))
+
+        with pytest.raises(SystemExit) as excinfo:
+            gui.main()
+
+        assert calls == ["cli"], "frozen main() with args must dispatch to the CLI, and only that"
+        assert excinfo.value.code == 0
+
     def test_ui_run_is_called_with_tuned_timings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """NiceGUI derives the socket.io heartbeat from reconnect_timeout; its 3.0
         default gives the browser only ~6s before the "Connection lost" banner."""

--- a/tests/test_gui_native_lifecycle.py
+++ b/tests/test_gui_native_lifecycle.py
@@ -276,6 +276,24 @@ class TestMainLifecycle:
         monkeypatch.setattr(gui, "_run_gui", lambda: None)
         gui.main()
 
+    def test_non_frozen_main_never_dispatches_to_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The sys.frozen gate, pinned so it cannot be removed by accident.
+
+        Without it, `uv run pytest --ignore=...` leaves sys.argv[1:] non-empty
+        for the whole test process, and test_keyboard_interrupt_exits_130 and
+        test_normal_return_does_not_raise would route into Click instead of
+        _run_gui(). Both are rescued by this gate, not by luck.
+        """
+        monkeypatch.delattr("sys.frozen", raising=False)
+        monkeypatch.setattr("sys.argv", ["ferry-gui", "--ignore=tests/x.py"])
+        called: list[str] = []
+        monkeypatch.setattr(gui, "_run_gui", lambda: called.append("gui"))
+        monkeypatch.setattr(gui, "configure_logging", lambda: None)
+
+        gui.main()
+
+        assert called == ["gui"], "non-frozen main() must go to the GUI"
+
     def test_ui_run_is_called_with_tuned_timings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """NiceGUI derives the socket.io heartbeat from reconnect_timeout; its 3.0
         default gives the browser only ~6s before the "Connection lost" banner."""

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #123 (symptom 3). Ships as v2.12.0.

## What was wrong

`Ferry.exe --help` opened the GUI. So did `Ferry.exe --version`, `Ferry.exe migrate`, and every other command.

The packaged binary's entry point is `gui.main()` (`ferry.spec:87`), which never read `sys.argv`. Arguments went nowhere. The Click group in `cli.py` was never called.

Windows users get only the binary, so `migrate`, `rollback`, `probe`, `stats`, `validate`, `retry-failed` and `export-blueprint` were all unreachable for them. pipx and source installs already had the `ferry` console script and were unaffected.

## What changed

New module `src/discord_ferry/core/entry.py`:

- `should_run_cli(argv)` decides whether to hand off to Click
- `acquire_console()` obtains somewhere to write
- `run_cli()` delegates to the Click group and never returns

`gui.main()` calls `should_run_cli` directly after `multiprocessing.freeze_support()`.

Four conditions must all hold before the handoff:

1. At least one argument is present
2. The process is frozen (`sys.frozen`), so `ferry-gui` from a source install behaves as before
3. `--multiprocessing-fork` is absent, so the native-window child process is not hijacked
4. A console is available

### Console acquisition

`ferry.spec:122` builds with `console=False`. On Windows that makes the PE GUI-subsystem: `sys.stdout` and `sys.stderr` are `None` and no console is attached. Dispatch alone would still print nothing.

`acquire_console()` tries two routes in order:

1. `sys.stdout` is already usable. Covers redirection, pipes and CI.
2. Windows only: `AttachConsole(ATTACH_PARENT_PROCESS)`, then reopen `CONOUT$` and `CONIN$`.

Route 1 goes first because a redirected `sys.stdout` is already a valid destination, and `AttachConsole` would replace it with the console.

`CONIN$` is reopened as well as `CONOUT$` because `migrate` and `rollback` prompt through `click.confirm`. A partial attach restores all three original streams before giving up.

When neither route works (launched from Explorer, or a file dropped on the exe) the GUI opens, as it did before. A command whose output reaches nobody is worse than the GUI.

### Also

`--version` on the Click group, reading `discord_ferry.__version__` directly. Package metadata is not reliable inside a PyInstaller bundle, and `ferry.spec` already treats `__init__.py` as the source of truth.

## Verification

```
uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

1435 tests pass. 22 of them are new.

Windows behaviour cannot be exercised on the dev machine (M1 Mac, no VM), so `release.yml`'s `build-windows` job now runs the exe it builds three ways:

- `--help` with stdout redirected: asserts exit 0 and `Usage:` in the output
- `--version` with stdout redirected: asserts the string matches `pyproject.toml`
- `--help` with no redirection at all, which is the only invocation that reaches `AttachConsole`

Invocation uses `System.Diagnostics.Process` with `ReadToEndAsync()` started on both streams before `WaitForExit(ms)`. Reading one stream to completion before starting the other deadlocks once the child fills the second pipe's buffer.

## Left for later

- Symptom 2 of #123: the WebView2 renderer fallback and `FERRY_NO_NATIVE`
- `install.md`, `first-migration.md` and `gui-walkthrough.md` all state that a browser opens automatically. It never does.
- `.github/ISSUE_TEMPLATE/bug_report.yml` asks for `report.json`, which cannot exist for a failure at the export stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
