### PR TITLE
test(cli): prove --version reads the module attribute, not package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   before 2.12.0.
 - `cli-reference.md` and `install.md`: the downloaded app takes commands. Both
   note the case where it opens the GUI because there is nowhere to write output.
+- Test covering where `--version` gets its value. The existing test asserted
+  that the output contains `discord_ferry.__version__` without pinning the
+  source. Removing the explicit argument from `click.version_option` makes
+  Click read `importlib.metadata`, which returns the same string in an
+  editable install, so that assertion kept passing while a PyInstaller bundle
+  reported the wrong version. The new test patches the module attribute to a
+  sentinel and reloads `cli.py`.
 
 ### Changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1438,12 +1438,44 @@ def test_version_flag_matches_package_version() -> None:
     ferry.spec regex-reads that file at build time, so it is the single source
     of truth. Package metadata is unreliable inside a PyInstaller bundle.
     """
-    from click.testing import CliRunner
-
     from discord_ferry import __version__
-    from discord_ferry.cli import main
 
     result = CliRunner().invoke(main, ["--version"])
 
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+def test_version_is_read_from_module_attribute_not_package_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The explicit version argument to click.version_option must stay.
+
+    Dropping it makes Click fall back to importlib.metadata. In an editable
+    install that metadata equals __init__.py, so the assertion above keeps
+    passing while a PyInstaller bundle reports the wrong version or fails
+    outright -- metadata is unreliable there, which is why ferry.spec
+    regex-reads __init__.py instead.
+
+    Patching the attribute and reloading proves the value reaching --version
+    travels through discord_ferry.__version__, not through package metadata.
+    """
+    import importlib
+
+    import discord_ferry
+    import discord_ferry.cli
+
+    sentinel = "9.9.9-not-a-real-version"
+    monkeypatch.setattr(discord_ferry, "__version__", sentinel)
+    try:
+        reloaded = importlib.reload(discord_ferry.cli)
+        result = CliRunner().invoke(reloaded.main, ["--version"])
+
+        assert result.exit_code == 0
+        assert sentinel in result.output
+    finally:
+        # Restore the attribute first: the reload re-runs `from discord_ferry
+        # import __version__` at cli.py:24 and would otherwise bake the
+        # sentinel into the module every later test imports.
+        monkeypatch.undo()
+        importlib.reload(discord_ferry.cli)


### PR DESCRIPTION
Closes a review item deferred from #126. Test only, no version bump.

## The gap

`test_version_flag_matches_package_version` asserts that `--version` output contains `discord_ferry.__version__`. It cannot tell where that string came from.

`cli.py:659` passes the version explicitly:

```python
@click.version_option(__version__, "--version", prog_name="ferry")
```

Remove that first argument and Click falls back to `importlib.metadata`. In an editable or pipx install the metadata version equals `__init__.py`, so the assertion still passes. Inside a PyInstaller bundle metadata is unreliable, which is why `ferry.spec` regex-reads `__init__.py` at build time. The test would stay green while the shipped binary reported the wrong version.

## The new test

Patches `discord_ferry.__version__` to `9.9.9-not-a-real-version` and reloads `discord_ferry.cli`, so the value reaching `--version` has to travel through the module attribute. `cli.py:24` does `from discord_ferry import __version__`, which is what makes the reload pick the sentinel up.

The `finally` block restores the attribute before the second reload. Reloading while the sentinel is still set would bake it into the module that every later test imports.

## Falsification

I simulated the regression by replacing the explicit argument with `None`, then ran both tests:

```
FAILED tests/test_cli.py::test_version_is_read_from_module_attribute_not_package_metadata
E   AssertionError: assert '9.9.9-not-a-real-version' in 'ferry, version 2.12.0\n'

1 failed, 1 passed, 66 deselected
```

The new test fails. The existing one passes. That split is the gap being closed.

`cli.py` was then restored in place and `git diff src/discord_ferry/cli.py` is empty, so nothing from the simulation is in this branch.

## Also

Drops the local imports of `CliRunner` and `main` from the existing test. Both are already imported at module level (`tests/test_cli.py:10,12`).

## Verification

`uv run ruff check src/ tests/test_cli.py && uv run ruff format --check . && uv run mypy src/ && uv run pytest` clean, **1436 passed**, up one from 1435. The reload has no effect on the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
