### PR TITLE
ci: assert the union trust store on macOS too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,25 @@ jobs:
             echo "::error::extracted size differs from the built bundle by more than 10%"
             exit 1
           }
+
+          # --- TLS trust (issue #134) ---
+          # Run the EXTRACTED bundle, not dist/, so this also proves the ditto
+          # round-trip kept certifi's cacert.pem. Windows has had this check since
+          # v2.13.0; without it here a macOS-only bundling regression ships unseen.
+          # Reads the app's own verdict rather than stat-ing a path: onedir keeps
+          # its resources inside the bundle, but the app is the only thing that
+          # knows whether load_verify_locations actually parsed them.
+          TLS_OUT=$("$APP/Contents/MacOS/Ferry" tls-check 2>&1) || {
+            echo "::error::tls-check failed to run from the extracted bundle"
+            echo "$TLS_OUT"
+            exit 1
+          }
+          echo "$TLS_OUT"
+          case "$TLS_OUT" in
+            *"trust-source: union"*) echo "tls-check OK: union trust store built" ;;
+            *) echo "::error::the macOS bundle did not build the union trust store"
+               exit 1 ;;
+          esac
           codesign --verify --deep --strict "$APP"
           # -print -quit rather than `| grep -q .`: under pipefail a SIGPIPE'd find
           # would surface as a bogus "missing" failure.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -181,6 +181,29 @@ def test_release_job_only_publishes_on_a_tag() -> None:
     )
 
 
+def test_release_workflow_asserts_the_union_branch_on_macos() -> None:
+    """SC-134-18 companion: macOS must gate on the union branch too.
+
+    Windows has asserted this since v2.13.0. Without the same check on macOS, a
+    bundling regression that drops certifi from the .app ships unseen, because
+    the macOS job otherwise only inspects symlinks and archive size.
+
+    Anchored to the literal assertion text, not to the words "tls-check" or
+    "trust-source" appearing somewhere. Matching those alone would stay green if
+    the case statement were weakened to accept any output, which is exactly the
+    hole this file already had to close once for the Windows job.
+    """
+    text = (_REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    macos_block = text.split("build-macos:")[1]
+    assert "tls-check" in macos_block, "the macOS job must run tls-check"
+    assert re.search(r'\*"trust-source: union"\*', macos_block), (
+        "the macOS job must gate on the union branch, not merely run the command"
+    )
+    assert "Contents/MacOS/Ferry" in macos_block, (
+        "it must run the extracted bundle's inner binary, so the ditto round-trip is covered"
+    )
+
+
 def test_release_workflow_asserts_the_union_branch() -> None:
     """SC-134-18.
 


### PR DESCRIPTION
Closes the last gap the v2.13.0 whole-branch review flagged. CI only, no version bump.

## The gap

Windows has gated on `trust-source: union` since v2.13.0, so a frozen binary that cannot build the union trust store fails the release. macOS builds the same binary from the same spec and **never runs it**. The job inspects symlink count and archive size, nothing else.

So a bundling regression that dropped certifi from the `.app` would ship unseen, and the first person to notice would be a macOS user whose export dies exactly the way issue #134 did.

## What this adds

One assertion in the existing "Verify the archived artifact" step:

```
TLS_OUT=$("$APP/Contents/MacOS/Ferry" tls-check 2>&1)
case "$TLS_OUT" in
  *"trust-source: union"*) echo "tls-check OK: union trust store built" ;;
  *) echo "::error::the macOS bundle did not build the union trust store"; exit 1 ;;
esac
```

Two deliberate choices:

**It runs the extracted bundle, not `dist/`.** That covers the `ditto` round-trip as well, so an archive that loses `cacert.pem` fails here rather than reaching a user. The step already extracts to `_verify/` for its symlink check, so this is free.

**It reads the app's own verdict rather than stat-ing a path.** Only the app knows whether `load_verify_locations` actually parsed the bundle. A file that exists but does not parse is the failure mode `trust-source` was invented to expose.

## Verification

`ruff`, `ruff format`, `mypy --strict`, `pytest` clean, **1465 passed**, one new test.

The guard test is anchored to the literal assertion text, not to the words `tls-check` or `trust-source` appearing somewhere in the file. Matching those alone would stay green if the case statement were weakened to accept any output, which is the hole this same file already had to close once for the Windows job.

Proven by weakening the gate to `*) echo "tls-check ran" ;;` and watching the test fail, then reverting in place.

## What this cannot tell us yet

No macOS CI job has ever executed the frozen binary, so this is the first time the `.app`'s argv dispatch runs on a runner. It uses the same `core/entry.py` path Windows already proves, and captured output satisfies the console check, so it should work. If it does not, this PR is where we find out, rather than on a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
