### PR TITLE
fix: probe --json emits parseable output, and the release.yml guards can fail (v2.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.2] - 2026-08-10
+
+### Fixed
+
+- `ferry probe --json` could print output that a JSON parser rejects. The payload went
+  through the module-level Rich console, which has `soft_wrap=False` and falls back to
+  80 columns when stdout is not a terminal. Rich wraps prose at the nearest space and
+  has no idea it is holding JSON, so the inserted newline could land inside a string
+  value. It now prints through `click.echo`, which does not wrap. `probe --json` is the
+  only `--json` path in the CLI, so no other command had the same shape.
+
+  The existing test passed an empty probe report, whose payload is far under 80 columns
+  and so never wrapped. The new test uses a realistic four-check report and parses stdout.
+
 ### Changed
+
+- The four `release.yml` structural tests in `tests/test_packaging.py` now assert that
+  each guarded branch reaches its `exit 1`, rather than only that the condition text is
+  present. A condition is not an assertion: deleting the `exit 1` turns the gate into a
+  warning that never fails a build, and all four tests stayed green through exactly that
+  change. Each now slices a bounded region after its own condition, so it stays tied to
+  its own branch among the workflow's dozen-plus `exit 1` lines. Verified by removing the
+  `exit 1` from each of the four branches in turn and confirming the matching test fails.
 
 - `docs/architecture/` and `scripts/check-deferral-fields.sh` are now gitignored, joining
   `.claude/`, `CLAUDE.md` and `docs/plans/`. Both hold the local development instruction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.1"
+version = "2.14.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.1"
+__version__ = "2.14.2"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1345,7 +1345,11 @@ def probe_cmd(
 
     if as_json:
         payload = {c.name: {"status": c.status, "detail": c.detail} for c in report.checks}
-        console.print(json.dumps(payload))
+        # click.echo, not console.print: the module-level Console has soft_wrap=False
+        # and falls back to 80 columns off a terminal, so it inserts a real newline
+        # wherever the wrap lands -- including inside a string value, which makes the
+        # output unparseable (issue #145). This branch is not for a human to read.
+        click.echo(json.dumps(payload))
         return
 
     table = Table(title="Stoat Probe Results")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -838,6 +838,69 @@ def test_probe_writes_notices_to_stderr_under_json(runner: CliRunner, proxy_env,
     assert "cannot use" in result.stderr  # the human gets told
 
 
+def test_probe_json_stdout_survives_a_realistic_payload(runner: CliRunner) -> None:
+    """Issue #145. `--json` promises machine-readable output, so stdout must parse.
+
+    The sibling test above passes an empty ProbeReport, whose payload is far under
+    80 columns and so never wrapped. That is exactly why this shipped unnoticed.
+    Killing: printing the payload through the module-level Rich console, which has
+    soft_wrap=False and falls back to 80 columns off a terminal, inserting a real
+    newline wherever the wrap lands -- often inside a `", "` separator.
+    """
+    import json as json_mod
+
+    from discord_ferry.migrator.probe import ProbeCheck, ProbeReport
+
+    report = ProbeReport(
+        checks=[
+            ProbeCheck(
+                name="autumn_limits",
+                status="ok",
+                detail="attachments 20000000, avatars 4000000, banners 6000000 from limits",
+            ),
+            ProbeCheck(
+                name="rate_window",
+                status="ok",
+                detail="X-RateLimit-Reset-After reported in milliseconds, bucket /servers, limit 5",
+            ),
+            ProbeCheck(
+                name="voice_channel",
+                status="warn",
+                detail="voice channel creation returned 200 but the channel type came back as Text",
+            ),
+            ProbeCheck(
+                name="webhooks",
+                status="ok",
+                detail="webhook created, executed and deleted against the throwaway server",
+            ),
+        ]
+    )
+
+    with patch(
+        "discord_ferry.migrator.probe.run_probe",
+        AsyncMock(return_value=report),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "probe",
+                "--json",
+                "--stoat-url",
+                "https://api.test",
+                "--token",
+                "t",
+                "--test-server-id",
+                "srv1",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    payload = json_mod.loads(result.stdout)
+    assert payload["voice_channel"]["status"] == "warn"
+    assert payload["autumn_limits"]["detail"].startswith("attachments 20000000")
+
+
 def test_no_create_invite_flag_threads_to_config(runner: CliRunner) -> None:
     mock_engine = _make_mock_engine()
     with patch("discord_ferry.cli.run_migration", mock_engine):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -21,6 +21,34 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DARWIN_BRANCH = '\nif sys.platform == "darwin":'
 
 
+def _fails_the_build_after(text: str, anchor: str, terminator: str) -> bool:
+    """True when `exit 1` appears between `anchor` and the `terminator` that closes its block.
+
+    Issue #146. A condition is not an assertion. The four release.yml guards below
+    used to anchor only on the condition text, so deleting the `exit 1` from the
+    branch body -- the single most likely way the gate gets weakened -- left every
+    one of them green while the workflow stopped failing the build. Measured, not
+    assumed: with one `exit 1` removed the whole group still passed.
+
+    The region is bounded by the block's own closing token, not by a character count.
+    `release.yml` carries seventeen `exit 1` lines, so a region that runs past the end
+    of its block would find the NEXT gate's exit and pass even with its own deleted --
+    the same vacuous shape this test exists to prevent. A fixed span cannot be right in
+    both directions: the Windows union branch already sat 272 characters from its exit,
+    so any budget loose enough to survive one added log line was also loose enough to
+    reach the following branch.
+
+    `terminator` is the block's closing token: the `}` at the step's indent for the
+    PowerShell `if` blocks, and `esac` for the bash `case` statements, whose `exit 1`
+    lives in the `*)` fallback rather than in the matched arm.
+    """
+    idx = text.find(anchor)
+    assert idx != -1, f"anchor not found in release.yml: {anchor!r}"
+    end = text.find(terminator, idx)
+    assert end != -1, f"terminator {terminator!r} not found after anchor {anchor!r}"
+    return "exit 1" in text[idx:end]
+
+
 def test_ferry_spec_bundles_dce_checksums() -> None:
     """ferry.spec must bundle dce_checksums.json into the frozen binary.
 
@@ -202,6 +230,9 @@ def test_release_workflow_asserts_the_union_branch_on_macos() -> None:
     assert "Contents/MacOS/Ferry" in macos_block, (
         "it must run the extracted bundle's inner binary, so the ditto round-trip is covered"
     )
+    assert _fails_the_build_after(macos_block, '*"trust-source: union"*', "esac"), (
+        "the union case must reach an exit 1, not merely echo an ::error:: and continue"
+    )
 
 
 def test_release_workflow_asserts_the_union_branch() -> None:
@@ -220,6 +251,9 @@ def test_release_workflow_asserts_the_union_branch() -> None:
     assert re.search(r"trust-source:\\s\*union", text), (
         "release.yml must assert the union branch, not merely mention trust-source"
     )
+    assert _fails_the_build_after(text, "-notmatch 'trust-source:\\s*union'", "\n          }"), (
+        "the Windows union branch must reach an exit 1, not merely write an ::error:: line"
+    )
 
 
 def test_release_workflow_asserts_the_proxy_keys() -> None:
@@ -231,3 +265,9 @@ def test_release_workflow_asserts_the_proxy_keys() -> None:
     text = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     assert re.search(r"proxy-source:\\s\*", text), "the Windows regex must assert, not mention"
     assert re.search(r'\*"proxy-source: "\*', text), "the macOS glob must assert"
+    assert _fails_the_build_after(text, "-notmatch 'proxy-source:\\s*'", "\n          }"), (
+        "the Windows proxy-key branch must reach an exit 1"
+    )
+    assert _fails_the_build_after(text, '*"proxy-source: "*', "esac"), (
+        "the macOS proxy-key case must reach an exit 1"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.1"
+version = "2.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Two independent fixes, both raised by the v2.14.x whole-branch reviews and verified against source before touching anything.

## #145: `probe --json` could emit output a JSON parser rejects

The payload went through the module-level Rich `Console()`, which has `soft_wrap=False` and falls back to 80 columns when stdout is not a terminal. Rich wraps prose at the nearest space and has no idea it is holding JSON, so the newline it inserts can land inside a string value.

Reproduced with a realistic four-check report. The wrap landed at column 77, mid-value:

```
"detail": "attachments 20000000, avatars \n4000000, banners 6000000 from limits"
```

`json.loads` fails with `Invalid control character at: line 1 column 77`.

Now printed with `click.echo`, which does not wrap. `probe --json` is the only `--json` path in the CLI, so no other command shares the shape.

**Why it went unnoticed:** the existing test passed an empty `ProbeReport`, whose payload is far under 80 columns and so never wrapped. The new test uses a realistic report and parses stdout.

## #146: four release.yml guard tests could not detect the gate being disabled

`tests/test_packaging.py` carries four tests whose stated purpose is to stop the release smoke checks being weakened. Each anchored only on its condition text, for example the regex `trust-source:\s*union`. A condition is not an assertion: the thing that fails the build is the `exit 1` in the branch body.

Measured rather than argued. With the `exit 1` removed from the Windows union branch and the condition left untouched, all five tests in the group still passed.

Each test now slices the region between its condition and that block's closing token, then asserts `exit 1` appears inside.

**On the boundary choice:** a fixed character budget was tried first and rejected during review. `release.yml` carries seventeen `exit 1` lines, and the Windows union branch already sat 272 characters from its own exit. Any budget loose enough to survive one added log line was also loose enough to reach the following branch's exit, which would make the test pass with its own deleted. That is precisely the vacuous shape these tests exist to prevent. The region is now bounded by the block's own terminator: `}` at the step indent for the PowerShell blocks, `esac` for the bash `case` statements, whose `exit 1` lives in the `*)` fallback rather than the matched arm.

**Verification:** the `exit 1` was removed from each of the four branches in turn, and the matching test confirmed red each time. `release.yml` was then restored byte-for-byte, checked with `git diff`.

```
CAUGHT   windows union      -> test_release_workflow_asserts_the_union_branch
CAUGHT   windows proxy key  -> test_release_workflow_asserts_the_proxy_keys
CAUGHT   macos union        -> test_release_workflow_asserts_the_union_branch_on_macos
CAUGHT   macos proxy key    -> test_release_workflow_asserts_the_proxy_keys
```

`release.yml` itself is unchanged by this PR.

## Verification

- `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest`
- 1638 passed, up from 1637. The single warning is the known #152 deferral, not new.
- Version bumped 2.14.1 to 2.14.2 across `pyproject.toml`, `__init__.py`, `CHANGELOG.md` and `uv.lock`.
- Second opinion (Mistral, code-reviewer): zero findings. The substantive catch this round was the fixed-span weakness, found in inline review.

Closes #145
Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkHteonqfTKhfVVcuY4fkT
