### PR TITLE
fix: no validation warning may leave the GUI with no way forward (#143)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ claude_log/
 # Internal design docs (kept locally, not in public repo)
 docs/plans/
 docs/superpowers/
+# Subagent-driven-development workspace: ledgers, briefs, per-task reports.
+# Scratch for one branch's build, never part of the product.
+.superpowers/
 docs/discord-ferry-claude-code-brief.md
 
 # MkDocs build output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   and no raw `<@` in its content, so a reply, a mention carried inside an embed, or an
   attachment-only message each condemned a whole channel. It now flags a message only
   when a mention's display form appears in the content as a whole token while its raw
-  form does not, and it reports how many messages are affected. Previously it stopped
-  at the first. (#143)
+  form does not, or when the content carries `@Unknown`, which is what the exporter
+  writes for a member it could not resolve. It also reports how many messages are
+  affected. Previously it stopped at the first. (#143)
 - `ferry validate` and the GUI now give the same explanation, which names what happens
   to the affected messages. The old wording pointed at a re-export flag that does not
   help in every case. `ferry validate` still exits 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-08-10
+
+### Fixed
+
+- The GUI could reach a state where migration was impossible. A `rendered_markdown`
+  warning disabled Start Migration, the only route to the migration screen, with no
+  override anywhere in the interface. The same export migrated normally through
+  `ferry migrate`, which never consulted the warning. The reason now renders with a
+  checkbox that enables the button. (#143)
+- The rendered-markdown check flagged any message with a non-empty `mentions` array
+  and no raw `<@` in its content, so a reply, a mention carried inside an embed, or an
+  attachment-only message each condemned a whole channel. It now flags a message only
+  when a mention's display form appears in the content as a whole token while its raw
+  form does not, and it reports how many messages are affected. Previously it stopped
+  at the first. (#143)
+- `ferry validate` and the GUI now give the same explanation, which names what happens
+  to the affected messages. The old wording pointed at a re-export flag that does not
+  help in every case. `ferry validate` still exits 1.
+
 ## [2.14.0] - 2026-08-10
 
 ### Added

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -32,8 +32,14 @@ ferry validate EXPORT_DIR
 
 - Source server name and export date
 - Counts: channels, categories, roles, messages, attachments, emoji, threads
-- Warnings (for example, missing media files or rendered markdown detected)
+- Warnings (for example, missing media files, or messages whose mentions were written as plain text instead of raw IDs)
 - An estimated migration time at the default 1.0s rate limit
+
+!!! warning "Exit code"
+    `ferry validate` prints everything above and then exits **1** when any message has mentions
+    written as plain text, so a script that gates on its exit status stops there. `ferry migrate`
+    is not affected by this warning. See
+    [Mentions written as plain text](troubleshooting.md#mentions-written-as-plain-text).
 
 **Options:**
 

--- a/docs/guides/gui-walkthrough.md
+++ b/docs/guides/gui-walkthrough.md
@@ -113,15 +113,21 @@ The server name and export date from the DCE export appear at the top of the scr
 
 ### Warnings List
 
-Any issues found during parsing are listed with amber indicators. Common warnings:
+Any issues found during parsing are listed. Amber entries are informational. A red entry needs your acknowledgement before the migration can start. Common warnings:
 
-- **Rendered markdown detected** — the export may have been made without `--markdown false`. Mention syntax may be lost.
+- **Mentions written as plain text** (red). One entry per channel, carrying a count: those messages have mentions written as plain text instead of raw IDs, so they will arrive as text, with no link back to the user. See [Mentions written as plain text](troubleshooting.md#mentions-written-as-plain-text) for what to do about it.
 - **Attachment files missing** — one or more attachment files were not found locally. Those files will be skipped.
 - **Channel limit may be exceeded** — the combined channel and thread count exceeds 200.
 - **Emoji limit will be reached** — the server has more than 100 custom emoji. Only the first 100 will be migrated.
 
-!!! info "Warnings vs errors"
-    Amber warnings allow migration to proceed. A red error (for example, no valid JSON files found) disables the **Start Migration** button until it is resolved.
+!!! info "Warnings and acknowledgement"
+    Amber warnings need no action, and the migration proceeds with them. When the mentions warning
+    is present, its full explanation appears above the buttons alongside a checkbox, **I understand,
+    migrate anyway**. Ticking that box is the only thing that enables **Start Migration**. The tick
+    does not persist: press **Back** and return to this screen, and the box is clear again.
+
+    A hard failure such as "No valid DCE JSON files found" stops the screen before the status is
+    drawn, so it never appears as a colour here.
 
 ### ETA Estimate
 
@@ -129,9 +135,9 @@ Based on your message count and the rate limit you chose, Ferry shows an estimat
 
 ### Overall Status
 
-- **Green** — everything looks good, migration can proceed.
-- **Amber** — warnings present, migration can proceed but review the warnings above.
-- **Red** — a blocking error was found. Migration is disabled until you resolve it.
+- **Green**, "Export looks good". No warnings were found.
+- **Amber**, "Warnings present, review before migrating". Read the warnings above, then proceed.
+- **Red**, "Acknowledgement needed before migrating". Tick **I understand, migrate anyway** to enable **Start Migration**. Red on this screen means acknowledgement is needed and nothing else.
 
 Use the **Back** button to return to the Setup screen and adjust settings, or click **Start Migration** to begin.
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -59,13 +59,16 @@ This page covers the most common problems encountered during migration, their ca
 | **Cause** | The export folder path is wrong, or the files are in the wrong format |
 | **Solution** | Confirm you are pointing Ferry at the folder that *contains* the `.json` files, not a parent folder. Also confirm you exported from DiscordChatExporter using `--format Json` (not HTML or CSV). |
 
-### Rendered markdown detected
+### Mentions written as plain text
 
 | | |
 |---|---|
-| **Symptom** | Ferry warns "Rendered markdown detected"; user mentions appear as `@Username` instead of raw mention IDs in Stoat messages |
-| **Cause** | The export was created without `--markdown false`. DiscordChatExporter rendered `<@123456789>` into `@Username`, destroying the data needed to reconstruct mentions. |
-| **Solution** | Re-export from DiscordChatExporter using the `--markdown false` flag. |
+| **Symptom** | Ferry warns, once per channel and with a count, that some messages "have mentions written as plain text instead of raw IDs". In Stoat those mentions arrive as `@Username` text |
+| **Cause** | Usually the export was created without `--markdown false`, so DiscordChatExporter rendered `<@123456789>` into `@Username` and the ID needed to rebuild the mention is gone. A message is also flagged when somebody typed a display name after an at-sign by hand, which is what the text looked like in Discord too. |
+| **Solution** | Check how the export was made before re-exporting. If `--markdown false` was missing, re-export with it and the mentions come back as IDs. If the export already used `--markdown false`, a re-export changes nothing, because the flagged text was typed that way in Discord. Either way, you can migrate the export as it stands: tick **I understand, migrate anyway** on the validate screen. What you give up is the link, since those mentions arrive as text with no link back to the user. |
+
+`ferry validate` exits 1 while this warning is present, so a script that gates on its exit status
+stops here. `ferry migrate` is not affected by the warning and never asks about it.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.0"
+version = "2.14.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.0"
+__version__ = "2.14.1"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -36,7 +36,11 @@ from discord_ferry.migrator.api import (
     api_set_role_permissions,
     api_upsert_categories,
 )
-from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
+from discord_ferry.parser.dce_parser import (
+    acknowledgement_required,
+    parse_export_directory,
+    validate_export,
+)
 from discord_ferry.state import MigrationState, load_state
 from discord_ferry.stats import summarize_state
 
@@ -790,9 +794,9 @@ def validate(export_dir: str, rate_limit: float) -> None:
     eta = _format_eta(total_messages, rate_limit)
     console.print(f"[bold]{total_messages:,}[/] messages at {rate_limit:.1f}s/msg = {eta}")
 
-    has_critical = any(w["type"] == "rendered_markdown" for w in warnings)
-    if has_critical:
-        console.print("\n[bold red]Critical warnings found.[/] Fix before migrating.")
+    reason = acknowledgement_required(warnings)
+    if reason is not None:
+        console.print(f"\n[bold red]{_safe(reason)}[/]")
         sys.exit(1)
     else:
         console.print("[bold green]Export looks good.[/]")

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -12,7 +12,7 @@ import secrets
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
 
 from nicegui import app, background_tasks, ui
@@ -25,7 +25,12 @@ from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
 from discord_ferry.errors import MigrationError
-from discord_ferry.parser.dce_parser import parse_export_directory, validate_export
+from discord_ferry.parser.dce_parser import (
+    _ACKNOWLEDGEABLE_TYPES,
+    acknowledgement_required,
+    parse_export_directory,
+    validate_export,
+)
 from discord_ferry.state import load_state
 
 _HAS_WEBVIEW = False
@@ -105,6 +110,38 @@ def _proxy_notice_lines() -> list[str]:
     releases.
     """
     return [f"[notice] {line}" for line in format_proxy_notices()]
+
+
+class _ValidateStatus(NamedTuple):
+    """Colour, chip text, and the reason acknowledgement is needed (or None).
+
+    A NamedTuple because `text` and `reason` are both `str` and a positional
+    tuple invites a swap between them.
+    """
+
+    colour: str
+    text: str
+    reason: str | None
+
+
+def _validate_status(warnings: list[dict[str, str]]) -> _ValidateStatus:
+    """Classify the validate screen's warnings ONCE.
+
+    Module level so it is testable; the equivalent logic was inline in
+    validate_page, which no unit test reached. Returns the reason rather than
+    taking it, so the colour and the reason cannot be handed contradictory
+    values.
+
+    Red means exactly one thing on this screen now: acknowledgement required.
+    Both early-exit blocks in validate_page return before the chip is created,
+    so a hard parse error never reaches it.
+    """
+    reason = acknowledgement_required(warnings)
+    if reason is not None:
+        return _ValidateStatus("red", "Acknowledgement needed before migrating", reason)
+    if warnings:
+        return _ValidateStatus("amber", "Warnings present, review before migrating", None)
+    return _ValidateStatus("green", "Export looks good", None)
 
 
 def _open_path(path: Path) -> None:
@@ -1071,23 +1108,12 @@ def validate_page() -> None:
                 return
 
             warnings = validate_export(exports, export_dir)
-            has_rendered_markdown = any(w["type"] == "rendered_markdown" for w in warnings)
+            status = _validate_status(warnings)
 
             guild_name = exports[0].guild.name
             ui.label(f"Export: {guild_name}").classes("text-2xl font-bold text-center mt-2")
 
-            # Status indicator
-            if has_rendered_markdown:
-                status_colour = "red"
-                status_text = "Critical warnings — fix before migrating"
-            elif warnings:
-                status_colour = "amber"
-                status_text = "Warnings present — review before migrating"
-            else:
-                status_colour = "green"
-                status_text = "Export looks good"
-
-            ui.chip(status_text, color=status_colour).classes("mx-auto my-2")
+            ui.chip(status.text, color=status.colour).classes("mx-auto my-2")
 
             # Summary table
             summary = _compute_summary(exports)
@@ -1124,7 +1150,7 @@ def validate_page() -> None:
                     "w-full mt-2"
                 ):
                     for w in warnings:
-                        colour = "red" if w["type"] == "rendered_markdown" else "orange"
+                        colour = "red" if w["type"] in _ACKNOWLEDGEABLE_TYPES else "orange"
                         ui.label(w["message"]).classes(f"text-{colour}-600 text-sm py-1")
 
             # Navigation buttons
@@ -1137,7 +1163,7 @@ def validate_page() -> None:
                     .props("color=amber-7 text-color=white unelevated")
                     .classes("font-semibold")
                 )
-                if has_rendered_markdown:
+                if status.reason is not None:
                     start_btn.disable()
 
 

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1153,6 +1153,12 @@ def validate_page() -> None:
                         colour = "red" if w["type"] in _ACKNOWLEDGEABLE_TYPES else "orange"
                         ui.label(w["message"]).classes(f"text-{colour}-600 text-sm py-1")
 
+            if status.reason is not None:
+                ui.label(status.reason).classes("text-red-600 text-sm mt-4")
+                ack = ui.checkbox("I understand, migrate anyway")
+            else:
+                ack = None
+
             # Navigation buttons
             with ui.row().classes("w-full justify-between mt-6"):
                 ui.button("Back", on_click=lambda: ui.navigate.to("/")).classes(
@@ -1163,8 +1169,12 @@ def validate_page() -> None:
                     .props("color=amber-7 text-color=white unelevated")
                     .classes("font-semibold")
                 )
-                if status.reason is not None:
-                    start_btn.disable()
+                if ack is not None:
+                    # A binding, not an on_change callback: a callback body is more
+                    # logic in the one place this design cannot make testable.
+                    # bind_from propagates at bind time, so the button starts
+                    # disabled without an explicit disable() call.
+                    start_btn.bind_enabled_from(ack, "value")
 
 
 # ---------------------------------------------------------------------------

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -69,6 +69,37 @@ that is the instruction the reporter of #143 followed with no effect. It lives
 in docs/guides/troubleshooting.md, qualified.
 """
 
+_ACKNOWLEDGEABLE_TYPES: frozenset[str] = frozenset({"rendered_markdown"})
+"""Warning types the user must acknowledge before migrating.
+
+The other five types validate_export can emit (http_attachment, empty_export,
+expired_cdn_url, channel_limit, emoji_limit) are informational and never gate
+the button.
+"""
+
+
+def acknowledgement_required(warnings: list[dict[str, str]]) -> str | None:
+    """The one explanation the GUI banner, the GUI warnings list and `ferry
+    validate` all share.
+
+    Returns the sentence when any warning needs acknowledging before migrating,
+    and None otherwise. Lives here rather than in gui.py so cli.py can import it
+    without pulling NiceGUI into the CLI.
+    """
+    hits = [w for w in warnings if w.get("type") in _ACKNOWLEDGEABLE_TYPES]
+    if not hits:
+        return None
+    total = 0
+    for w in hits:
+        try:
+            total += int(w.get("count", "0"))
+        except (TypeError, ValueError):
+            continue  # a malformed count must not raise on the validate screen
+    return (
+        f"{total} message(s) across {len(hits)} export file(s) have mentions "
+        f"written as plain text. They {RENDERED_MENTION_CONSEQUENCE}."
+    )
+
 
 def _is_word_char(ch: str) -> bool:
     """Word character for boundary purposes: alphanumeric or underscore.

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -51,6 +51,103 @@ _DCE_CHANNEL_TYPE_TO_INT: dict[str, int] = {
     "GuildMedia": 16,
 }
 
+UNRESOLVED_RENDER = "Unknown"
+"""What DCE writes for a member it cannot resolve.
+
+DCE 2.47.1, Exporting/PlainTextMarkdownVisitor.cs:
+    @{member?.DisplayName ?? member?.User.DisplayName ?? "Unknown"}
+In that case the JSON mentions array still carries a real name, so nothing in
+`mentions` can detect it.
+"""
+
+
+def _is_word_char(ch: str) -> bool:
+    """Word character for boundary purposes: alphanumeric or underscore.
+
+    Reproduces the intent of regex \\w without a pattern per display name.
+    Display names are user data, so a regex needs re.escape and a distinct
+    compiled pattern per name, churning the cache on a large export.
+    """
+    return ch.isalnum() or ch == "_"
+
+
+def _plain_form_present(content: str, candidate: str) -> bool:
+    """Is "@candidate" present in content as a standalone token?
+
+    Scans EVERY occurrence. A single str.find returns the first hit only, so
+    with candidate "Bob" and content "cc @Bobby, I meant @Bob" it would stop at
+    the rejected hit inside "@Bobby" and never see the genuine one.
+
+    Boundaries on BOTH sides. Without a leading check, "someone@bob.io" and
+    "http://x/@Alice" flag a correct raw export. The trade: a rendered mention
+    written with no space before it ("Hi<@1>" becomes "Hi@Alice") is missed.
+    Taken deliberately: #143 is a false positive that left a user with no way
+    forward, and the count is per file, so one missed message still leaves the
+    file flagged whenever another message in it renders.
+
+    Case-sensitive on purpose: DCE writes the nickname verbatim.
+    """
+    needle = "@" + candidate
+    idx = content.find(needle)
+    while idx != -1:
+        before_ok = idx == 0 or not _is_word_char(content[idx - 1])
+        after = idx + len(needle)
+        after_ok = after >= len(content) or not _is_word_char(content[after])
+        if before_ok and after_ok:
+            return True
+        idx = content.find(needle, idx + 1)
+    return False
+
+
+def _raw_form_present(content: str, mention_id: str) -> bool:
+    """Both spellings. DCE's MarkdownParser.cs matches <@!?(\\d+)>."""
+    if not mention_id:
+        return False
+    return f"<@{mention_id}>" in content or f"<@!{mention_id}>" in content
+
+
+def _candidate(mention: dict[str, str]) -> str:
+    """The single display form DCE would have rendered for this mention.
+
+    `nickname` only, with `name` as a fallback for a DCE version that stops
+    writing it. DCE's JSON `nickname` is `TryGetMember(id)?.DisplayName ??
+    user.DisplayName` while its renderer writes `member?.DisplayName ??
+    member?.User.DisplayName`, the same chain, so `nickname` already equals the
+    rendered string in every resolvable case. Adding `name` as a SECOND
+    candidate could never produce a true positive and did produce false ones,
+    because usernames are lowercase common words ("@everyone").
+    """
+    for key in ("nickname", "name"):
+        value = mention.get(key, "")
+        if value and value.strip():
+            return value.strip()
+    return ""
+
+
+def message_has_rendered_mention(content: str, mentions: list[dict[str, str]]) -> bool:
+    """Was a mention in this message written as plain text instead of raw IDs?"""
+    if "@" not in content:
+        return False
+
+    saw_raw_form = False
+    for mention in mentions:
+        if _raw_form_present(content, mention.get("id", "")):
+            saw_raw_form = True
+            continue
+        candidate = _candidate(mention)
+        if not candidate:
+            # An empty candidate would reduce the test to "content holds an
+            # at-sign", which flags most of Discord.
+            continue
+        if _plain_form_present(content, candidate):
+            return True
+
+    # Mention-independent: an unresolved member renders as "@Unknown" while the
+    # JSON still carries a real name. Runs LAST, and only when nothing in this
+    # message proved itself raw, so a message carrying <@id> is not condemned
+    # for discussing an unknown error.
+    return not saw_raw_form and _plain_form_present(content, UNRESOLVED_RENDER)
+
 
 def parse_export_directory(export_dir: Path, *, metadata_only: bool = False) -> list[DCEExport]:
     """Parse all DCE JSON files in a directory (top-level only).
@@ -211,13 +308,8 @@ def validate_export(
         for msg in msg_iter:
             has_messages = True
 
-            # Check for rendered markdown (first occurrence only)
-            if (
-                not markdown_warned
-                and msg.mentions
-                and "<@" not in msg.content
-                and "<#" not in msg.content
-            ):
+            # Check for rendered markdown (first occurrence only; Task 2 counts)
+            if not markdown_warned and message_has_rendered_mention(msg.content, msg.mentions):
                 warnings.append(
                     {
                         "type": "rendered_markdown",

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -79,12 +79,15 @@ the button.
 
 
 def acknowledgement_required(warnings: list[dict[str, str]]) -> str | None:
-    """The one explanation the GUI banner, the GUI warnings list and `ferry
-    validate` all share.
+    """The aggregate explanation the GUI banner and `ferry validate` both show.
 
     Returns the sentence when any warning needs acknowledging before migrating,
     and None otherwise. Lives here rather than in gui.py so cli.py can import it
     without pulling NiceGUI into the CLI.
+
+    The per-file warning rows do not carry this sentence. They share only
+    RENDERED_MENTION_CONSEQUENCE with it, which is what keeps the two
+    granularities from drifting into separate wordings.
     """
     hits = [w for w in warnings if w.get("type") in _ACKNOWLEDGEABLE_TYPES]
     if not hits:
@@ -323,7 +326,10 @@ def validate_export(
             of all messages.
 
     Returns:
-        List of warning dicts, each with 'type' and 'message' keys.
+        List of warning dicts. Every dict has 'type' and 'message'; some carry
+        more. A 'rendered_markdown' dict also carries 'count', the number of
+        affected messages in that export file, as a string, which
+        acknowledgement_required reads.
     """
     warnings: list[dict[str, str]] = []
     unique_channel_ids: set[str] = set()

--- a/src/discord_ferry/parser/dce_parser.py
+++ b/src/discord_ferry/parser/dce_parser.py
@@ -60,6 +60,15 @@ In that case the JSON mentions array still carries a real name, so nothing in
 `mentions` can detect it.
 """
 
+RENDERED_MENTION_CONSEQUENCE = "will arrive as text, with no link back to the user"
+"""The one consequence phrase. Shared by the per-file warning row, the GUI
+banner and `ferry validate`, so they cannot drift into three wordings.
+
+Deliberately does NOT carry "re-export with --markdown false". Unqualified,
+that is the instruction the reporter of #143 followed with no effect. It lives
+in docs/guides/troubleshooting.md, qualified.
+"""
+
 
 def _is_word_char(ch: str) -> bool:
     """Word character for boundary purposes: alphanumeric or underscore.
@@ -301,25 +310,15 @@ def validate_export(
         else:
             msg_iter = iter([])
 
-        markdown_warned = False
+        rendered_mention_count = 0
         http_warned = False
         has_messages = False
 
         for msg in msg_iter:
             has_messages = True
 
-            # Check for rendered markdown (first occurrence only; Task 2 counts)
-            if not markdown_warned and message_has_rendered_mention(msg.content, msg.mentions):
-                warnings.append(
-                    {
-                        "type": "rendered_markdown",
-                        "message": (
-                            f"Channel '{channel_name}': message {msg.id} has mentions but no raw "
-                            f"<@ syntax — export may have been created without --markdown false"
-                        ),
-                    }
-                )
-                markdown_warned = True
+            if message_has_rendered_mention(msg.content, msg.mentions):
+                rendered_mention_count += 1
 
             # Check for HTTP attachment URLs (first occurrence only) and expired CDN URLs
             for att in msg.attachments:
@@ -349,6 +348,22 @@ def validate_export(
             if msg.content:
                 for match in _CONTENT_EMOJI_RE.finditer(msg.content):
                     custom_emoji_ids.add(match.group(1))
+
+        # Below the loop, not inside it: the count needs every message, and
+        # msg_iter is a one-shot stream_messages generator whenever the caller
+        # passed metadata_only=True, which engine.py:396 always does.
+        if rendered_mention_count:
+            warnings.append(
+                {
+                    "type": "rendered_markdown",
+                    "count": str(rendered_mention_count),
+                    "message": (
+                        f"Channel '{channel_name}': {rendered_mention_count} message(s) "
+                        f"have mentions written as plain text instead of raw IDs, so "
+                        f"they {RENDERED_MENTION_CONSEQUENCE}."
+                    ),
+                }
+            )
 
         # Collect unique non-thread channel IDs
         if not export.is_thread:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,33 @@ def fixtures_dir() -> Path:
 
 
 @pytest.fixture
+def user_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """A writable stand-in for `app.storage.user`.
+
+    The real property is request-scoped (it reads a contextvar and a session
+    cookie), so a test body cannot seed it from outside a request. The page code
+    under test only ever treats it as a mapping.
+    """
+    store: dict[str, object] = {}
+    monkeypatch.setattr("nicegui.storage.Storage.user", property(lambda self: store), raising=False)
+    return store
+
+
+@pytest.fixture
+def tab_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """A writable stand-in for `app.storage.tab`.
+
+    The real property raises unless a connected client is resolvable from the
+    current task's slot stack -- which a test body does not have. That is the
+    very constraint this fix exists to respect, so the page code must still see
+    a plain mapping.
+    """
+    store: dict[str, object] = {}
+    monkeypatch.setattr("nicegui.storage.Storage.tab", property(lambda self: store), raising=False)
+    return store
+
+
+@pytest.fixture
 def proxy_env() -> Callable[..., AbstractContextManager[None]]:
     """Clear every *_proxy variable, then apply the given ones.
 

--- a/tests/fixtures/markdown_rendered_multi/markdown_rendered_multi.json
+++ b/tests/fixtures/markdown_rendered_multi/markdown_rendered_multi.json
@@ -1,0 +1,43 @@
+{
+  "guild": {"id": "111111111111111111", "name": "Test Server", "iconUrl": "media/guild_icon.png"},
+  "channel": {"id": "222222222222222226", "type": 0, "categoryId": "333333333333333333",
+              "category": "Text Channels", "name": "rendered-multi", "topic": ""},
+  "dateRange": {"after": null, "before": null},
+  "exportedAt": "2024-06-15T10:30:00+00:00",
+  "messages": [
+    {
+      "id": "900000000000000040", "type": "Default", "timestamp": "2024-01-20T12:00:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "hi @Alice 🌸!",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000003", "name": "ali",
+                    "discriminator": "0000", "nickname": "Alice 🌸"}],
+      "reference": null
+    },
+    {
+      "id": "900000000000000041", "type": "Default", "timestamp": "2024-01-20T12:01:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "cc @Bobby, I meant @Bob",
+      "author": {"id": "400000000000000001", "name": "alice", "discriminator": "0000",
+                 "nickname": "Alice", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000002", "name": "bob",
+                    "discriminator": "0000", "nickname": "Bob"}],
+      "reference": null
+    },
+    {
+      "id": "900000000000000042", "type": "Default", "timestamp": "2024-01-20T12:02:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "all good <@400000000000000001>",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": null
+    }
+  ],
+  "messageCount": 3
+}

--- a/tests/fixtures/markdown_rendered_multi/markdown_rendered_multi_b.json
+++ b/tests/fixtures/markdown_rendered_multi/markdown_rendered_multi_b.json
@@ -1,0 +1,32 @@
+{
+  "guild": {"id": "111111111111111111", "name": "Test Server", "iconUrl": "media/guild_icon.png"},
+  "channel": {"id": "222222222222222227", "type": 0, "categoryId": "333333333333333333",
+              "category": "Text Channels", "name": "rendered-multi-b", "topic": ""},
+  "dateRange": {"after": null, "before": null},
+  "exportedAt": "2024-06-15T10:30:00+00:00",
+  "messages": [
+    {
+      "id": "900000000000000050", "type": "Default", "timestamp": "2024-01-20T13:00:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "hey @Alice about that",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": null
+    },
+    {
+      "id": "900000000000000051", "type": "Default", "timestamp": "2024-01-20T13:01:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "all good <@400000000000000001>",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": null
+    }
+  ],
+  "messageCount": 2
+}

--- a/tests/fixtures/mentions_not_rendered/mentions_not_rendered.json
+++ b/tests/fixtures/mentions_not_rendered/mentions_not_rendered.json
@@ -1,0 +1,49 @@
+{
+  "guild": {"id": "111111111111111111", "name": "Test Server", "iconUrl": "media/guild_icon.png"},
+  "channel": {"id": "222222222222222225", "type": 0, "categoryId": "333333333333333333",
+              "category": "Text Channels", "name": "not-rendered", "topic": ""},
+  "dateRange": {"after": null, "before": null},
+  "exportedAt": "2024-06-15T10:30:00+00:00",
+  "messages": [
+    {
+      "id": "900000000000000030", "type": "Default", "timestamp": "2024-01-20T12:00:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "Sure, that works",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [], "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": {"messageId": "900000000000000029",
+                    "channelId": "222222222222222225",
+                    "guildId": "111111111111111111", "type": "Default"}
+    },
+    {
+      "id": "900000000000000031", "type": "Default", "timestamp": "2024-01-20T12:01:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [],
+      "embeds": [{"title": "Release", "description": "shipped by @Alice"}],
+      "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": null
+    },
+    {
+      "id": "900000000000000032", "type": "Default", "timestamp": "2024-01-20T12:02:00+00:00",
+      "timestampEdited": null, "isPinned": false,
+      "content": "",
+      "author": {"id": "400000000000000002", "name": "bob", "discriminator": "0000",
+                 "nickname": "Bob", "isBot": false, "roles": []},
+      "attachments": [{"id": "1", "url": "attachments/1/screenshot.png",
+                       "fileName": "screenshot.png", "fileSizeBytes": 100}],
+      "embeds": [], "stickers": [], "reactions": [],
+      "mentions": [{"id": "400000000000000001", "name": "alice",
+                    "discriminator": "0000", "nickname": "Alice"}],
+      "reference": null
+    }
+  ],
+  "messageCount": 3
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
@@ -55,13 +56,47 @@ def test_validate_help(runner: CliRunner) -> None:
 
 
 def test_validate_basic(runner: CliRunner) -> None:
-    # Fixtures include markdown_rendered.json which triggers a critical warning,
-    # so exit code is 1.  We still verify the table and warnings render.
+    # Fixtures include markdown_rendered.json, which needs acknowledging, so the
+    # exit code is 1.  We still verify the table and warnings render.  The
+    # wording of the closing line is pinned by
+    # test_validate_reports_the_consequence_and_still_exits_1, which controls
+    # the fixture set and the console width.
     result = runner.invoke(main, ["validate", FIXTURES_DIR])
     assert result.exit_code == 1
     assert "Export Summary" in result.output
     assert "Messages" in result.output
-    assert "Critical warnings found" in result.output
+
+
+def test_validate_reports_the_consequence_and_still_exits_1(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exit code is a settled decision: a command whose job is to pass or
+    fail an export keeps failing, and changing a documented exit code in a patch
+    release breaks anything scripted on it. Only the wording changes.
+
+    Rich wraps at 80 columns when not attached to a terminal, so COLUMNS is
+    pinned wide enough that the sentence under test stays on one line. Click 8.2
+    removed CliRunner(mix_stderr=...).
+
+    "across N export file(s)" is the discriminating fragment: only
+    acknowledgement_required counts files, so the per-channel warning row above
+    it cannot produce that phrasing. The consequence phrase alone would not
+    kill the old code, because the warning row already carries it.
+
+    Killing: a CLI that stops exiting 1, and one that keeps its own inline type
+    check instead of the shared classifier.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+    shutil.copy(Path(FIXTURES_DIR) / "markdown_rendered.json", tmp_path / "rendered.json")
+
+    result = runner.invoke(main, ["validate", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "1 message(s) across 1 export file(s) have mentions written as plain text." in (
+        result.output
+    )
+    assert "arrive as text" in result.output
+    assert "Critical warnings found" not in result.output
 
 
 def test_validate_empty_dir(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -76,6 +77,36 @@ async def test_run_migration_validates_exports(tmp_path: Path, proxy_env: Any) -
     assert len(state.warnings) == len(warning_events)
     # Author names should be populated from the fixture exports
     assert len(state.author_names) > 0
+
+
+async def test_rendered_markdown_warning_does_not_gate_the_migration(tmp_path: Path) -> None:
+    """The GUI blocked on this warning and the engine never did, which is the
+    real defect in #143. Pin the engine side so nobody closes the gap from the
+    wrong end.
+
+    Filters state.warnings by type rather than by length or position: the
+    proxy_env note on test_run_migration_validates_exports records that an
+    ambient proxy variable adds an unrelated preflight entry.
+
+    The observable is state.current_phase (state.py:102, set at engine.py:690
+    and again at :525 once the phase loop returns). state.completed_phases does
+    not exist. An engine that stopped at the warning would leave it "".
+
+    Killing: a gate added to the engine after engine.py:401, or one added to
+    validate_export that raises instead of returning a warning row."""
+    export_dir = tmp_path / "exports"
+    export_dir.mkdir()
+    shutil.copy(FIXTURES_DIR / "markdown_rendered.json", export_dir / "rendered.json")
+
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, export_dir=export_dir)
+    state = await run_migration(config, events.append, phase_overrides=_NOOP_OVERRIDES)
+
+    types = [w.get("type") for w in state.warnings]
+    assert "rendered_markdown" in types
+    # The run reached the phase loop and came out the far side.
+    assert state.current_phase != ""
+    assert any(e.phase == "connect" and e.status == "started" for e in events)
 
 
 async def test_run_migration_emits_phase_events(tmp_path: Path) -> None:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -624,3 +624,31 @@ def test_proxy_notice_lines_is_empty_on_a_clean_configuration(proxy_env, os_prox
 
     with os_proxy({}), proxy_env():
         assert _proxy_notice_lines() == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #143: the validate screen's status
+# ---------------------------------------------------------------------------
+
+
+def test_validate_status_three_states() -> None:
+    """The banner logic lived inline in validate_page, where nothing could reach
+    it. Module level, following _proxy_notice_lines.
+
+    Killing: a helper that colours every warning red, one with no clean state,
+    and one whose chip text and reason are the same object, which would make a
+    positional swap between them undetectable."""
+    from discord_ferry.gui import _validate_status
+
+    red = _validate_status([{"type": "rendered_markdown", "count": "2", "message": "x"}])
+    assert red.colour == "red"
+    assert red.reason is not None
+    assert red.text != red.reason
+    assert len(red.text) <= 45  # ui.chip carries 41 characters today
+    assert "fix" not in red.text.lower()  # the old wording named a fix that may not exist
+
+    amber = _validate_status([{"type": "http_attachment", "message": "x"}])
+    assert amber.colour == "amber"
+    assert amber.reason is None
+
+    assert _validate_status([]).colour == "green"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -644,7 +644,7 @@ def test_validate_status_three_states() -> None:
     assert red.colour == "red"
     assert red.reason is not None
     assert red.text != red.reason
-    assert len(red.text) <= 45  # ui.chip carries 41 characters today
+    assert len(red.text) <= 45  # the shipped chip is 39; the longest other is 41
     assert "fix" not in red.text.lower()  # the old wording named a fix that may not exist
 
     amber = _validate_status([{"type": "http_attachment", "message": "x"}])

--- a/tests/test_gui_export_task.py
+++ b/tests/test_gui_export_task.py
@@ -39,33 +39,6 @@ DISCORD_TOKEN = ".".join(("MTIzNDU2Nzg5MDEyMzQ1Njc4", "GhIjKl", "abcdefghijklmno
 STOAT_TOKEN = "SEKRET-stoat-token-abcd"  # noqa: S105
 
 
-@pytest.fixture
-def user_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
-    """A writable stand-in for `app.storage.user`.
-
-    The real property is request-scoped (it reads a contextvar and a session
-    cookie), so a test body cannot seed it from outside a request. The page code
-    under test only ever treats it as a mapping.
-    """
-    store: dict[str, object] = {}
-    monkeypatch.setattr("nicegui.storage.Storage.user", property(lambda self: store), raising=False)
-    return store
-
-
-@pytest.fixture
-def tab_store(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
-    """A writable stand-in for `app.storage.tab`.
-
-    The real property raises unless a connected client is resolvable from the
-    current task's slot stack -- which a test body does not have. That is the
-    very constraint this fix exists to respect, so the page code must still see
-    a plain mapping.
-    """
-    store: dict[str, object] = {}
-    monkeypatch.setattr("nicegui.storage.Storage.tab", property(lambda self: store), raising=False)
-    return store
-
-
 def _seed_orchestrated_session(store: dict[str, object], export_dir: Path) -> None:
     """Put the user store into the state /export expects."""
     store.update(

--- a/tests/test_gui_validate_ack.py
+++ b/tests/test_gui_validate_ack.py
@@ -1,0 +1,91 @@
+"""The acknowledgement gate on /validate (issue #143).
+
+An earlier draft of this design claimed a NiceGUI page closure cannot be
+reached from a test, and made this a manual check. That was wrong:
+conftest.py registers nicegui.testing.user_plugin and nicegui_app.py
+re-registers the routes. Getting that wrong would have left the entire
+user-visible fix uncovered, which is how the one-click export in #123 shipped
+dead for eleven releases.
+
+Both states are asserted, disabled before the tick and enabled after, because
+`bind_enabled_from` propagates at bind time. A binding that does not work
+leaves Start Migration disabled forever, which is #143 reproduced by the fix
+for #143, and only the second half of that pair can see it.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from nicegui.testing import User
+
+pytestmark = pytest.mark.nicegui_main_file("tests/nicegui_app.py")
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _seed_export(store: dict[str, object], tmp_path: Path, fixture: str) -> Path:
+    """Copy one DCE fixture into its own directory and point the session at it.
+
+    A dedicated subdirectory, never tmp_path itself: the autouse logging fixture
+    puts ferry.log there, and an export directory should hold export files only.
+    """
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    shutil.copy(FIXTURES_DIR / fixture, export_dir / "channel.json")
+    store["export_dir"] = str(export_dir)
+    store["stoat_url"] = "https://example.invalid"
+    return export_dir
+
+
+async def test_start_migration_is_blocked_until_acknowledged(
+    user: User, user_store: dict[str, object], tmp_path: Path
+) -> None:
+    """Killing: a checkbox that is never created, a binding that is never made
+    (which leaves the button dead forever, reproducing #143 with the fix for
+    #143), a binding wired backwards, and a gui.py that keeps its own inline
+    type check instead of calling the shared classifier.
+    """
+    _seed_export(user_store, tmp_path, "markdown_rendered.json")
+
+    await user.open("/validate")
+
+    # The classifier's own sentence must be on screen. This is what pins the
+    # GUI to acknowledgement_required rather than to a second inline check.
+    await user.should_see("will arrive as text")
+    # The consequence phrase alone is not enough: the per-file warning row
+    # inside the Warnings expansion shares it, so that assertion passes even
+    # with no reason label at all. Only acknowledgement_required's return value
+    # counts the files, so this fragment is the one that pins the shared
+    # classifier to the screen.
+    await user.should_see("export file(s) have mentions")
+
+    button = user.find("Start Migration").elements.pop()
+    assert button.enabled is False, (
+        "Start Migration should start disabled while the warning is unacknowledged"
+    )
+
+    user.find("I understand").click()
+    assert button.enabled is True, (
+        "ticking the acknowledgement must enable Start Migration; a binding that "
+        "does not propagate leaves the user in the #143 dead end"
+    )
+
+
+async def test_a_clean_export_needs_no_acknowledgement(
+    user: User, user_store: dict[str, object], tmp_path: Path
+) -> None:
+    """Killing: a checkbox created unconditionally, which would make every user
+    tick a box to migrate a perfectly good export.
+    """
+    _seed_export(user_store, tmp_path, "simple_channel.json")
+
+    await user.open("/validate")
+
+    assert user.find("Start Migration").elements.pop().enabled is True
+    await user.should_not_see("I understand")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,12 +12,16 @@ from discord_ferry.parser.dce_parser import (
     _parse_guild,
     _parse_message,
     _parse_reaction,
+    _raw_form_present,
     check_cdn_url_expiry,
+    message_has_rendered_mention,
     parse_export_directory,
     parse_single_export,
     validate_export,
 )
 from discord_ferry.parser.models import DCEExport, DCEMessage, DCEReaction
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 # ---------------------------------------------------------------------------
 # Parsing — parse_single_export
@@ -390,6 +394,155 @@ def test_validate_detects_rendered_markdown(fixtures_dir: Path) -> None:
     warnings = validate_export(exports, fixtures_dir)
     types = [w["type"] for w in warnings]
     assert "rendered_markdown" in types
+
+
+NOT_RENDERED_DIR = FIXTURES_DIR / "mentions_not_rendered"
+RENDERED_MULTI_DIR = FIXTURES_DIR / "markdown_rendered_multi"
+
+
+def test_validate_ignores_mentions_that_were_not_rendered() -> None:
+    """A reply, an embed-carried mention and an attachment-only message all have
+    a non-empty `mentions` array and no raw `<@` in content, so the OLD rule
+    flagged every one of them. None is evidence of an export made without
+    --markdown false. This is issue #143: one such message condemned a whole
+    channel and left the GUI with no way forward.
+
+    Killing: the old rule (mentions non-empty and no <@ in content)."""
+    exports = parse_export_directory(NOT_RENDERED_DIR)
+    warnings = validate_export(exports, NOT_RENDERED_DIR)
+    assert [w for w in warnings if w["type"] == "rendered_markdown"] == []
+
+
+_ALICE = {"id": "400000000000000001", "name": "alice", "nickname": "Alice"}
+_BOB = {"id": "400000000000000002", "name": "bob", "nickname": "Bob"}
+_EVERYONE = {"id": "400000000000000005", "name": "everyone", "nickname": "Everyone"}
+
+
+@pytest.mark.parametrize(
+    ("content", "mentions", "expected", "kills"),
+    [
+        ("Hey @Alice, check out #general!", [_ALICE], True, "a rule that never fires"),
+        (
+            "Hey <@400000000000000001>! cc @Alice",
+            [_ALICE],
+            False,
+            "_raw_form_present returning a constant False, or step 2 deleted",
+        ),
+        (
+            "Hey <@!400000000000000001>! cc @Alice",
+            [_ALICE],
+            False,
+            "a raw-form check that only knows <@id>",
+        ),
+        (
+            "<@400000000000000001> and @Bob",
+            [_ALICE, _BOB],
+            True,
+            "a per-MESSAGE raw check, which would clear the whole message",
+        ),
+        ("Sure, that works", [_ALICE], False, "the old rule"),
+        ("", [_BOB], False, "the old rule"),
+        (
+            "cc @Bobby, I meant @Bob",
+            [_BOB],
+            True,
+            "a single str.find, which stops at the first rejected occurrence",
+        ),
+        ("cc @Bobby about it", [_BOB], False, "no trailing check"),
+        (
+            "cc @Bob_smith about it",
+            [_BOB],
+            False,
+            "_is_word_char dropping the underscore arm",
+        ),
+        (
+            "mail me at someone@Bob.io",
+            [_BOB],
+            False,
+            "checking only the character AFTER the candidate",
+        ),
+        (
+            "@Bob look at this",
+            [_BOB],
+            True,
+            "a leading check that requires a preceding character to exist",
+        ),
+        (
+            "thanks @Bob",
+            [_BOB],
+            True,
+            "a trailing check that requires a following character to exist",
+        ),
+        (
+            "@everyone please read",
+            [_EVERYONE],
+            False,
+            "a case-insensitive match, or using name as a SECOND candidate",
+        ),
+        (
+            "hi @alice",
+            [{"id": "1", "name": "alice"}],
+            True,
+            "direct subscripting of the mention dict",
+        ),
+        (
+            "hi @Alice there",
+            [{"id": "1", "nickname": "  Alice  "}],
+            True,
+            "using the raw value, which would look for '@  Alice  '",
+        ),
+        (
+            "hi @ there",
+            [{"id": "1", "name": "", "nickname": "   "}],
+            False,
+            "no empty-candidate guard, which makes '@' alone a match",
+        ),
+        ("ping @Unknown please", [], True, "a rule that only ever consults the mentions array"),
+        ("the @Unknowns are a band", [], False, "a bare substring test for @Unknown"),
+        (
+            "what does @Unknown mean? <@400000000000000001>",
+            [_ALICE],
+            False,
+            "running the @Unknown test BEFORE the mention loop",
+        ),
+        (
+            "@here see <@400000000000000001>",
+            [_ALICE],
+            False,
+            "treating any at-sign token as a rendered mention",
+        ),
+        (
+            "the file /home/@Bob/x is here",
+            [_BOB],
+            True,
+            "NOTHING. Known residual: '/' is not a word character, so no boundary "
+            "check can tell a path from a mention after a bracket. Requiring "
+            "whitespace before '@' would fix it and break '(@Alice)', which is what "
+            "DCE renders for '(<@1>)'.",
+        ),
+        (
+            "Sure @Alice, that works",
+            [_ALICE],
+            True,
+            "NOTHING. Known residual: in a RAW export, a body that types a name as "
+            "plain text while that person is also the reply target is "
+            "indistinguishable from the true positive.",
+        ),
+    ],
+)
+def test_message_has_rendered_mention(
+    content: str, mentions: list[dict[str, str]], expected: bool, kills: str
+) -> None:
+    """Ported from the design prototype, where 41 of 43 mutants die against this
+    set. `kills` names the wrong implementation each row catches; rows saying
+    NOTHING are pinned known residuals, kept so they stay visible."""
+    assert message_has_rendered_mention(content, mentions) is expected, kills
+
+
+def test_raw_form_present_ignores_an_empty_id() -> None:
+    """Killing: dropping _raw_form_present's empty-id guard, which makes the
+    literal '<@>' read as raw evidence and suppress a genuine warning."""
+    assert _raw_form_present("see <@> and @Bob", "") is False
 
 
 def test_validate_detects_http_urls(fixtures_dir: Path) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -413,6 +413,22 @@ def test_validate_ignores_mentions_that_were_not_rendered() -> None:
     assert [w for w in warnings if w["type"] == "rendered_markdown"] == []
 
 
+def test_validate_counts_every_rendered_message_not_just_the_first() -> None:
+    """The old rule set markdown_warned=True on the first hit, so a user was told
+    an export was critical without being told how widespread it was. Three
+    messages out of a thousand and nine hundred out of a thousand looked
+    identical.
+
+    Killing: first-occurrence-only behaviour, and any implementation that takes
+    a message list, which reports ZERO on the engine's streaming path."""
+    exports = parse_export_directory(RENDERED_MULTI_DIR, metadata_only=True)
+    warnings = validate_export(exports, RENDERED_MULTI_DIR)
+    hits = [w for w in warnings if w["type"] == "rendered_markdown"]
+    assert len(hits) == 1
+    assert hits[0]["count"] == "2"
+    assert "2 message(s)" in hits[0]["message"]
+
+
 _ALICE = {"id": "400000000000000001", "name": "alice", "nickname": "Alice"}
 _BOB = {"id": "400000000000000002", "name": "bob", "nickname": "Bob"}
 _FLOWER = {"id": "400000000000000003", "name": "ali", "nickname": "Alice 🌸"}
@@ -542,9 +558,9 @@ _EVERYONE = {"id": "400000000000000005", "name": "everyone", "nickname": "Everyo
 def test_message_has_rendered_mention(
     content: str, mentions: list[dict[str, str]], expected: bool, kills: str
 ) -> None:
-    """Ported from the design prototype, where 41 of 43 mutants die against this
-    set. `kills` names the wrong implementation each row catches; rows saying
-    NOTHING are pinned known residuals, kept so they stay visible."""
+    """Ported from the design prototype. `kills` names the wrong implementation
+    each row catches; rows saying NOTHING are pinned known residuals, kept so
+    they stay visible."""
     assert message_has_rendered_mention(content, mentions) is expected, kills
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -421,14 +421,35 @@ def test_validate_counts_every_rendered_message_not_just_the_first() -> None:
     messages out of a thousand and nine hundred out of a thousand looked
     identical.
 
-    Killing: first-occurrence-only behaviour, and any implementation that takes
-    a message list, which reports ZERO on the engine's streaming path."""
+    Two exports, not one. With a single export in the directory, a counter
+    declared above `for export in exports:` instead of inside it would still
+    report "2" and pass every assertion here, while accumulating across channels
+    in the field. The second channel's count pins the counter's scope.
+
+    The consequence phrase is asserted through the constant, not as a literal.
+    A hand-written copy at the interpolation site in dce_parser.py would leave
+    every other assertion green while opening the wording drift the constant
+    exists to prevent.
+
+    Killing: first-occurrence-only behaviour; a per-directory counter; any
+    implementation that takes a message list, which reports ZERO on the engine's
+    streaming path; a consequence phrase written out by hand."""
     exports = parse_export_directory(RENDERED_MULTI_DIR, metadata_only=True)
     warnings = validate_export(exports, RENDERED_MULTI_DIR)
     hits = [w for w in warnings if w["type"] == "rendered_markdown"]
-    assert len(hits) == 1
-    assert hits[0]["count"] == "2"
-    assert "2 message(s)" in hits[0]["message"]
+    assert len(hits) == 2
+
+    # Key by channel name, not by list position: the row order follows the
+    # channel-name sort in parse_export_directory, which is not this test's
+    # subject.
+    by_channel = {w["message"].split("'")[1]: w for w in hits}
+    assert set(by_channel) == {"rendered-multi", "rendered-multi-b"}
+    assert by_channel["rendered-multi"]["count"] == "2"
+    assert by_channel["rendered-multi-b"]["count"] == "1"
+    assert "2 message(s)" in by_channel["rendered-multi"]["message"]
+    assert "1 message(s)" in by_channel["rendered-multi-b"]["message"]
+    for hit in hits:
+        assert RENDERED_MENTION_CONSEQUENCE in hit["message"]
 
 
 _ALICE = {"id": "400000000000000001", "name": "alice", "nickname": "Alice"}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -656,6 +656,20 @@ def test_acknowledgement_required_sums_across_files() -> None:
     assert RENDERED_MENTION_CONSEQUENCE in reason
     assert acknowledgement_required([]) is None
 
+    # A rendered_markdown row among other types: the file count must report the
+    # ACKNOWLEDGEABLE rows, not every warning. The http_attachment row carries a
+    # count it has no business carrying, so a total summed over all warnings
+    # instead of over the hits is caught here too.
+    mixed = acknowledgement_required(
+        [
+            {"type": "http_attachment", "count": "9", "message": "a"},
+            {"type": "rendered_markdown", "count": "2", "message": "b"},
+            {"type": "empty_export", "message": "c"},
+        ]
+    )
+    assert mixed is not None
+    assert "2 message(s) across 1 export file(s)" in mixed
+
 
 @pytest.mark.parametrize(
     "bad", [{"type": "rendered_markdown", "count": "lots"}, {"type": "rendered_markdown"}]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from discord_ferry.parser.dce_parser import (
+    RENDERED_MENTION_CONSEQUENCE,
     _coerce_channel_type,
     _infer_thread_info,
     _parse_author,
@@ -13,6 +14,7 @@ from discord_ferry.parser.dce_parser import (
     _parse_message,
     _parse_reaction,
     _raw_form_present,
+    acknowledgement_required,
     check_cdn_url_expiry,
     message_has_rendered_mention,
     parse_export_directory,
@@ -617,6 +619,53 @@ def test_validate_no_warnings_clean(fixtures_dir: Path, tmp_path: Path) -> None:
     exports = parse_export_directory(temp_dir)
     warnings = validate_export(exports, temp_dir)
     assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Acknowledgement classifier: acknowledgement_required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "warning_type",
+    ["http_attachment", "empty_export", "expired_cdn_url", "channel_limit", "emoji_limit"],
+)
+def test_acknowledgement_not_required_for_other_warning_types(warning_type: str) -> None:
+    """Spec S1.4: no warning type other than rendered_markdown may gate the
+    button, before or after.
+
+    Killing: a classifier that gates on any warning, and a widened
+    _ACKNOWLEDGEABLE_TYPES. Parametrizing over the real other five pins the
+    BEHAVIOUR; asserting the frozenset's contents by equality would only detect
+    change."""
+    assert acknowledgement_required([{"type": warning_type, "message": "x"}]) is None
+
+
+def test_acknowledgement_required_sums_across_files() -> None:
+    """Killing: a classifier that never fires, one that reports only the first
+    warning's count, and one that raises on a missing or non-numeric count."""
+    reason = acknowledgement_required(
+        [
+            {"type": "rendered_markdown", "count": "2", "message": "x"},
+            {"type": "rendered_markdown", "count": "1", "message": "y"},
+        ]
+    )
+    assert reason is not None
+    assert "3 message(s)" in reason
+    assert "2 export file(s)" in reason
+    assert RENDERED_MENTION_CONSEQUENCE in reason
+    assert acknowledgement_required([]) is None
+
+
+@pytest.mark.parametrize(
+    "bad", [{"type": "rendered_markdown", "count": "lots"}, {"type": "rendered_markdown"}]
+)
+def test_acknowledgement_required_tolerates_a_broken_count(bad: dict[str, str]) -> None:
+    """This runs while a GUI page is rendering. A bare int() or a bare subscript
+    would raise there.
+
+    Killing: int(w["count"]) without a guard."""
+    assert acknowledgement_required([bad]) is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -415,6 +415,8 @@ def test_validate_ignores_mentions_that_were_not_rendered() -> None:
 
 _ALICE = {"id": "400000000000000001", "name": "alice", "nickname": "Alice"}
 _BOB = {"id": "400000000000000002", "name": "bob", "nickname": "Bob"}
+_FLOWER = {"id": "400000000000000003", "name": "ali", "nickname": "Alice 🌸"}
+_PRONOUNS = {"id": "400000000000000004", "name": "cas", "nickname": "Bob (he/him)"}
 _EVERYONE = {"id": "400000000000000005", "name": "everyone", "nickname": "Everyone"}
 
 
@@ -442,6 +444,13 @@ _EVERYONE = {"id": "400000000000000005", "name": "everyone", "nickname": "Everyo
         ),
         ("Sure, that works", [_ALICE], False, "the old rule"),
         ("", [_BOB], False, "the old rule"),
+        (
+            "hi @Alice 🌸!",
+            [_FLOWER],
+            True,
+            r"a \b boundary, which cannot match after a non-word character",
+        ),
+        ("thanks @Bob (he/him).", [_PRONOUNS], True, r"a \b boundary"),
         (
             "cc @Bobby, I meant @Bob",
             [_BOB],

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.0"
+version = "2.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #143.

`Sector-7-Dev1` reported that Ferry refuses to migrate and offers no way to proceed. They were right on every point, including the parts that read like user error.

## What was wrong

**The GUI had a terminal state.** `Start Migration` is the only route to `/migrate` anywhere in `gui.py`, and it was disabled outright whenever the export carried a `rendered_markdown` warning. Back, or close the app. No advanced setting re-enabled it.

**The check that raised the warning was far broader than the defect it names.** It flagged any message with a non-empty `mentions` array and no raw `<@` in its content. A reply, a mention carried inside an embed, and an attachment-only message all satisfy that, so one message in a thousand condemned a whole channel. The reporter re-exported, which is what the docs said to do, and nothing changed.

**The asymmetry was the real defect.** `ferry migrate` never consulted this warning: the engine appends it to `state.warnings` and continues. So the same export migrated fine on the CLI and could not be migrated at all in the GUI. `docs/guides/gui-walkthrough.md` already documented that only a missing-JSON error should disable the button, so the docs and the code had disagreed since the check was written.

## What changed

- An acknowledgement in the validate screen enables the button. The decision lives in a module-level classifier, not in the page closure, and a page test drives the real page: disabled, tick, enabled.
- The check now flags a message only when a mention's display form appears in the content as a whole token while its raw form does not, or when the content carries `@Unknown`, which is what DiscordChatExporter writes for a member it could not resolve. It reports a count per export file instead of stopping at the first hit.
- The GUI banner, the GUI warning rows and `ferry validate` share one consequence phrase held in a single constant. `ferry validate` still exits 1.
- Three docs pages now match the shipped behaviour, and `troubleshooting.md` qualifies the re-export advice that failed the reporter.

## How it was verified

Built by subagent-driven development, ten tasks, each with a fresh implementer and a fresh-context review.

The design went through four critique rounds. Rounds 1 and 2 reviewed prose and each one introduced a defect while fixing the previous round's, so round 3 audited a **runnable prototype** instead. It mutation-tested it and **8 of 14 mutants survived**, including one where the count reported zero on the engine's streaming path while being perfectly correct in memory. The prototype now carries 48 checks, each naming the wrong implementation it kills, and the shipped tests are ported from it.

Every mutation named in the plan was observed red and restored: removing the button binding, emptying the classifier's type set, adding a gate to the engine, hoisting the counter above the per-export loop, and swapping the CLI's exit code.

1637 tests pass. A whole-branch review returned SAFE TO MERGE after checking packaging (no new third-party import, versions consistent, `uv lock --check` clean, `mkdocs build --strict` green), import direction (`discord_ferry.cli` pulls in no NiceGUI), and driving the real GUI page including the acknowledge, Back, return path.

## Deferred follow-ups

1. `tests/test_gui_validate_ack.py` emits the suite's only warning, `coroutine 'Outbox.loop' was never awaited`, from NiceGUI teardown.
2. `docs/reference/architecture.md:351` and `:624`, and `docs/reference/dce-format.md:22`, still frame the check as purely a missing `--markdown false` detector. Imprecise now rather than wrong.
3. The warning dict has no `channel` key, so a test parses the channel name back out of the message prose. Adding a key ripples through several consumers.
4. The verify command in `CLAUDE.md` is `uv run ... pytest`, which fails two tests on a venv without `--extra native`, while CI installs both extras.
5. `test_version_is_read_from_module_attribute_not_package_metadata` fails if any NiceGUI page-test module is collected first. Pre-existing, hidden by alphabetical ordering, would fire under a random-order plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
