### PR TITLE
ci: give auto-tag a manual trigger so a missed release can be recovered

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
     paths:
       - "pyproject.toml"
+  # Manual recovery lever. The tag-existence check makes this safe to run at any
+  # time: if the current version is already tagged the job does nothing, and if
+  # a release was missed it creates the tag and starts release.yml. v2.12.0 was
+  # missed exactly that way, and recovering it needed a hand-pushed tag because
+  # there was no way to ask this workflow to look again.
+  #
+  # The `paths` filter above applies only to the push trigger, so a dispatch
+  # runs regardless of what changed last.
+  workflow_dispatch:
 
 jobs:
   auto-tag:


### PR DESCRIPTION
Follow-up to #127. Two problems, one change.

## Recovery

When v2.12.0 reached `main` without a tag this morning, there was no way to ask this workflow to look again. It runs only on a push touching `pyproject.toml`, and that push had already happened. Recovery meant pushing the tag from a local clone by hand.

The tag-existence check from #127 makes a dispatch safe to run at any time:

- current version already tagged: the job reports there is nothing to do
- a release was missed: it creates the tag, which starts `release.yml`

## Verification of #127 itself

Nothing has bumped the version since #127 merged, so the fixed workflow has never run. Its logic was checked locally against this repo's real tags, but the CI path is unexercised: the App installation token, the `fetch-depth: 0` checkout, and whether tags are actually visible to `git rev-parse` on a runner. That last one is the exact thing that was broken before, when `fetch-depth: 2` meant `actions/checkout` passed `--no-tags`.

The failure mode is silence, so leaving it untested until the next release means finding out by not getting a release.

Once this merges I will dispatch it against the already-tagged 2.12.0 and confirm it reports nothing to do. That exercises the token, the deep fetch and tag visibility without creating anything.

## Note on ordering

`workflow_dispatch` is only offered from the default branch's copy of a workflow, so this cannot be tested before merge. That is the same constraint documented in `release.yml`, which is why that file lists itself in its own `pull_request` paths filter.

## Verification

```
python3 -c "...yaml.safe_load..."
triggers: ['push', 'workflow_dispatch']
push paths: ['pyproject.toml']
workflow_dispatch present: True
```

The `paths` filter applies only to the push trigger, so a dispatch runs regardless of what changed last. No version bump: CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
