### PR TITLE
feat: honour HTTP_PROXY, HTTPS_PROXY, NO_PROXY and OS proxy settings (v2.14.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,14 @@ jobs:
             if (Test-Path $log) { Write-Host "--- ferry.log ---"; Get-Content $log }
             exit 1
           }
+          # --- Proxy state (issue #135, Task 11) ---
+          # Pins only the KEY, not a value: CI runners have no controlled OS
+          # proxy state, so the resolved value varies and only the key's
+          # presence is assertable, unlike trust-source's fixed 'union'.
+          if ($tls.Out -notmatch 'proxy-source:\s*') {
+            Write-Host "::error::tls-check did not report proxy state"
+            exit 1
+          }
           Write-Host "tls-check OK: $($tls.Out -replace "`r?`n", ' | ')"
 
           # --- AttachConsole path (issue #123 symptom 3, no redirection) ---
@@ -306,6 +314,15 @@ jobs:
             *"trust-source: union"*) echo "tls-check OK: union trust store built" ;;
             *) echo "::error::the macOS bundle did not build the union trust store"
                exit 1 ;;
+          esac
+
+          # --- Proxy state (issue #135, Task 11) ---
+          # Pins only the KEY, not a value: CI runners have no controlled OS
+          # proxy state, so the resolved value varies and only the key's
+          # presence is assertable, unlike trust-source's fixed 'union'.
+          case "$TLS_OUT" in
+            *"proxy-source: "*) echo "tls-check OK: proxy state reported" ;;
+            *) echo "::error::tls-check did not report proxy state"; exit 1 ;;
           esac
           codesign --verify --deep --strict "$APP"
           # -print -quit rather than `| grep -q .`: under pipefail a SIGPIPE'd find

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   them. On Windows and macOS, when those variables are unset, Ferry falls back to the operating
   system's own proxy configuration (the registry on Windows, the system configuration on macOS),
   so a proxy set only in system settings still applies. The two sources merge per scheme rather
-  than one short-circuiting the other, and their bypass lists union: a host exempted by either
-  `NO_PROXY` or the system's own exception list is exempted.
+  than one short-circuiting the other. `NO_PROXY` always exempts a host. The system's own
+  exception list is honoured as well, for a proxy the system supplied, which is how `curl`
+  behaves: a proxy you set yourself in the environment is not filtered by the machine's list.
 
   Resolution installs through a `ClientRequest` subclass in `core/http.py`, the same session
   factory every outbound call already goes through for the v2.13.0 TLS trust policy. A proxy that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-08-10
+
+### Added
+
+- **Ferry now resolves an HTTP or HTTPS proxy for every outbound session, closing issue #135.**
+  `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` work the way most command-line tools already read
+  them. On Windows and macOS, when those variables are unset, Ferry falls back to the operating
+  system's own proxy configuration (the registry on Windows, the system configuration on macOS),
+  so a proxy set only in system settings still applies. The two sources merge per scheme rather
+  than one short-circuiting the other, and their bypass lists union: a host exempted by either
+  `NO_PROXY` or the system's own exception list is exempted.
+
+  Resolution installs through a `ClientRequest` subclass in `core/http.py`, the same session
+  factory every outbound call already goes through for the v2.13.0 TLS trust policy. A proxy that
+  requires authentication is handled on the request itself: Ferry strips the credential out of
+  the URL, sends it as a `Proxy-Authorization` header, and registers both the plaintext and
+  encoded forms for log redaction, so neither reaches `ferry.log`.
+
+  `FERRY_DISABLE_PROXY=1` turns proxy use off everywhere, and `ferry tls-check` reports what
+  Ferry actually resolved: `proxy-http`, `proxy-https`, `proxy-source` and `proxy-disabled`.
+  Eight existing network error handlers, the same call sites v2.13.0 wired for certificate
+  errors, now also recognize a proxy failure and name the proxy, the target host, and whether
+  the proxy itself rejected the request.
+
+  DiscordChatExporter runs as a separate process and cannot see any of the above, so the export
+  phase passes it an OS-resolved `HTTPS_PROXY` directly (only when the user has not already set
+  one), with the credential left out: a password sitting in a child process's environment is
+  readable by other processes on some systems. SOCKS proxies and a proxy set only through
+  `ALL_PROXY` are outside what Ferry supports; Ferry reports them by name instead of connecting
+  through them with no explanation, tracked as issue #141.
+
+  `yarl` and `multidict` are now direct dependencies. `core/http.py` imports `yarl.URL` and
+  `multidict.CIMultiDict` directly, and both previously reached the environment only through
+  aiohttp's own requirements, the same gap `certifi` closed in v2.13.0.
+
+### Documentation
+
+- Troubleshooting guide gains a Proxy Configuration section: the operating-system fallback, the
+  difference between `FERRY_DISABLE_PROXY` and `NO_PROXY`, why the kill switch cannot fix a
+  stale system proxy entry during export, why the GUI and `ferry tls-check` can disagree about a
+  `.env`-only proxy, and the SOCKS, `ALL_PROXY`, and authenticating-proxy limits.
+
 ## [2.13.1] - 2026-08-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `ALL_PROXY` are outside what Ferry supports; Ferry reports them by name instead of connecting
   through them with no explanation, tracked as issue #141.
 
+  The `aiohttp` floor moves from `>=3.9` to `>=3.14`. `core/http.py` imports `encode_basic_auth`,
+  which aiohttp added in 3.14.0 as the replacement for `BasicAuth` and `proxy_auth`, both of which
+  are deprecated for aiohttp 4.0. Anyone with a pinned `aiohttp` below 3.14 needs to raise it.
+
   `yarl` and `multidict` are now direct dependencies. `core/http.py` imports `yarl.URL` and
   `multidict.CIMultiDict` directly, and both previously reached the environment only through
   aiohttp's own requirements, the same gap `certifi` closed in v2.13.0.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -271,6 +271,8 @@ Ferry reads `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` the way most command-line
 | **Cause** | No environment variable is set for that scheme, so Ferry fell back to the operating system's own proxy configuration. |
 | **Solution** | Run `ferry tls-check` and read `proxy-source`: `env` means a variable you set, `os` means the system fallback. To stop the fallback for one scheme, set the matching environment variable yourself. To stop all proxy use, see `FERRY_DISABLE_PROXY` below. |
 
+`proxy-source` is a single value, not one per scheme. If you have `HTTP_PROXY` set in the environment and HTTPS falling back to the system, `tls-check` reports one source for both, and it is the one HTTPS resolved from. Read `proxy-http` and `proxy-https` to see the two addresses; when they differ, at least one of them came from the other source.
+
 `FERRY_DISABLE_PROXY=1` turns off every proxy Ferry would otherwise use, environment variable or system fallback, for every scheme. `NO_PROXY` is narrower: it exempts individual hosts (a comma-separated list, for example `NO_PROXY=stoat.internal,localhost`) while leaving the rest of the configuration in place. A third switch comes from Python's standard library rather than Ferry itself: setting the matching lowercase variable to an empty string turns off one scheme at a time. `http_proxy=""` disables the HTTP proxy without touching `https_proxy`.
 
 !!! tip "A TLS-inspecting proxy needs two settings, not one"

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -259,6 +259,60 @@ If it is specifically the DiscordChatExporter download that fails, you can place
 
 ---
 
+## Proxy Configuration
+
+Ferry reads `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` the way most command-line tools do, and that is where most proxy questions start. It goes wider than that, though: on Windows and macOS, when those variables are not set, Ferry falls back to the system proxy settings a browser on the same machine would use. Someone who only set `HTTPS_PROXY` can still find Ferry routing traffic through a second proxy they never configured.
+
+### Ferry uses a proxy you did not set
+
+| | |
+|---|---|
+| **Symptom** | Traffic goes through a proxy you never configured, or `ferry tls-check` reports a `proxy-source` of `os` |
+| **Cause** | No environment variable is set for that scheme, so Ferry fell back to the operating system's own proxy configuration. |
+| **Solution** | Run `ferry tls-check` and read `proxy-source`: `env` means a variable you set, `os` means the system fallback. To stop the fallback for one scheme, set the matching environment variable yourself. To stop all proxy use, see `FERRY_DISABLE_PROXY` below. |
+
+`FERRY_DISABLE_PROXY=1` turns off every proxy Ferry would otherwise use, environment variable or system fallback, for every scheme. `NO_PROXY` is narrower: it exempts individual hosts (a comma-separated list, for example `NO_PROXY=stoat.internal,localhost`) while leaving the rest of the configuration in place. A third switch comes from Python's standard library rather than Ferry itself: setting the matching lowercase variable to an empty string turns off one scheme at a time. `http_proxy=""` disables the HTTP proxy without touching `https_proxy`.
+
+!!! tip "A TLS-inspecting proxy needs two settings, not one"
+    A corporate proxy that inspects HTTPS traffic presents its own certificate in place of the real one. Routing through the proxy only solves half of that: Ferry also needs `SSL_CERT_FILE` pointed at a bundle that includes the proxy's certificate authority, the same mechanism described in [Certificate Errors](#certificate-errors) above. Without it, Ferry reaches the proxy and then fails to verify what the proxy hands back.
+
+### FERRY_DISABLE_PROXY=1 does not fix the export
+
+| | |
+|---|---|
+| **Symptom** | The kill switch is set, later migration phases run fine, but exporting from Discord (phase 0) still fails or still goes through a proxy |
+| **Cause** | DiscordChatExporter is a separate program and reads the operating system's proxy settings on its own. `FERRY_DISABLE_PROXY=1` only turns off proxy use inside Ferry; it has no way to reach into DCE's resolution. |
+| **Solution** | Clear the proxy at its source instead: on Windows, **Settings → Network & internet → Proxy**; on macOS, **System Settings → Network → (your connection) → Details → Proxies**. Once the system entry is gone, both Ferry and DCE stop using it. |
+
+!!! info "The proxy scan runs once per process"
+    Ferry reads the proxy configuration when it starts and keeps that answer for the rest of the run. Connecting to a VPN, or changing networks partway through a migration, does not change what Ferry uses. Restart Ferry after a network change if a stale proxy setting seems to be involved.
+
+### `ferry tls-check` reports a proxy the GUI does not use
+
+| | |
+|---|---|
+| **Symptom** | `ferry tls-check` reports a proxy, but the desktop GUI seems to run without one, or an export from the GUI goes through unproxied |
+| **Cause** | Ferry loads a `.env` file only on the command line. `ferry tls-check` and `ferry migrate` both call that loader, so a `.env` file's `HTTPS_PROXY` reaches them. The desktop GUI never calls it, so the same variable sitting only in `.env` never reaches the GUI. |
+| **Solution** | Set `HTTPS_PROXY` (and any other proxy variables) as real environment variables before launching the GUI, not only in `.env`. Or run the migration from the CLI, where `.env` already works. |
+
+### An authenticating proxy breaks the export phase
+
+| | |
+|---|---|
+| **Symptom** | Ferry connects through a proxy without trouble, but exporting from Discord (phase 0) fails with a `407` from the proxy |
+| **Cause** | When Ferry resolves a proxy from the system settings and that proxy needs a username and password, Ferry authenticates itself but cannot hand the credential to DiscordChatExporter. A password sitting in a child process's environment is readable by other processes on some systems, so Ferry withholds it and DCE receives only the proxy address. |
+| **Solution** | Set `HTTPS_PROXY` yourself with the credential in the URL (`https://user:pass@host:port`) if that trade-off is acceptable. DCE inherits a variable you set directly; it only misses the one Ferry resolved on your behalf. |
+
+### SOCKS and ALL_PROXY are not supported
+
+| | |
+|---|---|
+| **Symptom** | A proxy notice at startup or in `ferry tls-check` names a SOCKS proxy or `ALL_PROXY`, and Ferry connects direct anyway |
+| **Cause** | Ferry supports HTTP and HTTPS proxies only. A SOCKS proxy, or a proxy set exclusively through `ALL_PROXY`, falls outside what Ferry can use ([issue #141](https://github.com/nordscope-fi/Discord-stoat-ferry/issues/141)). |
+| **Solution** | Set `HTTP_PROXY` and `HTTPS_PROXY` directly if an HTTP or HTTPS proxy is available for the same server. Ferry writes a notice naming what it found, so the direct connection has a stated cause. There is no workaround for a SOCKS-only setup today; issue #141 tracks it. |
+
+---
+
 ## Flag Conflicts
 
 ### --resume and --incremental are mutually exclusive

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -458,6 +458,7 @@ class MigrationEvent:
 | `completed` | Phase finished successfully | Engine, at phase exit |
 | `error` | Fatal error occurred | Phase implementations |
 | `warning` | Non-fatal issue | Phase implementations |
+| `notice` | Configuration notice the user must see before the run starts. Printed unconditionally, not counted as a warning. | Preflight checks |
 | `skipped` | Phase was skipped (config flag or resume) | Engine |
 | `confirm` | Awaiting user confirmation (review gate) | Engine, once |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiohttp>=3.9",
+    "aiohttp>=3.14",  # encode_basic_auth landed in 3.14.0; core/http.py imports it
     "certifi>=2024.0",
     "click>=8.0",
     "ijson>=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.13.1"
+version = "2.14.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"
@@ -28,9 +28,11 @@ dependencies = [
     "certifi>=2024.0",
     "click>=8.0",
     "ijson>=3.0",
+    "multidict>=4.5",
     "nicegui>=2.0",
     "python-dotenv",
     "rich>=13.0",
+    "yarl>=1.17",
 ]
 
 [project.scripts]

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.13.1"
+__version__ = "2.14.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1336,14 +1336,18 @@ def probe_cmd(
 
 @main.command("tls-check")
 def tls_check_cmd() -> None:
-    """Report which certificate authorities Ferry trusts.
+    """Report which certificate authorities Ferry trusts, and the proxy state.
 
-    Prints four fixed keys that .github/workflows/release.yml parses. Changing
-    a key name breaks the Windows release check, so tests/test_cli.py pins them.
+    An earlier version of this docstring said "four fixed keys". describe_proxy
+    (Task 11) added proxy-http, proxy-https, proxy-source and proxy-disabled;
+    release.yml pins key names from both groups, so changing any breaks CI.
     """
-    from discord_ferry.core.http import describe_trust
+    from discord_ferry.core.http import describe_proxy, describe_trust
 
     for key, value in describe_trust().items():
+        click.echo(f"{key}: {value}")
+
+    for key, value in describe_proxy().items():
         click.echo(f"{key}: {value}")
 
 

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -24,7 +24,7 @@ from rich.table import Table
 from discord_ferry import __version__
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
-from discord_ferry.core.http import new_session
+from discord_ferry.core.http import format_proxy_notices, new_session
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError, StateError
@@ -59,6 +59,20 @@ _STATUS_ICONS: dict[str, str] = {
     "warning": ">>",
     "confirm": "??",
 }
+
+
+def _print_proxy_notices(*, to_stderr: bool = False) -> None:
+    """Render format_proxy_notices() for the three entry points that do real
+    network work outside run_migration (build, rollback, probe). run_migration's
+    own preflight already emits these through the event stream (core/engine.py);
+    this covers the paths that never construct a MigrationEvent at all.
+
+    `probe --json` prints machine-readable JSON to stdout, so its call passes
+    to_stderr=True to keep a notice off the channel a script parses.
+    """
+    sink = Console(stderr=True) if to_stderr else console
+    for line in format_proxy_notices():
+        sink.print(f"[cyan][i][/] {line}")
 
 
 def _format_eta(total_messages: int, rate_limit: float) -> str:
@@ -834,6 +848,7 @@ def build(
     if name:
         bp.name = name
 
+    _print_proxy_notices()
     console.print(f"[bold]Discord Ferry[/] — building server '{_safe(bp.name)}'\n")
 
     async def _build() -> None:
@@ -1271,6 +1286,7 @@ def rollback_cmd(
         if state.rollback_progress is not None and state.rollback_progress.failures:
             sys.exit(1)
 
+    _print_proxy_notices()
     console.print("[bold]Discord Ferry[/] — starting rollback\n")
     try:
         asyncio.run(_runner())
@@ -1308,6 +1324,10 @@ def probe_cmd(
     if not token:
         console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
         sys.exit(1)
+
+    # to_stderr=True: --json prints machine-readable JSON to stdout below, and a
+    # notice landing on that channel would corrupt it for a script parsing it.
+    _print_proxy_notices(to_stderr=True)
 
     # probe never builds a FerryConfig or a SecureTokenStore, so the engine's
     # _ensure_token_store hook never fires here. Without this line the Stoat

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -361,6 +361,12 @@ class _ProgressTracker:
                     self.warning_count += 1
                     if self.verbose:
                         self._log(f"[yellow][!!][/] {event.phase}: {_safe(event.message)}")
+                case "notice":
+                    # Printed unconditionally. A configuration problem the user
+                    # must see before the run, not a per-item warning. Does NOT
+                    # increment warning_count, so the "N warning(s) suppressed"
+                    # line stays accurate.
+                    self._log(f"[cyan][i][/] {event.phase}: {_safe(event.message)}")
                 case "confirm":
                     # Print review summary and ask for confirmation
                     if event.detail:
@@ -1054,6 +1060,12 @@ class _RollbackProgressTracker:
                     self.warning_count += 1
                     if self.verbose:
                         console.print(f"[yellow]    {_safe(event.message)}[/]")
+                case "notice":
+                    # Printed unconditionally. A configuration problem the user
+                    # must see before the run, not a per-item warning. Does NOT
+                    # increment warning_count, so the "N warning(s) suppressed"
+                    # line stays accurate.
+                    console.print(f"[cyan][i][/] {_safe(event.message)}")
                 case "error":
                     self.error_count += 1
                     console.print(f"[bold red][!!][/] {_safe(event.message)}")

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -15,7 +15,7 @@ import aiohttp  # noqa: TCH002
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.core.http import new_session
+from discord_ferry.core.http import format_proxy_notices, new_session
 from discord_ferry.core.security import SecureTokenStore, register_secret, safe_sanitize
 from discord_ferry.discord import (
     fetch_and_translate_guild_metadata,
@@ -280,6 +280,14 @@ async def run_migration(
         state = MigrationState()
         state.started_at = datetime.now(UTC).isoformat()
         state.is_dry_run = config.dry_run
+
+    # Preflight: surface any proxy configuration Ferry found but cannot use.
+    # core/http.py returns data and never emits; the engine decides. Emitted at
+    # "notice" rather than "warning" because cli.py gates warnings behind
+    # --verbose, which defaults off.
+    for line in format_proxy_notices():
+        on_event(MigrationEvent(phase="preflight", status="notice", message=line))
+        state.warnings.append({"phase": "preflight", "type": "proxy_notice", "message": line})
 
     # Phase 0: EXPORT — run DCE subprocess inline (orchestrated mode)
     if not config.skip_export:

--- a/src/discord_ferry/core/events.py
+++ b/src/discord_ferry/core/events.py
@@ -12,7 +12,8 @@ class MigrationEvent:
     """Progress event emitted by the migration engine."""
 
     phase: str
-    # "started", "progress", "completed", "error", "warning", "skipped", "confirm", "heartbeat"
+    # "started", "progress", "completed", "error", "warning", "notice",
+    # "skipped", "confirm", "heartbeat"
     status: str
     message: str
     current: int = 0

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -15,6 +15,7 @@ chain changes.
 from __future__ import annotations
 
 import logging
+import os
 import ssl
 import urllib.request
 from dataclasses import dataclass, field
@@ -97,21 +98,27 @@ def _get_ssl_context() -> ssl.SSLContext:
 
 
 def reset_http_state() -> None:
-    """Drop the cached context and its trust-source marker.
+    """Drop the cached context, its trust-source marker and the proxy state.
 
     Mirrors logging_setup.reset_logging and security.reset_secret_registry.
     tests/conftest.py calls this from its autouse fixture, so a test that
     exercises the fallback cannot poison the cache for the rest of the session,
     and the spy test always sees a cold cache.
 
-    Both module globals reset together: leaving _trust_source behind would let
+    Every module global resets together. Leaving _trust_source behind would let
     a test that forces the fallback branch leave "fallback" behind for every
     later test, and after a bare reset the module would claim "union" while no
-    context has been built yet.
+    context has been built yet. The same applies to the three proxy globals:
+    the scan, the per-host bypass memo and the notices are all derived from one
+    environment reading, so clearing a subset leaves the module answering from
+    two different worlds.
     """
-    global _ssl_context, _trust_source  # noqa: PLW0603
+    global _ssl_context, _trust_source, _proxy_scan, _proxy_notices  # noqa: PLW0603
     _ssl_context = None
     _trust_source = "unbuilt"
+    _proxy_scan = None
+    _bypass_memo.clear()
+    _proxy_notices = ()
 
 
 def describe_trust() -> dict[str, str]:
@@ -229,6 +236,15 @@ class ProxyNotice:
     outcome: str  # what Ferry did instead, e.g. "used the OS proxy", "connected direct"
 
 
+# Cached because the environment and platform scan costs about 45 us per call
+# through the macOS sysconf path. Only the SCAN is cached; the per-host bypass
+# decision is memoised separately and keyed by (host, source), because the
+# answer differs by proxy source.
+_proxy_scan: tuple[dict[str, str], dict[str, str]] | None = None
+_bypass_memo: dict[tuple[str, str], bool] = {}
+_proxy_notices: tuple[ProxyNotice, ...] = ()
+
+
 def _os_proxies() -> dict[str, str]:
     """The OS proxy map, or {} where no platform getter exists.
 
@@ -289,3 +305,100 @@ def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
     register_secret("proxy_password", password)
     register_secret("proxy_authorization", header)
     return url.with_user(None), header
+
+
+def _suppressed_schemes() -> set[str]:
+    """Schemes turned off by an empty `<scheme>_proxy`.
+
+    Uses the stdlib's own condition (urllib/request.py:2536-2554). A k.islower()
+    test would be wrong twice: it misses HTTPS_proxy="", which stdlib does pop,
+    and on Windows os.environ upper-cases every key, making the rule inert on
+    the one platform where the OS half has content to suppress.
+    """
+    out: set[str] = set()
+    for key, value in os.environ.items():
+        if len(key) > 6 and key[-6:].lower() == "_proxy" and not value:
+            out.add(key[:-6].lower())
+    if "REQUEST_METHOD" in os.environ:
+        # CVE-2016-1000110: stdlib pops 'http' in a CGI context. Under the merge
+        # a popped scheme becomes indistinguishable from an unmentioned one and
+        # the OS half would restore it, reversing the behaviour Ferry inherits.
+        out.add("http")
+    return out
+
+
+def _scheme_map() -> tuple[dict[str, str], dict[str, str]]:
+    """Return (env_proxies, os_proxies), merged per scheme, cached.
+
+    NEVER urllib.request.getproxies(): it is
+    `getproxies_environment() or getproxies_<os>()`, so any single *_proxy
+    variable short-circuits the OS half. Measured: NO_PROXY=localhost alone
+    yields {'no': 'localhost'} and a registry proxy is never seen.
+    """
+    global _proxy_scan  # noqa: PLW0603
+    if _proxy_scan is None:
+        suppressed = _suppressed_schemes()
+        env = {
+            k: v for k, v in urllib.request.getproxies_environment().items() if k not in suppressed
+        }
+        os_side = {k: v for k, v in _os_proxies().items() if k not in suppressed and k not in env}
+        _proxy_scan = (env, os_side)
+    return _proxy_scan
+
+
+def _is_bypassed(host: str, source: str, env: dict[str, str]) -> bool:
+    """The two bypass lists UNION, they do not alternate.
+
+    Alternation discards an explicitly-set NO_PROXY whenever the proxy came
+    from the OS, so a user exempting their self-hosted Stoat has that traffic
+    proxied anyway. proxy_bypass_environment is safe to call unconditionally:
+    it returns False when the 'no' key is absent (urllib/request.py:2567-2570).
+
+    Memoised by (host, source), and MISSES are memoised too, or every request to
+    a bypassed host pays the syscall.
+    """
+    key = (host, source)
+    if key not in _bypass_memo:
+        # Silenced for typing only: typeshed does not stub
+        # proxy_bypass_environment. Neither it nor getproxies_environment is in
+        # urllib.request.__all__ and the stubs happen to cover only the second.
+        # CPython defines both at module level on every platform (verified at
+        # urllib/request.py:2557 on 3.12.12), unlike the platform getters
+        # _os_proxies reaches by getattr, so no fallback is needed here.
+        _bypass_memo[key] = bool(
+            urllib.request.proxy_bypass_environment(host, env)  # type: ignore[attr-defined]
+        ) or (source == "os" and _os_proxy_bypass(host))
+    return _bypass_memo[key]
+
+
+def resolve_proxy(url: str | URL) -> ProxyChoice | None:
+    """The proxy for `url`, or None. NEVER raises: this runs inside
+    ClientRequest.__init__, so a raise kills the first request of a migration.
+    """
+    if os.environ.get("FERRY_DISABLE_PROXY"):
+        return None
+    try:
+        target = URL(url) if isinstance(url, str) else url
+    except (ValueError, TypeError):
+        return None
+
+    env, os_side = _scheme_map()
+    scheme = target.scheme
+    if scheme in env:
+        raw, source = env[scheme], "env"
+    elif scheme in os_side:
+        raw, source = os_side[scheme], "os"
+    else:
+        return None
+
+    try:
+        parsed = URL(raw)
+        if parsed.scheme.startswith("socks"):
+            return None
+        stripped, authorization = _strip_userinfo(parsed)
+    except (ValueError, TypeError):
+        return None
+
+    if _is_bypassed(target.host or "", source, env):
+        return None
+    return ProxyChoice(url=stripped, authorization=authorization, source=source)

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -453,11 +453,16 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
     `getproxies_registry` through `_os_proxies`, and stdlib can raise there
     outside (ValueError, TypeError).
 
-    The concrete `re.error` case documented on the sibling boundary is NOT on
-    this path, and an earlier version of this paragraph claimed it was. That one
-    comes from `proxy_bypass_registry`, reached by `_os_proxy_bypass` via
-    `_is_bypassed`, which only `resolve_proxy` calls. This boundary is justified
-    by analogy with the sibling, not by that citation.
+    This paragraph has now been wrong twice, in opposite directions, so it is
+    worth stating what is actually true. It first claimed a concrete `re.error`
+    case reached this path. It then claimed that case was real but belonged to
+    the sibling boundary instead. Neither holds: `_proxy_bypass_winreg_override`
+    uses `fnmatch`, not `re.match`, on every Python Ferry supports, so no
+    `re.error` case exists on either path. Corrected at the final review of the
+    proxy branch, alongside the sibling docstring that carried the same claim.
+
+    What justifies this boundary is the platform getters above, which Ferry does
+    not control and which stdlib can raise from outside (ValueError, TypeError).
 
     Every caller runs at preflight, so a raise here would abort the first thing a
     migration does in exchange for a message it was only ever going to print.

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -16,11 +16,20 @@ from __future__ import annotations
 
 import logging
 import ssl
+import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import aiohttp
 import certifi
+from aiohttp import encode_basic_auth
+
+# A runtime import, not a TYPE_CHECKING one. ProxyChoice.url has to stay
+# resolvable by typing.get_type_hints, and aiohttp checks a proxy with
+# `assert type(proxy) is URL` (client_reqrep.py:888), so this module and
+# aiohttp must hold the same class object.
+from yarl import URL  # noqa: TC002
 
 logger = logging.getLogger(__name__)
 
@@ -177,3 +186,73 @@ def tls_hint(exc: BaseException) -> str | None:
             )
         current = current.__cause__ or current.__context__
     return None
+
+
+# ---------------------------------------------------------------------------
+# Proxy support (issue #135)
+#
+# A proxy is part of how an outbound session reaches the network, so it lives
+# beside the trust policy rather than in a module of its own.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProxyChoice:
+    """A resolved proxy. The password is NEVER stored as its own attribute.
+
+    Only the pre-encoded Proxy-Authorization value is kept, so no field exists
+    that could be interpolated into a message in plaintext. `url` is a yarl.URL
+    because ClientRequest.__init__ asserts `type(proxy) is URL`
+    (client_reqrep.py:887-888).
+    """
+
+    url: URL
+    authorization: str | None
+    source: str  # "env" or "os"
+
+
+@dataclass(frozen=True)
+class ProxyNotice:
+    """A proxy configuration Ferry found but cannot use."""
+
+    kind: str  # stable identifier, e.g. "all_proxy_only", "socks", "malformed"
+    scheme: str
+    display: str  # redacted, never carries userinfo
+    outcome: str  # what Ferry did instead, e.g. "used the OS proxy", "connected direct"
+
+
+def _os_proxies() -> dict[str, str]:
+    """The OS proxy map, or {} where no platform getter exists.
+
+    getproxies_macosx_sysconf is defined only under `if sys.platform == 'darwin'`
+    and getproxies_registry only under `elif os.name == 'nt'`; the else branch at
+    urllib/request.py:2808-2811 defines neither. Resolving with getattr is what
+    lets this module import on Linux, and it is the seam every test patches.
+    """
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        fn = getattr(urllib.request, name, None)
+        if fn is not None:
+            return dict(fn())
+    return {}
+
+
+def _os_proxy_bypass(host: str) -> bool:
+    """The OS bypass list (Windows ProxyOverride, macOS ExceptionsList), or False."""
+    for name in ("proxy_bypass_macosx_sysconf", "proxy_bypass_registry"):
+        fn = getattr(urllib.request, name, None)
+        if fn is not None:
+            return bool(fn(host))
+    return False
+
+
+def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
+    """Split credentials out of a proxy URL.
+
+    Replaces aiohttp's strip_auth_from_url, which is NOT in
+    aiohttp.helpers.__all__ and is therefore a private symbol. Verified
+    equivalent across eight cases including percent-encoded `@` and `:`, a
+    non-ASCII password, password-only userinfo, and a URL carrying a path.
+    """
+    if url.raw_user is None and url.raw_password is None:
+        return url, None
+    return url.with_user(None), encode_basic_auth(url.user or "", url.password or "")

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 import ssl
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +30,8 @@ from aiohttp import encode_basic_auth
 # `assert type(proxy) is URL` (client_reqrep.py:888), so this module and
 # aiohttp must hold the same class object.
 from yarl import URL  # noqa: TC002
+
+from discord_ferry.core.security import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -207,8 +209,10 @@ class ProxyChoice:
     """
 
     url: URL
-    authorization: str | None
-    source: str  # "env" or "os"
+    # repr=False matches the project convention for credential-bearing fields
+    # (config.py:23, :53; core/security.py:16). base64 is not obfuscation.
+    authorization: str | None = field(repr=False)
+    source: str = ""  # "env" or "os"
 
 
 @dataclass(frozen=True)
@@ -246,13 +250,38 @@ def _os_proxy_bypass(host: str) -> bool:
 
 
 def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
-    """Split credentials out of a proxy URL.
+    """Split credentials out of a proxy URL, and register both forms as secrets.
+
+    This is the ONLY place in the feature where the plaintext password and the
+    encoded header value are both in hand. resolve_proxy receives only the
+    encoded form, so if registration does not happen here it cannot happen at
+    all.
+
+    BOTH forms are registered. sanitize masks by exact substring
+    (core/security.py:52-64), and what actually travels, and what
+    RequestInfo.headers holds, is the base64 form, which
+    ClientResponseError.__repr__ renders. Registering only the plaintext is the
+    v2.12.1 shape, where the desktop app never called register_secret and tokens
+    reached ferry.log in clear text for eleven releases.
 
     Replaces aiohttp's strip_auth_from_url, which is NOT in
-    aiohttp.helpers.__all__ and is therefore a private symbol. Verified
-    equivalent across eight cases including percent-encoded `@` and `:`, a
-    non-ASCII password, password-only userinfo, and a URL carrying a path.
+    aiohttp.helpers.__all__ and is therefore a private symbol.
+
+    ONE DELIBERATE DIVERGENCE: aiohttp's path encodes with latin1
+    (helpers.py:200-201), this uses encode_basic_auth's utf-8 default
+    (helpers.py:119). For a non-ASCII password the two produce different base64.
+    utf-8 is the better default (latin1 raises UnicodeEncodeError outside
+    Latin-1) and encode_basic_auth is the API aiohttp's own deprecation notice
+    steers callers to, so the divergence is intended rather than accidental.
+
+    Raises ValueError when the login contains ':' (helpers.py:125-126), which a
+    %3A in userinfo decodes to. Task 2's caller guards for this and turns it
+    into a ProxyNotice.
     """
     if url.raw_user is None and url.raw_password is None:
         return url, None
-    return url.with_user(None), encode_basic_auth(url.user or "", url.password or "")
+    password = url.password or ""
+    header = encode_basic_auth(url.user or "", password)
+    register_secret("proxy_password", password)
+    register_secret("proxy_authorization", header)
+    return url.with_user(None), header

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -310,10 +310,12 @@ def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
 def _suppressed_schemes() -> set[str]:
     """Schemes turned off by an empty `<scheme>_proxy`.
 
-    Uses the stdlib's own condition (urllib/request.py:2536-2554). A k.islower()
-    test would be wrong twice: it misses HTTPS_proxy="", which stdlib does pop,
-    and on Windows os.environ upper-cases every key, making the rule inert on
-    the one platform where the OS half has content to suppress.
+    stdlib's screen (urllib/request.py:2536), widened to any case. The widening
+    is deliberate and is why this must not filter the environment half: see
+    _scheme_map. A k.islower() test would be wrong twice: it misses
+    HTTPS_proxy="", which stdlib does pop, and on Windows os.environ upper-cases
+    every key, making the rule inert on the one platform where the OS half has
+    content to suppress.
     """
     out: set[str] = set()
     for key, value in os.environ.items():
@@ -337,10 +339,23 @@ def _scheme_map() -> tuple[dict[str, str], dict[str, str]]:
     """
     global _proxy_scan  # noqa: PLW0603
     if _proxy_scan is None:
+        # Suppression applies to the OS half ONLY. The environment half is
+        # stdlib's job and stdlib already does it: an empty lowercase
+        # `<scheme>_proxy` is popped in getproxies_environment's second pass
+        # (urllib/request.py:2548-2554). Filtering env here as well would be
+        # worse than redundant, because that pop is CASE-SENSITIVE while
+        # _suppressed_schemes is not. With `HTTPS_PROXY=""` and
+        # `https_proxy="http://x"`, stdlib returns {"https": "http://x"} (the
+        # uppercase name fails its `name[-6:] == "_proxy"` test) while Ferry
+        # would suppress "https" and connect direct, where curl, requests and
+        # stdlib all proxy. No proxy and no notice, which is precisely the
+        # outcome the merge exists to prevent.
+        #
+        # What suppression IS for: stdlib popping a scheme from env does not
+        # stop _os_proxies() supplying one for the same scheme, so without this
+        # filter the OS half would silently restore a switch the user turned off.
         suppressed = _suppressed_schemes()
-        env = {
-            k: v for k, v in urllib.request.getproxies_environment().items() if k not in suppressed
-        }
+        env = dict(urllib.request.getproxies_environment())
         os_side = {k: v for k, v in _os_proxies().items() if k not in suppressed and k not in env}
         _proxy_scan = (env, os_side)
     return _proxy_scan

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -212,7 +212,11 @@ class ProxyChoice:
     # repr=False matches the project convention for credential-bearing fields
     # (config.py:23, :53; core/security.py:16). base64 is not obfuscation.
     authorization: str | None = field(repr=False)
-    source: str = ""  # "env" or "os"
+    # No default. field(repr=False) supplies none, so `authorization` stays
+    # required and `source` needs none either. A default would let
+    # ProxyChoice(url, header) build with an empty source, and Task 2's bypass
+    # union branches on source == "os".
+    source: str  # "env" or "os"
 
 
 @dataclass(frozen=True)

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -667,6 +667,12 @@ def _proxy_identity(exc: BaseException) -> str | None:
         # `host is not None` guards the degenerate match. The getattr defaults
         # are None and a scheme-less value parses to host=None, so without it
         # None == None matches and the hint renders "None:None".
+        #
+        # It and the `candidate.host is None` check below are ALTERNATIVES, not
+        # complements: either alone closes that match, so with this one present
+        # the other cannot change any outcome and no test can tell them apart.
+        # Both are kept because each states its own half of the invariant at the
+        # point it applies. Do not read the pair as two necessary conditions.
         if scan is not None and host is not None:
             for key, raw in (*scan[0].items(), *scan[1].items()):
                 # http and https ONLY, and not because the others are unlikely.

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -448,12 +448,19 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
     The scan underneath (`_scheme_map`) is cached either way, so the repeat
     costs a dict walk rather than a syscall.
 
-    NEVER raises, for the same reason `_FerryRequest._resolve_or_direct` does
-    not: `_scheme_map()` reaches the platform getters, and stdlib can raise
-    there outside (ValueError, TypeError), `re.error` from
-    `proxy_bypass_registry` being the documented case. Every caller runs at
-    preflight, so a raise here would abort the first thing a migration does in
-    exchange for a message it was only ever going to print.
+    NEVER raises, mirroring `_FerryRequest._resolve_or_direct`. `_scheme_map()`
+    reaches the platform getters `getproxies_macosx_sysconf` and
+    `getproxies_registry` through `_os_proxies`, and stdlib can raise there
+    outside (ValueError, TypeError).
+
+    The concrete `re.error` case documented on the sibling boundary is NOT on
+    this path, and an earlier version of this paragraph claimed it was. That one
+    comes from `proxy_bypass_registry`, reached by `_os_proxy_bypass` via
+    `_is_bypassed`, which only `resolve_proxy` calls. This boundary is justified
+    by analogy with the sibling, not by that citation.
+
+    Every caller runs at preflight, so a raise here would abort the first thing a
+    migration does in exchange for a message it was only ever going to print.
     """
     global _proxy_notices  # noqa: PLW0603
     # ABOVE the cache read, not below it. resolve_proxy checks the kill switch
@@ -467,11 +474,24 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
     try:
         _proxy_notices = _scan_notices()
     except Exception:  # noqa: BLE001
-        logger.warning(
-            "Could not evaluate the proxy configuration; reporting no notices.",
-            exc_info=True,
+        logger.warning("Could not read the proxy configuration; connecting direct.", exc_info=True)
+        # Degrade VISIBLY. Returning () here would make "Ferry could not read the
+        # configuration" indistinguishable from "this machine is clean", which is
+        # the exact inversion these notices exist to prevent, and the warning
+        # above lands in a log file nobody is reading at preflight.
+        #
+        # NOT cached, deliberately. With five preflight readers the warning
+        # repeats, and that is the better trade than freezing a transient
+        # platform error for the life of the process. Do not "fix" it by
+        # assigning to _proxy_notices.
+        return (
+            ProxyNotice(
+                kind="unreadable",
+                scheme="?",
+                display="<unavailable>",
+                outcome="Ferry could not read the proxy configuration and connected direct.",
+            ),
         )
-        return ()
     return _proxy_notices
 
 
@@ -543,11 +563,15 @@ def _scan_notices() -> tuple[ProxyNotice, ...]:
 def _usable(raw: str | None) -> bool:
     """True when `raw` is a proxy Ferry can actually use. Never raises.
 
-    The `raw is None` guard is documentation rather than behaviour: URL(None)
-    raises TypeError, which the except arm below already catches and turns into
-    the same False. Measured, not assumed. It stays because the None case is a
-    normal input here (`env.get(s) or os_side.get(s)` on a scheme nobody
-    configured), and reaching it through an exception reads as an accident.
+    The `raw is None` guard is what makes the call below type-check. `raw` is
+    `str | None`, and deleting the guard removes the narrowing, so mypy reports
+    `Argument 1 to "URL" has incompatible type "str | None"` [arg-type].
+    Measured, and `mypy src/` is in the project verification command, so the gate
+    catches that mutant even though no pytest assertion can: at runtime the
+    except arm would catch the resulting TypeError from URL(None) and return the
+    same False. An earlier version of this comment called the guard
+    "documentation rather than behaviour", which was wrong for having checked
+    only one of the two tools that guard this file.
     """
     if raw is None:
         return False

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -457,9 +457,12 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
                 kind="all_proxy_only",
                 scheme="all",
                 display=_safe_display(env["all"]),
+                # Name the schemes, never a single source. The source is
+                # per-scheme: HTTP_PROXY in the environment with https from the
+                # OS would make any one-word answer wrong for one of them.
+                # `ferry tls-check` reports the source per scheme (Task 11).
                 outcome=(
-                    f"Used the {'environment' if all(s in env for s in covered) else 'OS'} "
-                    f"proxy for {', '.join(covered)} instead."
+                    f"Used the proxy configured for {', '.join(covered)} instead."
                     if covered
                     else "Connected direct. ALL_PROXY is not supported (see issue #141)."
                 ),

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -523,7 +523,14 @@ def _scan_notices() -> tuple[ProxyNotice, ...]:
                 # Name the schemes, never a single source. The source is
                 # per-scheme: HTTP_PROXY in the environment with https from the
                 # OS would make any one-word answer wrong for one of them.
-                # `ferry tls-check` reports the source per scheme (Task 11).
+                #
+                # This comment used to hand off to `ferry tls-check` as
+                # reporting the source PER SCHEME. It does not. describe_proxy
+                # writes one `proxy-source` key inside its scheme loop, so on a
+                # mixed configuration the last scheme to resolve wins. Corrected
+                # at the final review; the handoff promise is dropped rather
+                # than the diagnostic widened, because release.yml asserts on
+                # the single key name.
                 outcome=(
                     f"Used the proxy configured for {', '.join(covered)} instead."
                     if covered
@@ -783,17 +790,31 @@ class _FerryRequest(aiohttp.ClientRequest):
         request of a migration from inside ClientRequest.__init__.
 
         `resolve_proxy`'s own guards catch ValueError and TypeError, which is
-        not enough. `_is_bypassed` reaches `proxy_bypass_registry`, which hands
-        registry-controlled data to `_proxy_bypass_winreg_override`, where
-        `re.match(test, host)` raises `re.error` on a ProxyOverride entry
-        containing a regex metacharacter. Measured: `re.error` subclasses
-        Exception directly, not ValueError or TypeError, so it escapes both
-        guards. The affected population is Windows corporate machines, which is
-        this feature's entire audience and where issue #134 came from.
+        not enough, because `_is_bypassed` and `_scheme_map` reach platform code
+        Ferry does not control.
+
+        An earlier version of this docstring justified the boundary with a
+        specific mechanism: that `_proxy_bypass_winreg_override` calls
+        `re.match(test, host)` and so raises `re.error` on a ProxyOverride entry
+        holding a regex metacharacter. That is wrong on every Python Ferry
+        supports. CPython 3.11 and 3.12 both use `fnmatch(host, test)` there, and
+        `fnmatch.translate` escapes an unterminated `[` rather than raising. The
+        `re.match` form lives in `requests`, not the standard library. Corrected
+        at the final review of this branch.
+
+        The boundary stays, as defense in depth over that platform code. One
+        unguarded path is still real on 3.12: `_proxy_bypass_macosx_sysconf`
+        indexes `proxy_settings['exclude_simple']` without a guard, which raises
+        `KeyError`, and `KeyError` subclasses Exception directly rather than
+        ValueError or TypeError.
         """
         if url is None:
             return None
         try:
+            # `url` is typed `object` because it arrives through **kwargs, and the
+            # `is None` check above is the only narrowing available without
+            # re-parsing. resolve_proxy accepts `str | URL` and guards its own
+            # parse, so a wrong type becomes None rather than a raise.
             return resolve_proxy(url)  # type: ignore[arg-type]
         except Exception:  # noqa: BLE001
             logger.warning(

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -437,21 +437,64 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
     on resolve_proxy having run: every caller (engine preflight, build,
     rollback, probe, the GUI export screen) runs before the first request.
 
-    Pure and idempotent: builds once, then returns the same tuple on every call
-    and consumes nothing, so a second migration in the same GUI process reports
-    what the first did. The engine decides what to emit; this never does.
+    Pure and idempotent: builds once when there is anything to report, then
+    returns the same tuple on every call and consumes nothing, so a second
+    migration in the same GUI process reports what the first did. The engine
+    decides what to emit; this never does.
+
+    "Builds once" is qualified on purpose. An empty result is falsy, so a clean
+    machine re-runs the evaluation on every call, and `proxy_notices() is
+    proxy_notices()` holds there only because CPython interns the empty tuple.
+    The scan underneath (`_scheme_map`) is cached either way, so the repeat
+    costs a dict walk rather than a syscall.
+
+    NEVER raises, for the same reason `_FerryRequest._resolve_or_direct` does
+    not: `_scheme_map()` reaches the platform getters, and stdlib can raise
+    there outside (ValueError, TypeError), `re.error` from
+    `proxy_bypass_registry` being the documented case. Every caller runs at
+    preflight, so a raise here would abort the first thing a migration does in
+    exchange for a message it was only ever going to print.
     """
     global _proxy_notices  # noqa: PLW0603
-    if _proxy_notices:
-        return _proxy_notices
+    # ABOVE the cache read, not below it. resolve_proxy checks the kill switch
+    # first, so today nothing can reach this with a populated cache; a later
+    # task that sets the variable after preflight would otherwise keep serving
+    # notices for a proxy layer the user has since turned off.
     if os.environ.get("FERRY_DISABLE_PROXY"):
         return ()
+    if _proxy_notices:
+        return _proxy_notices
+    try:
+        _proxy_notices = _scan_notices()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not evaluate the proxy configuration; reporting no notices.",
+            exc_info=True,
+        )
+        return ()
+    return _proxy_notices
 
+
+def _scan_notices() -> tuple[ProxyNotice, ...]:
+    """Evaluate the scanned configuration. Called only by proxy_notices().
+
+    Split out so the never-raises boundary above is a single small statement
+    rather than a try wrapped around forty lines, where a later edit could drift
+    outside it without anyone noticing.
+    """
     env, os_side = _scheme_map()
     found: list[ProxyNotice] = []
 
     if "all" in env:
-        covered = [s for s in ("http", "https") if s in env or s in os_side]
+        # "Covered" means a scheme that actually RESOLVES, not one whose key is
+        # merely present. Key membership alone produces a self-contradicting
+        # notice on the commonest SOCKS setup, where shadowsocks, v2ray, `ssh -D`
+        # and Tor all document exporting ALL_PROXY, HTTP_PROXY and HTTPS_PROXY
+        # together as socks5. Ferry connects direct for both schemes
+        # (resolve_proxy returns None at the socks guard), yet a membership test
+        # reports "Used the proxy configured for http, https instead." on the
+        # line directly above two notices saying "Connected direct."
+        covered = [s for s in ("http", "https") if _usable(env.get(s) or os_side.get(s))]
         found.append(
             ProxyNotice(
                 kind="all_proxy_only",
@@ -494,12 +537,35 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
                 )
             )
 
-    _proxy_notices = tuple(found)
-    return _proxy_notices
+    return tuple(found)
+
+
+def _usable(raw: str | None) -> bool:
+    """True when `raw` is a proxy Ferry can actually use. Never raises.
+
+    The `raw is None` guard is documentation rather than behaviour: URL(None)
+    raises TypeError, which the except arm below already catches and turns into
+    the same False. Measured, not assumed. It stays because the None case is a
+    normal input here (`env.get(s) or os_side.get(s)` on a scheme nobody
+    configured), and reaching it through an exception reads as an accident.
+    """
+    if raw is None:
+        return False
+    try:
+        return not URL(raw).scheme.startswith("socks")
+    except (ValueError, TypeError):
+        return False
 
 
 def _safe_display(raw: str) -> str:
-    """A proxy URL with userinfo removed, for display. Never raises."""
+    """A proxy URL with userinfo removed, for display. Never raises.
+
+    NOT free of side effects, despite the name. `_strip_userinfo` registers both
+    the plaintext password and the encoded header as secrets, so reading notices
+    mutates the process-wide registry. That is the intended outcome and this is
+    the ONLY path that reaches it for an ALL_PROXY or a socks credential:
+    resolve_proxy returns at the socks guard one line before it would strip.
+    """
     try:
         return str(_strip_userinfo(URL(raw))[0])
     except (ValueError, TypeError):

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -430,6 +430,89 @@ def resolve_proxy(url: str | URL) -> ProxyChoice | None:
     return ProxyChoice(url=stripped, authorization=authorization, source=source)
 
 
+def proxy_notices() -> tuple[ProxyNotice, ...]:
+    """Configurations Ferry found but cannot use.
+
+    Forces the scan and evaluates the configuration ITSELF. It must not depend
+    on resolve_proxy having run: every caller (engine preflight, build,
+    rollback, probe, the GUI export screen) runs before the first request.
+
+    Pure and idempotent: builds once, then returns the same tuple on every call
+    and consumes nothing, so a second migration in the same GUI process reports
+    what the first did. The engine decides what to emit; this never does.
+    """
+    global _proxy_notices  # noqa: PLW0603
+    if _proxy_notices:
+        return _proxy_notices
+    if os.environ.get("FERRY_DISABLE_PROXY"):
+        return ()
+
+    env, os_side = _scheme_map()
+    found: list[ProxyNotice] = []
+
+    if "all" in env:
+        covered = [s for s in ("http", "https") if s in env or s in os_side]
+        found.append(
+            ProxyNotice(
+                kind="all_proxy_only",
+                scheme="all",
+                display=_safe_display(env["all"]),
+                outcome=(
+                    f"Used the {'environment' if all(s in env for s in covered) else 'OS'} "
+                    f"proxy for {', '.join(covered)} instead."
+                    if covered
+                    else "Connected direct. ALL_PROXY is not supported (see issue #141)."
+                ),
+            )
+        )
+
+    for scheme, raw in (*env.items(), *os_side.items()):
+        if scheme not in ("http", "https"):
+            continue
+        try:
+            parsed = URL(raw)
+        except (ValueError, TypeError):
+            found.append(
+                ProxyNotice(
+                    kind="malformed",
+                    scheme=scheme,
+                    display="<unparseable>",
+                    outcome="Connected direct.",
+                )
+            )
+            continue
+        if parsed.scheme.startswith("socks"):
+            found.append(
+                ProxyNotice(
+                    kind="socks",
+                    scheme=scheme,
+                    display=_safe_display(raw),
+                    outcome="Connected direct. SOCKS is not supported (see issue #141).",
+                )
+            )
+
+    _proxy_notices = tuple(found)
+    return _proxy_notices
+
+
+def _safe_display(raw: str) -> str:
+    """A proxy URL with userinfo removed, for display. Never raises."""
+    try:
+        return str(_strip_userinfo(URL(raw))[0])
+    except (ValueError, TypeError):
+        return "<unparseable>"
+
+
+def format_proxy_notices() -> list[str]:
+    """One user-facing line per notice. Lives here, not in a shell, so both
+    cli.py and gui.py render the same text without gui.py importing cli.py.
+    """
+    return [
+        f"Proxy configuration Ferry cannot use: {n.display} ({n.scheme}). {n.outcome}"
+        for n in proxy_notices()
+    ]
+
+
 class _FerryRequest(aiohttp.ClientRequest):
     """Fills in the proxy when the caller gave none.
 

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -618,7 +618,15 @@ def proxy_hint(exc: BaseException, *, target: str) -> str | None:
     ClientProxyConnectionError, which has no request_info at all. NEVER from
     request_info.url, which is the TARGET.
     """
-    target_host = URL(target).host or target
+    # Guarded for the same reason resolve_proxy guards the identical
+    # construction: every call site is inside an `except` block, and
+    # structure.py passes state.autumn_url, which is SERVER-supplied. A raise
+    # here replaces the error the user was about to be told about with a
+    # ValueError from the handler that was meant to explain it.
+    try:
+        target_host = URL(target).host or target
+    except (ValueError, TypeError):
+        target_host = target
     seen: set[int] = set()
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:
@@ -656,11 +664,32 @@ def _proxy_identity(exc: BaseException) -> str | None:
     if isinstance(exc, aiohttp.ClientConnectorCertificateError):
         host, port = getattr(exc, "host", None), getattr(exc, "port", None)
         scan = _proxy_scan
-        if scan is not None:
-            for raw in (*scan[0].values(), *scan[1].values()):
+        # `host is not None` guards the degenerate match. The getattr defaults
+        # are None and a scheme-less value parses to host=None, so without it
+        # None == None matches and the hint renders "None:None".
+        if scan is not None and host is not None:
+            for key, raw in (*scan[0].items(), *scan[1].items()):
+                # http and https ONLY, and not because the others are unlikely.
+                # The env half is getproxies_environment() verbatim, which keys
+                # NO_PROXY as 'no' (measured: NO_PROXY=https://stoat.internal:8443
+                # yields {'no': 'https://stoat.internal:8443'}). Scheme-prefixing
+                # NO_PROXY is a common mistake, and without this filter it makes
+                # every genuine certificate error for that host resolve as a
+                # proxy identity. Because the sites read
+                # `proxy_hint(...) or tls_hint(...)`, the correct SSL_CERT_FILE
+                # advice would then be REPLACED by proxy advice naming a host
+                # that is not a proxy -- on self-hosted Stoat behind a private
+                # CA, which is exactly where that advice matters.
+                #
+                # These two keys are also the only ones Ferry can proxy through:
+                # resolve_proxy indexes env/os_side by the TARGET's scheme.
+                if key not in ("http", "https"):
+                    continue
                 try:
                     candidate = URL(raw)
                 except (ValueError, TypeError):
+                    continue
+                if candidate.host is None:
                     continue
                 if candidate.host == host and candidate.port == port:
                     return f"{host}:{port}"

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -702,6 +702,31 @@ def _proxy_identity(exc: BaseException) -> str | None:
     return None
 
 
+def describe_proxy() -> dict[str, str]:
+    """Proxy state, for `ferry tls-check` and CI. Never prints userinfo.
+
+    Reports what resolution ACTUALLY produced, not what is configured. A
+    diagnostic that reports something other than what happens is the failure
+    v2.13.0 avoided by reading trust-source from a flag.
+    """
+    if os.environ.get("FERRY_DISABLE_PROXY"):
+        return {
+            "proxy-http": "none",
+            "proxy-https": "none",
+            "proxy-source": "none",
+            "proxy-disabled": "true",
+        }
+    out = {"proxy-disabled": "false", "proxy-source": "none"}
+    for scheme in ("http", "https"):
+        choice = resolve_proxy(f"{scheme}://example.invalid/")
+        if choice is None:
+            out[f"proxy-{scheme}"] = "none"
+        else:
+            out[f"proxy-{scheme}"] = f"{choice.url.host}:{choice.url.port}"
+            out["proxy-source"] = choice.source
+    return out
+
+
 def proxy_error_is_permanent(exc: BaseException) -> bool:
     """True when no retry can help.
 

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -162,7 +162,13 @@ def new_session(**kwargs: Any) -> aiohttp.ClientSession:
     NEVER subclass ClientSession. aioresponses patches
     ClientSession._request on the class; a subclass defining _request would
     shadow the patch and silently disable HTTP mocking across the test suite.
+    The proxy is installed through the REQUEST class instead, which is defined
+    at the bottom of this module beside the resolution it calls.
+
+    setdefault, never `request_class=_FerryRequest` as an argument: a caller
+    passing their own would then raise TypeError for a repeated keyword.
     """
+    kwargs.setdefault("request_class", _FerryRequest)
     connector = aiohttp.TCPConnector(ssl=_get_ssl_context())
     return aiohttp.ClientSession(connector=connector, **kwargs)
 
@@ -417,3 +423,33 @@ def resolve_proxy(url: str | URL) -> ProxyChoice | None:
     if _is_bypassed(target.host or "", source, env):
         return None
     return ProxyChoice(url=stripped, authorization=authorization, source=source)
+
+
+class _FerryRequest(aiohttp.ClientRequest):
+    """Fills in the proxy when the caller gave none.
+
+    Subclassing ClientRequest is safe. Subclassing ClientSession is NOT:
+    aioresponses patches ClientSession._request on the class, and a subclass
+    defining _request would shadow the patch and disable HTTP mocking across 21
+    test modules.
+
+    Note that self._request_class(...) is reached only at aiohttp
+    client.py:780, so under aioresponses this class is never constructed. That
+    is why the factory-installs test exists separately.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if kwargs.get("proxy") is None:
+            url = kwargs.get("url") or (args[1] if len(args) > 1 else None)
+            choice = resolve_proxy(url) if url is not None else None
+            if choice is not None:
+                kwargs["proxy"] = choice.url
+                if choice.authorization is not None:
+                    # A FRESH dict per request. connector.py:604-606 mutates
+                    # req.proxy_headers in place, and connection_key hashes it
+                    # (client_reqrep.py:970-972), so a shared mapping would
+                    # change the pool key between requests to the same host.
+                    merged = dict(kwargs.get("proxy_headers") or {})
+                    merged.setdefault("Proxy-Authorization", choice.authorization)
+                    kwargs["proxy_headers"] = merged
+        super().__init__(*args, **kwargs)

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -606,6 +606,80 @@ def format_proxy_notices() -> list[str]:
     ]
 
 
+def proxy_hint(exc: BaseException, *, target: str) -> str | None:
+    """Actionable guidance if `exc`'s chain holds a proxy failure.
+
+    Returns a MESSAGE, never an exception type, for the reason in tls_hint's
+    docstring. `target` has NO default: a str | None = None would let a
+    half-wired call site type-check clean and emit exactly the targetless
+    message this parameter exists to prevent.
+
+    Proxy identity comes from request_info.real_url, or .host/.port on
+    ClientProxyConnectionError, which has no request_info at all. NEVER from
+    request_info.url, which is the TARGET.
+    """
+    target_host = URL(target).host or target
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        proxy = _proxy_identity(current)
+        if proxy is not None:
+            detail = ""
+            status = getattr(current, "status", None)
+            if status == 407:
+                detail = " The proxy requires authentication; put credentials in the proxy URL."
+            elif status == 403:
+                detail = " The proxy refused the connection."
+            return (
+                f" The request to {target_host} went through the proxy at {proxy}, "
+                f"which did not accept it.{detail} Set FERRY_DISABLE_PROXY=1 to "
+                "bypass the proxy, or NO_PROXY to exempt this host."
+            )
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def _proxy_identity(exc: BaseException) -> str | None:
+    """`host:port` of the proxy, or None if `exc` is not a proxy failure.
+
+    Also matches a certificate error whose host equals the resolved proxy: with
+    an https:// proxy, connector.py:1630-1632 builds the error from proxy_req's
+    key, so tls_hint would otherwise tell the user to point SSL_CERT_FILE at a
+    bundle for a host they never configured.
+    """
+    if isinstance(exc, aiohttp.ClientHttpProxyError):
+        real = exc.request_info.real_url
+        return f"{real.host}:{real.port}"
+    if isinstance(exc, aiohttp.ClientProxyConnectionError):
+        return f"{getattr(exc, 'host', '?')}:{getattr(exc, 'port', '?')}"
+    if isinstance(exc, aiohttp.ClientConnectorCertificateError):
+        host, port = getattr(exc, "host", None), getattr(exc, "port", None)
+        scan = _proxy_scan
+        if scan is not None:
+            for raw in (*scan[0].values(), *scan[1].values()):
+                try:
+                    candidate = URL(raw)
+                except (ValueError, TypeError):
+                    continue
+                if candidate.host == host and candidate.port == port:
+                    return f"{host}:{port}"
+    return None
+
+
+def proxy_error_is_permanent(exc: BaseException) -> bool:
+    """True when no retry can help.
+
+    A 502, 503, 504 or connect timeout CAN recover, and those are exactly the
+    shapes api.py and autumn.py already retry in the direct case. Keeping this
+    separate from the hint is what stops proxy support turning a transient
+    upstream blip into a hard abort.
+    """
+    if isinstance(exc, aiohttp.ClientHttpProxyError):
+        return exc.status in (403, 407)
+    return isinstance(exc, aiohttp.ClientProxyConnectionError)
+
+
 class _FerryRequest(aiohttp.ClientRequest):
     """Fills in the proxy when the caller gave none.
 

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -26,6 +26,11 @@ import aiohttp
 import certifi
 from aiohttp import encode_basic_auth
 
+# A runtime import for the same reason as yarl below: _FerryRequest builds a
+# CIMultiDict per request, and aiohttp stores a MultiDict subclass by reference
+# rather than re-wrapping it (client_reqrep.py:1342-1346).
+from multidict import CIMultiDict  # noqa: TC002
+
 # A runtime import, not a TYPE_CHECKING one. ProxyChoice.url has to stay
 # resolvable by typing.get_type_hints, and aiohttp checks a proxy with
 # `assert type(proxy) is URL` (client_reqrep.py:888), so this module and
@@ -440,16 +445,49 @@ class _FerryRequest(aiohttp.ClientRequest):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if kwargs.get("proxy") is None:
-            url = kwargs.get("url") or (args[1] if len(args) > 1 else None)
-            choice = resolve_proxy(url) if url is not None else None
+            # `"url" in kwargs`, not `kwargs.get("url") or ...`: yarl.URL defines
+            # __bool__ (yarl/_url.py:566-567), so a falsy url= keyword would be
+            # discarded and args[1] read instead.
+            url = kwargs["url"] if "url" in kwargs else (args[1] if len(args) > 1 else None)
+            choice = self._resolve_or_direct(url)
             if choice is not None:
                 kwargs["proxy"] = choice.url
                 if choice.authorization is not None:
-                    # A FRESH dict per request. connector.py:604-606 mutates
-                    # req.proxy_headers in place, and connection_key hashes it
-                    # (client_reqrep.py:970-972), so a shared mapping would
-                    # change the pool key between requests to the same host.
-                    merged = dict(kwargs.get("proxy_headers") or {})
+                    # A FRESH mapping per request, so one caller's headers can
+                    # never leak into the next. CIMultiDict, not dict: HTTP
+                    # header names are case-insensitive, and a plain dict's
+                    # setdefault would not see a caller's `proxy-authorization`,
+                    # insert a second entry, and send TWO credentials to the
+                    # proxy (connector.py:606-610 writes both).
+                    merged: CIMultiDict[str] = CIMultiDict(kwargs.get("proxy_headers") or {})
                     merged.setdefault("Proxy-Authorization", choice.authorization)
                     kwargs["proxy_headers"] = merged
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _resolve_or_direct(url: object) -> ProxyChoice | None:
+        """Resolve, or fall through to a direct connection. NEVER raises.
+
+        This is the boundary where the design's "resolution never raises"
+        invariant actually has to hold, because a raise here kills the first
+        request of a migration from inside ClientRequest.__init__.
+
+        `resolve_proxy`'s own guards catch ValueError and TypeError, which is
+        not enough. `_is_bypassed` reaches `proxy_bypass_registry`, which hands
+        registry-controlled data to `_proxy_bypass_winreg_override`, where
+        `re.match(test, host)` raises `re.error` on a ProxyOverride entry
+        containing a regex metacharacter. Measured: `re.error` subclasses
+        Exception directly, not ValueError or TypeError, so it escapes both
+        guards. The affected population is Windows corporate machines, which is
+        this feature's entire audience and where issue #134 came from.
+        """
+        if url is None:
+            return None
+        try:
+            return resolve_proxy(url)  # type: ignore[arg-type]
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Could not resolve a proxy for this request; connecting direct.",
+                exc_info=True,
+            )
+            return None

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 
-from discord_ferry.core.http import tls_hint
+from discord_ferry.core.http import proxy_error_is_permanent, proxy_hint, tls_hint
 from discord_ferry.discord.models import DiscordChannel, DiscordRole, PermissionOverwrite
 from discord_ferry.errors import DiscordAuthError, MigrationError
 
@@ -160,12 +160,20 @@ async def _discord_request(session: aiohttp.ClientSession, token: str, path: str
         except (DiscordAuthError, MigrationError):
             raise
         except aiohttp.ClientError as exc:
-            hint = tls_hint(exc)
-            if hint is not None:
+            # Two lines: message and control flow are separate decisions over
+            # the same two values. Proxy wins over the certificate hint and they
+            # are never concatenated, for the reason in api.py.
+            cert = tls_hint(exc)
+            hint = proxy_hint(exc, target=url) or cert
+            if hint is not None and (cert is not None or proxy_error_is_permanent(exc)):
+                # Gated on permanence because this jumps over the whole
+                # _MAX_RETRIES loop. A proxy 502, 503, 504 or connect timeout can
+                # recover, and turning one into a hard failure would abort the
+                # metadata phase on a blip it used to survive.
                 raise MigrationError(f"Discord API network error: {exc}{hint}") from exc
             network_attempts += 1
             if network_attempts >= _MAX_RETRIES:
-                raise MigrationError(f"Discord API network error: {exc}") from exc
+                raise MigrationError(f"Discord API network error: {exc}{hint or ''}") from exc
             await asyncio.sleep(1)
 
 

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
@@ -14,6 +15,8 @@ from discord_ferry.errors import DiscordAuthError, MigrationError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
 
 DISCORD_API = "https://discord.com/api/v10"
 _MAX_RETRIES = 3
@@ -212,7 +215,8 @@ async def download_role_icon(
             if len(data) > _ROLE_ICON_MAX_BYTES:
                 return None
             return data
-    except aiohttp.ClientError:
+    except aiohttp.ClientError as exc:
+        logger.warning("Role icon download failed for role %s: %s", role_id, exc)
         return None
 
 

--- a/src/discord_ferry/exporter/manager.py
+++ b/src/discord_ferry/exporter/manager.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
-from discord_ferry.core.http import new_session, tls_hint
+from discord_ferry.core.http import new_session, proxy_error_is_permanent, proxy_hint, tls_hint
 from discord_ferry.errors import DCENotFoundError, ValidationError
 
 if TYPE_CHECKING:
@@ -174,9 +174,15 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
     )
 
     data: bytes | None = None
+    # Bound OUTSIDE the try and reassigned before each GET. The `except` below
+    # spans both requests, and `download_url` is bound inside the try, so on a
+    # first-GET failure `target=download_url` would raise UnboundLocalError from
+    # inside an error handler. This name is always bound before it is read.
+    current_url = release_url
     for attempt in range(2):
         try:
             async with new_session() as session:
+                current_url = release_url
                 async with session.get(
                     release_url, headers={"Accept": "application/vnd.github.v3+json"}
                 ) as resp:
@@ -197,6 +203,7 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
                         f"Asset {asset_name} not found in DCE v{DCE_VERSION} release"
                     )
 
+                current_url = download_url
                 async with session.get(download_url) as resp:
                     if resp.status != 200:
                         raise DCENotFoundError(
@@ -211,9 +218,19 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
             break  # success — exit retry loop
 
         except (aiohttp.ClientError, DCENotFoundError) as e:
-            hint = tls_hint(e)
-            if hint is not None:
-                # A certificate failure cannot succeed on retry; do not pay the sleep.
+            # Two lines: message and control flow are separate decisions over the
+            # same two values. Proxy wins over the certificate hint and they are
+            # never concatenated, for the reason in api.py.
+            cert = tls_hint(e)
+            hint = proxy_hint(e, target=current_url) or cert
+            if hint is not None and (cert is not None or proxy_error_is_permanent(e)):
+                # A certificate failure, a proxy 407/403 or an unreachable proxy
+                # cannot succeed on retry; do not pay the sleep.
+                #
+                # Gated on permanence because this jumps over the `attempt == 0`
+                # retry. This is the DCE download, Ferry's highest-traffic
+                # external failure path, so a proxy 502 or a connect timeout must
+                # keep the retry it has always had.
                 raise DCENotFoundError(f"Network error downloading DCE: {e}{hint}") from e
             if attempt == 0:
                 on_event(
@@ -225,7 +242,7 @@ async def download_dce(on_event: EventCallback, *, skip_verify: bool = False) ->
                 )
                 await asyncio.sleep(3)
             else:
-                raise DCENotFoundError(f"Network error downloading DCE: {e}") from e
+                raise DCENotFoundError(f"Network error downloading DCE: {e}{hint or ''}") from e
 
     assert data is not None  # unreachable — both-fail case raises above
 

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import new_session, tls_hint
+from discord_ferry.core.http import new_session, proxy_hint, tls_hint
 from discord_ferry.errors import DiscordAuthError, ExportError
 from discord_ferry.exporter.dce_output import (
     Banner,
@@ -330,20 +330,22 @@ async def validate_discord_token(token: str) -> None:
         DiscordAuthError: If the token is invalid (401), API returns unexpected
             status, or the network is unreachable.
     """
+    # Hoisted out of the try on purpose. As an inline literal there was no name
+    # the handler could pass as `target`, and proxy_hint takes no default for it.
+    url = "https://discord.com/api/v10/users/@me"
     try:
         async with (
             new_session() as session,
-            session.get(
-                "https://discord.com/api/v10/users/@me",
-                headers={"Authorization": token},
-            ) as resp,
+            session.get(url, headers={"Authorization": token}) as resp,
         ):
             if resp.status == 401:
                 raise DiscordAuthError("Invalid Discord token. Check that you copied it correctly.")
             if resp.status != 200:
                 raise DiscordAuthError(f"Discord API returned unexpected status {resp.status}")
     except aiohttp.ClientError as exc:
-        raise DiscordAuthError(f"Cannot reach Discord API: {exc}{tls_hint(exc) or ''}") from exc
+        # Proxy first, never both, no gate: this handler has no retry.
+        hint = proxy_hint(exc, target=url) or tls_hint(exc) or ""
+        raise DiscordAuthError(f"Cannot reach Discord API: {exc}{hint}") from exc
 
 
 async def run_dce_export(

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import shutil
 import signal
 import subprocess
@@ -16,7 +17,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import new_session, proxy_hint, tls_hint
+from discord_ferry.core.http import new_session, proxy_hint, resolve_proxy, tls_hint
 from discord_ferry.errors import DiscordAuthError, ExportError
 from discord_ferry.exporter.dce_output import (
     Banner,
@@ -372,11 +373,20 @@ async def run_dce_export(
     cmd = _build_dce_command(config, dce_path)
     config.export_dir.mkdir(parents=True, exist_ok=True)
 
+    child_env = dict(os.environ)  # full copy: dropping SYSTEMROOT or PATH breaks .NET on Windows
+    choice = resolve_proxy("https://discord.com/")
+    if choice is not None and choice.source == "os" and "HTTPS_PROXY" not in child_env:
+        # Only when the OS supplied it. If the user set the variable themselves,
+        # DCE already inherits it, and overwriting a deliberate setting is a
+        # surprise rather than a feature.
+        child_env["HTTPS_PROXY"] = str(choice.url)
+
     process = await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         creationflags=_CREATE_NO_WINDOW | _CREATE_NEW_PROCESS_GROUP,
+        env=child_env,
     )
 
     process_start = time.monotonic()

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -21,6 +21,7 @@ from nicegui.client import ClientConnectionTimeout
 from discord_ferry.config import FerryConfig
 from discord_ferry.core import entry
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
+from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError
@@ -93,6 +94,17 @@ _STEP_LABELS: list[str] = ["Configure", "Export", "Validate", "Migrate", "Done"]
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _proxy_notice_lines() -> list[str]:
+    """Proxy notices formatted for the GUI log panel.
+
+    Module level so it is testable. `_run_export` is a nested closure inside a
+    page function, so nothing inside it can be reached from a unit test, which
+    is the same blind spot that let the one-click export ship dead for eleven
+    releases.
+    """
+    return [f"[notice] {line}" for line in format_proxy_notices()]
 
 
 def _open_path(path: Path) -> None:
@@ -909,6 +921,12 @@ async def export_page() -> None:
 
         with client:
             try:
+                # Before any network call: the first three (validate_discord_token,
+                # get_dce_path's download fallback, run_dce_export) all run outside
+                # run_migration, so its preflight notice never reaches this screen.
+                for line in _proxy_notice_lines():
+                    log_display.push(line)
+
                 # Inside the try: a missing export_dir used to raise KeyError out
                 # here, above the handler, and vanish without a trace.
                 discord_server = str(storage.get("discord_server_id", ""))

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
 
-from discord_ferry.core.http import new_session, tls_hint
+from discord_ferry.core.http import new_session, proxy_error_is_permanent, proxy_hint, tls_hint
 from discord_ferry.errors import MigrationError
 
 if TYPE_CHECKING:
@@ -297,17 +297,28 @@ async def _api_request_inner(
                 text = await resp.text()
                 raise MigrationError(f"API error {resp.status}: {text}")
         except aiohttp.ClientError as exc:
-            hint = tls_hint(exc)
-            if hint is not None:
+            # Compute each hint ONCE. Message and control flow are separate
+            # decisions over the same two values, which is why this is two
+            # lines rather than one. Proxy wins over the certificate hint and
+            # they are NEVER concatenated: with an https:// proxy a certificate
+            # error is built from the PROXY's connection key
+            # (connector.py:1630-1632), so tls_hint would name a host the user
+            # never configured.
+            cert = tls_hint(exc)
+            hint = proxy_hint(exc, target=url) or cert
+            if hint is not None and (cert is not None or proxy_error_is_permanent(exc)):
                 # Above both consecutive_failures increments on purpose. Five
                 # short-circuited channels in the parallel message phase would
                 # otherwise open the breaker and add a 30s sleep to an error
                 # that cannot recover.
+                #
+                # Gated on permanence: a proxy 502, 503, 504 or connect timeout
+                # CAN recover and must keep the retries it already had.
                 raise MigrationError(f"Network error: {exc}{hint}") from exc
             if attempt == MAX_API_RETRIES - 1:
                 _circuit_state.consecutive_failures += 1
                 raise MigrationError(
-                    f"Network error after {MAX_API_RETRIES} retries: {exc}"
+                    f"Network error after {MAX_API_RETRIES} retries: {exc}{hint or ''}"
                 ) from exc
             delay = min(2**attempt, 60) + random.uniform(0.1, 0.5)
             await asyncio.sleep(delay)

--- a/src/discord_ferry/migrator/connect.py
+++ b/src/discord_ferry/migrator/connect.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import tls_hint
+from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.errors import StoatConnectionError
 from discord_ferry.migrator.api import api_fetch_server, get_session
 
@@ -93,9 +93,15 @@ async def _discover_autumn_url(session: aiohttp.ClientSession, stoat_url: str) -
                 raise StoatConnectionError(f"Stoat API returned status {response.status} at {url}")
             data = await response.json()
     except aiohttp.ClientError as e:
-        raise StoatConnectionError(
-            f"Cannot reach Stoat API at {url}: {e}{tls_hint(e) or ''}"
-        ) from e
+        # Proxy first, and NEVER both. With an https:// proxy a certificate
+        # error is built from the PROXY's connection key (connector.py:1630),
+        # so tls_hint would tell the user to point SSL_CERT_FILE at a bundle
+        # for a host they never configured.
+        #
+        # No permanence gate here: this handler has no retry to short-circuit,
+        # so the message is the only decision it makes.
+        hint = proxy_hint(e, target=url) or tls_hint(e) or ""
+        raise StoatConnectionError(f"Cannot reach Stoat API at {url}: {e}{hint}") from e
 
     try:
         autumn_url: str = data["features"]["autumn"]["url"]
@@ -150,6 +156,6 @@ async def _verify_token(session: aiohttp.ClientSession, stoat_url: str, token: s
                     f"Token verification failed with status {response.status}"
                 )
     except aiohttp.ClientError as e:
-        raise StoatConnectionError(
-            f"Token verification request failed: {e}{tls_hint(e) or ''}"
-        ) from e
+        # Proxy first, never both, and no gate: see _discover_autumn_url.
+        hint = proxy_hint(e, target=url) or tls_hint(e) or ""
+        raise StoatConnectionError(f"Token verification request failed: {e}{hint}") from e

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -8,6 +8,8 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
+
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
@@ -38,8 +40,6 @@ from discord_ferry.state import save_state
 from discord_ferry.uploader.autumn import upload_to_autumn, upload_with_cache
 
 if TYPE_CHECKING:
-    import aiohttp
-
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
     from discord_ferry.parser.models import DCEChannel, DCEExport
@@ -400,7 +400,7 @@ async def _resolve_role_icon(
             state.native_fidelity_counts.get("role_icons", 0) + 1
         )
         return icon_id
-    except (AutumnUploadError, OSError) as exc:
+    except (AutumnUploadError, OSError, aiohttp.ClientError) as exc:
         # Fixed template — never str(exc); the body may echo x-session-token.
         # tls_hint and proxy_hint are the two safe additions: each emits a host,
         # a port and fixed text, never the exception it inspected. Without them

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import tls_hint
+from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
 from discord_ferry.discord.metadata import RoleMeta, load_discord_metadata
 from discord_ferry.errors import AutumnUploadError, MigrationError
@@ -402,10 +402,14 @@ async def _resolve_role_icon(
         return icon_id
     except (AutumnUploadError, OSError) as exc:
         # Fixed template — never str(exc); the body may echo x-session-token.
-        # tls_hint is the one safe addition: it emits a host, a port and fixed
-        # text, never the exception it inspected. Without it this is the only
-        # Autumn failure that reaches the user with no cause at all.
-        hint = tls_hint(exc) or ""
+        # tls_hint and proxy_hint are the two safe additions: each emits a host,
+        # a port and fixed text, never the exception it inspected. Without them
+        # this is the only Autumn failure that reaches the user with no cause.
+        #
+        # Proxy first and never both, for the reason in api.py. No permanence
+        # gate: this handler already degrades to a warning either way, so there
+        # is no retry for a gate to preserve.
+        hint = proxy_hint(exc, target=state.autumn_url) or tls_hint(exc) or ""
         state.warnings.append(
             {
                 "phase": "roles",

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
-from discord_ferry.core.http import tls_hint
+from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.errors import AutumnUploadError
 
 if TYPE_CHECKING:
@@ -229,7 +229,13 @@ async def upload_to_autumn(
                 text = await response.text()
                 raise AutumnUploadError(f"Upload failed with status {response.status}: {text}")
         except aiohttp.ClientError as exc:
-            hint = tls_hint(exc)
+            # No permanence gate here, and that is not an oversight: BOTH arms
+            # of this handler raise, so there is no retry for a gate to
+            # preserve. A proxy 502 leaves this function as the raw
+            # ClientHttpProxyError it does today, exactly as before.
+            #
+            # Proxy first and never both, for the reason in api.py.
+            hint = proxy_hint(exc, target=url) or tls_hint(exc)
             if hint is None:
                 raise
             # Autumn is the one host v2.13.0's error work did not reach: no caller
@@ -244,8 +250,14 @@ async def upload_to_autumn(
             # site -- only exists once a request completed, which a certificate
             # failure guarantees it did not.
             #
-            # Raised rather than retried: a certificate failure cannot succeed on a
-            # second attempt, so the caller should not pay two sleeps to learn that.
+            # The same holds for the proxy arm: ClientHttpProxyError's text is
+            # the status line of the CONNECT response, written by the PROXY, and
+            # the tunnel to Autumn was never established, so no Autumn body
+            # exists to echo the token back.
+            #
+            # Raised rather than retried: neither a certificate failure nor a
+            # proxy that refuses outright can succeed on a second attempt, so the
+            # caller should not pay two sleeps to learn that.
             raise AutumnUploadError(f"Upload to Autumn failed: {exc}{hint}") from exc
         finally:
             fh.close()

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -231,8 +231,15 @@ async def upload_to_autumn(
         except aiohttp.ClientError as exc:
             # No permanence gate here, and that is not an oversight: BOTH arms
             # of this handler raise, so there is no retry for a gate to
-            # preserve. A proxy 502 leaves this function as the raw
-            # ClientHttpProxyError it does today, exactly as before.
+            # preserve.
+            #
+            # Every proxy failure is therefore CONVERTED, a 502 as much as a
+            # 407 -- proxy_hint has no status filter. That is deliberate, and
+            # structure.py:403 depends on it: its handler catches
+            # (AutumnUploadError, OSError): ClientHttpProxyError is a
+            # ClientResponseError, NOT an OSError, so leaving it raw would make
+            # a proxy failure ABORT the roles phase instead of degrading to a
+            # warning. Do not "restore" a raw ClientHttpProxyError here.
             #
             # Proxy first and never both, for the reason in api.py.
             hint = proxy_hint(exc, target=url) or tls_hint(exc)

--- a/src/discord_ferry/uploader/autumn.py
+++ b/src/discord_ferry/uploader/autumn.py
@@ -234,12 +234,15 @@ async def upload_to_autumn(
             # preserve.
             #
             # Every proxy failure is therefore CONVERTED, a 502 as much as a
-            # 407 -- proxy_hint has no status filter. That is deliberate, and
-            # structure.py:403 depends on it: its handler catches
-            # (AutumnUploadError, OSError): ClientHttpProxyError is a
-            # ClientResponseError, NOT an OSError, so leaving it raw would make
-            # a proxy failure ABORT the roles phase instead of degrading to a
-            # warning. Do not "restore" a raw ClientHttpProxyError here.
+            # 407 -- proxy_hint has no status filter. Do not "restore" a raw
+            # ClientHttpProxyError here.
+            #
+            # This paragraph used to say structure.py:403 DEPENDED on this
+            # conversion, since its (AutumnUploadError, OSError) handler would
+            # let a raw ClientHttpProxyError abort the roles phase. Task 8
+            # (2026-08-09) widened that handler to also catch
+            # aiohttp.ClientError, so that dependency no longer holds; the
+            # conversion stays anyway, for the hint text it attaches.
             #
             # Proxy first and never both, for the reason in api.py.
             hint = proxy_hint(exc, target=url) or tls_hint(exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,12 @@ def proxy_env() -> Callable[..., AbstractContextManager[None]]:
         for k in list(os.environ):
             if k.lower().endswith("_proxy"):
                 os.environ.pop(k)
+        # Also neutralise the kill switch and the CGI marker. An ambient
+        # FERRY_DISABLE_PROXY=1 turns every `is not None` assertion red and
+        # every `is None` assertion vacuous, and Task 11 builds its kill-switch
+        # tests on this fixture.
+        os.environ.pop("FERRY_DISABLE_PROXY", None)
+        os.environ.pop("REQUEST_METHOD", None)
         os.environ.update(pairs)
         try:
             yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import os
 from contextlib import contextmanager
@@ -106,6 +107,28 @@ def os_proxy() -> Callable[..., AbstractContextManager[None]]:
             yield
 
     return _apply
+
+
+@pytest.fixture
+async def fake_proxy():
+    """A loopback server that records the first request and answers a status.
+
+    Needed because aioresponses patches ClientSession._request, so the request
+    object is never constructed and proxy behaviour is invisible to all 21
+    aioresponses modules. Real-socket precedent: tests/test_gui_native_lifecycle.py.
+    """
+    captured: list[str] = []
+
+    def _make(status: bytes = b"403 Forbidden"):
+        async def handle(reader, writer):
+            captured.append((await reader.read(4096)).decode("latin1"))
+            writer.write(b"HTTP/1.1 " + status + b"\r\nContent-Length: 0\r\n\r\n")
+            await writer.drain()
+            writer.close()
+
+        return asyncio.start_server(handle, "127.0.0.1", 0)
+
+    return _make, captured
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import inspect
+import os
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from aiohttp.client_reqrep import ClientResponse
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
 
 from discord_ferry.core import logging_setup
 from discord_ferry.core.http import reset_http_state
@@ -56,6 +59,47 @@ pytest_plugins = ["nicegui.testing.user_plugin"]
 def fixtures_dir() -> Path:
     """Return the path to the test fixtures directory."""
     return FIXTURES_DIR
+
+
+@pytest.fixture
+def proxy_env() -> Callable[..., AbstractContextManager[None]]:
+    """Clear every *_proxy variable, then apply the given ones.
+
+    The autouse fixture does not neutralise these, so without this a developer
+    behind a proxy gets different results from CI.
+    """
+
+    @contextmanager
+    def _apply(**pairs: str) -> Iterator[None]:
+        saved = dict(os.environ)
+        for k in list(os.environ):
+            if k.lower().endswith("_proxy"):
+                os.environ.pop(k)
+        os.environ.update(pairs)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
+    return _apply
+
+
+@pytest.fixture
+def os_proxy() -> Callable[..., AbstractContextManager[None]]:
+    """Patch BOTH seams. Never patches a stdlib name: getproxies_registry does
+    not exist on ubuntu-latest, where CI runs."""
+
+    @contextmanager
+    def _apply(proxies: dict[str, str], bypass: set[str] | None = None) -> Iterator[None]:
+        hosts = bypass or set()
+        with (
+            patch("discord_ferry.core.http._os_proxies", return_value=dict(proxies)),
+            patch("discord_ferry.core.http._os_proxy_bypass", side_effect=lambda h: h in hosts),
+        ):
+            yield
+
+    return _apply
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import os
 from contextlib import contextmanager
@@ -14,7 +15,7 @@ import pytest
 from aiohttp.client_reqrep import ClientResponse
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
     from contextlib import AbstractContextManager
 
 from discord_ferry.core import logging_setup
@@ -110,25 +111,45 @@ def os_proxy() -> Callable[..., AbstractContextManager[None]]:
 
 
 @pytest.fixture
-async def fake_proxy():
+async def fake_proxy() -> AsyncIterator[
+    tuple[Callable[[bytes], Awaitable[asyncio.Server]], list[str]]
+]:
     """A loopback server that records the first request and answers a status.
 
     Needed because aioresponses patches ClientSession._request, so the request
     object is never constructed and proxy behaviour is invisible to all 21
     aioresponses modules. Real-socket precedent: tests/test_gui_native_lifecycle.py.
+
+    The fixture owns teardown. Every server it hands out is closed here, so a
+    test cannot leak a listening socket by forgetting, and `wait_closed` is
+    awaited so the loop does not shut down mid-close.
     """
     captured: list[str] = []
+    servers: list[asyncio.Server] = []
 
-    def _make(status: bytes = b"403 Forbidden"):
-        async def handle(reader, writer):
-            captured.append((await reader.read(4096)).decode("latin1"))
-            writer.write(b"HTTP/1.1 " + status + b"\r\nContent-Length: 0\r\n\r\n")
-            await writer.drain()
-            writer.close()
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        captured.append((await reader.read(4096)).decode("latin1"))
+        writer.write(_status[0])
+        await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
 
-        return asyncio.start_server(handle, "127.0.0.1", 0)
+    _status: list[bytes] = [b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n"]
 
-    return _make, captured
+    async def _make(status: bytes = b"403 Forbidden") -> asyncio.Server:
+        _status[0] = b"HTTP/1.1 " + status + b"\r\nContent-Length: 0\r\n\r\n"
+        server = await asyncio.start_server(handle, "127.0.0.1", 0)
+        servers.append(server)
+        return server
+
+    try:
+        yield _make, captured
+    finally:
+        for server in servers:
+            server.close()
+            with contextlib.suppress(Exception):
+                await server.wait_closed()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1539,3 +1539,36 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
     # A 403 from the proxy is permanent, so the short-circuit sits above both
     # consecutive_failures increments, exactly as the certificate case does.
     assert _circuit_state.consecutive_failures == 0
+
+
+async def test_a_proxy_502_still_retries(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-37 at api.py. Killing: wiring proxy_hint here without the
+    permanence gate, i.e. `if hint is not None:` alone.
+
+    A 502 from the proxy is NOT permanent, so it must keep the retries it had
+    before proxy support existed. The captured-request count is the FIRST
+    assertion, so it is the one that fails under the ungated mutant; the message
+    assertion below it is reached only when the retries actually happened.
+    """
+    from discord_ferry.migrator.api import MAX_API_RETRIES
+
+    _reset_circuit_state()
+    make, captured = fake_proxy
+    server = await make(b"502 Bad Gateway")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            patch("discord_ferry.migrator.api.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            async with new_session() as session:
+                with pytest.raises(MigrationError) as caught:
+                    await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    assert len(captured) == MAX_API_RETRIES, "the 502 was treated as permanent and never retried"
+    message = str(caught.value)
+    # The exhaustion message still names the proxy: the hint is computed either
+    # way, only the short-circuit is gated.
+    assert f"Network error after {MAX_API_RETRIES} retries" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
@@ -1505,3 +1506,36 @@ async def test_get_session_prefers_the_config_session() -> None:
         async with get_session(config) as yielded:
             assert yielded is shared
         assert not shared.closed
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at api.py:300
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at api.py:300.
+
+    A real socket, because aioresponses patches ClientSession._request and the
+    request object -- the only thing that carries a proxy -- is never built.
+
+    The circuit-breaker assertion is last on purpose: the proxy assertions above
+    it are what grade the wiring, and they must be the ones that fail first.
+    """
+    _reset_circuit_state()
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"):
+            async with new_session() as session:
+                with pytest.raises(MigrationError) as caught:
+                    await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+
+    message = str(caught.value)
+    assert "Network error" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message
+    # A 403 from the proxy is permanent, so the short-circuit sits above both
+    # consecutive_failures increments, exactly as the certificate case does.
+    assert _circuit_state.consecutive_failures == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1534,7 +1534,7 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
 
     message = str(caught.value)
     assert "Network error" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to api.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
     # A 403 from the proxy is permanent, so the short-circuit sits above both
     # consecutive_failures increments, exactly as the certificate case does.
@@ -1571,4 +1571,41 @@ async def test_a_proxy_502_still_retries(fake_proxy, proxy_env, os_proxy) -> Non
     # The exhaustion message still names the proxy: the hint is computed either
     # way, only the short-circuit is gated.
     assert f"Network error after {MAX_API_RETRIES} retries" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to api.test went through the proxy at 127.0.0.1:{port}" in message
+
+
+async def test_a_certificate_error_against_an_https_proxy_names_the_proxy_not_the_bundle(
+    mock_aiohttp: aioresponses, proxy_env, os_proxy
+) -> None:
+    """SC-135-52, integration half. Killing: concatenating the two hints.
+
+    The eight site tests all use an http:// proxy, where tls_hint is None, so a
+    site written as `proxy_hint(...) + (tls_hint(...) or "")` passes every one
+    of them. Only an https:// proxy makes both fire, and only then does the
+    precedence rule have an observable consequence: SSL_CERT_FILE advice for a
+    host the user never configured as a certificate authority.
+
+    aioresponses injects the exception rather than a socket serving it, which is
+    the same technique test_certificate_error_does_not_prime_the_circuit_breaker
+    uses. The scan is warmed through resolve_proxy, not by assigning the global.
+    """
+    from discord_ferry.core import http
+
+    _reset_circuit_state()
+    key = aiohttp.client_reqrep.ConnectionKey("secure-proxy", 8443, True, True, None, None, None)
+    cert_error = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("bad"))
+    mock_aiohttp.get(f"{BASE_URL}/servers/x", exception=cert_error)
+
+    with os_proxy({}), proxy_env(HTTPS_PROXY="https://secure-proxy:8443"):
+        assert http.resolve_proxy(f"{BASE_URL}/servers/x") is not None
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            async with aiohttp.ClientSession() as session:
+                with pytest.raises(MigrationError) as caught:
+                    await _api_request(session, "GET", f"{BASE_URL}/servers/x", TOKEN)
+
+    message = str(caught.value)
+    assert "went through the proxy at secure-proxy:8443" in message
+    assert "SSL_CERT_FILE" not in message, (
+        "proxy wins and REPLACES the certificate hint; appending both sends the "
+        "user to a CA bundle for a host they never configured"
+    )

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -7,6 +7,7 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import AutumnUploadError
 from discord_ferry.uploader.autumn import upload_to_autumn, upload_with_cache
 
@@ -850,3 +851,34 @@ async def test_non_certificate_client_error_is_re_raised_unchanged(
             await upload_to_autumn(session, AUTUMN_URL, "icons", file, TOKEN)
 
     assert not isinstance(caught.value, AutumnUploadError)
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at autumn.py:232
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(
+    tmp_path: Path, fake_proxy, proxy_env, os_proxy
+) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at autumn.py:232.
+
+    Without the call the hint is None, the `if hint is None: raise` arm fires,
+    and the raw ClientHttpProxyError escapes -- so pytest.raises fails on the
+    TYPE before any assertion below runs. That is the mutant's signature here.
+    """
+    file = tmp_path / "icon.png"
+    file.write_bytes(b"x" * 50)
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"):
+            async with new_session() as session:
+                with pytest.raises(AutumnUploadError) as caught:
+                    await upload_to_autumn(session, AUTUMN_URL, "icons", file, TOKEN)
+
+    message = str(caught.value)
+    assert "Upload to Autumn failed" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_autumn.py
+++ b/tests/test_autumn.py
@@ -880,5 +880,5 @@ async def test_a_refused_proxy_names_the_proxy(
 
     message = str(caught.value)
     assert "Upload to Autumn failed" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to autumn.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1531,6 +1531,42 @@ def test_tls_check_reports_the_branch_actually_taken(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# tls-check — proxy state (Task 11)
+# ---------------------------------------------------------------------------
+
+
+def test_tls_check_reports_the_proxy_keys(proxy_env, os_proxy) -> None:
+    """SC-135-42. Killing: a diagnostic that reports configuration rather than
+    resolution, which is what makes a diagnostic lie."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+    for key in ("proxy-https:", "proxy-source:", "proxy-disabled:"):
+        assert key in out
+
+
+def test_tls_check_keeps_the_original_four_keys() -> None:
+    """SC-135-43. Killing: breaking release.yml's Windows regex or macOS glob,
+    and with them the #134 gate.
+
+    A regression guard: describe_trust already prints all four today. It goes
+    red only if a later change drops or renames one of them.
+    """
+    out = CliRunner().invoke(main, ["tls-check"]).output
+    for key in ("ca-bundle:", "ca-bundle-readable:", "trust-source:", "ca-visible:"):
+        assert key in out
+
+
+def test_tls_check_never_prints_userinfo(proxy_env, os_proxy) -> None:
+    """SC-135-44. Killing: rendering the raw URL. Measured: str(URL), repr(URL)
+    and URL.human_repr() all leak userinfo."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://user:secret@corp:8080"):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+    assert "corp" in out
+    assert "secret" not in out
+    assert "user" not in out
+
+
+# ---------------------------------------------------------------------------
 # notice status
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1528,3 +1528,56 @@ def test_tls_check_reports_the_branch_actually_taken(tmp_path: Path) -> None:
         out = CliRunner().invoke(main, ["tls-check"]).output
     assert "ca-bundle-readable: true" in out  # the file is fine
     assert "trust-source: fallback" in out  # the trust is not
+
+
+# ---------------------------------------------------------------------------
+# notice status
+# ---------------------------------------------------------------------------
+
+
+def test_a_notice_prints_without_verbose() -> None:
+    """SC-135-38. Killing: emitting at status='warning'. Measured: cli.py:361-363
+    gates that behind `if self.verbose`, default off, so the user would see only
+    'N warning(s) suppressed' AFTER the run finished. A test asserting only that
+    the event was emitted would pass while the user saw nothing."""
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _ProgressTracker(verbose=False).on_event(
+            MigrationEvent(phase="preflight", status="notice", message="PROXY-NOTICE")
+        )
+    assert "PROXY-NOTICE" in buf.getvalue()
+
+
+def test_a_notice_does_not_inflate_the_warning_count() -> None:
+    """Killing: reusing 'error' or 'warning', which would make the final
+    'Warnings: N' line wrong for a configuration notice."""
+    from discord_ferry.cli import _ProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        tracker = _ProgressTracker(verbose=False)
+        tracker.on_event(MigrationEvent(phase="preflight", status="notice", message="x"))
+    assert tracker.warning_count == 0
+    assert tracker.error_count == 0
+
+
+def test_the_rollback_tracker_also_handles_notice() -> None:
+    """SC-135-39. Killing: adding an arm to one match and not the other. Neither
+    has a `case _`, so an unhandled status prints nothing at all, which is worse
+    than the gated 'warning' behaviour it replaced. rollback is one of the four
+    notice entry points."""
+    import asyncio
+
+    from discord_ferry.cli import _RollbackProgressTracker
+    from discord_ferry.core.events import MigrationEvent
+
+    buf, fake = _b5_console()
+    with patch("discord_ferry.cli.console", fake):
+        _RollbackProgressTracker(pause_event=asyncio.Event(), skip_confirmations=True).on_event(
+            MigrationEvent(phase="preflight", status="notice", message="ROLLBACK-NOTICE")
+        )
+    assert "ROLLBACK-NOTICE" in buf.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,6 +417,29 @@ def test_build_help(runner: CliRunner) -> None:
     assert "--blueprint" in result.output
 
 
+def test_build_prints_proxy_notice(runner: CliRunner, tmp_path: Path, proxy_env, os_proxy) -> None:
+    """Task 13. Killing: a build command that reaches api_create_server's
+    network call without ever calling _print_proxy_notices, leaving a proxied
+    user with no explanation. build is one of the four notice entry points
+    outside run_migration."""
+    from discord_ferry.blueprint import ServerBlueprint
+
+    bp = ServerBlueprint(name="Empty")
+    p = _write_bp(tmp_path, bp)
+    with (
+        os_proxy({}),
+        proxy_env(ALL_PROXY="socks5://sock:1080"),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "cannot use" in result.output
+
+
 # ---------------------------------------------------------------------------
 # Export-blueprint command
 # ---------------------------------------------------------------------------
@@ -633,6 +656,37 @@ def test_rollback_engine_error(runner: CliRunner, tmp_path: Path) -> None:
     assert "Lock conflict" in result.output
 
 
+def test_rollback_prints_proxy_notice(
+    runner: CliRunner, tmp_path: Path, proxy_env, os_proxy
+) -> None:
+    """Task 13. Killing: a rollback command that reaches run_rollback's network
+    work without ever calling _print_proxy_notices. rollback is one of the four
+    notice entry points outside run_migration."""
+    _write_rollback_state(tmp_path)
+    mock_engine = AsyncMock(return_value=MigrationState(stoat_server_id="srv01"))
+    with (
+        os_proxy({}),
+        proxy_env(ALL_PROXY="socks5://sock:1080"),
+        patch("discord_ferry.cli.run_rollback", mock_engine),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "rollback",
+                "--output-dir",
+                str(tmp_path),
+                "--yes",
+                "--stoat-url",
+                "http://localhost",
+                "--token",
+                "test-token",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "cannot use" in result.output
+
+
 def test_rollback_tracker_renders_suspect_columns() -> None:
     """SC-33: Rich table renders created_at + stoat_id columns for untracked suspects."""
     import asyncio as _asyncio
@@ -713,6 +767,40 @@ def test_probe_requires_test_server_id(runner: CliRunner) -> None:
         main, ["probe", "--stoat-url", "https://api.test", "--token", "t"], catch_exceptions=False
     )
     assert result.exit_code != 0  # Click flags the missing required option
+
+
+def test_probe_writes_notices_to_stderr_under_json(runner: CliRunner, proxy_env, os_proxy) -> None:
+    """Task 13. probe --json prints machine-readable JSON to stdout
+    (cli.py:1322-1324), so a notice printed to stdout would corrupt it. Killing:
+    a _print_proxy_notices call site that defaults to_stderr, or omits it, and
+    lands the notice on stdout instead."""
+    from discord_ferry.migrator.probe import ProbeReport
+
+    with (
+        os_proxy({}),
+        proxy_env(ALL_PROXY="socks5://sock:1080"),
+        patch(
+            "discord_ferry.migrator.probe.run_probe",
+            AsyncMock(return_value=ProbeReport()),
+        ),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "probe",
+                "--json",
+                "--stoat-url",
+                "https://api.test",
+                "--token",
+                "t",
+                "--test-server-id",
+                "srv1",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "cannot use" not in result.stdout  # stdout stays machine-readable
+    assert "cannot use" in result.stderr  # the human gets told
 
 
 def test_no_create_invite_flag_threads_to_config(runner: CliRunner) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1566,6 +1566,19 @@ def test_tls_check_never_prints_userinfo(proxy_env, os_proxy) -> None:
     assert "user" not in out
 
 
+def test_tls_check_reports_proxy_disabled_true_when_the_switch_is_set(proxy_env, os_proxy) -> None:
+    """Task 11 review fix. Killing: dropping describe_proxy's own
+    FERRY_DISABLE_PROXY early return. resolve_proxy's own kill-switch check
+    still makes proxy-http/proxy-https read 'none' either way, so those two
+    keys cannot catch a diagnostic that reports proxy-disabled: false while
+    everything is in fact suppressed, which is a diagnostic lying about its
+    own state.
+    """
+    with os_proxy({}), proxy_env(FERRY_DISABLE_PROXY="1"):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+    assert "proxy-disabled: true" in out
+
+
 # ---------------------------------------------------------------------------
 # notice status
 # ---------------------------------------------------------------------------

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -205,11 +205,17 @@ async def test_a_refused_proxy_names_the_proxy_discovering_autumn(
     # The site marker first: it passes under the wiring mutant, so the proxy
     # assertions below are guaranteed to be reached and graded.
     assert "Cannot reach Stoat API" in message
-    # The hint's own phrase, NOT a bare `127.0.0.1:{port}`. ClientHttpProxyError
-    # renders `url='http://127.0.0.1:PORT'` (its real_url, the proxy) in
-    # __str__, so a bare host substring is already present in the unwired
-    # message and could not fail. This assertion is the one that grades wiring.
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    # ONE assertion, naming the target AND the proxy.
+    #
+    # Not a bare `127.0.0.1:{port}`: ClientHttpProxyError renders
+    # `url='http://127.0.0.1:PORT'` (its real_url, the proxy) in __str__, so a
+    # bare host substring is already in the unwired message and cannot fail.
+    #
+    # Not split in two either. A separate `assert "api.test" in message` above
+    # this line would take the failure under the wiring mutant and this line
+    # would never run. Merged, one assertion grades wiring AND pins `target=`,
+    # which a copy-paste `target=path` would otherwise pass.
+    assert f"The request to api.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
 
 
@@ -235,5 +241,5 @@ async def test_a_refused_proxy_names_the_proxy_verifying_the_token(
 
     message = str(caught.value)
     assert "Token verification" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to api.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -177,3 +177,63 @@ async def test_run_connect_api_error_status(tmp_path: Path) -> None:
 
         with pytest.raises(StoatConnectionError, match="status 500"):
             await run_connect(config, state, [], lambda e: None)
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at both handlers in this module
+# ---------------------------------------------------------------------------
+#
+# Real sockets, not aioresponses: aioresponses patches ClientSession._request,
+# so the request object is never built and the proxy is invisible. The two
+# handlers are reached separately because a blanket refusing proxy fails the
+# first request, and `_discover_autumn_url` runs before `_verify_token`.
+
+
+async def test_a_refused_proxy_names_the_proxy_discovering_autumn(
+    tmp_path: Path, fake_proxy, proxy_env, os_proxy
+) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at connect.py:97."""
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"):
+            with pytest.raises(StoatConnectionError) as caught:
+                await run_connect(_make_config(tmp_path), MigrationState(), [], lambda e: None)
+
+    message = str(caught.value)
+    # The site marker first: it passes under the wiring mutant, so the proxy
+    # assertions below are guaranteed to be reached and graded.
+    assert "Cannot reach Stoat API" in message
+    # The hint's own phrase, NOT a bare `127.0.0.1:{port}`. ClientHttpProxyError
+    # renders `url='http://127.0.0.1:PORT'` (its real_url, the proxy) in
+    # __str__, so a bare host substring is already present in the unwired
+    # message and could not fail. This assertion is the one that grades wiring.
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message
+
+
+async def test_a_refused_proxy_names_the_proxy_verifying_the_token(
+    tmp_path: Path, fake_proxy, proxy_env, os_proxy
+) -> None:
+    """SC-135-28 at connect.py:154, the second handler in this module.
+
+    The API root is mocked so discovery succeeds; only `/users/@me` is passed
+    through to the real connector, which is what puts this test at :154 rather
+    than at :97. The "Token verification" assertion is what pins that, and it
+    holds under the wiring mutant, so the proxy assertions below it always run.
+    """
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"):
+            with aioresponses(passthrough=[f"{STOAT_URL}/users/@me"]) as m:
+                m.get(f"{STOAT_URL}/", payload=_API_ROOT_RESPONSE)
+                with pytest.raises(StoatConnectionError) as caught:
+                    await run_connect(_make_config(tmp_path), MigrationState(), [], lambda e: None)
+
+    message = str(caught.value)
+    assert "Token verification" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import ssl
 
 import aiohttp
@@ -9,7 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.discord import fetch_and_translate_guild_metadata
-from discord_ferry.discord.client import fetch_guild_channels, fetch_guild_roles
+from discord_ferry.discord.client import download_role_icon, fetch_guild_channels, fetch_guild_roles
 from discord_ferry.errors import DiscordAuthError
 
 DISCORD_API = "https://discord.com/api/v10"
@@ -397,6 +398,23 @@ async def test_download_role_icon_none_on_client_error():
             from discord_ferry.discord.client import download_role_icon
 
             assert await download_role_icon(s, "r1", "hash") is None
+
+
+async def test_a_role_icon_download_failure_logs_its_reason(caplog) -> None:
+    """Killing: swallowing the reason. Today any ClientError returns None and
+    structure.py reports 'Role icon download failed' with no cause."""
+    with aioresponses() as m:
+        m.get(
+            "https://cdn.discordapp.com/role-icons/r1/abc.png",
+            exception=aiohttp.ClientProxyConnectionError(
+                aiohttp.client_reqrep.ConnectionKey("corp", 8080, False, True, None, None, None),
+                OSError("refused"),
+            ),
+        )
+        async with aiohttp.ClientSession() as s:
+            with caplog.at_level(logging.WARNING):
+                assert await download_role_icon(s, "r1", "abc") is None
+    assert "corp" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -703,7 +703,7 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
 
     message = str(caught.value)
     assert "Discord API network error" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to discord.com went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
     assert sleep.await_count == 0, "a refused proxy must not pay the 1s retry sleep"
 
@@ -739,4 +739,4 @@ async def test_a_proxy_502_still_retries(fake_proxy, proxy_env, os_proxy) -> Non
     assert len(captured) == _MAX_RETRIES, "the 502 was treated as permanent and never retried"
     message = str(caught.value)
     assert "Discord API network error" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to discord.com went through the proxy at 127.0.0.1:{port}" in message

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -706,3 +706,37 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
     assert f"went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
     assert sleep.await_count == 0, "a refused proxy must not pay the 1s retry sleep"
+
+
+async def test_a_proxy_502_still_retries(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-37 at discord/client.py. Killing: wiring proxy_hint here without
+    the permanence gate, i.e. `if hint is not None:` alone.
+
+    This handler jumps over the whole _MAX_RETRIES loop, so an ungated hint
+    would abort the metadata phase on a proxy blip it used to survive. The
+    captured-request count is the FIRST assertion, so it is the one that fails
+    under the mutant.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.core.http import new_session
+    from discord_ferry.discord.client import _MAX_RETRIES
+    from discord_ferry.errors import MigrationError
+
+    make, captured = fake_proxy
+    server = await make(b"502 Bad Gateway")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            async with new_session() as session:
+                with pytest.raises(MigrationError) as caught:
+                    await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+    assert len(captured) == _MAX_RETRIES, "the 502 was treated as permanent and never retried"
+    message = str(caught.value)
+    assert "Discord API network error" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -665,3 +665,44 @@ async def test_discord_reset_after_header_is_seconds_not_milliseconds(
     assert calls[0] == pytest.approx(5.0, abs=0.05), (
         "Discord's X-RateLimit-Reset-After is delta-seconds: 5 must mean 5s, not 0.005s"
     )
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at discord/client.py:163
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at client.py:163.
+
+    A real socket: aioresponses patches ClientSession._request, so the request
+    object that carries a proxy is never built.
+
+    `asyncio.sleep` is patched so an unwired run costs no wall time, and the
+    await_count assertion pins the permanence half -- a refused proxy is
+    permanent, so it must jump over the _MAX_RETRIES loop rather than pay it.
+    That assertion is LAST, so the wiring assertions above it fail first.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from discord_ferry.core.http import new_session
+    from discord_ferry.errors import MigrationError
+
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            patch("discord_ferry.discord.client.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        ):
+            async with new_session() as session:
+                with pytest.raises(MigrationError) as caught:
+                    await fetch_guild_roles(session, TOKEN, GUILD_ID)
+
+    message = str(caught.value)
+    assert "Discord API network error" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message
+    assert sleep.await_count == 0, "a refused proxy must not pay the 1s retry sleep"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,11 +55,19 @@ def _make_config(tmp_path: Path, **overrides: object) -> FerryConfig:
     return FerryConfig(**defaults)  # type: ignore[arg-type]
 
 
-async def test_run_migration_validates_exports(tmp_path: Path) -> None:
-    """Engine parses exports and emits validate events."""
+async def test_run_migration_validates_exports(tmp_path: Path, proxy_env: Any) -> None:
+    """Engine parses exports and emits validate events.
+
+    Wrapped in proxy_env() with no arguments: an ambient proxy variable on the
+    developer's machine (set by a corp VPN, Docker Desktop, etc.) makes
+    format_proxy_notices() append a preflight entry to state.warnings with no
+    matching validate-phase warning event, which would otherwise make this
+    assertion fail off CI while passing on a clean runner.
+    """
     events: list[MigrationEvent] = []
     config = _make_config(tmp_path)
-    state = await run_migration(config, events.append, phase_overrides=_NOOP_OVERRIDES)
+    with proxy_env():
+        state = await run_migration(config, events.append, phase_overrides=_NOOP_OVERRIDES)
     validate_events = [e for e in events if e.phase == "validate"]
     assert any(e.status == "started" for e in validate_events)
     assert any(e.status == "completed" for e in validate_events)
@@ -2009,3 +2017,18 @@ async def test_run_rollback_initializes_token_store(tmp_path: Path) -> None:
 
     assert config.token_store is not None
     assert "SEKRET-TOKEN-abcd" not in config.token_store.sanitize("x SEKRET-TOKEN-abcd y")
+
+
+async def test_preflight_emits_and_persists_a_proxy_notice(
+    tmp_path: Path, proxy_env: Any, os_proxy: Any
+) -> None:
+    """SC-135-40. Killing: emitting an event and never appending, so report.json,
+    the artefact users are asked to attach to bug reports, omits the cause."""
+    events: list[MigrationEvent] = []
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        state = await run_migration(
+            _make_config(tmp_path, dry_run=True), events.append, phase_overrides=_NOOP_OVERRIDES
+        )
+
+    assert any(e.status == "notice" and e.phase == "preflight" for e in events)
+    assert any(w.get("type", "").startswith("proxy_") for w in state.warnings)

--- a/tests/test_exporter_manager.py
+++ b/tests/test_exporter_manager.py
@@ -497,8 +497,10 @@ async def test_a_refused_proxy_names_the_proxy(tmp_path, fake_proxy, proxy_env, 
 
     message = str(caught.value)
     assert "Network error downloading DCE" in message
-    assert "api.github.com" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    # ONE assertion: see the note in tests/test_exporter_runner.py. The split
+    # version put `assert "api.github.com" in message` above the phrase, so the
+    # phrase line never ran under this site's own mutant.
+    assert f"The request to api.github.com went through the proxy at 127.0.0.1:{port}" in message
     assert slept.await_count == 0, "a refused proxy is permanent and must not pay the 3s retry"
 
 
@@ -528,4 +530,6 @@ async def test_a_proxy_502_still_retries(tmp_path, fake_proxy, proxy_env, os_pro
                 await download_dce(lambda _e: None)
 
     assert len(captured) >= 2, "the 502 was treated as permanent and never retried"
-    assert f"went through the proxy at 127.0.0.1:{port}" in str(caught.value)
+    assert f"The request to api.github.com went through the proxy at 127.0.0.1:{port}" in str(
+        caught.value
+    )

--- a/tests/test_exporter_manager.py
+++ b/tests/test_exporter_manager.py
@@ -462,3 +462,70 @@ class TestDceChecksumsJson:
                     f"dce_checksums.json[{version!r}][{platform_key!r}] = {value!r} "
                     "does not look like a 64-char lowercase hex SHA-256 string"
                 )
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at exporter/manager.py:214
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(tmp_path, fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at manager.py:214.
+
+    This site also carried the worst of the two target-binding hazards: the
+    `except` spans both `session.get` calls and `download_url` is bound INSIDE
+    the try, so a failure on the first GET left it unbound and
+    `proxy_hint(e, target=download_url)` would raise UnboundLocalError from
+    inside an error handler. This test fails on the FIRST GET, so it is exactly
+    the case that would have raised.
+    """
+    from discord_ferry.errors import DCENotFoundError
+
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            patch("discord_ferry.exporter.manager._get_dce_dir", return_value=tmp_path),
+            patch("discord_ferry.exporter.manager._get_asset_name", return_value="test.zip"),
+            patch("discord_ferry.exporter.manager.asyncio.sleep", new_callable=AsyncMock) as slept,
+        ):
+            with pytest.raises(DCENotFoundError) as caught:
+                await download_dce(lambda _e: None)
+
+    message = str(caught.value)
+    assert "Network error downloading DCE" in message
+    assert "api.github.com" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert slept.await_count == 0, "a refused proxy is permanent and must not pay the 3s retry"
+
+
+async def test_a_proxy_502_still_retries(tmp_path, fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-37. Killing: wiring proxy_hint at manager.py without the
+    permanence gate, which would turn a retryable blip into a hard failure on
+    the DCE download, this repo's highest-traffic external failure path.
+
+    A 502 from the proxy is NOT permanent, so this must take the `attempt == 0`
+    retry and reach the socket twice. The message still names the proxy: the
+    hint is computed either way, only the short-circuit is gated.
+    """
+    from discord_ferry.errors import DCENotFoundError
+
+    make, captured = fake_proxy
+    server = await make(b"502 Bad Gateway")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            patch("discord_ferry.exporter.manager._get_dce_dir", return_value=tmp_path),
+            patch("discord_ferry.exporter.manager._get_asset_name", return_value="test.zip"),
+            patch("discord_ferry.exporter.manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(DCENotFoundError) as caught:
+                await download_dce(lambda _e: None)
+
+    assert len(captured) >= 2, "the 502 was treated as permanent and never retried"
+    assert f"went through the proxy at 127.0.0.1:{port}" in str(caught.value)

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -917,13 +917,16 @@ class TestDceChildProxyEnvironment:
             captured_env.update(kwargs.get("env") or {})
             raise RuntimeError("stop here")
 
-        with os_proxy({"https": "http://corp:8080"}), proxy_env():
-            with patch(
+        with (
+            os_proxy({"https": "http://corp:8080"}),
+            proxy_env(),
+            patch(
                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
                 side_effect=fake_exec,
-            ):
-                with pytest.raises(RuntimeError):
-                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         assert captured_env.get("HTTPS_PROXY") == "http://corp:8080"
         assert "PATH" in captured_env, "the child must inherit the rest of the environment"
@@ -942,13 +945,16 @@ class TestDceChildProxyEnvironment:
             captured_env.update(kwargs.get("env") or {})
             raise RuntimeError("stop here")
 
-        with os_proxy({"https": "http://corp:8080"}), proxy_env(FERRY_DISABLE_PROXY="1"):
-            with patch(
+        with (
+            os_proxy({"https": "http://corp:8080"}),
+            proxy_env(FERRY_DISABLE_PROXY="1"),
+            patch(
                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
                 side_effect=fake_exec,
-            ):
-                with pytest.raises(RuntimeError):
-                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         assert "HTTPS_PROXY" not in captured_env
 
@@ -964,12 +970,15 @@ class TestDceChildProxyEnvironment:
             captured_env.update(kwargs.get("env") or {})
             raise RuntimeError("stop here")
 
-        with os_proxy({"https": "http://corp:8080"}), proxy_env(HTTPS_PROXY="http://mine:9999"):
-            with patch(
+        with (
+            os_proxy({"https": "http://corp:8080"}),
+            proxy_env(HTTPS_PROXY="http://mine:9999"),
+            patch(
                 "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
                 side_effect=fake_exec,
-            ):
-                with pytest.raises(RuntimeError):
-                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         assert captured_env["HTTPS_PROXY"] == "http://mine:9999"

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -889,3 +889,87 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
     # never ran. Merged, it grades wiring and pins `target=` together.
     assert f"The request to discord.com went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
+
+
+# ---------------------------------------------------------------------------
+# Task 14 — the OS-resolved proxy must reach the DCE child environment
+#
+# DCE is a separate .NET process reached through create_subprocess_exec; it
+# inherits only the environment. .NET reads env vars then OS settings, so
+# Ferry silently resolving a proxy from OS settings while the environment
+# stays empty is the one gap that matters: DCE sees nothing.
+# ---------------------------------------------------------------------------
+
+
+class TestDceChildProxyEnvironment:
+    @pytest.mark.asyncio
+    async def test_an_os_resolved_proxy_reaches_the_dce_child(
+        self, tmp_path: Path, proxy_env, os_proxy
+    ) -> None:
+        """Killing: an export that succeeds while every later phase fails, teaching
+        the user their proxy works. .NET on macOS and Windows reads env then OS
+        settings, but only Ferry sees an OS proxy when the environment is silent.
+        """
+        cfg = _make_config(tmp_path)
+        captured_env: dict[str, str] = {}
+
+        async def fake_exec(*args: object, **kwargs: object) -> None:
+            captured_env.update(kwargs.get("env") or {})
+            raise RuntimeError("stop here")
+
+        with os_proxy({"https": "http://corp:8080"}), proxy_env():
+            with patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                side_effect=fake_exec,
+            ):
+                with pytest.raises(RuntimeError):
+                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+        assert captured_env.get("HTTPS_PROXY") == "http://corp:8080"
+        assert "PATH" in captured_env, "the child must inherit the rest of the environment"
+
+    @pytest.mark.asyncio
+    async def test_the_kill_switch_suppresses_injection(
+        self, tmp_path: Path, proxy_env, os_proxy
+    ) -> None:
+        """S2 criterion 4. Killing: a kill switch that stops Ferry proxying while
+        still pushing a proxy at the child.
+        """
+        cfg = _make_config(tmp_path)
+        captured_env: dict[str, str] = {}
+
+        async def fake_exec(*args: object, **kwargs: object) -> None:
+            captured_env.update(kwargs.get("env") or {})
+            raise RuntimeError("stop here")
+
+        with os_proxy({"https": "http://corp:8080"}), proxy_env(FERRY_DISABLE_PROXY="1"):
+            with patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                side_effect=fake_exec,
+            ):
+                with pytest.raises(RuntimeError):
+                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+        assert "HTTPS_PROXY" not in captured_env
+
+    @pytest.mark.asyncio
+    async def test_a_users_own_variable_is_not_overwritten(
+        self, tmp_path: Path, proxy_env, os_proxy
+    ) -> None:
+        """Killing: clobbering a deliberate user setting."""
+        cfg = _make_config(tmp_path)
+        captured_env: dict[str, str] = {}
+
+        async def fake_exec(*args: object, **kwargs: object) -> None:
+            captured_env.update(kwargs.get("env") or {})
+            raise RuntimeError("stop here")
+
+        with os_proxy({"https": "http://corp:8080"}), proxy_env(HTTPS_PROXY="http://mine:9999"):
+            with patch(
+                "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+                side_effect=fake_exec,
+            ):
+                with pytest.raises(RuntimeError):
+                    await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
+
+        assert captured_env["HTTPS_PROXY"] == "http://mine:9999"

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -926,10 +927,18 @@ class TestDceChildProxyEnvironment:
             ),
             pytest.raises(RuntimeError),
         ):
+            # Snapshot INSIDE the fixtures: proxy_env has already rewritten
+            # os.environ by here, so this is the environment the child should
+            # actually inherit.
+            before = set(os.environ)
             await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         assert captured_env.get("HTTPS_PROXY") == "http://corp:8080"
-        assert "PATH" in captured_env, "the child must inherit the rest of the environment"
+        # Superset, not `"PATH" in captured_env`. That weaker form passes against a
+        # curated env={"PATH": ..., "HTTPS_PROXY": ...} that dropped SYSTEMROOT, which
+        # is the regression the implementation's own comment warns about and the one
+        # release.yml cannot catch, because the smoke jobs never run a real export.
+        assert set(captured_env) >= before - {"HTTPS_PROXY"}
 
     @pytest.mark.asyncio
     async def test_the_kill_switch_suppresses_injection(

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -884,8 +884,8 @@ async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) 
 
     message = str(caught.value)
     assert "Cannot reach Discord API" in message
-    # discord.com, not the proxy host: proves `target` came from the call site
-    # and named the host the user was trying to reach.
-    assert "discord.com" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    # ONE assertion, not two. A separate `assert "discord.com" in message` above
+    # the phrase took the failure under this site's mutant, so the phrase line
+    # never ran. Merged, it grades wiring and pins `target=` together.
+    assert f"The request to discord.com went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -858,3 +858,34 @@ class TestOverlongStdoutActivity:
             await run_dce_export(cfg, tmp_path / "dce", events.append)
 
         assert any("truncated" in (e.message or "") for e in events)
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at exporter/runner.py:346
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at runner.py:346.
+
+    This site also carried a target-binding hazard: the URL was an inline
+    literal inside the `try`, so there was no name to pass as `target`. It is
+    hoisted to a variable above the try.
+    """
+    from discord_ferry.errors import DiscordAuthError
+
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"):
+            with pytest.raises(DiscordAuthError) as caught:
+                await validate_discord_token("dt")
+
+    message = str(caught.value)
+    assert "Cannot reach Discord API" in message
+    # discord.com, not the proxy host: proves `target` came from the call site
+    # and named the host the user was trying to reach.
+    assert "discord.com" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -593,3 +593,34 @@ def test_exposed_settings_wiring_pins() -> None:
     # (d) tokens still never touch app.storage.user (existing invariant re-pinned)
     assert 'storage["token"] =' not in source
     assert 'storage["discord_token"] =' not in source
+
+
+# ---------------------------------------------------------------------------
+# Task 13: proxy notices on the export screen
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_notice_lines_formats_for_the_log_panel(proxy_env, os_proxy) -> None:
+    """Task 13. _run_export is a nested closure inside export_page, unreachable
+    from a unit test (see gui.py:893's docstring), the same blind spot that let
+    the one-click export ship dead for eleven releases. _proxy_notice_lines is
+    module level so its formatting is testable even though the call site is not.
+    Killing: a formatter that drops the "[notice] " prefix _run_export's push
+    relies on, or that fails to surface a real notice at all."""
+    from discord_ferry.gui import _proxy_notice_lines
+
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        lines = _proxy_notice_lines()
+    assert lines == [
+        "[notice] Proxy configuration Ferry cannot use: socks5://sock:1080 (all). "
+        "Connected direct. ALL_PROXY is not supported (see issue #141)."
+    ]
+
+
+def test_proxy_notice_lines_is_empty_on_a_clean_configuration(proxy_env, os_proxy) -> None:
+    """A clean machine must produce no line, not a stray '[notice] ' row in the
+    log panel."""
+    from discord_ferry.gui import _proxy_notice_lines
+
+    with os_proxy({}), proxy_env():
+        assert _proxy_notice_lines() == []

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -18,6 +18,7 @@ import pytest
 from yarl import URL
 
 from discord_ferry.core import http
+from discord_ferry.core.security import reset_secret_registry, sanitize_secrets
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "discord_ferry"
 
@@ -280,3 +281,77 @@ def test_strip_userinfo_leaves_a_clean_url_alone() -> None:
     stripped, header = http._strip_userinfo(URL("http://corp:8080"))
     assert stripped == URL("http://corp:8080")
     assert header is None
+
+
+def test_strip_userinfo_handles_password_only_userinfo() -> None:
+    """Killing: `or` in place of `and` in the guard.
+
+    yarl reports raw_user as None for an empty username (_parse.py:130), so an
+    `or` short-circuits on this input and returns the URL with the password
+    still in it, which is then assigned to kwargs["proxy"] and rendered by every
+    downstream exception repr. Both existing strip tests pass under that mutant:
+    the credentialed URL has neither part None, the clean URL has both.
+    """
+    stripped, header = http._strip_userinfo(URL("http://:PROXYTOKEN@corp:8080"))
+    assert "PROXYTOKEN" not in str(stripped)
+    assert stripped == URL("http://corp:8080")
+    assert header is not None
+    assert base64.b64decode(header.split()[-1]).decode() == ":PROXYTOKEN"
+
+
+def test_strip_userinfo_registers_both_credential_forms() -> None:
+    """SC-135-49. Killing: registering only the plaintext, or neither.
+
+    sanitize masks by exact substring, and the base64 form is what travels and
+    what RequestInfo.headers holds. This is the second redaction layer; without
+    it sanitize_secrets can never mask a proxy credential reaching ferry.log.
+    """
+    reset_secret_registry()
+    _, header = http._strip_userinfo(URL("http://ferryuser:SUPERSECRET@corp:8080"))
+    assert header is not None
+    masked = sanitize_secrets(f"plaintext=SUPERSECRET encoded={header}")
+    assert "SUPERSECRET" not in masked
+    assert header.split()[-1] not in masked
+
+
+def test_os_proxies_returns_what_the_platform_getter_reports() -> None:
+    """Killing: a seam that ignores the OS entirely and always returns {}.
+
+    Nothing else in the 15-task plan executes the getattr branch: every later
+    test patches the seams themselves. Without this, `_os_proxies` could be
+    `return {}` and ship, passing the whole suite while leaving "Ferry honours
+    OS proxy settings" inert on both platforms where it matters.
+
+    This is the one place patching a stdlib name is correct, because Task 1 is
+    the seam's own unit test. create=True makes it run identically on
+    ubuntu-latest, where neither getter exists.
+    """
+    with (
+        patch.object(
+            urllib.request,
+            "getproxies_macosx_sysconf",
+            lambda: {"https": "http://corp:8080"},
+            create=True,
+        ),
+        patch.object(urllib.request, "getproxies_registry", None, create=True),
+    ):
+        assert http._os_proxies() == {"https": "http://corp:8080"}
+
+
+def test_os_proxy_bypass_returns_what_the_platform_getter_reports() -> None:
+    """Killing: a seam that always returns False, which reads as 'never bypass'.
+
+    Also pins the second name in the getattr loop: the registry variant is
+    reached only when the darwin one is absent, which nothing else proves.
+    """
+    with (
+        patch.object(urllib.request, "proxy_bypass_macosx_sysconf", None, create=True),
+        patch.object(
+            urllib.request,
+            "proxy_bypass_registry",
+            lambda host: host == "internal.corp",
+            create=True,
+        ),
+    ):
+        assert http._os_proxy_bypass("internal.corp") is True
+        assert http._os_proxy_bypass("api.stoat.chat") is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1550,3 +1550,19 @@ def test_permanence_is_false_for_unrelated_errors(exc: BaseException) -> None:
     test cannot see that: OSError is not a ClientConnectorError.
     """
     assert http.proxy_error_is_permanent(exc) is False
+
+
+# --- The kill switch, a regression guard (Task 11) ---------------------------
+#
+# resolve_proxy already checks FERRY_DISABLE_PROXY as its first statement
+# (core/http.py:404-405), before the env/os merge runs, so the assertion below
+# already passes today. It exists to catch a LATER change that moves the check
+# below source selection, where an env-supplied proxy could slip through while
+# the OS half stayed suppressed -- exactly the "suppresses only one half"
+# failure the switch exists to prevent.
+
+
+def test_the_kill_switch_disables_both_sources(proxy_env, os_proxy) -> None:
+    """SC-135-14. Killing: a switch that suppresses only one half."""
+    with os_proxy(CORP), proxy_env(HTTPS_PROXY="http://env:3128", FERRY_DISABLE_PROXY="1"):
+        assert http.resolve_proxy(TARGET) is None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1316,19 +1316,48 @@ def test_the_kill_switch_wins_over_a_populated_cache(proxy_env, os_proxy) -> Non
         assert http.proxy_notices() == ()
 
 
-def test_proxy_notices_never_raises(proxy_env, os_proxy) -> None:
-    """The total boundary, mirroring _FerryRequest._resolve_or_direct.
+def test_an_unreadable_configuration_degrades_visibly(proxy_env, os_proxy) -> None:
+    """The total boundary, and that it degrades VISIBLY rather than to ().
 
-    `_scheme_map()` reaches the platform getters, and `re.error` subclasses
-    Exception directly rather than ValueError or TypeError, so it escapes both
-    narrow guards inside the loop. Mutant rows H and I showed what escaping
-    looks like from the inside: the exception surfaces at the call and no
-    assertion in the test is ever reached. Every caller runs at preflight, so
-    that aborts the first thing a migration does.
+    Two things are asserted, and the second is the one that matters. Returning
+    () would satisfy "never raises" while making "Ferry could not read the
+    configuration" indistinguishable from "this machine is clean", which is the
+    inversion these notices exist to prevent. So this asserts on the rendered
+    line a user would see, not on the absence of output.
+
+    `_scheme_map()` reaches the platform getters `getproxies_macosx_sysconf` and
+    `getproxies_registry` through `_os_proxies`, and stdlib can raise there
+    outside (ValueError, TypeError). `re.error` is used here because it
+    subclasses Exception directly and so escapes both narrow guards; the
+    documented `re.error` path in this module belongs to the SIBLING boundary
+    (`proxy_bypass_registry`, reached only from resolve_proxy), not to this one.
+    An earlier version of this docstring inherited that attribution verbatim and
+    was wrong about it.
     """
     with (
         os_proxy({}),
         proxy_env(ALL_PROXY="socks5://sock:1080"),
         patch("discord_ferry.core.http._scheme_map", side_effect=re.error("boom")),
     ):
-        assert http.proxy_notices() == ()
+        notices = http.proxy_notices()
+        lines = http.format_proxy_notices()
+    assert [n.kind for n in notices] == ["unreadable"]
+    assert lines == [
+        "Proxy configuration Ferry cannot use: <unavailable> (?). "
+        "Ferry could not read the proxy configuration and connected direct."
+    ]
+
+
+def test_an_unreadable_configuration_is_not_cached(proxy_env, os_proxy) -> None:
+    """The degraded notice must NOT be frozen for the life of the process.
+
+    A transient platform error at preflight would otherwise make every later
+    reader in the same GUI process report an unreadable configuration, long
+    after the machine started answering again. Caching it also inverts the
+    warning: the log line would appear once and the wrong notice forever.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        with patch("discord_ferry.core.http._scheme_map", side_effect=re.error("boom")):
+            assert [n.kind for n in http.proxy_notices()] == ["unreadable"]
+        assert http._proxy_notices == ()
+        assert [n.kind for n in http.proxy_notices()] == ["all_proxy_only"]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -939,3 +939,60 @@ async def test_one_requests_proxy_headers_do_not_leak_into_the_next(proxy_env, o
     assert second.proxy_headers is not None
     assert "X-Caller" in first.proxy_headers
     assert "X-Caller" not in second.proxy_headers
+
+
+# --- End to end on a real socket (Task 4) ------------------------------------
+#
+# No source of its own. These two drive the whole path that every test above
+# only reaches in pieces: environment variable -> resolve_proxy -> _FerryRequest
+# -> a CONNECT on a loopback socket. Nothing mocked below the socket, because
+# aioresponses replaces ClientSession._request and would skip the request class
+# entirely.
+
+
+async def test_a_configured_proxy_receives_a_connect(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-01 and SC-135-47. An HTTPS target on purpose: proxy_headers with
+    encode_basic_auth sends nothing on an http target and works over CONNECT, so
+    an http-target test would report a false failure."""
+    make, captured = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://ferryuser:SUPERSECRET@127.0.0.1:{port}"):
+            caught: BaseException | None = None
+            async with http.new_session() as session:
+                try:
+                    await session.get(TARGET, timeout=aiohttp.ClientTimeout(total=5))
+                except BaseException as exc:  # noqa: BLE001
+                    caught = exc
+
+    lines = [ln for ln in captured[0].split("\r\n") if ln]
+    assert lines[0].startswith("CONNECT api.stoat.chat:443")
+    auth = [ln for ln in lines if ln.lower().startswith("proxy-authorization")]
+    assert auth, "the credential never reached the proxy"
+    assert base64.b64decode(auth[0].split()[-1]).decode() == "ferryuser:SUPERSECRET"
+    assert "SUPERSECRET" not in lines[0]
+    assert isinstance(caught, aiohttp.ClientHttpProxyError)
+
+
+async def test_no_credential_reaches_the_exception(fake_proxy, proxy_env, os_proxy) -> None:
+    """SC-135-48. reset_secret_registry FIRST: with the registry populated the
+    redaction layer masks a stripping-layer leak and this passes over a real
+    leak. This repo shipped rollback redaction that was inert for that reason."""
+    reset_secret_registry()
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with os_proxy({}), proxy_env(HTTPS_PROXY=f"http://ferryuser:SUPERSECRET@127.0.0.1:{port}"):
+            async with http.new_session() as session:
+                with pytest.raises(aiohttp.ClientHttpProxyError) as caught:
+                    await session.get(TARGET, timeout=aiohttp.ClientTimeout(total=5))
+
+    exc = caught.value
+    assert exc.request_info.real_url.password is None
+    assert "SUPERSECRET" not in str(exc)
+    # url is the TARGET, real_url is the PROXY. Getting these backwards names
+    # the target twice and never the proxy.
+    assert "api.stoat.chat" in str(exc.request_info.url)
+    assert "127.0.0.1" in str(exc.request_info.real_url)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,6 +6,7 @@ how an outbound session reaches the network.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import ssl
 import urllib.request
@@ -696,3 +697,170 @@ def test_a_cgi_environment_keeps_the_http_scheme_suppressed(proxy_env, os_proxy)
     with os_proxy(CORP), proxy_env(REQUEST_METHOD="GET"):
         assert http.resolve_proxy("http://plain.invalid/x") is None
         assert http.resolve_proxy(TARGET) is not None
+
+
+# --- The request subclass and the factory wiring (Task 3) --------------------
+#
+# Every test below that builds a _FerryRequest builds it DIRECTLY. That is not a
+# shortcut: ClientSession only reaches self._request_class at client.py:780, and
+# aioresponses replaces ClientSession._request wholesale, so under a mock the
+# class is never constructed at all. The factory-installs test is what connects
+# the two halves, and Task 4 drives the whole path over a real socket.
+
+
+async def test_the_subclass_fills_the_proxy(proxy_env, os_proxy) -> None:
+    """SC-135-09, half one. Killing: a subclass that ignores its resolver."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"):
+        req = http._FerryRequest("GET", URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy == URL("http://corp:8080")
+
+
+async def test_the_factory_installs_the_request_class() -> None:
+    """SC-135-10, half two. Killing: 'wrote the subclass correctly, forgot
+    request_class='. Measured: the subclass is constructed 0 times under
+    aioresponses and 1 time on a real attempt, so no mocked test can see this,
+    and the test above stays green against the mutant. Mirrors
+    test_http.py's `connector._ssl is ctx`."""
+    async with http.new_session() as session:
+        assert session._request_class is http._FerryRequest
+        assert type(session) is aiohttp.ClientSession
+
+
+async def test_a_callers_own_request_class_survives() -> None:
+    """SC-135-12. Killing: a hardcoded request_class= raising
+    'TypeError: got multiple values for keyword argument'."""
+
+    class Other(aiohttp.ClientRequest):
+        pass
+
+    async with http.new_session(request_class=Other) as session:
+        assert session._request_class is Other
+
+
+async def test_a_callers_explicit_proxy_wins(proxy_env, os_proxy) -> None:
+    """The FALSE branch of `kwargs.get("proxy") is None`.
+
+    Killing: filling the proxy in unconditionally, which would redirect a caller
+    that named a specific proxy to the ambient one and attach a credential meant
+    for a different host. proxy_headers stays None because update_proxy nulls it
+    when nothing supplied any (client_reqrep.py:1335), so this also proves no
+    header was injected.
+    """
+    caller = URL("http://caller-chose-this:9999")
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        req = http._FerryRequest("GET", URL(TARGET), proxy=caller, loop=asyncio.get_running_loop())
+    assert req.proxy == caller
+    assert req.proxy_headers is None
+
+
+async def test_the_url_can_arrive_as_a_keyword(proxy_env, os_proxy) -> None:
+    """The `kwargs.get("url")` half of the url lookup.
+
+    aiohttp passes method and url positionally (client.py:780-782), so the
+    positional half is the one production takes and this is the only test that
+    enters the keyword half. Killing: `url = args[1]` with no kwargs lookup,
+    which silently stops proxying for any caller using keywords.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"):
+        req = http._FerryRequest(method="GET", url=URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy == URL("http://corp:8080")
+
+
+async def test_a_missing_url_raises_type_error_not_index_error(proxy_env, os_proxy) -> None:
+    """The two guards that keep a malformed call aiohttp's problem, not Ferry's.
+
+    Killing two mutants at once. A bare `args[1]` raises IndexError from Ferry's
+    own frame before super() ever runs, and dropping `if url is not None` calls
+    resolve_proxy(None), which reaches `target.scheme` and raises AttributeError
+    despite that function's "never raises" contract. Neither is a TypeError, so
+    either one turns this red.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"), pytest.raises(TypeError):
+        http._FerryRequest("GET", loop=asyncio.get_running_loop())
+
+
+async def test_no_configured_proxy_leaves_the_request_direct(proxy_env, os_proxy) -> None:
+    """The FALSE branch of `choice is not None`.
+
+    Killing: `kwargs["proxy"] = choice.url` outside the guard, which raises
+    AttributeError on None and would kill the first request of every migration
+    on every machine that has no proxy at all.
+    """
+    with os_proxy({}), proxy_env():
+        req = http._FerryRequest("GET", URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy is None
+    assert req.proxy_headers is None
+
+
+async def test_the_credential_becomes_a_proxy_authorization_header(proxy_env, os_proxy) -> None:
+    """The `choice.authorization is not None` branch.
+
+    Killing: setting the proxy and dropping the header, which reaches the user
+    as a 407 they cannot explain because the credential they configured was
+    parsed, stripped, and then thrown away.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        req = http._FerryRequest("GET", URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy == URL("http://corp:8080")
+    assert "SUPERSECRET" not in str(req.proxy)
+    assert req.proxy_headers is not None
+    encoded = req.proxy_headers["Proxy-Authorization"]
+    assert base64.b64decode(encoded.split()[-1]).decode() == "ferryuser:SUPERSECRET"
+
+
+async def test_a_callers_proxy_headers_are_merged_not_clobbered(proxy_env, os_proxy) -> None:
+    """The merge. Killing: `kwargs["proxy_headers"] = {"Proxy-Authorization": ...}`,
+    which drops every header the caller set.
+
+    Direct construction is the only route into this branch today:
+    ClientSession nulls proxy_headers whenever proxy is None (client.py:648-649),
+    so through a session a caller's headers only ever arrive alongside a caller's
+    proxy, which the guard above already declines to touch.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        req = http._FerryRequest(
+            "GET",
+            URL(TARGET),
+            proxy_headers={"X-Caller": "1"},
+            loop=asyncio.get_running_loop(),
+        )
+    assert req.proxy_headers is not None
+    assert req.proxy_headers["X-Caller"] == "1"
+    assert "Proxy-Authorization" in req.proxy_headers
+
+
+async def test_a_callers_own_proxy_authorization_is_not_overwritten(proxy_env, os_proxy) -> None:
+    """setdefault, not assignment. Killing: `merged["Proxy-Authorization"] = ...`,
+    which overrides a credential the caller chose deliberately.
+
+    The getall() count matters as much as the value: proxy_headers becomes a
+    CIMultiDict (client_reqrep.py:1342-1345), which happily holds two values for
+    one case-insensitive key, and both would then travel to the proxy.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        req = http._FerryRequest(
+            "GET",
+            URL(TARGET),
+            proxy_headers={"Proxy-Authorization": "Basic Y2FsbGVyOnBhc3M="},
+            loop=asyncio.get_running_loop(),
+        )
+    assert req.proxy_headers is not None
+    assert req.proxy_headers["Proxy-Authorization"] == "Basic Y2FsbGVyOnBhc3M="
+    assert len(req.proxy_headers.getall("Proxy-Authorization")) == 1
+
+
+async def test_one_requests_proxy_headers_do_not_leak_into_the_next(proxy_env, os_proxy) -> None:
+    """A FRESH dict per request. Killing: hoisting `merged` to a module-level
+    mapping reused by every request, where the first caller's headers travel to
+    the proxy on every later request and connection_key
+    (client_reqrep.py:970-972) changes between two requests to the same host,
+    defeating connection reuse for the whole migration.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        loop = asyncio.get_running_loop()
+        first = http._FerryRequest("GET", URL(TARGET), proxy_headers={"X-Caller": "1"}, loop=loop)
+        second = http._FerryRequest("GET", URL(TARGET), loop=loop)
+    assert first.proxy_headers is not None
+    assert second.proxy_headers is not None
+    assert "X-Caller" in first.proxy_headers
+    assert "X-Caller" not in second.proxy_headers

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1049,7 +1049,26 @@ def test_the_notice_outcome_is_true(proxy_env, os_proxy) -> None:
     was in fact used."""
     with os_proxy(CORP), proxy_env(ALL_PROXY="socks5://sock:1080"):
         notices = http.proxy_notices()
-    assert any("OS" in n.outcome for n in notices)
+    assert any("http" in n.outcome and "https" in n.outcome for n in notices)
+
+
+def test_the_all_proxy_outcome_does_not_name_a_single_source(proxy_env, os_proxy) -> None:
+    """Killing: an outcome that picks one source word for a mixed configuration.
+
+    With HTTP_PROXY in the environment and https from the OS, the two covered
+    schemes have different sources, so any one-word answer is wrong for one of
+    them. The outcome names the schemes and leaves the source to
+    `ferry tls-check`, which reports it per scheme.
+    """
+    with (
+        os_proxy({"https": "http://corp:8080"}),
+        proxy_env(ALL_PROXY="socks5://sock:1080", HTTP_PROXY="http://env:3128"),
+    ):
+        notices = http.proxy_notices()
+    outcomes = " ".join(n.outcome for n in notices)
+    assert "http" in outcomes
+    assert "OS" not in outcomes
+    assert "environment" not in outcomes
 
 
 @pytest.mark.parametrize(
@@ -1116,7 +1135,13 @@ def test_proxy_notices_is_idempotent(proxy_env, os_proxy) -> None:
     migration in one GUI process reports nothing and describe_proxy() then
     reports a clean configuration that is not clean."""
     with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
-        assert http.proxy_notices() == http.proxy_notices()
+        first = http.proxy_notices()
+        second = http.proxy_notices()
+        # `==` alone tests non-draining, not caching: ProxyNotice is a frozen
+        # dataclass, so a rebuild-every-call implementation returns an EQUAL
+        # tuple and passes. `is` is what pins the docstring's "builds once".
+        assert first == second
+        assert first is second
 
 
 # The seven tests below are not in the task brief. Each closes a branch of
@@ -1174,14 +1199,15 @@ def test_building_a_display_never_raises(proxy_env, os_proxy, bad: str) -> None:
     assert [n.display for n in notices] == ["<unparseable>"]
 
 
-def test_the_environment_wording_is_used_when_the_environment_covers_it(
-    proxy_env, os_proxy
-) -> None:
-    """The 'environment' half of the outcome ternary, which nothing else enters.
+def test_the_all_proxy_outcome_names_a_scheme_the_environment_supplies(proxy_env, os_proxy) -> None:
+    """The `s in env` half of the `covered` comprehension, which nothing else pins.
 
-    test_the_notice_outcome_is_true pins the 'OS' half only, so hardcoding "OS"
-    passes it. Getting this backwards tells a user to look at a machine-wide
-    setting they never made.
+    Dropping that half leaves test_the_notice_outcome_is_true green, because both
+    of its schemes come from the OS. It also survives
+    test_the_all_proxy_outcome_does_not_name_a_single_source: that test's
+    `"http" in outcomes` is satisfied by the substring inside "https", so an
+    outcome naming https alone still passes it. An exact outcome on an
+    environment-only configuration is what fails.
     """
     with (
         os_proxy({}),
@@ -1192,7 +1218,7 @@ def test_the_environment_wording_is_used_when_the_environment_covers_it(
         ),
     ):
         notices = http.proxy_notices()
-    assert [n.outcome for n in notices] == ["Used the environment proxy for http, https instead."]
+    assert [n.outcome for n in notices] == ["Used the proxy configured for http, https instead."]
 
 
 def test_the_kill_switch_silences_the_notices(proxy_env, os_proxy) -> None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1361,3 +1361,54 @@ def test_an_unreadable_configuration_is_not_cached(proxy_env, os_proxy) -> None:
             assert [n.kind for n in http.proxy_notices()] == ["unreadable"]
         assert http._proxy_notices == ()
         assert [n.kind for n in http.proxy_notices()] == ["all_proxy_only"]
+
+
+# --- Proxy hints and the permanence gate (Task 6) ----------------------------
+
+
+def _proxy_conn_error(host: str = "corp", port: int = 8080):
+    key = aiohttp.client_reqrep.ConnectionKey(host, port, False, True, None, None, None)
+    return aiohttp.ClientProxyConnectionError(key, OSError("refused"))
+
+
+def test_hint_names_the_proxy_and_the_target() -> None:
+    """SC-135-24. Killing: reading the target from the exception. Measured:
+    ClientProxyConnectionError has no request_info and no status, and the target
+    is in neither the exception nor its __cause__, which holds only
+    ConnectionRefusedError. The target must come from the call site."""
+    hint = http.proxy_hint(_proxy_conn_error(), target="https://api.stoat.chat/x")
+    assert hint is not None
+    assert "proxy" in hint.lower()
+    assert "corp" in hint
+    assert "api.stoat.chat" in hint
+
+
+def test_hint_is_none_for_a_non_proxy_error() -> None:
+    assert http.proxy_hint(OSError("boom"), target="https://x/") is None
+
+
+@pytest.mark.parametrize(
+    ("status", "permanent"), [(407, True), (403, True), (502, False), (503, False)]
+)
+def test_permanence_gate(status: int, permanent: bool) -> None:
+    """SC-135-36. Killing: branching retries on the hint string, under which
+    every proxy failure aborts. A 502 at manager.py would turn a retryable blip
+    into a hard failure on the DCE download."""
+    exc = aiohttp.ClientHttpProxyError(
+        request_info=aiohttp.RequestInfo(
+            URL("https://api.stoat.chat/x"), "CONNECT", (), URL("http://corp:8080")
+        ),
+        history=(),
+        status=status,
+    )
+    assert http.proxy_error_is_permanent(exc) is permanent
+
+
+def test_an_unreachable_proxy_is_permanent() -> None:
+    assert http.proxy_error_is_permanent(_proxy_conn_error()) is True
+
+
+def test_a_non_proxy_error_is_not_a_permanent_proxy_error() -> None:
+    """Killing: a gate that returns True for anything it does not recognise,
+    which would abort ordinary network retries."""
+    assert http.proxy_error_is_permanent(OSError("boom")) is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,14 +1,21 @@
-"""Trust policy for every outbound HTTPS call (issue #134)."""
+"""Trust policy for every outbound HTTPS call (issue #134).
+
+Proxy support (issue #135) lands in the same module, because a proxy is part of
+how an outbound session reaches the network.
+"""
 
 from __future__ import annotations
 
+import base64
 import ssl
+import urllib.request
 from pathlib import Path
 from unittest.mock import patch
 
 import aiohttp
 import certifi
 import pytest
+from yarl import URL
 
 from discord_ferry.core import http
 
@@ -234,3 +241,42 @@ def test_hint_is_a_message_not_an_exception_type() -> None:
     key = aiohttp.client_reqrep.ConnectionKey("h", 443, True, True, None, None, None)
     exc = aiohttp.ClientConnectorCertificateError(key, ssl.SSLCertVerificationError("x"))
     assert isinstance(http.tls_hint(exc), str)
+
+
+# ---------------------------------------------------------------------------
+# Proxy support (issue #135)
+# ---------------------------------------------------------------------------
+
+
+def test_os_seams_never_raise_on_any_platform() -> None:
+    """SC-135-02 support. The seams must work on Linux, where neither getter exists."""
+    assert isinstance(http._os_proxies(), dict)
+    assert isinstance(http._os_proxy_bypass("example.com"), bool)
+
+
+def test_os_seams_fall_through_when_no_getter_exists() -> None:
+    """The Linux path. A direct stdlib call would raise AttributeError here."""
+    with (
+        patch.object(urllib.request, "getproxies_macosx_sysconf", None, create=True),
+        patch.object(urllib.request, "getproxies_registry", None, create=True),
+        patch.object(urllib.request, "proxy_bypass_macosx_sysconf", None, create=True),
+        patch.object(urllib.request, "proxy_bypass_registry", None, create=True),
+    ):
+        assert http._os_proxies() == {}
+        assert http._os_proxy_bypass("example.com") is False
+
+
+def test_strip_userinfo_removes_credentials_and_keeps_them() -> None:
+    """SC-135-46. Killing: passing the URL through unstripped, which authenticates
+    correctly and is therefore the tempting implementation."""
+    stripped, header = http._strip_userinfo(URL("http://ferryuser:SUPERSECRET@corp:8080"))
+    assert "SUPERSECRET" not in str(stripped)
+    assert stripped == URL("http://corp:8080")
+    assert header is not None and header.startswith("Basic ")
+    assert base64.b64decode(header.split()[-1]).decode() == "ferryuser:SUPERSECRET"
+
+
+def test_strip_userinfo_leaves_a_clean_url_alone() -> None:
+    stripped, header = http._strip_userinfo(URL("http://corp:8080"))
+    assert stripped == URL("http://corp:8080")
+    assert header is None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -346,6 +346,27 @@ def test_os_proxies_returns_what_the_platform_getter_reports() -> None:
         assert http._os_proxies() == {"https": "http://corp:8080"}
 
 
+def test_os_proxies_reaches_the_registry_getter() -> None:
+    """Killing: dropping the second name from the getattr loop.
+
+    Every other test in this file either nulls getproxies_registry or never
+    reaches it, so `for name in ("getproxies_macosx_sysconf",):` survives them
+    all. Windows is the primary platform for OS-supplied proxies and the
+    registry getter is the only way Ferry reads them, so this branch carries
+    decision 1 of the feature.
+    """
+    with (
+        patch.object(urllib.request, "getproxies_macosx_sysconf", None, create=True),
+        patch.object(
+            urllib.request,
+            "getproxies_registry",
+            lambda: {"https": "http://registry-proxy:8080"},
+            create=True,
+        ),
+    ):
+        assert http._os_proxies() == {"https": "http://registry-proxy:8080"}
+
+
 def test_os_proxy_bypass_returns_what_the_platform_getter_reports() -> None:
     """Killing: a seam that always returns False, which reads as 'never bypass'.
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1412,3 +1412,129 @@ def test_a_non_proxy_error_is_not_a_permanent_proxy_error() -> None:
     """Killing: a gate that returns True for anything it does not recognise,
     which would abort ordinary network retries."""
     assert http.proxy_error_is_permanent(OSError("boom")) is False
+
+
+def test_a_407_names_the_proxy_not_the_target_twice() -> None:
+    """SC-135-25. Killing: request_info.url for proxy identity. url is the
+    TARGET, real_url is the PROXY, so that mutant names the target twice."""
+    exc = aiohttp.ClientHttpProxyError(
+        request_info=aiohttp.RequestInfo(
+            URL("https://api.stoat.chat/x"), "CONNECT", (), URL("http://corp:8080")
+        ),
+        history=(),
+        status=407,
+    )
+    hint = http.proxy_hint(exc, target="https://api.stoat.chat/x")
+    assert hint is not None
+    assert "the proxy at corp:8080" in hint
+    assert "api.stoat.chat" not in hint.split("went through")[1]
+    assert "requires authentication" in hint
+
+
+def test_a_certificate_error_against_an_https_proxy_is_a_proxy_failure(proxy_env, os_proxy) -> None:
+    """SC-135-52, and the ONLY instrument for "proxy wins, never concatenated".
+
+    With an https:// proxy, connector.py builds the certificate error from the
+    PROXY's connection key, so this is the one shape where proxy_hint and
+    tls_hint BOTH fire. Every one of the eight site tests uses an http:// proxy,
+    where tls_hint is None, so a mutant that concatenated the two hints passes
+    all eight of them and only fails here.
+
+    The scan is warmed through resolve_proxy, NOT by assigning _proxy_scan.
+    _proxy_identity reads that global directly and the autouse fixture resets
+    it, so a hand-built scan would grade the test's own fixture rather than the
+    real environment read.
+    """
+    key = aiohttp.client_reqrep.ConnectionKey("secure-proxy", 8443, True, True, None, None, None)
+    cert_error = aiohttp.ClientConnectorCertificateError(
+        key, ssl.SSLCertVerificationError("unable to get local issuer certificate")
+    )
+    with os_proxy({}), proxy_env(HTTPS_PROXY="https://secure-proxy:8443"):
+        assert http.resolve_proxy("https://api.stoat.chat/x") is not None
+        hint = http.proxy_hint(cert_error, target="https://api.stoat.chat/x")
+
+    # Both fire on this shape. That is what makes it the precedence instrument
+    # rather than merely another positive case.
+    assert http.tls_hint(cert_error) is not None
+    assert hint is not None
+    assert "went through the proxy at secure-proxy:8443" in hint
+    assert "SSL_CERT_FILE" not in hint, (
+        "the certificate hint must be REPLACED, not appended: SSL_CERT_FILE "
+        "advice here names a bundle for a host the user never configured"
+    )
+
+
+def test_a_scheme_prefixed_no_proxy_is_not_a_proxy_identity(proxy_env, os_proxy) -> None:
+    """The certificate branch must read http/https entries only.
+
+    getproxies_environment() keys NO_PROXY as 'no' and returns its raw value.
+    Measured: NO_PROXY=https://stoat.internal:8443 yields
+    {'no': 'https://stoat.internal:8443'}. Scheme-prefixing NO_PROXY is a common
+    mistake, and an unfiltered scan makes every genuine certificate error for
+    that host resolve as a proxy identity. Because the sites read
+    `proxy_hint(...) or tls_hint(...)`, the correct SSL_CERT_FILE advice is then
+    REPLACED by proxy advice naming a host that is not a proxy -- on self-hosted
+    Stoat behind a private CA, which is where that advice matters most.
+    """
+    key = aiohttp.client_reqrep.ConnectionKey("stoat.internal", 8443, True, True, None, None, None)
+    cert_error = aiohttp.ClientConnectorCertificateError(
+        key, ssl.SSLCertVerificationError("unable to get local issuer certificate")
+    )
+    with os_proxy({}), proxy_env(NO_PROXY="https://stoat.internal:8443"):
+        # Warms the scan through the real path even though it resolves to None.
+        assert http.resolve_proxy("https://stoat.internal:8443/x") is None
+        assert http._proxy_scan is not None, "the scan must be warm for this test to grade anything"
+        assert "no" in http._proxy_scan[0], "the fixture must reproduce the 'no' key"
+        hint = http.proxy_hint(cert_error, target="https://stoat.internal:8443/x")
+
+    assert hint is None
+    # The advice the user actually needs must survive.
+    assert "SSL_CERT_FILE" in (http.tls_hint(cert_error) or "")
+
+
+def test_proxy_hint_survives_a_self_referential_chain() -> None:
+    """Mirrors SC-134-22 for tls_hint. Deleting the `seen` set spins forever,
+    and it does so INSIDE an exception handler at eight call sites, so the
+    symptom is a hung migration with no error at all."""
+    exc = ValueError("loop")
+    exc.__context__ = exc
+    assert http.proxy_hint(exc, target="https://x/") is None
+
+
+def test_an_unparseable_target_does_not_raise_inside_a_handler() -> None:
+    """URL(target) is guarded because every call site is inside an `except`.
+
+    structure.py passes state.autumn_url, which is SERVER-supplied. Measured:
+    URL("http://[") raises ValueError("Invalid IPv6 URL"). Unguarded, that
+    ValueError replaces the error the handler existed to explain. resolve_proxy
+    guards the identical construction for the same reason.
+    """
+    hint = http.proxy_hint(_proxy_conn_error(), target="http://[")
+    assert hint is not None
+    assert "the proxy at corp:8080" in hint
+    assert "http://[" in hint, "the unparseable target falls back to the raw string"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("nope"),
+        TimeoutError(),
+        aiohttp.ClientOSError("boom"),
+        aiohttp.ClientConnectorError(
+            aiohttp.client_reqrep.ConnectionKey("api.test", 443, True, True, None, None, None),
+            OSError("refused"),
+        ),
+    ],
+)
+def test_permanence_is_false_for_unrelated_errors(exc: BaseException) -> None:
+    """Mirrors test_tls_hint_ignores_unrelated_errors, and the last parameter is
+    the one that matters.
+
+    ClientProxyConnectionError IS a ClientConnectorError subclass, so the
+    over-broad `isinstance(exc, ClientConnectorError)` mutant marks every
+    ordinary connection failure permanent and short-circuits the retry loops at
+    api.py, discord/client.py and exporter/manager.py. An OSError-only negative
+    test cannot see that: OSError is not a ClientConnectorError.
+    """
+    assert http.proxy_error_is_permanent(exc) is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1566,3 +1566,36 @@ def test_the_kill_switch_disables_both_sources(proxy_env, os_proxy) -> None:
     """SC-135-14. Killing: a switch that suppresses only one half."""
     with os_proxy(CORP), proxy_env(HTTPS_PROXY="http://env:3128", FERRY_DISABLE_PROXY="1"):
         assert http.resolve_proxy(TARGET) is None
+
+
+# --- describe_proxy's userinfo layer, isolated (Task 11 review fix) ----------
+#
+# resolve_proxy always strips userinfo via _strip_userinfo before building a
+# ProxyChoice, so choice.url never carries it in production, and str(),
+# repr(), .human_repr() and describe_proxy's own f"{host}:{port}" all render
+# the same safe string against a REAL resolve_proxy. That makes the choice of
+# formatting untestable through the real path. This test patches resolve_proxy
+# to hand back a ProxyChoice built directly with unstripped userinfo, standing
+# in for a future resolve_proxy that stops stripping, so describe_proxy's own
+# formatting choice is what is actually graded.
+
+
+def test_describe_proxy_never_prints_userinfo_even_if_resolve_stops_stripping(
+    proxy_env,
+) -> None:
+    """Killing: formatting choice.url with str(), repr() or .human_repr()
+    instead of reading .host/.port. Against a real resolve_proxy all four
+    render identically, because the userinfo is already gone by the time
+    describe_proxy sees it; this isolates the formatting from that upstream
+    stripping so a regression in the formatting itself is still caught.
+    """
+    choice = http.ProxyChoice(
+        url=URL("http://user:secret@corp:8080"), authorization=None, source="env"
+    )
+    with (
+        proxy_env(),
+        patch("discord_ferry.core.http.resolve_proxy", return_value=choice),
+    ):
+        out = http.describe_proxy()
+    assert all("secret" not in v for v in out.values())
+    assert all("user" not in v for v in out.values())

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -971,14 +971,30 @@ async def test_a_configured_proxy_receives_a_connect(fake_proxy, proxy_env, os_p
     auth = [ln for ln in lines if ln.lower().startswith("proxy-authorization")]
     assert auth, "the credential never reached the proxy"
     assert base64.b64decode(auth[0].split()[-1]).decode() == "ferryuser:SUPERSECRET"
+    # A sanity check on the CONNECT line's shape, NOT a stripping detector.
+    # client_reqrep.py:1435-1438 builds the path from `self.url`, which
+    # connector.py:1648 has already reassigned to the TARGET, so this line
+    # structurally cannot carry the proxy's userinfo under any implementation.
+    # The stripping mutant is killed by test_no_credential_reaches_the_exception.
     assert "SUPERSECRET" not in lines[0]
     assert isinstance(caught, aiohttp.ClientHttpProxyError)
 
 
 async def test_no_credential_reaches_the_exception(fake_proxy, proxy_env, os_proxy) -> None:
-    """SC-135-48. reset_secret_registry FIRST: with the registry populated the
-    redaction layer masks a stripping-layer leak and this passes over a real
-    leak. This repo shipped rollback redaction that was inert for that reason."""
+    """SC-135-48. Kills the mutant that returns the unstripped proxy URL.
+
+    Either assertion below kills it independently: `ClientResponseError.__str__`
+    renders `str(request_info.real_url)` (client_exceptions.py:108-109) and
+    yarl's __str__ does not hide userinfo, so the password reaches both
+    `.password` and `str(exc)`.
+
+    `reset_secret_registry()` does NOT protect these assertions, and an earlier
+    version of this docstring wrongly said it did. Neither `.password` nor
+    `str(exc)` passes through `sanitize_secrets`, which only the logging
+    Formatter consults. The registry matters for SC-135-50, which asserts on
+    ferry.log. The call stays as cheap insurance against a future assertion here
+    that does read log output, and for no stronger reason than that.
+    """
     reset_secret_registry()
     make, _ = fake_proxy
     server = await make(b"403 Forbidden")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
+import re
 import ssl
 import urllib.request
 from pathlib import Path
@@ -754,7 +756,7 @@ async def test_a_callers_explicit_proxy_wins(proxy_env, os_proxy) -> None:
 
 
 async def test_the_url_can_arrive_as_a_keyword(proxy_env, os_proxy) -> None:
-    """The `kwargs.get("url")` half of the url lookup.
+    """The `"url" in kwargs` half of the url lookup.
 
     aiohttp passes method and url positionally (client.py:780-782), so the
     positional half is the one production takes and this is the only test that
@@ -767,16 +769,63 @@ async def test_the_url_can_arrive_as_a_keyword(proxy_env, os_proxy) -> None:
 
 
 async def test_a_missing_url_raises_type_error_not_index_error(proxy_env, os_proxy) -> None:
-    """The two guards that keep a malformed call aiohttp's problem, not Ferry's.
+    """The `len(args) > 1` guard: a malformed call stays aiohttp's problem.
 
-    Killing two mutants at once. A bare `args[1]` raises IndexError from Ferry's
-    own frame before super() ever runs, and dropping `if url is not None` calls
-    resolve_proxy(None), which reaches `target.scheme` and raises AttributeError
-    despite that function's "never raises" contract. Neither is a TypeError, so
-    either one turns this red.
+    Killing: a bare `args[1]`, which raises IndexError from Ferry's own frame
+    before super() ever runs, so the caller is told the wrong thing about their
+    own mistake. IndexError is not a TypeError, so that turns this red.
+
+    It does NOT cover `_resolve_or_direct`'s `if url is None` guard. That guard
+    stopped being observable here the moment the resolver call was wrapped in
+    `except Exception`: without it, resolve_proxy(None) raises AttributeError,
+    the wrapper swallows it, and this test still sees its TypeError. The test
+    below is what pins that guard.
     """
     with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"), pytest.raises(TypeError):
         http._FerryRequest("GET", loop=asyncio.get_running_loop())
+
+
+async def test_a_missing_url_never_reaches_the_resolver(proxy_env, os_proxy) -> None:
+    """`_resolve_or_direct`'s `if url is None: return None`.
+
+    Killing: dropping that guard. The visible cost is no longer an exception,
+    because `except Exception` catches the AttributeError resolve_proxy(None)
+    raises; it is a warning logged with a full traceback on a request that never
+    had a url to resolve. Asserting the resolver is not called pins the guard
+    itself rather than one of its downstream symptoms.
+    """
+    with (
+        os_proxy({}),
+        proxy_env(HTTPS_PROXY="http://corp:8080"),
+        patch("discord_ferry.core.http.resolve_proxy") as resolver,
+        pytest.raises(TypeError),
+    ):
+        http._FerryRequest("GET", loop=asyncio.get_running_loop())
+    resolver.assert_not_called()
+
+
+async def test_a_raising_resolver_connects_direct(proxy_env, os_proxy, caplog) -> None:
+    """SC-135 constraint 12, meant totally. Killing: narrowing the wrapper to
+    `except (ValueError, TypeError)`.
+
+    re.error is the concrete case. `_is_bypassed` reaches proxy_bypass_registry,
+    which hands a registry-controlled ProxyOverride entry to
+    `_proxy_bypass_winreg_override`, and `re.match(test, host)` raises re.error
+    on an entry like `internal[`. re.error subclasses Exception directly, so it
+    escapes resolve_proxy's own ValueError/TypeError guards and would kill the
+    first request of a migration from inside ClientRequest.__init__ on exactly
+    the Windows corporate machines this feature exists for.
+    """
+    boom = re.error("unterminated character set at position 8")
+    with (
+        os_proxy({}),
+        proxy_env(HTTPS_PROXY="http://corp:8080"),
+        patch("discord_ferry.core.http.resolve_proxy", side_effect=boom),
+        caplog.at_level(logging.WARNING, logger="discord_ferry.core.http"),
+    ):
+        req = http._FerryRequest("GET", URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy is None
+    assert "connecting direct" in caplog.text
 
 
 async def test_no_configured_proxy_leaves_the_request_direct(proxy_env, os_proxy) -> None:
@@ -829,32 +878,58 @@ async def test_a_callers_proxy_headers_are_merged_not_clobbered(proxy_env, os_pr
     assert "Proxy-Authorization" in req.proxy_headers
 
 
-async def test_a_callers_own_proxy_authorization_is_not_overwritten(proxy_env, os_proxy) -> None:
-    """setdefault, not assignment. Killing: `merged["Proxy-Authorization"] = ...`,
-    which overrides a credential the caller chose deliberately.
+async def test_a_proxy_without_a_credential_sets_no_proxy_headers(proxy_env, os_proxy) -> None:
+    """Killing: deleting the `if choice.authorization is not None:` guard.
 
-    The getall() count matters as much as the value: proxy_headers becomes a
-    CIMultiDict (client_reqrep.py:1342-1345), which happily holds two values for
-    one case-insensitive key, and both would then travel to the proxy.
+    Dedenting the body runs `merged.setdefault("Proxy-Authorization", None)`,
+    which inserts a None VALUE rather than leaving the mapping empty.
+    connection_key then hashes (("Proxy-Authorization", None),) instead of None,
+    and a `Proxy-Authorization: None` header reaches the CONNECT request. The
+    empty-CIMultiDict mutant is invisible; this one is not.
     """
-    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"):
+        req = http._FerryRequest("GET", URL(TARGET), loop=asyncio.get_running_loop())
+    assert req.proxy == URL("http://corp:8080")
+    assert req.proxy_headers is None
+
+
+@pytest.mark.parametrize(
+    "spelling", ["Proxy-Authorization", "proxy-authorization", "PROXY-AUTHORIZATION"]
+)
+async def test_a_callers_credential_survives_in_any_case(
+    proxy_env, os_proxy, spelling: str
+) -> None:
+    """Killing: a plain `dict` for `merged`.
+
+    HTTP header names are case-insensitive. A dict's setdefault does not see a
+    differently-cased key, so it inserts a SECOND Proxy-Authorization and both
+    travel to the proxy (connector.py:606-610). The previous version of this
+    test asserted len(getall(...)) == 1 while feeding only the canonical
+    spelling, which is structurally guaranteed under a plain dict and therefore
+    could not fail.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SECRET@corp:8080"):
         req = http._FerryRequest(
             "GET",
             URL(TARGET),
-            proxy_headers={"Proxy-Authorization": "Basic Y2FsbGVyOnBhc3M="},
+            proxy_headers={spelling: "Basic Y2FsbGVy"},
             loop=asyncio.get_running_loop(),
         )
     assert req.proxy_headers is not None
-    assert req.proxy_headers["Proxy-Authorization"] == "Basic Y2FsbGVyOnBhc3M="
     assert len(req.proxy_headers.getall("Proxy-Authorization")) == 1
+    assert req.proxy_headers["Proxy-Authorization"] == "Basic Y2FsbGVy"
 
 
 async def test_one_requests_proxy_headers_do_not_leak_into_the_next(proxy_env, os_proxy) -> None:
-    """A FRESH dict per request. Killing: hoisting `merged` to a module-level
+    """A FRESH mapping per request. Killing: hoisting `merged` to a module-level
     mapping reused by every request, where the first caller's headers travel to
-    the proxy on every later request and connection_key
-    (client_reqrep.py:970-972) changes between two requests to the same host,
-    defeating connection reuse for the whole migration.
+    the proxy on every later request.
+
+    Now that `merged` is a CIMultiDict, update_proxy stores it by reference
+    (client_reqrep.py:1342-1346 only re-wraps NON-MultiDict mappings), so a
+    shared one would also collect the Host that connector.py:606-610 writes into
+    it in place, and connection_key (client_reqrep.py:970-972) would shift under
+    the pool between two requests to the same host.
     """
     with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
         loop = asyncio.get_running_loop()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -491,6 +491,21 @@ def test_mixed_case_emptied_scheme_also_suppresses(proxy_env, os_proxy) -> None:
         assert http.resolve_proxy(TARGET) is None
 
 
+def test_an_uppercase_empty_variable_does_not_suppress_a_lowercase_one(proxy_env, os_proxy) -> None:
+    """Killing: filtering the environment half by `_suppressed_schemes`.
+
+    stdlib's pop is case-SENSITIVE (urllib/request.py:2548-2554), so
+    `HTTPS_PROXY=""` does not pop and `getproxies_environment()` returns the
+    lowercase variable's value. Ferry's suppression scan is case-INsensitive.
+    Applying it to the env half would drop a proxy the user explicitly set, with
+    no proxy and no notice, where curl, requests and stdlib all proxy.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="", https_proxy="http://mine:3128"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://mine:3128"
+
+
 @pytest.mark.parametrize("bad", ["http://host:notaport", "http://[::1"])
 def test_a_malformed_proxy_never_raises(proxy_env, os_proxy, bad: str) -> None:
     """SC-135-22. Killing: an unguarded parse. Resolution runs inside
@@ -498,6 +513,25 @@ def test_a_malformed_proxy_never_raises(proxy_env, os_proxy, bad: str) -> None:
     from inside the constructor. Both of these raise ValueError in yarl."""
     with os_proxy({}), proxy_env(HTTPS_PROXY=bad):
         assert http.resolve_proxy(TARGET) is None
+
+
+def test_the_choice_carries_the_stripped_url_and_the_credential(proxy_env, os_proxy) -> None:
+    """Killing: `ProxyChoice(url=raw, authorization=None, source=source)`.
+
+    That mutant discards _strip_userinfo's outputs and passes every other test
+    in this task, because `str()` of the raw string compares equal and no other
+    happy-path test feeds a credentialed proxy. aiohttp asserts
+    `type(proxy) is URL` (client_reqrep.py:887-888), so it would kill the first
+    request of every migration. Nothing before Task 3 would catch it.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://ferryuser:SUPERSECRET@corp:8080"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert type(choice.url) is URL
+    assert "SUPERSECRET" not in str(choice.url)
+    assert choice.url == URL("http://corp:8080")
+    assert choice.authorization is not None
+    assert base64.b64decode(choice.authorization.split()[-1]).decode() == "ferryuser:SUPERSECRET"
 
 
 def test_reset_clears_the_scan_the_memo_and_the_notices(proxy_env, os_proxy) -> None:
@@ -513,10 +547,10 @@ def test_reset_clears_the_scan_the_memo_and_the_notices(proxy_env, os_proxy) -> 
 
 
 # The nine tests below are not in the task brief. Each closes a branch of
-# resolve_proxy, _scheme_map, _is_bypassed or _suppressed_schemes that the ten
-# above leave unexecuted or unpinned, found by enumerating the decisions in the
-# source rather than by reading the brief back. Every one was confirmed red
-# against a mutant of the exact line it claims to cover.
+# resolve_proxy, _scheme_map, _is_bypassed or _suppressed_schemes that the
+# twelve above leave unexecuted or unpinned, found by enumerating the decisions
+# in the source rather than by reading the brief back. Every one was confirmed
+# red against a mutant of the exact line it claims to cover.
 
 
 @pytest.mark.parametrize(
@@ -536,12 +570,12 @@ def test_a_socks_proxy_resolves_to_none(proxy_env, os_proxy, env_value, os_map) 
     rather than the parsed scheme, which is the shape getproxies_registry
     produces on Windows.
     """
-    pairs = {"HTTPS_PROXY": env_value} if env_value else {}
+    pairs = {"HTTPS_PROXY": env_value} if env_value is not None else {}
     with os_proxy(os_map), proxy_env(**pairs):
         assert http.resolve_proxy(TARGET) is None
 
 
-def test_the_scan_is_cached_and_reset_makes_it_cold(proxy_env) -> None:
+def test_the_scan_is_cached(proxy_env) -> None:
     """Killing: a _scheme_map that rebuilds per call and never sets _proxy_scan.
 
     test_reset_clears_the_scan_the_memo_and_the_notices cannot fail against that
@@ -549,10 +583,11 @@ def test_the_scan_is_cached_and_reset_makes_it_cold(proxy_env) -> None:
     and its second is trivially true when nothing was ever cached. So this is the
     only test that proves the scan half of the cache exists at all.
 
-    Patches the seams directly rather than through os_proxy, because it needs the
-    call count.
+    The cache is cold at entry because the autouse fixture calls
+    reset_http_state, which is also what makes `scan_spy.call_count == 1` an
+    assertion about caching rather than about test order. Patches the seams
+    directly rather than through os_proxy, because it needs the call count.
     """
-    http.reset_http_state()
     with (
         proxy_env(),
         patch("discord_ferry.core.http._os_proxies", return_value=dict(CORP)) as scan_spy,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -420,3 +420,244 @@ def test_os_proxy_bypass_reaches_the_darwin_getter() -> None:
     ):
         assert http._os_proxy_bypass("internal.corp") is True
         assert http._os_proxy_bypass("api.stoat.chat") is False
+
+
+# --- Resolution, the merge and the bypass union (Task 2) ---------------------
+
+CORP = {"https": "http://corp:8080", "http": "http://corp:8080"}
+TARGET = "https://api.stoat.chat/x"
+
+
+def test_unrelated_proxy_variable_does_not_mask_os_discovery(proxy_env, os_proxy) -> None:
+    """SC-135-03. Killing: calling urllib.request.getproxies(), which is
+    `getproxies_environment() or getproxies_<os>()`. {'no': 'localhost'} is
+    truthy, so the OS half is skipped and the user gets no proxy AND no message."""
+    with os_proxy(CORP), proxy_env(NO_PROXY="localhost"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://corp:8080"
+    assert choice.source == "os"
+
+
+def test_environment_wins_for_a_scheme_it_defines(proxy_env, os_proxy) -> None:
+    """SC-135-04. Killing: 'ignore getproxies_environment entirely'. The test
+    above stays green against that mutant, which is why both exist."""
+    with os_proxy(CORP), proxy_env(HTTPS_PROXY="http://env:3128"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://env:3128"
+    assert choice.source == "env"
+
+
+def test_no_proxy_is_honoured_when_the_proxy_came_from_the_os(proxy_env, os_proxy) -> None:
+    """SC-135-05, the round-5 Critical. Killing: routing the two bypass lists as
+    if/else instead of a union, which discards an explicitly-set NO_PROXY
+    whenever the proxy came from the OS. Linux never takes the OS branch and CI
+    runs Linux only, so nothing else can see this."""
+    with os_proxy(CORP, bypass=set()), proxy_env(NO_PROXY="api.stoat.chat"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_os_bypass_list_is_still_consulted(proxy_env, os_proxy) -> None:
+    """SC-135-07. Killing: `bypassed = proxy_bypass_environment(...)` alone.
+    The two tests above call _os_proxy_bypass against an empty set, where False
+    is indistinguishable from never calling it, so this is what proves the call."""
+    with os_proxy(CORP, bypass={"api.stoat.chat"}), proxy_env():
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_a_host_on_neither_list_is_still_proxied(proxy_env, os_proxy) -> None:
+    """SC-135-08. Killing: an over-eager bypass that disables the feature."""
+    with os_proxy(CORP, bypass=set()), proxy_env():
+        assert http.resolve_proxy(TARGET) is not None
+
+
+def test_no_proxy_still_exempts_an_env_supplied_proxy(proxy_env, os_proxy) -> None:
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://env:3128", NO_PROXY="api.stoat.chat"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_emptied_scheme_stays_off(proxy_env, os_proxy) -> None:
+    """SC-135-16. Killing: a merge that treats 'emptied' as 'unmentioned' and
+    lets the OS half restore it, making the documented off switch do nothing."""
+    with os_proxy(CORP), proxy_env(https_proxy=""):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_mixed_case_emptied_scheme_also_suppresses(proxy_env, os_proxy) -> None:
+    """SC-135-17. Killing: a k.islower() scan condition, which misses this and is
+    inert on Windows, where os.environ upper-cases every key."""
+    with os_proxy(CORP), proxy_env(HTTPS_proxy=""):
+        assert http.resolve_proxy(TARGET) is None
+
+
+@pytest.mark.parametrize("bad", ["http://host:notaport", "http://[::1"])
+def test_a_malformed_proxy_never_raises(proxy_env, os_proxy, bad: str) -> None:
+    """SC-135-22. Killing: an unguarded parse. Resolution runs inside
+    ClientRequest.__init__, so a raise kills the first request of a migration
+    from inside the constructor. Both of these raise ValueError in yarl."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY=bad):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_reset_clears_the_scan_the_memo_and_the_notices(proxy_env, os_proxy) -> None:
+    """SC-135-13. Killing: a reset that clears half its state. That exact defect
+    shipped into the v2.13.0 plan when a str.replace anchor silently no-opped."""
+    with os_proxy(CORP), proxy_env():
+        http.resolve_proxy(TARGET)
+    assert http._proxy_scan is not None or http._bypass_memo
+    http.reset_http_state()
+    assert http._proxy_scan is None
+    assert http._bypass_memo == {}
+    assert http._proxy_notices == ()
+
+
+# The nine tests below are not in the task brief. Each closes a branch of
+# resolve_proxy, _scheme_map, _is_bypassed or _suppressed_schemes that the ten
+# above leave unexecuted or unpinned, found by enumerating the decisions in the
+# source rather than by reading the brief back. Every one was confirmed red
+# against a mutant of the exact line it claims to cover.
+
+
+@pytest.mark.parametrize(
+    ("env_value", "os_map"),
+    [("socks5://sock:1080", {}), (None, {"https": "socks4://sock:1080"})],
+)
+def test_a_socks_proxy_resolves_to_none(proxy_env, os_proxy, env_value, os_map) -> None:
+    """Killing: deleting the socks guard from resolve_proxy.
+
+    Nothing else in the plan pins it. Task 5's socks tests assert on
+    proxy_notices() only, and a notice does not stop the URL being handed to
+    aiohttp, whose update_proxy raises ValueError for any scheme but http
+    (client_reqrep.py). resolve_proxy runs inside ClientRequest.__init__, so
+    that raise kills the first request of the migration.
+
+    Both halves matter: the OS case also kills a guard keyed off the dict name
+    rather than the parsed scheme, which is the shape getproxies_registry
+    produces on Windows.
+    """
+    pairs = {"HTTPS_PROXY": env_value} if env_value else {}
+    with os_proxy(os_map), proxy_env(**pairs):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_the_scan_is_cached_and_reset_makes_it_cold(proxy_env) -> None:
+    """Killing: a _scheme_map that rebuilds per call and never sets _proxy_scan.
+
+    test_reset_clears_the_scan_the_memo_and_the_notices cannot fail against that
+    mutant: its first assertion is a disjunction the memo half satisfies alone,
+    and its second is trivially true when nothing was ever cached. So this is the
+    only test that proves the scan half of the cache exists at all.
+
+    Patches the seams directly rather than through os_proxy, because it needs the
+    call count.
+    """
+    http.reset_http_state()
+    with (
+        proxy_env(),
+        patch("discord_ferry.core.http._os_proxies", return_value=dict(CORP)) as scan_spy,
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        assert http.resolve_proxy(TARGET) is not None
+        assert http._proxy_scan is not None
+        assert http.resolve_proxy("https://other.invalid/y") is not None
+        assert scan_spy.call_count == 1
+
+
+def test_the_bypass_decision_is_memoised_including_misses(proxy_env) -> None:
+    """Killing: dropping the memo, or memoising only the True answers.
+
+    A miss that is not stored pays the OS syscall on every request to a host
+    Ferry does proxy, which is the common case rather than the rare one. Also
+    pins the key shape: (host, source), not host alone, because the answer
+    differs by source.
+    """
+    http.reset_http_state()
+    with (
+        proxy_env(),
+        patch("discord_ferry.core.http._os_proxies", return_value=dict(CORP)),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False) as bypass_spy,
+    ):
+        assert http.resolve_proxy(TARGET) is not None
+        assert http.resolve_proxy(TARGET) is not None
+        assert bypass_spy.call_count == 1
+    assert http._bypass_memo == {("api.stoat.chat", "os"): False}
+
+
+def test_the_os_bypass_list_does_not_veto_an_env_supplied_proxy(proxy_env, os_proxy) -> None:
+    """Killing: dropping the `source == "os"` guard from the union.
+
+    A plain `a or b` reads like a simplification and passes every other test
+    here, because they never combine an env-supplied proxy with a non-empty OS
+    bypass list. It would let a machine-wide exception list veto a proxy the user
+    set explicitly for this process, which is the opposite of the precedence the
+    merge applies everywhere else.
+    """
+    with os_proxy(CORP, bypass={"api.stoat.chat"}), proxy_env(HTTPS_PROXY="http://env:3128"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert choice.source == "env"
+
+
+def test_a_url_object_target_resolves_like_its_string(proxy_env, os_proxy) -> None:
+    """The URL half of `url: str | URL`, unexecuted by every test above.
+
+    Task 3's _FerryRequest passes the URL object form (args[1] is a yarl.URL),
+    so this is the branch production takes, not the string one.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://env:3128"):
+        choice = http.resolve_proxy(URL(TARGET))
+    assert choice is not None
+    assert str(choice.url) == "http://env:3128"
+
+
+def test_a_colon_in_the_proxy_login_never_raises(proxy_env, os_proxy) -> None:
+    """The second half of the never-raise contract, and the one the brief names.
+
+    _strip_userinfo raises ValueError when the login contains ':' (aiohttp
+    helpers.py:125-126, RFC 7617), and a %3A in userinfo decodes to exactly that:
+    yarl reports raw_user='user%3Aname' and user='user:name'. The malformed-proxy
+    test cannot reach it, because its inputs die in URL(raw) one line earlier. A
+    try narrowed to the parse alone therefore passes the whole suite and raises
+    out of ClientRequest.__init__ on the first request of the migration.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://user%3Aname:pw@corp:8080"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_a_malformed_target_never_raises(proxy_env, os_proxy) -> None:
+    """The target parse, the other guarded parse in resolve_proxy.
+
+    Distinct from test_a_malformed_proxy_never_raises, which feeds a bad PROXY
+    url and never executes this guard. Same yarl ValueError, different line.
+    """
+    with os_proxy(CORP), proxy_env():
+        assert http.resolve_proxy("http://[::1") is None
+
+
+def test_the_scheme_map_merges_per_scheme(proxy_env, os_proxy) -> None:
+    """`k not in env` on the OS half, which nothing else can observe.
+
+    resolve_proxy consults env first, so a duplicated https entry in the OS half
+    changes no resolution and every test above stays green. It is visible only
+    here, and it matters to Task 5, whose notice loop walks both dicts and would
+    report the same scheme twice.
+    """
+    with os_proxy(CORP), proxy_env(HTTPS_PROXY="http://env:3128"):
+        env, os_side = http._scheme_map()
+    assert env == {"https": "http://env:3128"}
+    assert os_side == {"http": "http://corp:8080"}
+
+
+def test_a_cgi_environment_keeps_the_http_scheme_suppressed(proxy_env, os_proxy) -> None:
+    """CVE-2016-1000110, the branch of _suppressed_schemes nothing else enters.
+
+    getproxies_environment pops 'http' when REQUEST_METHOD is set, because a
+    remote client controls the Proxy header. Under the merge that pop is
+    indistinguishable from the scheme never being mentioned, so without the
+    REQUEST_METHOD clause the OS half puts the proxy straight back and Ferry
+    reverses a stdlib mitigation it silently inherits everywhere else.
+    """
+    with os_proxy(CORP), proxy_env(REQUEST_METHOD="GET"):
+        assert http.resolve_proxy("http://plain.invalid/x") is None
+        assert http.resolve_proxy(TARGET) is not None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1432,13 +1432,24 @@ def test_a_407_names_the_proxy_not_the_target_twice() -> None:
 
 
 def test_a_certificate_error_against_an_https_proxy_is_a_proxy_failure(proxy_env, os_proxy) -> None:
-    """SC-135-52, and the ONLY instrument for "proxy wins, never concatenated".
+    """SC-135-52, the unit half. What this grades, and what it does NOT.
 
     With an https:// proxy, connector.py builds the certificate error from the
     PROXY's connection key, so this is the one shape where proxy_hint and
-    tls_hint BOTH fire. Every one of the eight site tests uses an http:// proxy,
-    where tls_hint is None, so a mutant that concatenated the two hints passes
-    all eight of them and only fails here.
+    tls_hint BOTH fire. This test grades two things about that shape:
+    _proxy_identity recognises the certificate error as a proxy failure at all,
+    and proxy_hint's OWN return value never carries SSL_CERT_FILE.
+
+    It does NOT grade the precedence rule at any call site. proxy_hint never
+    calls tls_hint, and this test reads proxy_hint's return value directly, so a
+    site written as `proxy_hint(...) + (tls_hint(...) or "")` cannot turn this
+    line red. Only a change to proxy_hint itself can. The site-level instrument
+    is test_a_certificate_error_against_an_https_proxy_names_the_proxy_not_the_bundle
+    in tests/test_api.py, and it covers ONE of the eight sites; see that test.
+
+    An earlier version of this docstring called this "the ONLY instrument for
+    proxy wins, never concatenated". That was prose outrunning what the
+    assertion below can detect.
 
     The scan is warmed through resolve_proxy, NOT by assigning _proxy_scan.
     _proxy_identity reads that global directly and the autouse fixture resets
@@ -1453,14 +1464,15 @@ def test_a_certificate_error_against_an_https_proxy_is_a_proxy_failure(proxy_env
         assert http.resolve_proxy("https://api.stoat.chat/x") is not None
         hint = http.proxy_hint(cert_error, target="https://api.stoat.chat/x")
 
-    # Both fire on this shape. That is what makes it the precedence instrument
-    # rather than merely another positive case.
+    # Both fire on this shape. Pinned because it is the premise the site-level
+    # precedence test rests on: without it that test would grade nothing.
     assert http.tls_hint(cert_error) is not None
     assert hint is not None
     assert "went through the proxy at secure-proxy:8443" in hint
     assert "SSL_CERT_FILE" not in hint, (
-        "the certificate hint must be REPLACED, not appended: SSL_CERT_FILE "
-        "advice here names a bundle for a host the user never configured"
+        "proxy_hint's own return value must never carry certificate advice. "
+        "Whether a CALL SITE appends it is a different question, graded in "
+        "tests/test_api.py, not here"
     )
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -299,6 +299,22 @@ def test_strip_userinfo_handles_password_only_userinfo() -> None:
     assert base64.b64decode(header.split()[-1]).decode() == ":PROXYTOKEN"
 
 
+def test_strip_userinfo_handles_user_only_userinfo() -> None:
+    """Killing: dropping the `or ""` from `password = url.password or ""`.
+
+    The mirror of the password-only case, and the only one of the two that no
+    test supplied an input for. yarl reports password as None for
+    `http://ferryuser@corp:8080`, and encode_basic_auth interpolates with an
+    f-string (helpers.py:127), so the mutant does not raise. It builds
+    `ferryuser:None` and sends that to the proxy as a real credential, which
+    fails authentication with a header Ferry believes it got right.
+    """
+    stripped, header = http._strip_userinfo(URL("http://ferryuser@corp:8080"))
+    assert stripped == URL("http://corp:8080")
+    assert header is not None
+    assert base64.b64decode(header.split()[-1]).decode() == "ferryuser:"
+
+
 def test_strip_userinfo_registers_both_credential_forms() -> None:
     """SC-135-49. Killing: registering only the plaintext, or neither.
 
@@ -381,6 +397,26 @@ def test_os_proxy_bypass_returns_what_the_platform_getter_reports() -> None:
             lambda host: host == "internal.corp",
             create=True,
         ),
+    ):
+        assert http._os_proxy_bypass("internal.corp") is True
+        assert http._os_proxy_bypass("api.stoat.chat") is False
+
+
+def test_os_proxy_bypass_reaches_the_darwin_getter() -> None:
+    """Killing: a darwin branch that ignores its argument or returns a constant.
+
+    The fourth of four loop-name combinations. Without it, that branch is
+    exercised only by the type-only smoke test, which asserts isinstance(bool)
+    and therefore cannot fail against a constant.
+    """
+    with (
+        patch.object(
+            urllib.request,
+            "proxy_bypass_macosx_sysconf",
+            lambda host: host == "internal.corp",
+            create=True,
+        ),
+        patch.object(urllib.request, "proxy_bypass_registry", None, create=True),
     ):
         assert http._os_proxy_bypass("internal.corp") is True
         assert http._os_proxy_bypass("api.stoat.chat") is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1289,8 +1289,15 @@ def test_a_malformed_scheme_proxy_does_not_count_as_covered(proxy_env, os_proxy)
     """
     with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080", HTTPS_PROXY="http://[::1"):
         notices = http.proxy_notices()
-    all_notice = next(n for n in notices if n.kind == "all_proxy_only")
-    assert all_notice.outcome == "Connected direct. ALL_PROXY is not supported (see issue #141)."
+    # A list and an assertion, NOT next(). Under the mutant this test kills, the
+    # raise from _usable is caught by proxy_notices' never-raises boundary and
+    # the result is (), so next() died with a bare StopIteration that named
+    # neither the test's subject nor its expectation.
+    all_notices = [n for n in notices if n.kind == "all_proxy_only"]
+    assert all_notices, "the ALL_PROXY notice must survive an unparseable sibling"
+    assert all_notices[0].outcome == (
+        "Connected direct. ALL_PROXY is not supported (see issue #141)."
+    )
     assert any(n.kind == "malformed" for n in notices)
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -314,6 +314,14 @@ def test_strip_userinfo_registers_both_credential_forms() -> None:
     assert header.split()[-1] not in masked
 
 
+def test_proxy_choice_requires_a_source() -> None:
+    """Killing: a default on `source`. Task 2's bypass union branches on
+    source == "os", so a ProxyChoice built without one silently takes the
+    env-only path and drops the OS bypass list."""
+    with pytest.raises(TypeError):
+        http.ProxyChoice(URL("http://corp:8080"), None)  # type: ignore[call-arg]
+
+
 def test_os_proxies_returns_what_the_platform_getter_reports() -> None:
     """Killing: a seam that ignores the OS entirely and always returns {}.
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1012,3 +1012,214 @@ async def test_no_credential_reaches_the_exception(fake_proxy, proxy_env, os_pro
     # the target twice and never the proxy.
     assert "api.stoat.chat" in str(exc.request_info.url)
     assert "127.0.0.1" in str(exc.request_info.real_url)
+
+
+# --- Notices, the configurations Ferry cannot use (Task 5) -------------------
+#
+# NOT ONE TEST BELOW CALLS resolve_proxy BEFORE READING THE NOTICES, on purpose.
+# Every reader of proxy_notices() -- the engine preflight, `build`, `rollback`,
+# `probe` and the GUI export screen -- runs before the first request is made, so
+# a resolve-time implementation returns () at all five and the configuration-time
+# half of the feature ships inert. A test that resolved first would create the
+# condition it then asserted, which is the shape that let this repo ship inert
+# rollback redaction in v2.6.16.
+
+
+def test_all_proxy_only_is_reported(proxy_env, os_proxy) -> None:
+    """SC-135-18. Killing TWO implementations.
+
+    First: delegating to get_env_proxy_for_url, which filters ALL_PROXY out
+    before Ferry can see it.
+
+    Second, and this is why the test does NOT call resolve_proxy first:
+    recording notices as a side effect of resolution. Every reader of
+    proxy_notices() -- engine preflight, build, rollback, probe, and the GUI
+    export screen -- runs BEFORE any request is made, so a resolve-time
+    implementation returns () at all five and the feature ships inert. A test
+    that called resolve_proxy first would create the condition it then asserts,
+    which is the shape that let this repo ship inert rollback redaction.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        notices = http.proxy_notices()
+    assert any(n.kind == "all_proxy_only" for n in notices)
+
+
+def test_the_notice_outcome_is_true(proxy_env, os_proxy) -> None:
+    """SC-135-18. Killing: a notice claiming 'connected direct' when an OS proxy
+    was in fact used."""
+    with os_proxy(CORP), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        notices = http.proxy_notices()
+    assert any("OS" in n.outcome for n in notices)
+
+
+@pytest.mark.parametrize(
+    ("env_value", "os_map"),
+    [("socks5://sock:1080", {}), (None, {"https": "socks4://sock:1080"})],
+)
+def test_socks_is_detected_by_url_scheme(proxy_env, os_proxy, env_value, os_map) -> None:
+    """SC-135-19. Killing: keying the check off the dict name. getproxies_registry
+    writes socks4://host:port into proxies['http'] on Windows, the exact corporate
+    population this targets."""
+    pairs = {"HTTPS_PROXY": env_value} if env_value else {}
+    with os_proxy(os_map), proxy_env(**pairs):
+        notices = http.proxy_notices()
+    assert any(n.kind == "socks" for n in notices)
+
+
+def test_no_proxy_is_never_reported_as_a_broken_proxy(proxy_env, os_proxy) -> None:
+    """SC-135-20. Killing: 'any key that is not http or https is unusable', which
+    would report the user's own NO_PROXY, since getproxies_environment maps it to
+    a {'no': ...} entry."""
+    with os_proxy({}), proxy_env(NO_PROXY="example.com"):
+        assert http.proxy_notices() == ()
+
+
+def test_an_https_proxy_is_not_reported(proxy_env, os_proxy) -> None:
+    """SC-135-21. Killing: a notice written by one task and deleted by another.
+    S7 makes https:// usable."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="https://tls-proxy:8443"):
+        assert http.proxy_notices() == ()
+        assert http.resolve_proxy(TARGET) is not None
+
+
+def test_reset_actually_clears_the_notices(proxy_env, os_proxy) -> None:
+    """The first assertion in the feature that can fail on `_proxy_notices = ()`.
+
+    Task 2's reset test asserts `_proxy_notices == ()` before and after, which
+    holds trivially because nothing in that task ever writes the global.
+    Deleting the line from reset_http_state() left all 1503 tests green.
+
+    It matters here because proxy_notices() returns early when the tuple is
+    truthy, so a reset that forgets it leaks one test's notices into every later
+    test in the session, and this task's positive assertions would pass on the
+    leak.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        assert http.proxy_notices() != ()
+    http.reset_http_state()
+    assert http._proxy_notices == ()
+
+
+def test_notices_exist_before_any_request_is_made(proxy_env, os_proxy) -> None:
+    """The defect this task exists to prevent, pinned directly.
+
+    Every reader of proxy_notices() runs before the first request. Recording
+    notices inside resolve_proxy would make all five read sites return nothing.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        # No resolve_proxy call anywhere in this test, on purpose.
+        assert http.proxy_notices() != ()
+
+
+def test_proxy_notices_is_idempotent(proxy_env, os_proxy) -> None:
+    """SC-135-23. Killing: a drain-on-read implementation, under which a second
+    migration in one GUI process reports nothing and describe_proxy() then
+    reports a clean configuration that is not clean."""
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        assert http.proxy_notices() == http.proxy_notices()
+
+
+# The seven tests below are not in the task brief. Each closes a branch of
+# proxy_notices() or _safe_display() that the eight above leave unexecuted or
+# unpinned, found by enumerating the decisions in the source rather than by
+# reading the brief back. Every one was confirmed red against a mutant of the
+# exact line it claims to cover.
+
+
+def test_a_malformed_proxy_url_is_reported(proxy_env, os_proxy) -> None:
+    """The `except (ValueError, TypeError)` arm of the notice loop, which no test
+    in the brief enters.
+
+    Deleting that arm and letting URL(raw) raise would take proxy_notices() out
+    through every one of its five callers, and the engine preflight is the first
+    thing a migration runs. resolve_proxy already returns None for this input
+    (test_a_malformed_proxy_never_raises), so without the notice the user is
+    connected direct with nothing said.
+    """
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://[::1"):
+        notices = http.proxy_notices()
+    assert [(n.kind, n.scheme, n.display) for n in notices] == [
+        ("malformed", "https", "<unparseable>")
+    ]
+
+
+@pytest.mark.parametrize("variable", ["ALL_PROXY", "HTTPS_PROXY"])
+def test_a_notice_display_never_carries_userinfo(proxy_env, os_proxy, variable) -> None:
+    """Constraint 5, at BOTH _safe_display call sites.
+
+    The ALL_PROXY case covers the display built in the all_proxy_only branch and
+    the HTTPS_PROXY case the one built in the socks branch; a `display=raw`
+    mutant at either site survives the other test. Notices reach ferry.log and
+    the GUI, and a proxy password is a credential like any other.
+    """
+    with os_proxy({}), proxy_env(**{variable: "socks5://ferryuser:SUPERSECRET@sock:1080"}):
+        notices = http.proxy_notices()
+    assert notices
+    assert all("SUPERSECRET" not in n.display for n in notices)
+    assert notices[0].display == "socks5://sock:1080"
+
+
+@pytest.mark.parametrize("bad", ["http://[::1", "http://user%3Aname:pw@corp:8080"])
+def test_building_a_display_never_raises(proxy_env, os_proxy, bad: str) -> None:
+    """_safe_display's except arm, reached by both of the two paths into it.
+
+    The first input dies in URL(raw); the second parses and then dies in
+    _strip_userinfo, which raises ValueError when the login contains ':' and a
+    %3A in userinfo decodes to exactly that (aiohttp helpers.py:125-126). A try
+    narrowed to the parse alone therefore passes the first case and raises out of
+    the preflight on the second.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY=bad):
+        notices = http.proxy_notices()
+    assert [n.display for n in notices] == ["<unparseable>"]
+
+
+def test_the_environment_wording_is_used_when_the_environment_covers_it(
+    proxy_env, os_proxy
+) -> None:
+    """The 'environment' half of the outcome ternary, which nothing else enters.
+
+    test_the_notice_outcome_is_true pins the 'OS' half only, so hardcoding "OS"
+    passes it. Getting this backwards tells a user to look at a machine-wide
+    setting they never made.
+    """
+    with (
+        os_proxy({}),
+        proxy_env(
+            ALL_PROXY="socks5://sock:1080",
+            HTTP_PROXY="http://env:3128",
+            HTTPS_PROXY="http://env:3128",
+        ),
+    ):
+        notices = http.proxy_notices()
+    assert [n.outcome for n in notices] == ["Used the environment proxy for http, https instead."]
+
+
+def test_the_kill_switch_silences_the_notices(proxy_env, os_proxy) -> None:
+    """FERRY_DISABLE_PROXY, the one early return in proxy_notices nothing else
+    takes. With the kill switch on, Ferry connects direct by instruction, so a
+    notice saying it could not use a proxy would be a report of a decision the
+    user made.
+    """
+    with os_proxy(CORP), proxy_env(ALL_PROXY="socks5://sock:1080", FERRY_DISABLE_PROXY="1"):
+        assert http.proxy_notices() == ()
+
+
+def test_format_proxy_notices_renders_one_line_per_notice(proxy_env, os_proxy) -> None:
+    """The only test of format_proxy_notices, which the brief lists as a produced
+    interface and then never exercises. Both shells render from it, so a
+    KeyError or a missing field here reaches the user, not a test.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        lines = http.format_proxy_notices()
+    assert lines == [
+        "Proxy configuration Ferry cannot use: socks5://sock:1080 (all). "
+        "Connected direct. ALL_PROXY is not supported (see issue #141)."
+    ]
+
+
+def test_format_proxy_notices_is_empty_on_a_clean_configuration(proxy_env, os_proxy) -> None:
+    """A clean machine must produce no line at all, not an empty-string line that
+    a shell would print as a blank row."""
+    with os_proxy({}), proxy_env():
+        assert http.format_proxy_notices() == []

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import os
 import re
 import ssl
 import urllib.request
@@ -1052,6 +1053,33 @@ def test_the_notice_outcome_is_true(proxy_env, os_proxy) -> None:
     assert any("http" in n.outcome and "https" in n.outcome for n in notices)
 
 
+def test_the_all_proxy_outcome_is_not_contradicted_by_its_own_siblings(proxy_env, os_proxy) -> None:
+    """Killing: `covered` built from key membership rather than usability.
+
+    The canonical SOCKS setup exports all three variables together, which
+    shadowsocks, v2ray, `ssh -D` and Tor all document. Under a membership test
+    the ALL_PROXY notice claims "Used the proxy configured for http, https
+    instead." while the two notices printed directly after it say "Connected
+    direct. SOCKS is not supported." The first line is false and contradicts the
+    other two.
+
+    `test_the_notice_outcome_is_true` cannot see this: it is the mirror case,
+    and its docstring names only the direction where an OS proxy WAS used.
+    """
+    with (
+        os_proxy({}),
+        proxy_env(
+            ALL_PROXY="socks5://127.0.0.1:1080",
+            HTTP_PROXY="socks5://127.0.0.1:1080",
+            HTTPS_PROXY="socks5://127.0.0.1:1080",
+        ),
+    ):
+        lines = http.format_proxy_notices()
+    joined = " ".join(lines)
+    assert "Used the proxy configured for" not in joined
+    assert any("ALL_PROXY is not supported" in line for line in lines)
+
+
 def test_the_all_proxy_outcome_does_not_name_a_single_source(proxy_env, os_proxy) -> None:
     """Killing: an outcome that picks one source word for a mixed configuration.
 
@@ -1249,3 +1277,51 @@ def test_format_proxy_notices_is_empty_on_a_clean_configuration(proxy_env, os_pr
     a shell would print as a blank row."""
     with os_proxy({}), proxy_env():
         assert http.format_proxy_notices() == []
+
+
+def test_a_malformed_scheme_proxy_does_not_count_as_covered(proxy_env, os_proxy) -> None:
+    """_usable's except arm, which nothing else enters.
+
+    test_a_malformed_proxy_url_is_reported sets no ALL_PROXY, so it never
+    evaluates `covered` at all. Without the guard here the ALL_PROXY notice
+    would claim a scheme was used that cannot even be parsed, on the same
+    configuration whose next line reports it as malformed.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080", HTTPS_PROXY="http://[::1"):
+        notices = http.proxy_notices()
+    all_notice = next(n for n in notices if n.kind == "all_proxy_only")
+    assert all_notice.outcome == "Connected direct. ALL_PROXY is not supported (see issue #141)."
+    assert any(n.kind == "malformed" for n in notices)
+
+
+def test_the_kill_switch_wins_over_a_populated_cache(proxy_env, os_proxy) -> None:
+    """The kill-switch check sits ABOVE the cache read.
+
+    test_the_kill_switch_silences_the_notices cannot see the ordering: its cache
+    is cold, so both placements return (). Below the cache read, a process that
+    read notices at preflight and then had FERRY_DISABLE_PROXY set would keep
+    serving them for a proxy layer that is now off. proxy_env restores the whole
+    environment on exit, so setting the variable in place here is contained.
+    """
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
+        assert http.proxy_notices() != ()
+        os.environ["FERRY_DISABLE_PROXY"] = "1"
+        assert http.proxy_notices() == ()
+
+
+def test_proxy_notices_never_raises(proxy_env, os_proxy) -> None:
+    """The total boundary, mirroring _FerryRequest._resolve_or_direct.
+
+    `_scheme_map()` reaches the platform getters, and `re.error` subclasses
+    Exception directly rather than ValueError or TypeError, so it escapes both
+    narrow guards inside the loop. Mutant rows H and I showed what escaping
+    looks like from the inside: the exception surfaces at the call and no
+    assertion in the test is ever reached. Every caller runs at preflight, so
+    that aborts the first thing a migration does.
+    """
+    with (
+        os_proxy({}),
+        proxy_env(ALL_PROXY="socks5://sock:1080"),
+        patch("discord_ferry.core.http._scheme_map", side_effect=re.error("boom")),
+    ):
+        assert http.proxy_notices() == ()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -220,3 +220,14 @@ def test_release_workflow_asserts_the_union_branch() -> None:
     assert re.search(r"trust-source:\\s\*union", text), (
         "release.yml must assert the union branch, not merely mention trust-source"
     )
+
+
+def test_release_workflow_asserts_the_proxy_keys() -> None:
+    """SC-135-45. Killing: a workflow test that checks the key is MENTIONED
+    rather than ASSERTED. That exact defect shipped in v2.13.0's plan, where
+    weakening the Windows gate would have left the test green. Anchored to the
+    assertion's structure.
+    """
+    text = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert re.search(r"proxy-source:\\s\*", text), "the Windows regex must assert, not mention"
+    assert re.search(r'\*"proxy-source: "\*', text), "the macOS glob must assert"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3187,5 +3187,5 @@ async def test_a_refused_proxy_names_the_proxy(
     assert icon_warnings
     message = icon_warnings[0]["message"]
     assert "Role icon upload failed" in message
-    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert f"The request to autumn.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -631,6 +631,49 @@ async def test_run_roles_icon_upload_error_is_token_safe(tmp_path: Path) -> None
     assert all("icon" not in body for body in patch_bodies)
 
 
+async def test_a_server_disconnect_degrades_rather_than_aborting(tmp_path: Path) -> None:
+    """SC-135-35. Killing: forgetting to widen structure.py:403.
+
+    Aimed at ServerDisconnectedError, NOT a proxy 403. Task 7 already converts a
+    proxy 403 into AutumnUploadError at autumn.py, which :403 catches, so a
+    proxy-403 test passes without the widening and grades nothing.
+
+    Reachable: ServerDisconnectedError -> ServerConnectionError ->
+    ClientConnectionError -> ClientError, with no OSError, so
+    (AutumnUploadError, OSError) misses it and it aborts the roles phase.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    save_discord_metadata(
+        DiscordMetadata(
+            guild_id="111",
+            fetched_at="t",
+            server_default_permissions=0,
+            role_permissions={},
+            channel_metadata={},
+            role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+        ),
+        tmp_path,
+    )
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+        m.post(f"{AUTUMN_URL}/icons", exception=aiohttp.ServerDisconnectedError(), repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+        await run_roles(config, state, exports, events.append)  # must NOT raise
+
+    assert any(w.get("type") == "role_icon_upload_failed" for w in state.warnings)
+
+
 async def test_run_roles_truncates_long_name(tmp_path: Path) -> None:
     """ROLES phase truncates role names exceeding 32 characters."""
     events: list[MigrationEvent] = []

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3126,3 +3126,66 @@ async def test_run_roles_icon_warning_never_carries_the_response_body(tmp_path: 
     for w in icon_warnings:
         assert "SENTINEL_BODY" not in w["message"]
         assert config.token not in w["message"]
+
+
+# ---------------------------------------------------------------------------
+# #135 — a refusing proxy must name itself at structure.py:408
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refused_proxy_names_the_proxy(
+    tmp_path: Path, fake_proxy, proxy_env, os_proxy
+) -> None:
+    """SC-135-28. Killing: proxy_hint defined and never called at structure.py:408.
+
+    This handler throws `str(exc)` away on purpose (the Autumn body may echo
+    x-session-token), so the hint upload_to_autumn already put in the message
+    never reaches the user and has to be re-derived from the __cause__ chain.
+    The same shape as the certificate test above it.
+
+    Only the Autumn host is passed through to the real connector; the Stoat
+    calls stay mocked, so exactly one request meets the proxy.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    role = DCERole(id="r1", name="Mods")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    save_discord_metadata(
+        DiscordMetadata(
+            guild_id="111",
+            fetched_at="t",
+            server_default_permissions=0,
+            role_permissions={},
+            channel_metadata={},
+            role_metadata={"r1": RoleMeta(hoist=True, position=0, icon_hash="abc123")},
+        ),
+        tmp_path,
+    )
+
+    make, _ = fake_proxy
+    server = await make(b"403 Forbidden")
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        with (
+            os_proxy({}),
+            proxy_env(HTTPS_PROXY=f"http://127.0.0.1:{port}"),
+            aioresponses(passthrough=[AUTUMN_URL]) as m,
+            patch(
+                "discord_ferry.migrator.structure.download_role_icon",
+                new=AsyncMock(return_value=b"pngbytes"),
+            ),
+        ):
+            m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Mods"})
+            m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", payload={}, repeat=True)
+            m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+            # Must NOT raise — a proxy failure on an icon degrades like any other.
+            await run_roles(config, state, exports, events.append)
+
+    icon_warnings = [w for w in state.warnings if w.get("type") == "role_icon_upload_failed"]
+    assert icon_warnings
+    message = icon_warnings[0]["message"]
+    assert "Role icon upload failed" in message
+    assert f"went through the proxy at 127.0.0.1:{port}" in message
+    assert "FERRY_DISABLE_PROXY" in message

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ native = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.9" },
+    { name = "aiohttp", specifier = ">=3.14" },
     { name = "aioresponses", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "certifi", specifier = ">=2024.0" },
     { name = "click", specifier = ">=8.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -454,16 +454,18 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.13.1"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "certifi" },
     { name = "click" },
     { name = "ijson" },
+    { name = "multidict" },
     { name = "nicegui" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "yarl" },
 ]
 
 [package.optional-dependencies]
@@ -490,6 +492,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "ijson", specifier = ">=3.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0" },
+    { name = "multidict", specifier = ">=4.5" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "nicegui", specifier = ">=2.0" },
     { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -499,6 +502,7 @@ requires-dist = [
     { name = "pywebview", marker = "extra == 'native'", specifier = ">=5.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "yarl", specifier = ">=1.17" },
 ]
 provides-extras = ["native", "dev", "docs"]
 


### PR DESCRIPTION
Closes #135.

Ferry ignored proxy configuration entirely. Every session came from `core/http.py`'s `new_session()` with aiohttp's default `trust_env=False`, and proxy resolution is gated on that flag, so `HTTPS_PROXY` had no effect on any request. There was no flag, no config field and no environment variable that worked.

## What this adds

- **Resolution for every outbound session**, installed once in `core/http.py` and inherited by all eight former session sites. `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` behave the way other command-line tools read them. On Windows and macOS, when those variables are unset, Ferry falls back to the operating system's own proxy configuration, which is where a managed machine keeps it.
- **`FERRY_DISABLE_PROXY=1`** turns proxy use off wholesale. `NO_PROXY` exempts individual hosts.
- **Proxy failures explain themselves** at eight network error handlers, the same call sites v2.13.0 wired for certificate errors. A failure names the proxy, the target, and whether the proxy itself rejected the request.
- **`ferry tls-check` reports what resolution actually produced**, not what is configured: `proxy-http`, `proxy-https`, `proxy-source`, `proxy-disabled`. Both release smoke jobs assert on it.
- **Configuration notices reach the user before the run**, through a new `notice` event status that both CLI trackers print without `-v`, plus the four entry points that do network work outside `run_migration`.
- **The DCE subprocess gets an OS-resolved proxy**, which closes the failure shape where the export succeeds and every later phase fails.

Credentials never reach a log, report, diagnostic or child process. The URL handed to aiohttp carries no userinfo; the credential travels as a `Proxy-Authorization` header, and both the plaintext and encoded forms are registered for redaction.

## Two design decisions worth reading

**Ferry calls neither `urllib.request.getproxies()` nor `proxy_bypass()`.** Both are `getproxies_environment() or <os variant>`, so a single `*_proxy` variable masks all OS configuration. Ferry uses `getproxies_environment()` plus its own seam, merged per scheme.

**The two bypass lists union, they do not alternate.** An alternating rule discards an explicitly set `NO_PROXY` whenever the proxy came from the OS. Four rounds of prose review missed this; a runnable prototype found it.

`ClientRequest` is subclassed, never `ClientSession`, because `aioresponses` patches `ClientSession._request` on the class and a subclass defining `_request` would disable HTTP mocking across 22 test files.

## Verification

- 1597 tests, up from 1474 at the branch point
- `ruff check .`, `ruff format --check .`, `mypy src/` clean
- The design prototype passes 37/37, exit 0
- Every task's tests were observed failing against a named wrong implementation before the fix

## The defect the per-task reviews could not see

`core/http.py` imports `encode_basic_auth` at module level, and aiohttp added it in 3.14.0, while `pyproject.toml` still declared `aiohttp>=3.9`. Verified in throwaway environments: absent in 3.12.0 and 3.13.0, present in 3.14.0. Any resolver landing in the permitted range produced a Ferry that failed at import, with no command and no GUI. CI could not see it, because `uv.lock` pins 3.14.3 for every job and both frozen binaries. The floor is now `>=3.14`.

## Known limitations, stated rather than hidden

- **An authenticating OS-resolved proxy breaks the export phase.** DCE receives the proxy address without credentials and gets a 407 it cannot answer. Ferry does not pass the credential to a child process, because a password in a child environment is readable by other processes on some systems. Documented with the workaround.
- **`FERRY_DISABLE_PROXY` cannot rescue the export phase**, because DCE reads OS settings itself.
- **`proxy-source` is a single value, not one per scheme.** On a mixed configuration the last scheme to resolve wins.
- **The GUI export screen's notice call site is not behaviourally covered.** It sits in a nested closure no unit test can reach. The formatter it calls is tested on both paths. Not covered with an `inspect.getsource` assertion, which this project bans as coverage.
- **The precedence rule "proxy hint wins, never concatenated" is graded at one of eight sites.** All eight are the identical one-line expression; a site rewritten to concatenate would stay green.
- **No test executes the real platform proxy getter.** Every test patches the seam, because CI runs on ubuntu-latest where those functions do not exist. The OS path is provable only on a real Windows or macOS machine.

## Follow-ups found during this work, not yet filed

1. `probe --json` can emit unparseable JSON. It prints through Rich, which wraps at 80 columns outside a terminal and can break a line at a `json.dumps` separator. Pre-existing and unrelated to proxies.
2. The four `release.yml` structural tests anchor to the workflow's condition text rather than requiring `exit 1` in the same block, so weakening a check to a warning keeps them green. Two of the four predate this branch.
3. A NiceGUI `user`-fixture test for the export screen's pre-network wiring, which would close limitation 4 above.
4. `describe_proxy` and `run_dce_export` call `resolve_proxy` outside the `_resolve_or_direct` boundary, so they inherit only its narrow guards while the docstring promises it never raises.
5. Proxy password redaction leaves the last four characters visible, which is a larger fraction of a human-chosen password than of an opaque token.
6. The project's documented verification command is `ruff check src/` while CI runs `ruff check .`. New test code can pass locally and fail on push, which happened once on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
