### PR TITLE
fix: trust the OS store plus certifi on every outbound HTTPS call (v2.13.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,8 @@ jobs:
           }
           if ($tls.Out -notmatch 'trust-source:\s*union') {
             Write-Host "::error::the frozen exe did not build the union trust store"
-            Write-Host $tls.Out
+            Write-Host $tls.Out; Write-Host $tls.Err
+            if (Test-Path $log) { Write-Host "--- ferry.log ---"; Get-Content $log }
             exit 1
           }
           Write-Host "tls-check OK: $($tls.Out -replace "`r?`n", ' | ')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "ferry.spec"
       - ".github/workflows/release.yml"
+      - "src/discord_ferry/core/http.py"
   workflow_dispatch:
 
 concurrency:
@@ -149,6 +150,22 @@ jobs:
             exit 1
           }
           Write-Host "--version OK ($expected)"
+
+          # --- TLS trust (issue #134) ---
+          # Parses the exe's own report. It must NOT stat the path from pwsh: onefile
+          # deletes sys._MEIPASS on exit, so any post-hoc Test-Path always fails.
+          $tls = Invoke-Ferry @('tls-check')
+          if ($tls.Code -ne 0) {
+            Write-Host "::error::tls-check exited $($tls.Code)"
+            Write-Host $tls.Out; Write-Host $tls.Err
+            exit 1
+          }
+          if ($tls.Out -notmatch 'trust-source:\s*union') {
+            Write-Host "::error::the frozen exe did not build the union trust store"
+            Write-Host $tls.Out
+            exit 1
+          }
+          Write-Host "tls-check OK: $($tls.Out -replace "`r?`n", ' | ')"
 
           # --- AttachConsole path (issue #123 symptom 3, no redirection) ---
           # This check must not use Invoke-Ferry. Invoke-Ferry redirects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-08-07
+
+### Fixed
+
+- **The packaged Windows binary could not verify the TLS certificate for
+  `api.github.com`, so DiscordChatExporter never downloaded and the export
+  never started (issue #134).** Ferry inherited whatever trust the operating
+  system offered, with no fallback and no documented override.
+
+  Every outbound session now goes through one factory in `core/http.py` that
+  builds an SSL context trusting the union of the OS certificate store and
+  certifi's bundled roots. All 8 previous session sites use it. Verification
+  stays strict throughout: `CERT_REQUIRED` and hostname checking are on in
+  both the union and fallback branches, so nothing in this change can turn
+  verification off. `certifi` is now a direct dependency, and `ferry.spec`
+  names it so `cacert.pem` reaches the frozen binary.
+
+  `SSL_CERT_FILE` already overrode the trust store before this change; it is
+  now documented rather than newly supported.
+
+  Six existing certificate-error handlers now give actionable guidance
+  instead of a raw traceback, each keeping its own exception type. Three
+  retry loops recognize a certificate failure and stop instead of paying
+  backoff a bad certificate cannot survive, and a certificate failure no
+  longer primes the circuit breaker.
+
+  `ferry tls-check` reports the resolved bundle, whether it is readable,
+  which trust branch was taken, and how many certificates are visible. The
+  Windows release job now runs it against a real runner and asserts the
+  union branch.
+
+  This does not identify what caused the original report's certificate
+  failure. If `ferry tls-check` still shows a problem after upgrading, see
+  the troubleshooting guide.
+
 ## [2.12.1] - 2026-08-06
 
 ### Security

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -14,7 +14,7 @@ Ferry's command-line interface provides the same migration capability as the GUI
 
 ## Commands
 
-Ferry has seven top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, `stats`, and `probe`.
+Ferry has eight top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, `stats`, `probe`, and `tls-check`.
 
 ---
 
@@ -447,3 +447,52 @@ ferry probe --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN" \
 ferry probe --stoat-url https://stoat.example.com --token "$STOAT_TOKEN" \
   --test-server-id 01ABCDEF234567890ABCDEFGH --json > probe-results.json
 ```
+
+---
+
+## `ferry tls-check`
+
+Report which certificate authorities Ferry currently trusts for outbound HTTPS. Read-only: it makes no network calls itself. Use it to diagnose certificate errors such as `unable to get local issuer certificate`. See [Certificate Errors](troubleshooting.md#unable-to-get-local-issuer-certificate) in the troubleshooting guide.
+
+```
+ferry tls-check
+```
+
+No options or flags.
+
+### What it prints
+
+Four fixed lines:
+
+| Key | Meaning |
+|------|-------------|
+| `ca-bundle` | Path to the certifi CA bundle Ferry carries |
+| `ca-bundle-readable` | `true` if that bundle exists on disk and could be read, `false` otherwise |
+| `trust-source` | `union` if Ferry loaded the bundle successfully on top of the operating system's trust store, `fallback` if it could not and is relying on the OS store alone |
+| `ca-visible` | Number of CA certificates the resulting SSL context reports |
+
+**Example output:**
+
+```
+ca-bundle: /path/to/certifi/cacert.pem
+ca-bundle-readable: true
+trust-source: union
+ca-visible: 179
+```
+
+!!! info "A low ca-visible count is not necessarily a problem"
+    On Linux, trust often resolves through OpenSSL's hashed capath directory rather than a single readable bundle. `ca-visible` cannot enumerate certificates trusted that way, so it can read `0` on a machine where TLS handshakes work fine. Treat `ca-visible` as a diagnostic hint, not a health check. `trust-source: union` is the line that confirms Ferry's own bundle loaded.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Always. A missing or unreadable bundle is reported as `trust-source: fallback`, not a nonzero exit. |
+
+### Examples
+
+```bash
+ferry tls-check
+```
+
+Run this first when a migration fails with a certificate error, before changing proxy or antivirus settings. `trust-source: fallback` means Ferry's own bundle did not load and you are relying on the operating system's trust store alone.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -226,6 +226,39 @@ If the window will not close, or Ferry does not start again, quit the leftovers 
 
 ---
 
+## Certificate Errors
+
+### unable to get local issuer certificate
+
+| | |
+|---|---|
+| **Symptom** | Ferry (or the DiscordChatExporter download it triggers) fails with `unable to get local issuer certificate`, or another TLS/SSL certificate error |
+| **Cause** | The machine cannot verify the server's certificate. Common causes are HTTPS-scanning antivirus, a corporate proxy that intercepts TLS traffic, or a certificate authority missing from the machine's trust store. |
+| **Solution** | Point Ferry at a certificate bundle that includes the missing authority using the `SSL_CERT_FILE` environment variable, described below. |
+
+```powershell
+# Windows PowerShell
+$env:SSL_CERT_FILE = "C:\path\to\your-ca-bundle.pem"
+ferry migrate --export-dir ...
+```
+
+`SSL_CERT_FILE` is a standard OpenSSL variable, not a Ferry-specific one, so it works the same way on every platform. Ferry does not replace its own trust with the bundle you point it at: it adds the bundle's roots on top of the OS certificate store and the roots Ferry ships with, so this only widens what Ferry can verify.
+
+Run `ferry tls-check` to see what Ferry can currently verify. See the [CLI reference](cli-reference.md#ferry-tls-check) for what each line means.
+
+If it is specifically the DiscordChatExporter download that fails, you can place the binary yourself instead of letting Ferry download it:
+
+1. Download `DiscordChatExporter.Cli.exe` (or the matching binary for your OS) from the [DiscordChatExporter releases page](https://github.com/Tyrrrz/DiscordChatExporter/releases).
+2. Place it at `%USERPROFILE%\.discord-ferry\bin\dce\2.47.1\DiscordChatExporter.Cli.exe`. The version folder name must be exactly `2.47.1`. Ferry looks there first, and if a binary already exists, it uses that binary without downloading anything.
+
+!!! warning "This skips a safety check"
+    Ferry normally verifies the SHA-256 hash of the DCE binary it downloads. Placing a binary in this folder yourself bypasses that check entirely, because the download step that computes the hash never runs. Only do this with a binary you got directly from the official releases page above.
+
+!!! info "DCE still makes its own certificate checks"
+    DiscordChatExporter is a separate .NET program. It makes its own HTTPS calls against the Windows certificate store, independent of Ferry's. If the root store itself is the problem, exporting from Discord can still fail with a certificate error after the DCE download succeeds, or after you place the binary manually. That is the same underlying cause reappearing, not a new bug.
+
+---
+
 ## Flag Conflicts
 
 ### --resume and --incremental are mutually exclusive

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -248,8 +248,8 @@ Run `ferry tls-check` to see what Ferry can currently verify. See the [CLI refer
 
 If it is specifically the DiscordChatExporter download that fails, you can place the binary yourself instead of letting Ferry download it:
 
-1. Download `DiscordChatExporter.Cli.exe` (or the matching binary for your OS) from the [DiscordChatExporter releases page](https://github.com/Tyrrrz/DiscordChatExporter/releases).
-2. Place it at `%USERPROFILE%\.discord-ferry\bin\dce\2.47.1\DiscordChatExporter.Cli.exe`. The version folder name must be exactly `2.47.1`. Ferry looks there first, and if a binary already exists, it uses that binary without downloading anything.
+1. Download the Windows archive (`DiscordChatExporter.Cli.win-x64.zip`, or the matching archive for your OS) from the [DiscordChatExporter releases page](https://github.com/Tyrrrz/DiscordChatExporter/releases), then extract it.
+2. Place the extracted `DiscordChatExporter.Cli.exe` at `%USERPROFILE%\.discord-ferry\bin\dce\2.47.1\DiscordChatExporter.Cli.exe`. The version folder name must be exactly `2.47.1`. Ferry looks there first, and if a binary already exists, it uses that binary without downloading anything.
 
 !!! warning "This skips a safety check"
     Ferry normally verifies the SHA-256 hash of the DCE binary it downloads. Placing a binary in this folder yourself bypasses that check entirely, because the download step that computes the hash never runs. Only do this with a binary you got directly from the official releases page above.

--- a/ferry.spec
+++ b/ferry.spec
@@ -5,7 +5,7 @@ import re
 import sys
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_all, collect_submodules
+from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
 
 # Read version from source to avoid hardcoding
 _version_match = re.search(
@@ -24,6 +24,11 @@ nicegui_datas, nicegui_bins, nicegui_imports = collect_all("nicegui")
 # aiohttp has its own data files
 aiohttp_datas, aiohttp_bins, aiohttp_imports = collect_all("aiohttp")
 
+# certifi's cacert.pem is the fallback trust store core/http.py loads on top of
+# the OS store (issue #134). hooks-contrib would usually collect it, but only
+# if the analysis sees certifi imported; naming it here removes that condition.
+certifi_datas = collect_data_files("certifi")
+
 # pywebview (optional — native desktop window mode)
 try:
     webview_datas, webview_bins, webview_imports = collect_all("webview")
@@ -38,7 +43,7 @@ ferry_imports = collect_submodules("discord_ferry")
 # Aggregate
 # ---------------------------------------------------------------------------
 
-all_datas = nicegui_datas + aiohttp_datas + webview_datas + [
+all_datas = nicegui_datas + aiohttp_datas + webview_datas + certifi_datas + [
     ("src/discord_ferry/templates/*.json", "discord_ferry/templates"),
     # Pinned DCE SHA-256 hashes — MUST be bundled, otherwise exporter/manager.py
     # silently skips checksum verification in the frozen binary (the supply-chain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.12.1"
+version = "2.13.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     "aiohttp>=3.9",
+    "certifi>=2024.0",
     "click>=8.0",
     "ijson>=3.0",
     "nicegui>=2.0",

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.12.1"
+__version__ = "2.13.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1322,5 +1322,18 @@ def probe_cmd(
     console.print(table)
 
 
+@main.command("tls-check")
+def tls_check_cmd() -> None:
+    """Report which certificate authorities Ferry trusts.
+
+    Prints four fixed keys that .github/workflows/release.yml parses. Changing
+    a key name breaks the Windows release check, so tests/test_cli.py pins them.
+    """
+    from discord_ferry.core.http import describe_trust
+
+    for key, value in describe_trust().items():
+        click.echo(f"{key}: {value}")
+
+
 if __name__ == "__main__":
     main()

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse
 
-import aiohttp
+import aiohttp  # noqa: TCH002
 import click
 from dotenv import load_dotenv
 from rich.console import Console
@@ -24,6 +24,7 @@ from rich.table import Table
 from discord_ferry import __version__
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
+from discord_ferry.core.http import new_session
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError, StateError
@@ -830,7 +831,7 @@ def build(
     console.print(f"[bold]Discord Ferry[/] — building server '{_safe(bp.name)}'\n")
 
     async def _build() -> None:
-        async with aiohttp.ClientSession() as session:
+        async with new_session() as session:
             # Create server
             result = await api_create_server(session, stoat_url, token, bp.name)
             server_id = result["_id"]

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -11,10 +11,11 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from typing import Any
 
-import aiohttp
+import aiohttp  # noqa: TCH002
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.events import EventCallback, MigrationEvent
+from discord_ferry.core.http import new_session
 from discord_ferry.core.security import SecureTokenStore, register_secret, safe_sanitize
 from discord_ferry.discord import (
     fetch_and_translate_guild_metadata,
@@ -334,7 +335,7 @@ async def run_migration(
                 )
             )
             try:
-                async with aiohttp.ClientSession() as discord_session:
+                async with new_session() as discord_session:
                     meta = await fetch_and_translate_guild_metadata(
                         discord_session, config.discord_token, config.discord_server_id
                     )
@@ -492,7 +493,7 @@ async def run_migration(
 
     init_request_semaphore(config.max_concurrent_requests)
 
-    async with aiohttp.ClientSession() as session:
+    async with new_session() as session:
         config.session = session
 
         # S17: Acquire advisory migration lock on the target server (existing server only).
@@ -565,7 +566,7 @@ async def run_migration(
             )
         )
         try:
-            async with aiohttp.ClientSession() as validation_session:
+            async with new_session() as validation_session:
                 server = await api_fetch_server(
                     validation_session, config.stoat_url, config.token, state.stoat_server_id
                 )

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import ssl
+from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -100,6 +101,35 @@ def reset_http_state() -> None:
     global _ssl_context, _trust_source  # noqa: PLW0603
     _ssl_context = None
     _trust_source = "unbuilt"
+
+
+def describe_trust() -> dict[str, str]:
+    """Report the trust configuration, for `ferry tls-check` and CI.
+
+    Rebuilds through the real code path on every call rather than trusting a
+    cached context, so the report cannot drift from what sessions actually
+    use. A real invocation of `ferry tls-check` is a fresh process and would
+    always see a cold cache anyway; the reset only matters for a long-lived
+    process (CliRunner-based tests included) that calls this more than once,
+    where a stale cache would otherwise report the first call's trust state
+    forever, including after certifi's bundle stops resolving.
+    """
+    try:
+        bundle = certifi.where()
+    except OSError:
+        bundle = "<unresolved>"
+    readable = bundle != "<unresolved>" and Path(bundle).is_file()
+    reset_http_state()
+    context = _get_ssl_context()
+    return {
+        "ca-bundle": bundle,
+        "ca-bundle-readable": "true" if readable else "false",
+        # Read from the flag the build set, NOT inferred from counts. A readable
+        # but malformed bundle still raises, and a count comparison would then
+        # report a healthy union while trust had silently degraded.
+        "trust-source": _trust_source,
+        "ca-visible": str(len(context.get_ca_certs(binary_form=True))),
+    }
 
 
 def new_session(**kwargs: Any) -> aiohttp.ClientSession:

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -47,17 +47,21 @@ def _build_ssl_context() -> ssl.SSLContext:
     """
     global _trust_source  # noqa: PLW0603
     context = ssl.create_default_context()
+    bundle = "<unresolved>"
     try:
-        context.load_verify_locations(cafile=certifi.where())
+        bundle = certifi.where()
+        context.load_verify_locations(cafile=bundle)
         _trust_source = "union"
-    except (OSError, ssl.SSLError):
+    except OSError:
+        # ssl.SSLError subclasses OSError, so catching OSError alone covers
+        # both a missing/unreadable bundle path and a malformed PEM file.
         _trust_source = "fallback"
         # Degrade to exactly today's behaviour, never to unverified transport.
         # A missing bundle is a packaging slip; it must not cost all networking.
         logger.warning(
             "could not load the bundled CA roots from %s; "
             "falling back to the operating system trust store only",
-            certifi.where(),
+            bundle,
             exc_info=True,
         )
     return context
@@ -81,15 +85,21 @@ def _get_ssl_context() -> ssl.SSLContext:
 
 
 def reset_http_state() -> None:
-    """Drop the cached context.
+    """Drop the cached context and its trust-source marker.
 
     Mirrors logging_setup.reset_logging and security.reset_secret_registry.
     tests/conftest.py calls this from its autouse fixture, so a test that
     exercises the fallback cannot poison the cache for the rest of the session,
     and the spy test always sees a cold cache.
+
+    Both module globals reset together: leaving _trust_source behind would let
+    a test that forces the fallback branch leave "fallback" behind for every
+    later test, and after a bare reset the module would claim "union" while no
+    context has been built yet.
     """
-    global _ssl_context  # noqa: PLW0603
+    global _ssl_context, _trust_source  # noqa: PLW0603
     _ssl_context = None
+    _trust_source = "unbuilt"
 
 
 def new_session(**kwargs: Any) -> aiohttp.ClientSession:

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -106,20 +106,19 @@ def reset_http_state() -> None:
 def describe_trust() -> dict[str, str]:
     """Report the trust configuration, for `ferry tls-check` and CI.
 
-    Rebuilds through the real code path on every call rather than trusting a
-    cached context, so the report cannot drift from what sessions actually
-    use. A real invocation of `ferry tls-check` is a fresh process and would
-    always see a cold cache anyway; the reset only matters for a long-lived
-    process (CliRunner-based tests included) that calls this more than once,
-    where a stale cache would otherwise report the first call's trust state
-    forever, including after certifi's bundle stops resolving.
+    Builds through the real code path rather than re-deriving it, so the report
+    cannot drift from what sessions actually use. Reads the CACHED context, on
+    purpose: that is what sessions actually use, and rebuilding here would drop
+    a context already in service mid-migration, breaking `_get_ssl_context`'s
+    "one parse, once per process" cost model and re-logging the fallback
+    warning on every call. Tests that must observe a fresh build call
+    `reset_http_state()` themselves, same as `tests/test_http.py` already does.
     """
     try:
         bundle = certifi.where()
     except OSError:
         bundle = "<unresolved>"
     readable = bundle != "<unresolved>" and Path(bundle).is_file()
-    reset_http_state()
     context = _get_ssl_context()
     return {
         "ca-bundle": bundle,

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -1,0 +1,140 @@
+"""One place that builds every outbound HTTPS session.
+
+Issue #134: the packaged Windows binary could not verify api.github.com,
+because Ferry inherited whatever trust the operating system offered and had no
+fallback. Every session now trusts the union of the OS store and certifi's
+bundled roots.
+
+certifi is imported at module level on purpose. That is what guarantees
+PyInstaller's analysis includes the package, so pyinstaller-hooks-contrib's
+hook-certifi.py fires and cacert.pem reaches the frozen app. Relying on
+nicegui's httpx chain to pull it in would make the whole fix inert the day that
+chain changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+from typing import Any
+
+import aiohttp
+import certifi
+
+logger = logging.getLogger(__name__)
+
+# Cached because 8 call sites may build sessions repeatedly and each build
+# parses a PEM bundle. Only the CONTEXT is cached: a TCPConnector or
+# ClientSession resolves a running loop at construction (connector.py:298,
+# client.py:353), and cli.py calls asyncio.run() four separate times, so a
+# cached connector would hand a dead loop to the second command in a process.
+_ssl_context: ssl.SSLContext | None = None
+# Records which branch _build_ssl_context took. Inferring it from certificate
+# counts does not work: in the fallback the context IS the plain default one, so
+# any "visible >= baseline" comparison is trivially true and would report a
+# healthy union while the bundle silently failed to load.
+_trust_source: str = "unbuilt"
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """Return a context trusting the OS store plus certifi's roots.
+
+    create_default_context() is called with NO cafile, capath or cadata.
+    Passing any of them suppresses load_default_certs(), which is what loads
+    the OS store (and, on Windows, the Windows certificate stores). The result
+    would silently be certifi INSTEAD of the OS store, breaking every machine
+    that depends on a corporate root.
+    """
+    global _trust_source  # noqa: PLW0603
+    context = ssl.create_default_context()
+    try:
+        context.load_verify_locations(cafile=certifi.where())
+        _trust_source = "union"
+    except (OSError, ssl.SSLError):
+        _trust_source = "fallback"
+        # Degrade to exactly today's behaviour, never to unverified transport.
+        # A missing bundle is a packaging slip; it must not cost all networking.
+        logger.warning(
+            "could not load the bundled CA roots from %s; "
+            "falling back to the operating system trust store only",
+            certifi.where(),
+            exc_info=True,
+        )
+    return context
+
+
+def _get_ssl_context() -> ssl.SSLContext:
+    """Return the cached context, building it on first use.
+
+    Lazy so commands that never open a socket do not pay the PEM parse. The
+    build does blocking disk I/O on the running loop; aiohttp builds its own
+    contexts at import time for that reason (connector.py:892-896). One parse
+    of a few tens of milliseconds, once per process, is accepted.
+
+    Whichever context is produced, success or fallback, is the one cached, so
+    a failure warning is logged once rather than per session.
+    """
+    global _ssl_context  # noqa: PLW0603 - module-level cache, mirrors api._circuit_state
+    if _ssl_context is None:
+        _ssl_context = _build_ssl_context()
+    return _ssl_context
+
+
+def reset_http_state() -> None:
+    """Drop the cached context.
+
+    Mirrors logging_setup.reset_logging and security.reset_secret_registry.
+    tests/conftest.py calls this from its autouse fixture, so a test that
+    exercises the fallback cannot poison the cache for the rest of the session,
+    and the spy test always sees a cold cache.
+    """
+    global _ssl_context  # noqa: PLW0603
+    _ssl_context = None
+
+
+def new_session(**kwargs: Any) -> aiohttp.ClientSession:
+    """Build a ClientSession carrying Ferry's trust policy.
+
+    A fresh TCPConnector every call, deliberately: it binds to the running
+    loop. No cleanup is attempted if ClientSession() raises after the connector
+    exists, because TCPConnector.close() is async and cannot be awaited here,
+    and BaseConnector.__del__ returns early when _conns is empty
+    (connector.py:354-358), which it always is for a connector that never
+    opened a connection.
+
+    NEVER subclass ClientSession. aioresponses patches
+    ClientSession._request on the class; a subclass defining _request would
+    shadow the patch and silently disable HTTP mocking across the test suite.
+    """
+    connector = aiohttp.TCPConnector(ssl=_get_ssl_context())
+    return aiohttp.ClientSession(connector=connector, **kwargs)
+
+
+def tls_hint(exc: BaseException) -> str | None:
+    """Return actionable guidance if `exc`'s chain holds a certificate failure.
+
+    Returns a MESSAGE, never an exception. The six call sites raise four
+    different types that callers select on, and StoatConnectionError sits under
+    FerryError rather than MigrationError. A single new class would either
+    escape cli.py's four `except MigrationError` handlers, printing a raw
+    traceback, or swallow gui.py's specific `except DiscordAuthError`.
+
+    The walk is bounded by a visited set: a self-referential __context__ would
+    otherwise spin forever.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, aiohttp.ClientConnectorCertificateError):
+            host = getattr(current, "host", "the server")
+            port = getattr(current, "port", 443)
+            return (
+                f" Could not verify the TLS certificate for {host}:{port}. "
+                "This usually means antivirus with HTTPS scanning, a corporate "
+                "proxy, or a certificate authority missing from this machine. "
+                "Point SSL_CERT_FILE at a CA bundle that includes it, or see "
+                "the troubleshooting guide."
+            )
+        current = current.__cause__ or current.__context__
+    return None

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 
+from discord_ferry.core.http import tls_hint
 from discord_ferry.discord.models import DiscordChannel, DiscordRole, PermissionOverwrite
 from discord_ferry.errors import DiscordAuthError, MigrationError
 
@@ -159,6 +160,9 @@ async def _discord_request(session: aiohttp.ClientSession, token: str, path: str
         except (DiscordAuthError, MigrationError):
             raise
         except aiohttp.ClientError as exc:
+            hint = tls_hint(exc)
+            if hint is not None:
+                raise MigrationError(f"Discord API network error: {exc}{hint}") from exc
             network_attempts += 1
             if network_attempts >= _MAX_RETRIES:
                 raise MigrationError(f"Discord API network error: {exc}") from exc

--- a/src/discord_ferry/exporter/manager.py
+++ b/src/discord_ferry/exporter/manager.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import DCENotFoundError, ValidationError
 
 if TYPE_CHECKING:
@@ -175,7 +176,7 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
     data: bytes | None = None
     for attempt in range(2):
         try:
-            async with aiohttp.ClientSession() as session:
+            async with new_session() as session:
                 async with session.get(
                     release_url, headers={"Accept": "application/vnd.github.v3+json"}
                 ) as resp:

--- a/src/discord_ferry/exporter/manager.py
+++ b/src/discord_ferry/exporter/manager.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
-from discord_ferry.core.http import new_session
+from discord_ferry.core.http import new_session, tls_hint
 from discord_ferry.errors import DCENotFoundError, ValidationError
 
 if TYPE_CHECKING:
@@ -211,6 +211,10 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
             break  # success — exit retry loop
 
         except (aiohttp.ClientError, DCENotFoundError) as e:
+            hint = tls_hint(e)
+            if hint is not None:
+                # A certificate failure cannot succeed on retry; do not pay the sleep.
+                raise DCENotFoundError(f"Network error downloading DCE: {e}{hint}") from e
             if attempt == 0:
                 on_event(
                     MigrationEvent(

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import DiscordAuthError, ExportError
 from discord_ferry.exporter.dce_output import (
     Banner,
@@ -331,7 +332,7 @@ async def validate_discord_token(token: str) -> None:
     """
     try:
         async with (
-            aiohttp.ClientSession() as session,
+            new_session() as session,
             session.get(
                 "https://discord.com/api/v10/users/@me",
                 headers={"Authorization": token},

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import new_session
+from discord_ferry.core.http import new_session, tls_hint
 from discord_ferry.errors import DiscordAuthError, ExportError
 from discord_ferry.exporter.dce_output import (
     Banner,
@@ -343,7 +343,7 @@ async def validate_discord_token(token: str) -> None:
             if resp.status != 200:
                 raise DiscordAuthError(f"Discord API returned unexpected status {resp.status}")
     except aiohttp.ClientError as exc:
-        raise DiscordAuthError(f"Cannot reach Discord API: {exc}") from exc
+        raise DiscordAuthError(f"Cannot reach Discord API: {exc}{tls_hint(exc) or ''}") from exc
 
 
 async def run_dce_export(

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
 
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import MigrationError
 
 if TYPE_CHECKING:
@@ -75,7 +76,7 @@ async def get_session(config: FerryConfig) -> AsyncIterator[aiohttp.ClientSessio
     if config.session is not None:
         yield config.session
     else:
-        async with aiohttp.ClientSession() as session:
+        async with new_session() as session:
             yield session
 
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
 
-from discord_ferry.core.http import new_session
+from discord_ferry.core.http import new_session, tls_hint
 from discord_ferry.errors import MigrationError
 
 if TYPE_CHECKING:
@@ -297,6 +297,13 @@ async def _api_request_inner(
                 text = await resp.text()
                 raise MigrationError(f"API error {resp.status}: {text}")
         except aiohttp.ClientError as exc:
+            hint = tls_hint(exc)
+            if hint is not None:
+                # Above both consecutive_failures increments on purpose. Five
+                # short-circuited channels in the parallel message phase would
+                # otherwise open the breaker and add a 30s sleep to an error
+                # that cannot recover.
+                raise MigrationError(f"Network error: {exc}{hint}") from exc
             if attempt == MAX_API_RETRIES - 1:
                 _circuit_state.consecutive_failures += 1
                 raise MigrationError(

--- a/src/discord_ferry/migrator/connect.py
+++ b/src/discord_ferry/migrator/connect.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.http import tls_hint
 from discord_ferry.errors import StoatConnectionError
 from discord_ferry.migrator.api import api_fetch_server, get_session
 
@@ -92,7 +93,9 @@ async def _discover_autumn_url(session: aiohttp.ClientSession, stoat_url: str) -
                 raise StoatConnectionError(f"Stoat API returned status {response.status} at {url}")
             data = await response.json()
     except aiohttp.ClientError as e:
-        raise StoatConnectionError(f"Cannot reach Stoat API at {url}: {e}") from e
+        raise StoatConnectionError(
+            f"Cannot reach Stoat API at {url}: {e}{tls_hint(e) or ''}"
+        ) from e
 
     try:
         autumn_url: str = data["features"]["autumn"]["url"]
@@ -147,4 +150,6 @@ async def _verify_token(session: aiohttp.ClientSession, stoat_url: str, token: s
                     f"Token verification failed with status {response.status}"
                 )
     except aiohttp.ClientError as e:
-        raise StoatConnectionError(f"Token verification request failed: {e}") from e
+        raise StoatConnectionError(
+            f"Token verification request failed: {e}{tls_hint(e) or ''}"
+        ) from e

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -6,8 +6,9 @@ import contextlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import aiohttp
+import aiohttp  # noqa: TCH002
 
+from discord_ferry.core.http import new_session
 from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_webhook,
@@ -70,7 +71,7 @@ async def run_probe(
     """
     report = ProbeReport()
     own_session = session is None
-    sess = session or aiohttp.ClientSession()
+    sess = session or new_session()
     try:
         await _check_autumn(sess, stoat_url, report)
         await _check_voice_bug(sess, stoat_url, token, test_server_id, report)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 from discord_ferry.core import logging_setup
+from discord_ferry.core.http import reset_http_state
 from discord_ferry.core.security import reset_secret_registry
 
 # --- aioresponses / aiohttp 3.14 compatibility shim ---------------------------
@@ -73,8 +74,10 @@ def _isolate_ferry_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> I
     monkeypatch.setattr(logging_setup, "_log_path", lambda: tmp_path / "ferry.log")
     logging_setup.reset_logging()
     reset_secret_registry()
+    reset_http_state()
     try:
         yield
     finally:
         logging_setup.reset_logging()
         reset_secret_registry()
+        reset_http_state()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -570,19 +570,25 @@ async def test_certificate_error_does_not_prime_the_circuit_breaker(
     """SC-134-26.
 
     Placing the short-circuit below either increment would let five
-    short-circuited channels open the breaker and add a 30s sleep.
+    short-circuited channels open the breaker and add a 30s sleep. Patching
+    asyncio.sleep and asserting it is never awaited also closes a narrower
+    mutant: a guard placed below the FIRST increment but above the second
+    still leaves consecutive_failures == 0 on this single-attempt call, since
+    the `attempt == MAX_API_RETRIES - 1` increment never runs on attempt 0.
     """
     _reset_circuit_state()
     key = aiohttp.client_reqrep.ConnectionKey("api.stoat.chat", 443, True, True, None, None, None)
     cert_error = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
 
     mock_aiohttp.get(f"{BASE_URL}/servers/x", exception=cert_error)
-    async with aiohttp.ClientSession() as session:
-        with pytest.raises(MigrationError) as caught:
-            await _api_request(session, "GET", f"{BASE_URL}/servers/x", TOKEN)
+    with patch("asyncio.sleep", new_callable=AsyncMock) as slept:
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError) as caught:
+                await _api_request(session, "GET", f"{BASE_URL}/servers/x", TOKEN)
 
     assert "SSL_CERT_FILE" in str(caught.value)
     assert _circuit_state.consecutive_failures == 0
+    assert slept.await_count == 0, "a certificate error must not pay the backoff sleep"
 
 
 async def test_api_502_retry_exhaustion(mock_aiohttp: aioresponses) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import pytest
 from aioresponses import aioresponses
 
+from discord_ferry.config import FerryConfig
 from discord_ferry.errors import MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
@@ -1462,3 +1464,16 @@ async def test_429_reset_after_is_capped(mock_aiohttp: aioresponses) -> None:
             await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
 
     assert calls[0] == pytest.approx(60.0, abs=0.05)
+
+
+async def test_get_session_prefers_the_config_session() -> None:
+    """SC-134-5: the config branch must survive the factory swap."""
+    from discord_ferry.core.http import new_session
+    from discord_ferry.migrator.api import get_session
+
+    async with new_session() as shared:
+        config = FerryConfig(export_dir=Path("."), stoat_url="https://x.invalid", token="t")
+        config.session = shared
+        async with get_session(config) as yielded:
+            assert yielded is shared
+        assert not shared.closed

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -571,10 +571,10 @@ async def test_certificate_error_does_not_prime_the_circuit_breaker(
 
     Placing the short-circuit below either increment would let five
     short-circuited channels open the breaker and add a 30s sleep. Patching
-    asyncio.sleep and asserting it is never awaited also closes a narrower
-    mutant: a guard placed below the FIRST increment but above the second
-    still leaves consecutive_failures == 0 on this single-attempt call, since
-    the `attempt == MAX_API_RETRIES - 1` increment never runs on attempt 0.
+    asyncio.sleep and asserting it is never awaited catches a guard moved
+    below `await asyncio.sleep(delay)`: on this single-attempt call, that
+    placement would still let the sleep run before the guard raises, and the
+    assertion would catch it.
     """
     _reset_circuit_state()
     key = aiohttp.client_reqrep.ConnectionKey("api.stoat.chat", 443, True, True, None, None, None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import ssl
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -561,6 +562,27 @@ async def test_api_network_error_exhausted(mock_aiohttp: aioresponses) -> None:
     async with aiohttp.ClientSession() as session:
         with pytest.raises(MigrationError, match="Network error after 3 retries"):
             await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+
+async def test_certificate_error_does_not_prime_the_circuit_breaker(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-134-26.
+
+    Placing the short-circuit below either increment would let five
+    short-circuited channels open the breaker and add a 30s sleep.
+    """
+    _reset_circuit_state()
+    key = aiohttp.client_reqrep.ConnectionKey("api.stoat.chat", 443, True, True, None, None, None)
+    cert_error = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+
+    mock_aiohttp.get(f"{BASE_URL}/servers/x", exception=cert_error)
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as caught:
+            await _api_request(session, "GET", f"{BASE_URL}/servers/x", TOKEN)
+
+    assert "SSL_CERT_FILE" in str(caught.value)
+    assert _circuit_state.consecutive_failures == 0
 
 
 async def test_api_502_retry_exhaustion(mock_aiohttp: aioresponses) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import certifi
 import pytest
 from click.testing import CliRunner
 
@@ -1479,3 +1480,30 @@ def test_version_is_read_from_module_attribute_not_package_metadata(
         # sentinel into the module every later test imports.
         monkeypatch.undo()
         importlib.reload(discord_ferry.cli)
+
+
+# ---------------------------------------------------------------------------
+# tls-check
+# ---------------------------------------------------------------------------
+
+
+def test_tls_check_prints_the_four_pinned_keys() -> None:
+    """SC-134-16. These key names are a contract with release.yml's parser."""
+    result = CliRunner().invoke(main, ["tls-check"])
+    assert result.exit_code == 0
+    for key in ("ca-bundle:", "ca-bundle-readable:", "trust-source:", "ca-visible:"):
+        assert key in result.output
+
+
+def test_tls_check_reports_the_branch_actually_taken(tmp_path: Path) -> None:
+    """SC-134-17.
+
+    Reporting only that certifi exists would prove packaging while leaving the
+    silent fallback invisible, which is the failure this check exists to catch.
+    """
+    assert "trust-source: union" in CliRunner().invoke(main, ["tls-check"]).output
+
+    missing = tmp_path / "nope.pem"
+    with patch.object(certifi, "where", return_value=str(missing)):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+    assert "trust-source: fallback" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 from click.testing import CliRunner
 
 from discord_ferry.cli import main
+from discord_ferry.core.http import reset_http_state
 from discord_ferry.errors import MigrationError
 from discord_ferry.state import MigrationState
 
@@ -1500,10 +1501,30 @@ def test_tls_check_reports_the_branch_actually_taken(tmp_path: Path) -> None:
 
     Reporting only that certifi exists would prove packaging while leaving the
     silent fallback invisible, which is the failure this check exists to catch.
+
+    `describe_trust()` reads the cached SSL context, matching what sessions
+    actually use, so this test resets it itself between invocations -- the
+    same thing `tests/test_http.py` already does around every case that must
+    observe a fresh build, on top of the autouse fixture that only resets
+    between test FUNCTIONS.
     """
     assert "trust-source: union" in CliRunner().invoke(main, ["tls-check"]).output
 
     missing = tmp_path / "nope.pem"
+    reset_http_state()
     with patch.object(certifi, "where", return_value=str(missing)):
         out = CliRunner().invoke(main, ["tls-check"]).output
     assert "trust-source: fallback" in out
+
+    # A missing bundle only proves certifi.where() failed to resolve a path.
+    # The check this command exists for is a bundle that RESOLVES and READS
+    # but does not PARSE: load_verify_locations() raises ssl.SSLError (an
+    # OSError subclass) on malformed PEM content, which must still flip the
+    # flag to fallback even though the file itself is perfectly readable.
+    bad = tmp_path / "garbage.pem"
+    bad.write_text("not a certificate")
+    reset_http_state()
+    with patch.object(certifi, "where", return_value=str(bad)):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+    assert "ca-bundle-readable: true" in out  # the file is fine
+    assert "trust-source: fallback" in out  # the trust is not

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ssl
+
 import aiohttp
 import pytest
 from aioresponses import aioresponses
@@ -546,6 +548,32 @@ async def test_discord_network_error_bounded(mock_discord: aioresponses) -> None
         async with aiohttp.ClientSession() as session:
             with pytest.raises(MigrationError, match="Discord API network error"):
                 await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+
+async def test_certificate_error_skips_the_network_retry(mock_discord: aioresponses) -> None:
+    """SC-134-27.
+
+    Mirrors the api.py and manager.py short-circuit tests. A certificate
+    failure cannot succeed on retry, so the 1s sleep must never be paid, and
+    the await_count assertion also proves only one request was attempted
+    instead of _MAX_RETRIES.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.errors import MigrationError
+
+    url = f"{DISCORD_API}/guilds/{GUILD_ID}/roles"
+    key = aiohttp.client_reqrep.ConnectionKey("discord.com", 443, True, True, None, None, None)
+    cert_error = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+    mock_discord.get(url, exception=cert_error)
+
+    with patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError) as caught:
+                await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+    assert "SSL_CERT_FILE" in str(caught.value)
+    assert sleep.await_count == 0, "a certificate error must not pay the 1s retry sleep"
 
 
 async def test_discord_403_raises_migration_error(mock_discord: aioresponses) -> None:  # SC-21

--- a/tests/test_exporter_manager.py
+++ b/tests/test_exporter_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import ssl
 import subprocess
 import zipfile
 from pathlib import Path
@@ -227,6 +228,41 @@ class TestDownloadDceRetry:
 
             with pytest.raises(DCENotFoundError):
                 await download_dce(events.append)
+
+    @pytest.mark.asyncio
+    async def test_certificate_error_skips_the_download_retry(self, tmp_path):
+        """SC-134-25.
+
+        The mock must raise from an awaited call that yields. A synchronously
+        raising mock inside a retry loop has produced an unbounded hang in this
+        project before.
+        """
+        from discord_ferry.errors import DCENotFoundError
+
+        events = []
+        release_url = (
+            f"https://api.github.com/repos/Tyrrrz/DiscordChatExporter/releases/tags/{DCE_VERSION}"
+        )
+        key = aiohttp.client_reqrep.ConnectionKey(
+            "api.github.com", 443, True, True, None, None, None
+        )
+        cert_error = aiohttp.ClientConnectorCertificateError(
+            key, ssl.SSLCertVerificationError("bad")
+        )
+
+        with (
+            aioresponses() as m,
+            patch("discord_ferry.exporter.manager._get_dce_dir", return_value=tmp_path),
+            patch("discord_ferry.exporter.manager._get_asset_name", return_value="test.zip"),
+            patch("asyncio.sleep", new_callable=AsyncMock) as slept,
+        ):
+            m.get(release_url, exception=cert_error)
+
+            with pytest.raises(DCENotFoundError) as caught:
+                await download_dce(events.append)
+
+        assert "SSL_CERT_FILE" in str(caught.value)
+        assert slept.await_count == 0, "a certificate error must not pay the 3s retry sleep"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -216,3 +216,15 @@ def test_tls_hint_finds_a_wrapped_certificate_error() -> None:
     outer = RuntimeError("download failed")
     outer.__cause__ = inner
     assert "api.github.com" in (http.tls_hint(outer) or "")
+
+
+def test_hint_is_a_message_not_an_exception_type() -> None:
+    """SC-134-23, the contract that keeps six call sites' types intact.
+
+    StoatConnectionError sits under FerryError, not MigrationError. A single
+    new exception class would escape cli.py's four `except MigrationError`
+    handlers, or swallow gui.py's `except DiscordAuthError`.
+    """
+    key = aiohttp.client_reqrep.ConnectionKey("h", 443, True, True, None, None, None)
+    exc = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("x"))
+    assert isinstance(http.tls_hint(exc), str)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,198 @@
+"""Trust policy for every outbound HTTPS call (issue #134)."""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import aiohttp
+import certifi
+import pytest
+
+from discord_ferry.core import http
+
+if TYPE_CHECKING:
+    pass
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "discord_ferry"
+
+
+def test_context_starts_from_the_default_context_with_no_ca_arguments() -> None:
+    """SC-134-7, the PRIMARY replacement detector.
+
+    Two wrong implementations drop the OS store and both are caught here:
+      (a) ssl.SSLContext(PROTOCOL_TLS_CLIENT) never calls create_default_context,
+          so call_count is 0;
+      (b) create_default_context(cafile=certifi.where()) suppresses
+          load_default_certs entirely, so the kwargs check fails.
+
+    call_count == 1 is not decoration. A warm module cache means the factory
+    never calls create_default_context, the spy records nothing, and an
+    assertion written only as "no call had CA arguments" passes over an empty
+    list. That is the same vacuous shape this project already had to fix once.
+    """
+    http.reset_http_state()
+
+    real = ssl.create_default_context
+    with patch("ssl.create_default_context", side_effect=real) as spy:
+        http._build_ssl_context()
+
+    assert spy.call_count == 1, "context must be built exactly once, from a cold cache"
+    _, kwargs = spy.call_args
+    for forbidden in ("cafile", "capath", "cadata"):
+        assert forbidden not in kwargs, (
+            f"create_default_context must receive no {forbidden}: passing one "
+            "suppresses load_default_certs() and drops the OS trust store"
+        )
+
+
+def test_context_trusts_the_union_of_os_and_certifi() -> None:
+    """SC-134-8, corroborating only.
+
+    binary_form=True is mandatory: the default dict form is unhashable and
+    set() raises TypeError.
+
+    Known limitation: on a platform whose default context reports no
+    certificates (trust resolved through a hashed capath), this collapses to
+    union == certifi and a replacement implementation satisfies it too. The
+    real detector is the test above.
+    """
+    http.reset_http_state()
+
+    default = ssl.create_default_context()
+    certifi_only = ssl.create_default_context(cafile=certifi.where())
+    union = http._build_ssl_context()
+
+    d = set(default.get_ca_certs(binary_form=True))
+    c = set(certifi_only.get_ca_certs(binary_form=True))
+    u = set(union.get_ca_certs(binary_form=True))
+
+    assert u == d | c
+    assert u >= c
+    assert u >= d
+
+
+def test_verification_stays_strict() -> None:
+    """SC-134-14."""
+    http.reset_http_state()
+    ctx = http._build_ssl_context()
+    assert ctx.verify_mode is ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+
+
+def test_context_is_cached() -> None:
+    """SC-134-9."""
+    http.reset_http_state()
+    real = ssl.create_default_context
+    with patch("ssl.create_default_context", side_effect=real) as spy:
+        http._get_ssl_context()
+        http._get_ssl_context()
+    assert spy.call_count == 1
+
+
+def test_reset_clears_the_cache() -> None:
+    """SC-134-10. Without this, every later test sees a warm cache."""
+    http.reset_http_state()
+    first = http._get_ssl_context()
+    http.reset_http_state()
+    second = http._get_ssl_context()
+    assert first is not second
+
+
+def test_fallback_keeps_verification_strict(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """SC-134-15.
+
+    The tempting wrong fix is ssl._create_unverified_context() or
+    verify_mode = CERT_NONE. Either turns a packaging slip into silent
+    unverified transport.
+    """
+    http.reset_http_state()
+    missing = tmp_path / "nope.pem"
+    with caplog.at_level("WARNING"), patch.object(certifi, "where", return_value=str(missing)):
+        ctx = http._build_ssl_context()
+
+    assert ctx.verify_mode is ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+    assert str(missing) in caplog.text
+
+
+def test_module_imports_certifi() -> None:
+    """SC-134-13: guarantees PyInstaller's analysis sees the dependency."""
+    assert hasattr(http, "certifi")
+
+
+def test_no_bare_client_session_outside_the_factory() -> None:
+    """SC-134-1 and SC-134-2, a reintroduction guard only.
+
+    This is a text scan. This project bans text scans as COVERAGE, because
+    inspect.getsource assertions let an 11-release outage ship green. It is
+    admissible here purely to stop a new bare session appearing later; the
+    behavioural proof that the factory works lives in the aioresponses and
+    ownership tests.
+    """
+    allowlist = {"core/http.py"}
+    offenders: list[str] = []
+    for path in _SRC.rglob("*.py"):
+        rel = path.relative_to(_SRC).as_posix()
+        if rel in allowlist:
+            continue
+        if "ClientSession(" in path.read_text(encoding="utf-8"):
+            offenders.append(rel)
+    assert not offenders, (
+        f"these files build a session directly instead of using core.http.new_session: {offenders}"
+    )
+    assert allowlist == {"core/http.py"}, "the allowlist must not grow"
+
+
+async def test_factory_session_is_intercepted_by_aioresponses() -> None:
+    """SC-134-3.
+
+    The trap: a ClientSession subclass defining _request shadows the attribute
+    aioresponses patches, silently disabling mocking in 22 test files. A custom
+    connector is fine, which is what this proves.
+    """
+    from aioresponses import aioresponses
+
+    with aioresponses() as mocked:
+        mocked.get("https://example.invalid/x", status=200, payload={"ok": True})
+        async with http.new_session() as session:
+            resp = await session.get("https://example.invalid/x")
+            assert (await resp.json())["ok"] is True
+
+
+def test_tls_hint_recognises_a_certificate_error() -> None:
+    """SC-134-19, SC-134-21."""
+    key = aiohttp.client_reqrep.ConnectionKey("api.github.com", 443, True, True, None, None, None)
+    exc = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+    hint = http.tls_hint(exc)
+    assert hint is not None
+    assert "api.github.com" in hint
+    assert "SSL_CERT_FILE" in hint
+    assert "antivirus" in hint.lower()
+    assert "proxy" in hint.lower()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [ValueError("nope"), TimeoutError(), aiohttp.ClientOSError("boom")],
+)
+def test_tls_hint_ignores_unrelated_errors(exc: BaseException) -> None:
+    """SC-134-20.
+
+    ClientConnectorCertificateError IS an OSError subclass, so an
+    isinstance(exc, OSError) check would wrongly match ClientOSError and attach
+    TLS advice to unrelated failures. So would matching the word "certificate"
+    in a message.
+    """
+    assert http.tls_hint(exc) is None
+
+
+def test_tls_hint_survives_a_self_referential_chain() -> None:
+    """SC-134-22: a naive while-loop over __context__ would spin forever."""
+    exc = ValueError("loop")
+    exc.__context__ = exc
+    assert http.tls_hint(exc) is None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ssl
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import aiohttp
@@ -12,9 +11,6 @@ import certifi
 import pytest
 
 from discord_ferry.core import http
-
-if TYPE_CHECKING:
-    pass
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "discord_ferry"
 
@@ -134,13 +130,14 @@ def test_no_bare_client_session_outside_the_factory() -> None:
     behavioural proof that the factory works lives in the aioresponses and
     ownership tests.
     """
+    assert _SRC.is_dir(), "the src tree must actually resolve, or rglob silently yields nothing"
     allowlist = {"core/http.py"}
     offenders: list[str] = []
     for path in _SRC.rglob("*.py"):
         rel = path.relative_to(_SRC).as_posix()
         if rel in allowlist:
             continue
-        if "ClientSession(" in path.read_text(encoding="utf-8"):
+        if "aiohttp.ClientSession(" in path.read_text(encoding="utf-8"):
             offenders.append(rel)
     assert not offenders, (
         f"these files build a session directly instead of using core.http.new_session: {offenders}"
@@ -162,6 +159,20 @@ async def test_factory_session_is_intercepted_by_aioresponses() -> None:
         async with http.new_session() as session:
             resp = await session.get("https://example.invalid/x")
             assert (await resp.json())["ok"] is True
+
+
+async def test_new_session_carries_the_ferry_context() -> None:
+    """The factory must install the context it built, not aiohttp's default.
+
+    Without this, replacing new_session's body with a bare ClientSession()
+    passes every other test in the suite, including the Windows CI gate.
+    """
+    http.reset_http_state()
+    ctx = http._get_ssl_context()
+    async with http.new_session() as session:
+        connector = session.connector
+        assert isinstance(connector, aiohttp.TCPConnector)
+        assert connector._ssl is ctx
 
 
 def test_tls_hint_recognises_a_certificate_error() -> None:
@@ -196,3 +207,12 @@ def test_tls_hint_survives_a_self_referential_chain() -> None:
     exc = ValueError("loop")
     exc.__context__ = exc
     assert http.tls_hint(exc) is None
+
+
+def test_tls_hint_finds_a_wrapped_certificate_error() -> None:
+    """The chain walk must actually walk."""
+    key = aiohttp.client_reqrep.ConnectionKey("api.github.com", 443, True, True, None, None, None)
+    inner = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+    outer = RuntimeError("download failed")
+    outer.__cause__ = inner
+    assert "api.github.com" in (http.tls_hint(outer) or "")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -219,11 +219,17 @@ def test_tls_hint_finds_a_wrapped_certificate_error() -> None:
 
 
 def test_hint_is_a_message_not_an_exception_type() -> None:
-    """SC-134-23, the contract that keeps six call sites' types intact.
+    """SC-134-23.
 
-    StoatConnectionError sits under FerryError, not MigrationError. A single
-    new exception class would escape cli.py's four `except MigrationError`
-    handlers, or swallow gui.py's `except DiscordAuthError`.
+    Checks only that tls_hint() returns a str for a certificate error. It does
+    not verify that any of the six call sites still raise their original
+    exception type; a new exception class raised at one of those sites (for
+    example connect.py) would not be caught here.
+
+    The reason type preservation matters: StoatConnectionError sits under
+    FerryError, not MigrationError. A single new exception class would escape
+    cli.py's four `except MigrationError` handlers, or swallow gui.py's
+    `except DiscordAuthError`.
     """
     key = aiohttp.client_reqrep.ConnectionKey("h", 443, True, True, None, None, None)
     exc = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("x"))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -42,6 +42,24 @@ def test_ferry_spec_bundles_dce_checksums() -> None:
     )
 
 
+def test_ferry_spec_collects_certifi() -> None:
+    """SC-134-12: cacert.pem must reach the frozen binary.
+
+    pyinstaller-hooks-contrib ships hook-certifi.py, which fires only if the
+    analysis sees certifi imported. core/http.py imports it at module level, so
+    that holds today. Naming it in the spec too means the bundle does not
+    depend on that import surviving a future refactor.
+    """
+    spec_text = (_REPO_ROOT / "ferry.spec").read_text(encoding="utf-8")
+    # Match the CALL, not the word. ferry.spec carries a comment mentioning
+    # certifi, so a substring check would pass even with the collection deleted.
+    assert re.search(r'collect_data_files\(\s*["\']certifi["\']\s*\)', spec_text), (
+        "ferry.spec must call collect_data_files('certifi'), else cacert.pem may "
+        "not be bundled and the TLS trust fix is inert in the shipped app"
+    )
+    assert re.search(r"certifi_datas", spec_text), "certifi_datas must reach all_datas"
+
+
 def test_ferry_spec_builds_onedir_on_darwin() -> None:
     """macOS must build onedir, not onefile.
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -182,8 +182,18 @@ def test_release_job_only_publishes_on_a_tag() -> None:
 
 
 def test_release_workflow_asserts_the_union_branch() -> None:
-    """SC-134-18."""
+    """SC-134-18.
+
+    A bare "trust-source" substring check would stay green even if the workflow's
+    PowerShell condition were weakened from `-notmatch 'trust-source:\\s*union'` to
+    `-notmatch 'trust-source'`, or if the `$tls.Code -ne 0` check next to it were
+    deleted -- either change would stop the Windows gate from gating while this test
+    kept passing. Assert the union branch itself is checked, not merely mentioned.
+    """
     text = (_REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     assert "tls-check" in text
     assert "trust-source" in text
     assert "core/http.py" in text, "http.py must be in the paths filter"
+    assert re.search(r"trust-source:\\s\*union", text), (
+        "release.yml must assert the union branch, not merely mention trust-source"
+    )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -179,3 +179,11 @@ def test_release_job_only_publishes_on_a_tag() -> None:
     assert "startsWith(github.ref, 'refs/tags/')" in release_job, (
         "the release job must be gated on a tag ref"
     )
+
+
+def test_release_workflow_asserts_the_union_branch() -> None:
+    """SC-134-18."""
+    text = (_REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "tls-check" in text
+    assert "trust-source" in text
+    assert "core/http.py" in text, "http.py must be in the paths filter"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -57,7 +57,12 @@ def test_ferry_spec_collects_certifi() -> None:
         "ferry.spec must call collect_data_files('certifi'), else cacert.pem may "
         "not be bundled and the TLS trust fix is inert in the shipped app"
     )
-    assert re.search(r"certifi_datas", spec_text), "certifi_datas must reach all_datas"
+    # Anchored to the all_datas line. A bare certifi_datas search matches the
+    # assignment above it, so dropping it from the concatenation would leave
+    # this test green while nothing was bundled.
+    assert re.search(r"all_datas\s*=[^\n]*certifi_datas", spec_text), (
+        "certifi_datas must appear in the all_datas concatenation, not merely be assigned"
+    )
 
 
 def test_ferry_spec_builds_onedir_on_darwin() -> None:

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -242,3 +242,16 @@ async def test_server_bucket_we_have_no_limit_for_is_reported(mock_aiohttp: aior
     result = _check(report, "autumn_limits")
     assert result.startswith("warn:")
     assert "stickers" in result
+
+
+async def test_probe_does_not_close_an_injected_session() -> None:
+    """SC-134-4: run_probe closes only what it created."""
+    from discord_ferry.core.http import new_session
+
+    async with new_session() as injected:
+        with aioresponses() as mocked:
+            mocked.get("https://example.invalid/", status=500, repeat=True)
+            await run_probe(
+                "https://example.invalid", "tok", "srv", lambda _e: None, session=injected
+            )
+        assert not injected.closed, "an injected session must outlive run_probe"

--- a/uv.lock
+++ b/uv.lock
@@ -458,6 +458,7 @@ version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "certifi" },
     { name = "click" },
     { name = "ijson" },
     { name = "nicegui" },
@@ -485,6 +486,7 @@ native = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "aioresponses", marker = "extra == 'dev'", specifier = ">=0.7" },
+    { name = "certifi", specifier = ">=2024.0" },
     { name = "click", specifier = ">=8.0" },
     { name = "ijson", specifier = ">=3.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.12.1"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #134. Releases as **v2.13.0**.

## The failure

A packaged Windows binary could not verify the TLS certificate for `api.github.com`, so it could not download DiscordChatExporter and the export never started:

```
Cannot connect to host api.github.com:443 ssl:True
[SSLCertVerificationError: unable to get local issuer certificate]
```

Every outbound session built a bare `aiohttp.ClientSession()`, inheriting whatever trust the operating system offered, with no fallback and no documented override.

## What changed

**One factory, all eight sites.** New `src/discord_ferry/core/http.py` builds every session with an SSL context trusting the **union** of the OS certificate store and certifi's bundled roots. The union matters in both directions: certifi alone would break machines relying on a corporate root, and the OS store alone leaves #134 unfixed.

The sequencing is the part that is easy to get wrong. `ssl.create_default_context()` must be called with no `cafile`, `capath` or `cadata`, because passing any of them suppresses `load_default_certs()` and silently yields replacement rather than addition. A test spies on that call and asserts it received none.

**Verification never weakens.** `verify_mode` stays `CERT_REQUIRED` and `check_hostname` stays `True` on every path, including the fallback taken when certifi's bundle cannot be loaded. That path degrades to today's behaviour, never to unverified transport.

**Only the context is cached.** `cli.py` calls `asyncio.run()` four separate times; a cached `TCPConnector` or `ClientSession` would bind to a dead loop and break the second command in a process. An `SSLContext` is loop-agnostic.

**Certificate failures now explain themselves** at six existing handlers, each keeping its own exception type. A single new exception class would have escaped `cli.py`'s four `except MigrationError` handlers or swallowed the GUI's `except DiscordAuthError`, so the helper returns a message rather than raising. Certificate errors also short-circuit three retry loops and never prime the circuit breaker.

**`ferry tls-check`** reports the resolved bundle, whether it is readable, which branch was taken, and how many certificates are visible. The Windows release job asserts `trust-source: union` on a real runner, which is the only place this can be proven: the development machine is an M1 Mac.

## Verification

`ruff`, `ruff format`, `mypy --strict` and `pytest` clean. **1464 tests pass**, 26 of them new.

Locally:

```
ca-bundle-readable: true
trust-source: union
ca-visible: 179
```

Every new test was falsified against a named wrong implementation before being accepted, not merely written and observed to pass.

## Honest limits

- **`SSL_CERT_FILE` already worked.** It is now documented, not newly supported.
- **The reporter's root cause is still unknown.** If it turns out to be corporate TLS interception, certifi does not help them and `SSL_CERT_FILE` is their fix. Ask for `ferry tls-check` output before closing #134.
- **DCE is outside this fix.** It is a separate .NET process using the Windows store directly, so a broken root store can still fail the export after the download succeeds. Documented in troubleshooting.
- **Proxy support is unrelated and absent.** Ferry ignores `HTTP_PROXY` entirely, because `trust_env` defaults to False. Split out as #135 with the analysis, including why the flag cannot simply be switched on.
- **macOS packaging is not gated** by an equivalent smoke check.

## Process

Written through the project's design pipeline: brief, spec, three fresh-context critique rounds, 27 test scenarios, then seven tasks each implemented by a fresh subagent and reviewed by a fresh reviewer, plus a whole-branch review.

Worth recording: five of the six Critical or Important findings across those reviews were defects in the **plan**, not the implementations, and every one was the same shape, an assertion that could not fail. The reviews caught all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
