### PR TITLE
content: ignore the local instruction layer's ADRs and deferral checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ claude_log/
 
 # Internal design docs (kept locally, not in public repo)
 docs/plans/
+docs/architecture/
+scripts/check-deferral-fields.sh
 docs/superpowers/
 # Subagent-driven-development workspace: ledgers, briefs, per-task reports.
 # Scratch for one branch's build, never part of the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `docs/architecture/` and `scripts/check-deferral-fields.sh` are now gitignored, joining
+  `.claude/`, `CLAUDE.md` and `docs/plans/`. Both hold the local development instruction
+  layer rather than anything the tool ships, and both are backed up outside this repo.
+
 ## [2.14.1] - 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds two paths to `.gitignore`, both part of this project's local development
setup rather than anything the tool ships:

- `docs/architecture/` — architecture decision records for the local workflow
- `scripts/check-deferral-fields.sh` — read by a local git hook

`.gitignore` already covers `.claude/`, `CLAUDE.md` and `docs/plans/` for the
same reason. These two were newer and had not been added. Both are backed up
outside this repo.

No product code changes.

## Verification

```
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

All pass: 1637 tests, 0 lint errors, 0 type errors.

Also confirmed no untracked, un-ignored path remains that would reach the
public repo:

```
git status --porcelain | grep '^??'   # empty
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
