### PR TITLE
content: docs said the packaged app opens a browser; it opens its own window

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,8 @@ body:
     id: version
     attributes:
       label: Ferry version
-      placeholder: "e.g. 0.1.0"
+      description: "Shown on the Setup screen, or run `ferry --version` (2.12.0 and later)"
+      placeholder: "e.g. 2.12.0"
     validations:
       required: true
   - type: textarea
@@ -41,14 +42,39 @@ body:
       label: What did you expect to happen?
     validations:
       required: true
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Where did it stop?
+      description: Roughly the last thing you saw before it went wrong
+      options:
+        - Before the app opened (blank window, will not launch)
+        - Setup screen (tokens, server selection)
+        - Exporting from Discord
+        - Reviewing what will be created
+        - Creating the server, channels or roles
+        - Migrating messages
+        - After it finished (something is wrong with the result)
+        - Somewhere else
+    validations:
+      required: true
   - type: textarea
     id: logs
     attributes:
-      label: Error messages or logs
-      description: Paste any error messages, or attach ferry-output/report.json
+      label: Log file and error messages
+      description: |
+        From version 2.11.1 Ferry always writes a log. Tokens are stripped before anything is
+        written, so it is safe to attach.
+
+        - Windows: `%USERPROFILE%\.discord-ferry\logs\ferry.log`
+        - macOS and Linux: `~/.discord-ferry/logs/ferry.log`
+
+        Attach that file if you can, and paste any on-screen error here. `ferry-output/report.json`
+        is written only after a migration reaches the reporting stage, so it will not exist for a
+        failure before that point. Leave it out if it is not there.
       render: shell
   - type: textarea
     id: export-info
     attributes:
       label: Export details
-      description: "Approximate server size: channels, messages, attachments"
+      description: "Approximate server size: channels, messages, attachments. Skip if it never got that far."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   earlier. The checkout now fetches tags as well; at `fetch-depth: 2` it passed
   `--no-tags`, leaving the duplicate-tag guard with nothing to find.
 
+- `install.md`, `first-migration.md` and `gui-walkthrough.md` said a browser
+  opens automatically. The packaged Windows and macOS apps bundle a window
+  toolkit, so NiceGUI sets `show=False` and no browser is opened (issue #123).
+  A `pipx` install does open a browser, because `pywebview` sits in the optional
+  `native` extra. The pages now cover the two routes separately and give
+  `http://localhost:8765` as a supported way in.
+
+### Added
+
+- `troubleshooting.md`: entry for a blank window or the message *"Your browser
+  does not support ES modules"*, with the Edge WebView2 Runtime fix.
+- `troubleshooting.md`: entry for `Ferry.exe` ignoring `--help` on versions
+  before 2.12.0.
+- `cli-reference.md` and `install.md`: the downloaded app takes commands. Both
+  note the case where it opens the GUI because there is nowhere to write output.
+
+### Changed
+
+- `bug_report.yml` asks for the log file at `~/.discord-ferry/logs/ferry.log`,
+  added in 2.11.1. It previously asked for `ferry-output/report.json`, which
+  cannot exist for a failure before the reporting stage. Tokens are stripped
+  before anything is written to the log. The form also gains a "where did it
+  stop?" field, and the version placeholder no longer reads `0.1.0`.
+
 ## [2.12.0] - 2026-08-06
 
 ### Added

--- a/docs/getting-started/first-migration.md
+++ b/docs/getting-started/first-migration.md
@@ -33,13 +33,16 @@ Before you start, confirm you have these ready:
 === "GUI (Windows / macOS)"
 
     1. Double-click **Ferry.exe** (Windows) or open **Ferry.app** (macOS).
-    2. Your default browser opens automatically at `http://localhost:8765`.
+    2. Ferry opens its own window. No browser is launched.
     3. You will see the Setup screen.
 
     <!-- screenshot: ferry-setup-screen -->
 
-    !!! info "Browser did not open?"
-        Open your browser manually and go to `http://localhost:8765`.
+    !!! info "Window blank or missing?"
+        Open `http://localhost:8765` in any browser while Ferry is running. That address is
+        fully supported and shows the same interface. See
+        [Troubleshooting](../guides/troubleshooting.md#ferry-window-is-blank-or-says-your-browser-does-not-support-es-modules)
+        if the window itself will not draw.
 
 === "CLI (Linux / advanced)"
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -10,7 +10,16 @@ Pick your operating system below to get started.
 
     1. Go to the [Discord Ferry releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases) on GitHub.
     2. Under the latest release, click **Ferry-windows-x86_64.exe** to download it.
-    3. Double-click the downloaded file to run it. Your browser will open automatically.
+    3. Double-click the downloaded file to run it. Ferry opens its own window.
+
+    !!! info "No browser opens"
+        The downloaded app draws its own window and does not launch your browser. If the window
+        stays blank or does not appear, open `http://localhost:8765` in any browser while Ferry
+        is running. That address is fully supported and gives you the same interface.
+
+    !!! tip "The app also takes commands"
+        `Ferry-windows-x86_64.exe --help` lists every command, and `--version` reports the build.
+        See the [CLI Reference](../guides/cli-reference.md) for what each command does.
 
     <!-- screenshot: windows-smartscreen-warning -->
 
@@ -58,6 +67,11 @@ Pick your operating system below to get started.
 
         Ferry opens. From now on you can launch it with a normal double-click.
 
+    !!! info "No browser opens"
+        Ferry.app draws its own window and does not launch your browser. If the window stays
+        blank or does not appear, open `http://localhost:8765` in any browser while Ferry is
+        running. That address is fully supported and gives you the same interface.
+
         **Not seeing the button?** It only appears *after* macOS has blocked Ferry, and it disappears again after about an hour. Double-click **Ferry.app** once more, then go straight back to **Privacy & Security**.
 
     !!! tip "Faster, if you are comfortable with Terminal"
@@ -104,7 +118,10 @@ Pick your operating system below to get started.
         ```
 
     !!! info "No desktop app on Linux"
-        On Linux, Ferry opens in your web browser instead of a separate application window. This is normal — it works the same as the Windows and macOS versions.
+        Installed this way, Ferry opens in your web browser and does not draw its own window.
+        The downloaded Windows and macOS apps bundle the window toolkit; a `pipx` install leaves
+        it out unless you ask for it with `pipx install "discord-ferry[native]"`. Everything
+        else behaves identically.
 
 ---
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -3,7 +3,12 @@
 Ferry's command-line interface provides the same migration capability as the GUI, without a browser. It is useful for running unattended overnight migrations, scripting, or running on a remote server.
 
 !!! info "Prerequisites"
-    The CLI is included in the same `ferry` binary as the GUI. Run `ferry --help` to confirm it is working.
+    A `pipx` or source install puts `ferry` on your PATH. Run `ferry --help` to confirm it is working.
+
+    From version **2.12.0** the downloaded apps take the same commands:
+    `Ferry-windows-x86_64.exe --help` on Windows, or the binary inside `Ferry.app` on macOS. Run
+    them from a terminal so the output has somewhere to go. Launched with no console, from a
+    service or a scheduled task, the app opens the GUI.
 
 ---
 

--- a/docs/guides/gui-walkthrough.md
+++ b/docs/guides/gui-walkthrough.md
@@ -3,9 +3,11 @@
 This guide walks through every screen of the Discord Ferry web interface. Ferry runs a small local web server when you launch it — no data ever leaves your machine.
 
 !!! info "Launching the GUI"
-    On **Windows**, double-click the downloaded `Ferry-windows-x86_64.exe`. On **macOS**, open **Ferry.app** — see [Installation](../getting-started/install.md) if macOS blocks it the first time. On **Linux**, run `ferry-gui` in a terminal.
+    On **Windows**, double-click the downloaded `Ferry-windows-x86_64.exe`. On **macOS**, open **Ferry.app** (see [Installation](../getting-started/install.md) if macOS blocks it the first time). On **Linux**, run `ferry-gui` in a terminal.
 
-    Your browser will open automatically to `http://localhost:8765`. If it does not, open that URL manually.
+    The downloaded Windows and macOS apps draw their own window and do not launch a browser. A `pipx` install has no window toolkit bundled, so `ferry-gui` opens your browser instead.
+
+    Either way, `http://localhost:8765` reaches the same interface while Ferry is running. Use it if the window stays blank or never appears.
 
 ---
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -139,6 +139,35 @@ xattr -dr com.apple.quarantine /Applications/Ferry.app
 
 The `-r` flag matters. Without it the quarantine flag is cleared only from the bundle folder, while the executable inside it stays blocked and the app still refuses to open. If you kept Ferry somewhere other than `/Applications`, substitute that path.
 
+### Ferry window is blank or says "Your browser does not support ES modules"
+
+| | |
+|---|---|
+| **Symptom** | The Ferry window opens but stays empty, or shows the message *"Your browser does not support ES modules."* |
+| **Cause** | Ferry draws its window using a renderer supplied by the operating system. On Windows that is the **Microsoft Edge WebView2 Runtime**, which is present on Windows 11 but not guaranteed on Windows 10. When it is missing or broken, the window falls back to a legacy engine that cannot run Ferry's interface. |
+| **Solution** | Install or repair the [Evergreen WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/). If it is already installed, run the installer again; it repairs a broken install. |
+
+!!! tip "Use `localhost:8765` meanwhile"
+    Ferry serves its interface at `http://localhost:8765` whether or not the window draws. Open
+    that address in any browser and carry on.
+
+### Ferry.exe ignores `--help` and every other command
+
+| | |
+|---|---|
+| **Symptom** | Running `Ferry-windows-x86_64.exe --help` from PowerShell prints nothing and opens the GUI. |
+| **Cause** | Versions before **2.12.0** ignored command-line arguments entirely. |
+| **Solution** | Upgrade to 2.12.0 or later from the [releases page](https://github.com/nordscope-fi/Discord-stoat-ferry/releases). |
+
+!!! info "One case still opens the GUI by design"
+    The app opens the GUI instead of running the command when there is nowhere to write output.
+    That happens when it is launched from a Windows service, a scheduled task, or by dropping a
+    file onto the icon. Run it from a terminal, or redirect its output to a file, and the
+    command runs normally.
+
+    Because the app is windowed, your shell prints its next prompt before Ferry's output
+    arrives. The output prints underneath that new prompt.
+
 ---
 
 ## The Window Stops Responding


### PR DESCRIPTION
Closes the documentation half of #123. No version bump: content and CI template only.

## Browser auto-open claim was wrong on three pages

`install.md:13` (Windows download), `first-migration.md:36` (GUI tab, `Ferry.exe` / `Ferry.app`) and `gui-walkthrough.md:8` (all three platforms in one sentence) each said a browser opens automatically.

`gui.py` sets `native = _HAS_WEBVIEW`, and the packaged Windows and macOS apps bundle pywebview, so `native` is true. NiceGUI then sets `show = False` (`nicegui/ui_run.py:240-241`; its docstring at `:107` says native "deactivates `show`"). The app draws its own window and never touches a browser.

Issue #123 reported changing the default browser to try to fix a blank window. No browser change could have affected it.

## pipx install: the browser claim was correct

`install.md:101` describes the `pipx` route and says the GUI opens in your browser. That is right, because `pywebview` sits in `[project.optional-dependencies] native` and a plain `pipx install discord-ferry` leaves it out. So `_HAS_WEBVIEW` is false, `native` is false, and NiceGUI's default `show=True` applies.

The pages now cover the two routes separately. The Linux note previously explained this as a Linux limitation; the deciding factor is the install route.

## Added

- **Troubleshooting: blank window or "Your browser does not support ES modules".** Carries the Edge WebView2 Runtime fix, plus `localhost:8765` as the way to keep working. The section had no coverage of a window that fails to render.
- **Troubleshooting: `Ferry.exe` ignores `--help`.** Resolved by upgrading to 2.12.0, with the one remaining case that opens the GUI by design.
- **`cli-reference.md` and `install.md`: the downloaded app takes commands.** Spec item S8 from the v2.12.0 work, which shipped the capability without documenting it.

## Bug report template

It asked for `ferry-output/report.json`. That file is written only after a migration reaches the reporting stage, so it cannot exist for an export-stage failure, which is where 4 of the 5 externally-reported bugs have landed.

It now asks for `~/.discord-ferry/logs/ferry.log` (added in 2.11.1), states that tokens are stripped before anything is written, and adds a "where did it stop?" dropdown. The version placeholder said `0.1.0`.

## Verification

- `mkdocs build --strict` clean
- The new cross-link resolves: the generated anchor id in `site/guides/troubleshooting/index.html` matches the `href` emitted in `site/getting-started/first-migration/index.html`. Checked against the built HTML, because this project has no `validation.anchors` config, so `--strict` alone would not catch a mismatch.
- `bug_report.yml` parses, and all 8 fields resolve with the expected `required` flags
- `uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` clean, 1435 passed

## Still open

#128 tracks the actual WebView2 fix: `FERRY_NO_NATIVE`, a renderer fallback, and the `ferry.spec` hidden-import question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
