### PR TITLE
fix(ci): auto-tag now decides from tag existence, not a HEAD~1 diff

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -21,40 +21,47 @@ jobs:
           client-id: ${{ vars.AUTO_TAG_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTO_TAG_APP_PRIVATE_KEY }}
 
+      # fetch-depth: 0 fetches tags. The previous depth-2 checkout passed
+      # --no-tags, so the duplicate-tag guard below had no tags to find and
+      # could never have fired.
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Check for version bump
+      # Decide from the tags that exist, not from a diff against HEAD~1.
+      # A rebase merge lands the version-bump commit in the middle of the
+      # pushed range, so HEAD and HEAD~1 can both already carry the new
+      # version. That is how v2.12.0 reached main with no tag, no release and
+      # no PyPI publish, from a job that reported success. Asking "is this
+      # version tagged yet?" gives the same answer under squash, rebase and
+      # merge commits alike, and self-heals a release that was missed earlier.
+      - name: Decide whether a tag is needed
         id: version
         run: |
           CURRENT=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
-          PREVIOUS=$(git show HEAD~1:pyproject.toml | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/')
+          TAG="v${CURRENT}"
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
-          if [ "$CURRENT" != "$PREVIOUS" ]; then
-            echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists, nothing to do"
           else
-            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist yet, creating it"
           fi
 
       - name: Configure git identity
-        if: steps.version.outputs.bumped == 'true'
+        if: steps.version.outputs.needed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Create and push tag
-        if: steps.version.outputs.bumped == 'true'
+        if: steps.version.outputs.needed == 'true'
         env:
-          VERSION: ${{ steps.version.outputs.current }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="v${VERSION}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-          else
-            git tag -a "$TAG" -m "$TAG"
-            git push origin "$TAG"
-            echo "Created and pushed tag $TAG"
-          fi
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+          echo "Created and pushed tag $TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`auto-tag.yml` now checks whether the current version is already tagged.**
+  It previously compared `pyproject.toml` at `HEAD` against `HEAD~1`. A rebase
+  merge lands the version-bump commit in the middle of the pushed range, so both
+  of those commits can already carry the new version, and the job then reported
+  success without creating a tag. v2.12.0 reached `main` that way: no tag, no
+  GitHub Release, no PyPI publish. A tag-existence check gives the same answer
+  under squash, rebase and merge commits, and repairs a release that was missed
+  earlier. The checkout now fetches tags as well; at `fetch-depth: 2` it passed
+  `--no-tags`, leaving the duplicate-tag guard with nothing to find.
+
 ## [2.12.0] - 2026-08-06
 
 ### Added


### PR DESCRIPTION
## What went wrong

v2.12.0 merged to `main` this morning. `auto-tag.yml` ran, finished in 13 seconds, reported success, and created no tag. No tag meant `release.yml` never ran, so there was no GitHub Release and no PyPI publish. Nothing reported that a release had been skipped.

The workflow decided from a two-commit window:

```sh
CURRENT=$(grep -m1 '^version' pyproject.toml | ...)     # HEAD
PREVIOUS=$(git show HEAD~1:pyproject.toml | ...)        # HEAD~1
```

A rebase merge replays every commit onto `main`, so the version-bump commit stays wherever it sat on the branch. In #126 it was seventh of ten:

| ref | version | commit |
|---|---|---|
| `HEAD` | 2.12.0 | fix(entry): run the command when there is somewhere to write… |
| `HEAD~1` | 2.12.0 | fix(entry): cover AttachConsole in CI… |
| `HEAD~2` | 2.12.0 | content: complete the command list… |
| `HEAD~3` | 2.12.0 | **chore: release v2.12.0** |
| `HEAD~4` | 2.11.1 | ci: assert the built exe honours --help… |

`CURRENT` and `PREVIOUS` were both 2.12.0, so `bumped=false`.

## Why it had not fired before

Two rules that are each fine alone. `/df-ship` selects `--rebase` for 3+ commits with code, to keep per-commit atomicity. `auto-tag.yml` assumed the bump was at the tip or one behind it.

Both held until now because v2.11.1 was squash-merged, which collapses the branch into one commit and puts the bump at the tip. PR #125 carried no version bump. #126 was the first rebase merge with a version bump.

## The fix

Decide from tag existence. `refs/tags/v$CURRENT` present means there is nothing to do; absent means create it. That answers the same under squash, rebase and merge commits, and it repairs a release missed on an earlier push.

## Second defect in the same file

The duplicate-tag guard called `git rev-parse "$TAG"` on a clone that `actions/checkout` had fetched with `--no-tags`, because `fetch-depth` was 2. There were no tags in that clone, so the guard had nothing to find and could never have fired. `fetch-depth: 0` fetches them, which is also what the new check needs.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses, and all five steps resolve
- `git rev-parse -q --verify refs/tags/v2.12.0` succeeds against the real repo (would set `needed=false`); an absent tag fails (would set `needed=true`)
- `uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` clean, 1435 passed

The tag interpolation goes through `env:` rather than into the `run:` body, and the value comes from `pyproject.toml` in the repo rather than from event payload.

## Note on v2.12.0

Already recovered by hand: the tag was pushed from a local clone, `release.yml` ran, and v2.12.0 is published on GitHub Releases and PyPI. This PR stops the next one needing that.

No version bump: CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
