### PR TITLE
fix: explain certificate failures on the Autumn upload path (v2.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.13.1] - 2026-08-07
+
+### Fixed
+
+- **A certificate failure while uploading a file to Autumn gave no reason
+  (issue #137).** v2.13.0 wired actionable guidance into six error handlers,
+  but Autumn had none: `upload_to_autumn` let a `ClientConnectorCertificateError`
+  propagate unwrapped, and `structure.py`'s role-icon handler catches it as an
+  `OSError` and discards the text on purpose, so the user saw a fixed template
+  with no cause at all.
+
+  `upload_to_autumn` now converts a certificate failure into an
+  `AutumnUploadError` naming the host and `SSL_CERT_FILE`, which covers all five
+  callers at once. Every other `ClientError` is re-raised untouched, so no
+  caller's `except` clause changes what it matches. The certificate case raises
+  on the first attempt rather than paying two retry sleeps for an error no
+  retry can clear.
+
+  The role-icon handler re-derives the hint from the `__cause__` chain, since
+  it discards the message. It still never interpolates the exception: the
+  Autumn response body may echo `x-session-token`, and `tls_hint` emits only a
+  host, a port and fixed text.
+
+  Reaches anyone on a self-hosted Stoat whose Autumn file host sits behind a
+  different certificate authority than the API host.
+
 ## [2.13.0] - 2026-08-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.13.0"
+version = "2.13.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.13.0"
+__version__ = "2.13.1"

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.http import tls_hint
 from discord_ferry.discord.client import download_role_icon
 from discord_ferry.discord.metadata import RoleMeta, load_discord_metadata
 from discord_ferry.errors import AutumnUploadError, MigrationError
@@ -399,13 +400,17 @@ async def _resolve_role_icon(
             state.native_fidelity_counts.get("role_icons", 0) + 1
         )
         return icon_id
-    except (AutumnUploadError, OSError):
+    except (AutumnUploadError, OSError) as exc:
         # Fixed template — never str(exc); the body may echo x-session-token.
+        # tls_hint is the one safe addition: it emits a host, a port and fixed
+        # text, never the exception it inspected. Without it this is the only
+        # Autumn failure that reaches the user with no cause at all.
+        hint = tls_hint(exc) or ""
         state.warnings.append(
             {
                 "phase": "roles",
                 "type": "role_icon_upload_failed",
-                "message": f"Role icon upload failed for role '{role_name}'.",
+                "message": f"Role icon upload failed for role '{role_name}'.{hint}",
             }
         )
         return None

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
+from discord_ferry.core.http import tls_hint
 from discord_ferry.errors import AutumnUploadError
 
 if TYPE_CHECKING:
@@ -227,6 +228,25 @@ async def upload_to_autumn(
 
                 text = await response.text()
                 raise AutumnUploadError(f"Upload failed with status {response.status}: {text}")
+        except aiohttp.ClientError as exc:
+            hint = tls_hint(exc)
+            if hint is None:
+                raise
+            # Autumn is the one host v2.13.0's error work did not reach: no caller
+            # of this function has a handler that could explain a certificate
+            # failure, and structure.py's role-icon path discards the text entirely.
+            # Converting here covers every caller at once.
+            #
+            # Interpolating `exc` is safe in THIS branch and nowhere else in this
+            # function. A connection-level aiohttp error carries a host, a port and
+            # an OpenSSL reason; the response body -- which may echo
+            # x-session-token, hence the fixed template at structure.py's catch
+            # site -- only exists once a request completed, which a certificate
+            # failure guarantees it did not.
+            #
+            # Raised rather than retried: a certificate failure cannot succeed on a
+            # second attempt, so the caller should not pay two sleeps to learn that.
+            raise AutumnUploadError(f"Upload to Autumn failed: {exc}{hint}") from exc
         finally:
             fh.close()
 

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -1,5 +1,6 @@
 """Tests for the Autumn file uploader."""
 
+import ssl
 from pathlib import Path
 
 import aiohttp
@@ -768,3 +769,84 @@ async def test_429_boolean_body_retry_after_is_ignored(
         result = await upload_to_autumn(session, AUTUMN_URL, "attachments", file, TOKEN)
     assert result == "ok"
     assert slept[0] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Certificate failures (#137) — the one host v2.13.0's error work did not reach
+# ---------------------------------------------------------------------------
+
+
+def _cert_error(host: str = "cdn.stoatusercontent.com") -> aiohttp.ClientConnectorCertificateError:
+    key = aiohttp.client_reqrep.ConnectionKey(host, 443, True, True, None, None, None)
+    return aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+
+
+async def test_certificate_error_becomes_an_actionable_autumn_error(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """A certificate failure against Autumn names the host and the override.
+
+    Kills two mutants. Without the `except aiohttp.ClientError` arm the raw
+    ClientConnectorCertificateError propagates and `pytest.raises` fails on the
+    type. Converting to AutumnUploadError but dropping `tls_hint` leaves a
+    message with no host and no SSL_CERT_FILE, which the last two assertions
+    reject — that is exactly the unactionable state #137 was filed about.
+    """
+    file = tmp_path / "icon.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/icons", exception=_cert_error())
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError) as caught:
+            await upload_to_autumn(session, AUTUMN_URL, "icons", file, TOKEN)
+
+    message = str(caught.value)
+    assert "cdn.stoatusercontent.com" in message
+    assert "SSL_CERT_FILE" in message
+    # Pins the explicit `from exc`. tls_hint also walks __context__, which Python
+    # sets implicitly, so structure.py's role-icon handler would still re-derive
+    # the hint without it — this assertion guards the idiom, not that behaviour.
+    assert isinstance(caught.value.__cause__, aiohttp.ClientConnectorCertificateError)
+
+
+async def test_certificate_error_is_not_retried(
+    tmp_path: Path, mock_aiohttp: aioresponses, slept: list[float]
+) -> None:
+    """A certificate failure raises on attempt 1 rather than sleeping twice.
+
+    Guards the plausible wrong fix rather than the current code: handling
+    ClientError inside the loop invites `continue`, which would pay two backoff
+    sleeps before failing with an error no retry can clear. Only one response is
+    mocked, so a retry would also change the exception the caller sees.
+    """
+    file = tmp_path / "icon.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/icons", exception=_cert_error())
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(AutumnUploadError):
+            await upload_to_autumn(session, AUTUMN_URL, "icons", file, TOKEN)
+
+    assert slept == [], "a certificate error must not pay the retry backoff"
+
+
+async def test_non_certificate_client_error_is_re_raised_unchanged(
+    tmp_path: Path, mock_aiohttp: aioresponses
+) -> None:
+    """Only certificate failures are converted; every other ClientError is untouched.
+
+    Kills the over-broad fix: wrapping every ClientError in AutumnUploadError
+    would change what each of the five callers' except clauses match, so a
+    connection reset that a caller deliberately lets escape would start being
+    swallowed as a warning instead. `pytest.raises(aiohttp.ClientError)` passes
+    under both implementations — the AutumnUploadError check is what discriminates.
+    """
+    file = tmp_path / "icon.png"
+    file.write_bytes(b"x" * 50)
+    mock_aiohttp.post(f"{AUTUMN_URL}/icons", exception=aiohttp.ClientOSError("connection reset"))
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(aiohttp.ClientError) as caught:
+            await upload_to_autumn(session, AUTUMN_URL, "icons", file, TOKEN)
+
+    assert not isinstance(caught.value, AutumnUploadError)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ssl
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
@@ -3011,3 +3013,116 @@ async def test_too_many_roles_break_leaves_unmapped_unfinalized(tmp_path: Path) 
         await run_roles(config, state, exports, lambda e: None)
     assert "r1" in state.role_map and "r2" not in state.role_map
     assert "r1" in state.roles_finalized and "r2" not in state.roles_finalized
+
+
+# ---------------------------------------------------------------------------
+# #137 — the role-icon path discards the message, so it re-derives the hint
+# ---------------------------------------------------------------------------
+
+
+async def test_run_roles_icon_certificate_failure_explains_itself(tmp_path: Path) -> None:
+    """A certificate failure uploading a role icon names the host and the override.
+
+    This handler throws `str(exc)` away on purpose, so the hint upload_to_autumn
+    already put in the message never reaches the user — it has to be re-derived
+    from the __cause__ chain here. Dropping the `tls_hint(exc)` call leaves the
+    bare fixed template, which the last two assertions reject: that bare template
+    is the unactionable dead end #137 was filed about.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    key = aiohttp.client_reqrep.ConnectionKey(
+        "cdn.stoatusercontent.com", 443, True, True, None, None, None
+    )
+    cert_error = aiohttp.ClientConnectorCertificateError(
+        key, ssl.SSLCertVerificationError("unable to get local issuer certificate")
+    )
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        m.post(f"{AUTUMN_URL}/icons", exception=cert_error, repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        # Must NOT raise — a certificate failure on an icon degrades like any other.
+        await run_roles(config, state, exports, events.append)
+
+    icon_warnings = [w for w in state.warnings if w.get("type") == "role_icon_upload_failed"]
+    assert icon_warnings
+    message = icon_warnings[0]["message"]
+    assert "cdn.stoatusercontent.com" in message
+    assert "SSL_CERT_FILE" in message
+
+
+async def test_run_roles_icon_warning_never_carries_the_response_body(tmp_path: Path) -> None:
+    """The hint is the only thing added — the Autumn body still never appears.
+
+    Uses a non-retryable error status so the AutumnUploadError raised carries the
+    response body verbatim. The pre-existing token-safety test uses a non-JSON 200,
+    whose exception text is a fixed template, so it cannot see this: appending
+    `{exc}` beside the hint would leave that test green and this one red.
+    """
+    events: list[MigrationEvent] = []
+    # A distinctive token: the module default is "tok", three characters that a
+    # substring check would clear even if the body were interpolated verbatim.
+    config = _make_config(tmp_path, token="stoat-session-token-SENTINEL")
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        m.post(
+            f"{AUTUMN_URL}/icons",
+            status=400,
+            body=f"x-session-token echoed: {config.token} SENTINEL_BODY",
+            repeat=True,
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    icon_warnings = [w for w in state.warnings if w.get("type") == "role_icon_upload_failed"]
+    assert icon_warnings
+    for w in icon_warnings:
+        assert "SENTINEL_BODY" not in w["message"]
+        assert config.token not in w["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #137.

v2.13.0 gave six error handlers actionable guidance for a TLS certificate failure. Autumn was the one host it did not reach.

## The gap

`upload_to_autumn` has no handler that could see a connection error: its `try:` pairs with a `finally:`, and the two handlers in the file guard `response.json()` **after** the connection already succeeded. So a `ClientConnectorCertificateError` from the POST propagated out unwrapped.

`migrator/structure.py:402` then catches it as an `OSError`, because that class is an `OSError` subclass, and its handler discards the exception text on purpose. The user saw a fixed template with no cause at all.

Reaches anyone on a self-hosted Stoat whose Autumn file host sits behind a different certificate authority than the API host.

## The fix

Convert at the chokepoint, re-derive at the catch site that discards.

`upload_to_autumn` is the one function every Autumn upload passes through, so a single `except aiohttp.ClientError` arm covers all five callers. It converts **only** when `tls_hint` returns a hint and bare-`raise`s everything else, so each caller's `except` clause keeps matching exactly what it matched before. Wrapping every `ClientError` would have redrawn those boundaries.

The certificate case raises on the first attempt instead of paying two retry sleeps, since no retry can clear it.

`structure.py`'s role-icon handler throws the message away, so it calls `tls_hint(exc)` itself against the `__cause__` chain. It still never interpolates `exc`: the Autumn response body may echo `x-session-token`, and `tls_hint` emits only a host, a port and fixed text.

Interpolating `exc` inside the new handler in `autumn.py` is safe, and the comment says why. A connection-level aiohttp error carries a host, a port and an OpenSSL reason; the response body only exists once a request completed, which a certificate failure guarantees it did not.

## Tests

Five new tests. Each was proven red against a named wrong implementation before being accepted, with the mutant applied and reverted in place.

| Wrong implementation | Test that caught it |
|---|---|
| No `except ClientError` arm (the pre-fix state) | `test_certificate_error_becomes_an_actionable_autumn_error`, `test_certificate_error_is_not_retried` |
| Convert but drop `tls_hint` | `test_certificate_error_becomes_an_actionable_autumn_error` |
| Wrap **every** `ClientError` | `test_non_certificate_client_error_is_re_raised_unchanged` |
| Drop `from exc` | same test, `__cause__` assertion |
| Drop `tls_hint` at `structure.py` | `test_run_roles_icon_certificate_failure_explains_itself` |
| Reintroduce `{exc}` at `structure.py` | `test_run_roles_icon_warning_never_carries_the_response_body` |

That last row matters. The **pre-existing** token-safety test stayed green under the same mutant, confirmed by running it. It drives the failure with a non-JSON 200, whose exception text is a fixed template, so no body exists to leak. The new test uses a 400 carrying a body, which is the only shape where the server's text reaches the exception.

`test_certificate_error_is_not_retried` guards a plausible future wrong fix (handling `ClientError` inside the loop and `continue`-ing) rather than this change; today no `ClientError` path sleeps. Its docstring says so.

Also checked by hand: with `upload_with_cache`'s single-flight coalescing, both the leader and the waiter get the actionable error, and the cache is not poisoned.

## Verification

`ruff check`, `ruff format --check .`, `mypy src/` and the full suite: 1470 tests pass.

## Not in this PR

- `discord/client.py:189` `download_role_icon` swallows every `ClientError` and returns `bytes | None`, so a certificate failure there is unactionable too. Carrying a message needs a signature change, and the Discord metadata fetch at `client.py:161` runs first and already explains itself.
- `state.warnings` bypasses `safe_sanitize` at roughly fifteen sites in `structure.py`, unlike the four migrator modules that all use it, and `reporter.py` writes warnings verbatim into `report.json`. Systemic, and rooted in `api.py` and `autumn.py` interpolating a server response body into an exception message. Filed separately.
