### PR TITLE
chore: changelog the aiohttp 3.14.3 security bump merged in #122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   before anything is written to the log. The form also gains a "where did it
   stop?" field, and the version placeholder no longer reads `0.1.0`.
 
+### Security
+
+- **aiohttp 3.14.1 → 3.14.3** (`uv.lock` only, no source change), clearing three
+  Dependabot alerts. Ferry uses aiohttp as an HTTP **client** only: `src/` contains
+  no `aiohttp.web` usage and opens no aiohttp websockets, and NiceGUI's own server
+  runs on uvicorn. Applicability of each advisory:
+  - **High, out-of-bounds heap read in the C HTTP response parser** on a malformed
+    chunked response. This one **affects Ferry**, which parses responses from Stoat,
+    Autumn, the Discord API and the Discord CDN.
+  - **Medium, HTTP request smuggling via WebSocket upgrade.** Server-side
+    (`aiohttp.web`). No effect on Ferry.
+  - **Medium, WebSocket client accepts compressed frames without a negotiated
+    `permessage-deflate`.** Ferry opens no aiohttp websockets. No effect on Ferry.
+
+  3.14.3 also fixes the client dropping only the first of `Authorization`, `Cookie`
+  and `Proxy-Authorization` when a redirect crosses an origin. Ferry sets at most
+  one of those three (`Authorization`, at `discord/client.py:128`,
+  `exporter/runner.py:337` and `migrator/structure.py:242`), so the header that got
+  dropped was always the only one present.
+
 ## [2.12.0] - 2026-08-06
 
 ### Added


### PR DESCRIPTION
Follow-up to #122, which Dependabot opened and which carried no changelog entry. This repo documents dependency bumps with an applicability analysis (see the 2.6.x and 2.9.x Security sections), and #122 cleared three open alerts, one of them high severity.

## What #122 actually cleared

| Severity | Advisory | Reaches Ferry? |
|---|---|---|
| **High** | Out-of-bounds heap read in the C HTTP response parser, on a malformed chunked response | **Yes** |
| Medium | HTTP request smuggling via WebSocket upgrade | No |
| Medium | WebSocket client accepts compressed frames without a negotiated `permessage-deflate` | No |

## How I decided that

Checked against `src/` rather than assumed:

- `grep -rn "aiohttp" src/ | grep -E "web|WebSocket|ws_connect|WSMsgType"` returns nothing. Ferry has no `aiohttp.web` usage and opens no aiohttp websockets.
- Every use is a `ClientSession` (`cli.py:833`, `migrator/api.py:78`, `migrator/probe.py:73`, `core/engine.py:337,495`).
- NiceGUI's own server runs on uvicorn, not `aiohttp.web`.

So the smuggling advisory (server-side) and the websocket-frame advisory (client websockets) have no path into Ferry. The C-parser read does: Ferry parses responses from Stoat, Autumn, the Discord API and the Discord CDN, and a malformed chunked response from any of them reaches that parser.

## The redirect fix in 3.14.3

3.14.3 also fixes the client dropping only the first of `Authorization`, `Cookie` and `Proxy-Authorization` when a redirect crosses an origin. That sounds like a credential leak for Ferry, which sends `Authorization` with the Discord token. It is not one here: Ferry sets at most one of those three headers on any request, so the single header the buggy loop dropped was always the only one present. `migrator/structure.py:240-242` builds its dict empty and adds `Authorization` alone; `discord/client.py:128` pairs it only with `Content-Type`; `exporter/runner.py:337` sends it alone.

Recorded in the changelog so the reasoning is not re-derived next time.

## Verification

`uv run ruff check src/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` clean, **1436 passed** on aiohttp 3.14.3. That also confirms the version-conditional `aioresponses` shim in `conftest.py` still holds on 3.14.3.

Changelog only. No version bump, no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
