### PR TITLE
fix(gui): register both tokens so ferry.log masks them (v2.12.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,11 +63,17 @@ body:
     attributes:
       label: Log file and error messages
       description: |
-        From version 2.11.1 Ferry always writes a log. Tokens are stripped before anything is
-        written, so it is safe to attach.
+        From version 2.11.1 Ferry always writes a log.
 
         - Windows: `%USERPROFILE%\.discord-ferry\logs\ferry.log`
         - macOS and Linux: `~/.discord-ferry/logs/ferry.log`
+
+        **From 2.12.1 onward, tokens are masked before anything is written, so the file is
+        safe to attach.**
+
+        **On 2.11.1 and 2.12.0 the desktop app did not mask the Stoat token.** If you ran
+        one of those versions, search the file for your Stoat token before attaching it, and
+        rotate the token if you find it. Command-line users were never affected.
 
         Attach that file if you can, and paste any on-screen error here. `ferry-output/report.json`
         is written only after a migration reaches the reporting stage, so it will not exist for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-08-06
+
+### Security
+
+- The desktop app never called `register_secret`, so the Stoat token was not
+  masked in `~/.discord-ferry/logs/ferry.log`. Affects versions 2.11.1 and
+  2.12.0. Command-line users were not affected. `_store_session_tokens` now
+  calls `register_secret` for both tokens.
+
+  If you ran the desktop app on those versions, check
+  `~/.discord-ferry/logs/ferry.log` for your Stoat token and rotate it if found.
+
+  `bug_report.yml` said tokens were always masked. It now gives the version
+  floor.
+
+- aiohttp 3.14.1 to 3.14.3 in `uv.lock`, with no source change. This resolves
+  three Dependabot alerts. Ferry calls aiohttp as a client. `src/` contains no
+  `aiohttp.web` code and no aiohttp websockets, and NiceGUI serves over uvicorn.
+  - High, out-of-bounds heap read in the C HTTP response parser on a malformed
+    chunked response. Ferry parses responses from Stoat, Autumn, the Discord API
+    and the Discord CDN, all of which use this parser.
+  - Medium, HTTP request smuggling via WebSocket upgrade. Server-side code only.
+  - Medium, WebSocket client accepts compressed frames without a negotiated
+    `permessage-deflate`. Needs an aiohttp websocket client.
+
+### Added
+
+- `test_gui_token_entry_registers_both_tokens` (SC-123-21) calls
+  `_store_session_tokens`, logs both tokens, and reads the log file back.
+  Removing the `register_secret` calls makes it fail.
+- `test_rotation_bounds_the_file_count` (SC-123-16) writes past the rotation
+  threshold and checks the file count stays at `_BACKUP_COUNT + 1`. It fails when
+  `_BACKUP_COUNT` is 0.
+
 ### Fixed
 
 - **`auto-tag.yml` now checks whether the current version is already tagged.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.12.0"
+version = "2.12.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.12.0"
+__version__ = "2.12.1"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -22,6 +22,7 @@ from discord_ferry.config import FerryConfig
 from discord_ferry.core import entry
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.core.logging_setup import configure_logging
+from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError
 from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
 from discord_ferry.state import load_state
@@ -188,7 +189,18 @@ def _store_session_tokens(store: MutableMapping[str, Any], *, stoat: str, discor
     see Batch 8 / F8b). The parameter is named ``store`` (not ``storage``) so the
     security source-inspection guard, which forbids token assignment via the
     disk-backed ``storage`` alias, cannot false-match this body.
+
+    Registration happens here because this is the only place either token enters
+    the GUI. ``cli.py`` registers at ``_build_config``; without the equivalent
+    call the GUI had no redaction for the Stoat token at all. The Discord token
+    is shaped distinctively enough for ``_DISCORD_TOKEN_RE`` to catch unregistered
+    copies, but a Stoat token is an arbitrary string, so ``sanitize_secrets`` is
+    the only thing that can mask it. Anything logged before this point, including
+    a traceback carrying it, reached ``ferry.log`` in clear text -- the file the
+    bug template asks users to attach to public issues.
     """
+    register_secret("stoat", stoat)
+    register_secret("discord", discord)
     store["token"] = stoat
     store["discord_token"] = discord
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -96,6 +96,39 @@ def test_reset_detaches_the_handler(tmp_path: Path) -> None:
     assert not [h for h in logging.getLogger().handlers if h.get_name() == "ferry-file"]
 
 
+def test_rotation_bounds_the_file_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SC-123-16: emitting past maxBytes x (backupCount + 1) drops the oldest file.
+
+    This patches `_MAX_BYTES` down so the test writes kilobytes instead of the
+    8 MB the real 2 MB x 4 bound would need. The handler reads the module
+    constant when it is constructed, so the patch has to land before
+    `configure_logging`.
+
+    An unbounded handler on a long migration fills the disk instead of helping
+    diagnose it, so the bound is the thing worth pinning.
+    """
+    monkeypatch.setattr(logging_setup, "_MAX_BYTES", 2048)
+    path = logging_setup.configure_logging(path=tmp_path / "ferry.log")
+    assert path is not None
+
+    log = logging.getLogger("discord_ferry.rotation_probe")
+    for i in range(400):
+        log.info("%s %d", "x" * 200, i)
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    produced = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith("ferry.log"))
+
+    # ~100 KB emitted into a 2 KB file: with no rotation this is one huge file,
+    # and with no backupCount it keeps accumulating siblings.
+    assert produced == ["ferry.log", "ferry.log.1", "ferry.log.2", "ferry.log.3"], produced
+    assert len(produced) == logging_setup._BACKUP_COUNT + 1
+
+    # The oldest content must be gone, not merely renamed: record 0 was written
+    # long before the final rotation.
+    assert "x" * 200 + " 0\n" not in path.read_text(encoding="utf-8")
+
+
 def test_debug_records_do_not_reach_the_file(log_file: Path) -> None:
     """SC-123-26: messages.py logs per message at DEBUG.
 
@@ -216,6 +249,44 @@ def test_probe_command_registers_its_token() -> None:
 
     source = inspect.getsource(cli.probe_cmd.callback)
     assert "register_secret" in source, "probe_cmd must register its token"
+
+
+def test_gui_token_entry_registers_both_tokens(log_file: Path) -> None:
+    """SC-123-21: the GUI's token entry point must register for redaction.
+
+    Behavioural on purpose. It drives the real entry point and reads the file,
+    because a source-string assertion here would pass on code that never runs.
+
+    `cli.py` registers at `_build_config`. `gui.py` had no equivalent, so a Stoat
+    token reaching `ferry.log` through any GUI path was written in clear text.
+    The Discord regex floor cannot cover for it: a Stoat token is an opaque
+    string with no matchable shape, so `sanitize_secrets` is the only thing that
+    can mask it, and that needs registration.
+
+    Windows users reach Ferry only through the GUI, and `bug_report.yml` tells
+    them `ferry.log` is safe to attach to a public issue.
+    """
+    from discord_ferry.gui import _store_session_tokens
+
+    # What the GUI does when the user submits the setup form.
+    _store_session_tokens({}, stoat=STOAT_TOKEN, discord=DISCORD_TOKEN)
+
+    log = logging.getLogger("discord_ferry.gui_token_probe")
+    log.warning("stoat=%s discord=%s", STOAT_TOKEN, DISCORD_TOKEN)
+    try:
+        raise RuntimeError(f"upload failed for {STOAT_TOKEN}")
+    except RuntimeError:
+        log.error("with traceback", exc_info=True)
+
+    written = _read(log_file)
+
+    # The records must actually be present, or the assertions below pass on an
+    # empty file. That is how the original #123 tests stayed green.
+    assert "with traceback" in written
+    assert "upload failed for" in written
+
+    assert STOAT_TOKEN not in written, "Stoat token reached ferry.log in clear text"
+    assert DISCORD_TOKEN not in written, "Discord token reached ferry.log in clear text"
 
 
 def test_cli_group_configures_logging() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Releases as **2.12.1**. Supersedes #131, whose changelog entry is folded in here.

## The bug

The desktop app never called `register_secret`. The Stoat token was therefore written to `~/.discord-ferry/logs/ferry.log` unmasked, including inside tracebacks.

Masking has two layers: `sanitize_secrets`, which covers secrets passed to `register_secret`, and `_DISCORD_TOKEN_RE`, which matches Discord token shapes. `cli.py` registers at `_build_config`. `gui.py` had no equivalent call, and a Stoat token is opaque, so neither layer touched it.

Affects **2.11.1 and 2.12.0**, the releases that added the log file. Command-line users were not affected.

This matters because Windows users reach Ferry only through the desktop app, and `bug_report.yml` asks for that file on public issues.

## Evidence

A probe with the registry cleared, logging both tokens and raising an exception carrying the Stoat token:

```
before:  STOAT leaked: True    DISCORD leaked: False
after:   STOAT leaked: False   DISCORD leaked: False   (log still populated)
```

The Discord token survived on shape alone. Running the test against the unfixed function prints the leak in full:

```
RuntimeError: upload failed for SEKRET-stoat-token-abcd
```

## The fix

`register_secret` for both tokens in `_store_session_tokens`. That function has exactly one caller and is the only place either token enters the GUI, so it covers the whole surface. It mirrors `cli.py:614-616`.

## Tests

- `test_gui_token_entry_registers_both_tokens` (SC-123-21) drives the real entry point and reads the log file back. It asserts the records landed before asserting the tokens are absent, so it cannot pass on an empty file. Removing the `register_secret` calls makes it fail.
- `test_rotation_bounds_the_file_count` (SC-123-16) writes past the rotation threshold and checks the file count. Setting `_BACKUP_COUNT` to 0 makes it fail.

Both were run against deliberately broken source, then the source was restored in place and `git diff` confirmed empty.

Note on SC-123-21: the spec describes it as a full simulated export asserting no token in the log. That path logs nothing at INFO, so the assertion would have passed against an empty file. This version tests the property that has teeth.

## bug_report.yml

It said tokens are always masked. It now gives the version floor and tells anyone who ran 2.11.1 or 2.12.0 to check the file and rotate.

## Verification

`uv run ruff check src/ tests/ && uv run ruff format --check . && uv run mypy src/ && uv run pytest` clean, **1438 passed**. Version bumped in all four files including `uv.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
