### PR TITLE
fix: a second migration into an existing output directory no longer crashes on Windows (v2.14.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,4 @@ jobs:
         run: uv sync --locked --extra dev --extra native
 
       - name: Run the state and metadata suites
-        # `uv run` resolves independently of `uv sync`, so the extras are named
-        # again on purpose.
-        run: uv run --extra dev --extra native pytest tests/test_state.py tests/test_metadata.py -v
+        run: uv run pytest tests/test_state.py tests/test_metadata.py -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,32 @@ jobs:
       - name: Run contract + replay tests
         run: uv run pytest tests/test_dce_contract.py tests/test_dce_output_replay.py -v
 
+
+  windows-atomic-write:
+    name: Atomic writes on Windows
+    # The rest of CI is ubuntu-only, so nothing here has ever executed on Win32.
+    # Issue #172 was an os.rename that refuses an existing destination there and
+    # replaces it everywhere else, which no Linux runner can see. It reached a
+    # user instead of a test.
+    #
+    # Two named files rather than the whole suite: #174 tracks the full leg and
+    # is blocked on triaging an unknown number of unrelated first-run failures.
+    # Naming two files sidesteps that blocker and covers what this code touches.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --locked --extra dev --extra native
+
+      - name: Run the state and metadata suites
+        # `uv run` resolves independently of `uv sync`, so the extras are named
+        # again on purpose.
+        run: uv run --extra dev --extra native pytest tests/test_state.py tests/test_metadata.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.4] - 2026-08-11
+
+### Fixed
+
+- Running a migration a second time into an output directory Ferry had already
+  written to crashed on Windows with `[WinError 183]`, at the first checkpoint
+  save. This hit resume, `--incremental`, and any run that reused an existing
+  export, so a Windows user who ran Ferry twice into the same folder lost the
+  migration and could not resume. The three writers that finish an atomic write
+  now overwrite an existing destination on Windows, as they always did on macOS
+  and Linux (#172).
+
+### Changed
+
+- CI now runs the state and metadata test suites on Windows. Nothing in this
+  project's tests had ever executed on Windows, which is why #172 reached a user
+  rather than a test run (#174).
+
 ## [2.14.3] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- Running a migration a second time into an output directory Ferry had already
-  written to crashed on Windows with `[WinError 183]`, at the first checkpoint
-  save. This hit resume, `--incremental`, and any run that reused an existing
-  export, so a Windows user who ran Ferry twice into the same folder lost the
-  migration and could not resume. The three writers that finish an atomic write
-  now overwrite an existing destination on Windows, as they always did on macOS
-  and Linux (#172).
+- Migrations crashed on Windows with `[WinError 183]` at a checkpoint save. Ferry
+  saves its checkpoint at every phase boundary and every 50 messages, writing to
+  a temporary file and then swapping it over the previous one. That swap used a
+  call that replaces the destination on macOS and Linux but refuses it on
+  Windows, so the save died as soon as a checkpoint file already existed. A run
+  into a fresh folder got as far as its second save, inside the server and
+  channel phase; a run into a folder Ferry had already written to, which is what
+  resume, `--incremental` and reusing an existing export all do, died at the
+  first. Either way the migration ended early and could not be resumed. The
+  three affected writers now overwrite on Windows as they always did elsewhere
+  (#172).
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.3"
+version = "2.14.4"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.3"
+__version__ = "2.14.4"

--- a/src/discord_ferry/discord/metadata.py
+++ b/src/discord_ferry/discord/metadata.py
@@ -70,7 +70,8 @@ def save_discord_metadata(meta: DiscordMetadata, output_dir: Path) -> None:
     tmp_path = output_dir / "discord_metadata.json.tmp"
     final_path = output_dir / "discord_metadata.json"
     tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    tmp_path.rename(final_path)
+    # replace, not rename: see state.py and issue #172.
+    tmp_path.replace(final_path)
 
 
 def load_discord_metadata(output_dir: Path) -> DiscordMetadata | None:

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -199,8 +199,10 @@ def save_state(state: MigrationState, output_dir: Path) -> None:
     mm_tmp = output_dir / "message_map.json.tmp"
     mm_final = output_dir / "message_map.json"
     mm_tmp.write_text(json.dumps(message_map, indent=2), encoding="utf-8")
-    # replace, not rename: os.rename refuses an existing destination on Windows,
-    # so every second run into an existing output directory died here (#172).
+    # replace, not rename: os.rename refuses an existing destination on Windows and
+    # replaces it everywhere else. save_state runs at every phase boundary and every
+    # checkpoint_interval messages, so the SECOND save of any run died here, not only
+    # a second run into an existing directory (#172).
     mm_tmp.replace(mm_final)
 
     tmp_path = output_dir / "state.json.tmp"

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -199,7 +199,9 @@ def save_state(state: MigrationState, output_dir: Path) -> None:
     mm_tmp = output_dir / "message_map.json.tmp"
     mm_final = output_dir / "message_map.json"
     mm_tmp.write_text(json.dumps(message_map, indent=2), encoding="utf-8")
-    mm_tmp.rename(mm_final)
+    # replace, not rename: os.rename refuses an existing destination on Windows,
+    # so every second run into an existing output directory died here (#172).
+    mm_tmp.replace(mm_final)
 
     tmp_path = output_dir / "state.json.tmp"
     final_path = output_dir / "state.json"
@@ -211,7 +213,7 @@ def save_state(state: MigrationState, output_dir: Path) -> None:
     # pairs and no free text, and walking it measured ~290ms at 100k entries against
     # ~3ms for everything else, on a path that runs every 50 messages. Issue #140, ADR-014.
     tmp_path.write_text(json.dumps(scrub_document(data), indent=2), encoding="utf-8")
-    tmp_path.rename(final_path)
+    tmp_path.replace(final_path)
 
 
 def load_state(output_dir: Path) -> MigrationState:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import inspect
 import os
 from contextlib import contextmanager
@@ -202,3 +203,37 @@ def _isolate_ferry_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> I
         logging_setup.reset_logging()
         reset_secret_registry()
         reset_http_state()
+
+
+# --- Windows filesystem semantics ---------------------------------------------
+# POSIX rename(2) is an atomic replace, so on Linux and macOS a swap onto an
+# existing file just works and no test can tell Path.rename from Path.replace.
+# Win32 MoveFile refuses, which is issue #172: every second migration into an
+# existing output directory died at the first checkpoint save.
+#
+# ci.yml runs the suite on ubuntu-latest only, so this fixture is the only way a
+# pull request can see that difference. The windows-atomic-write job runs the
+# same files on a real Windows runner, where no simulation is needed.
+_REAL_RENAME = Path.rename
+
+
+def _win32_rename(self: Path, target: str | Path) -> Path:
+    """Path.rename with Win32 MoveFile semantics: refuse an existing destination."""
+    if Path(target).exists():
+        raise FileExistsError(
+            errno.EEXIST,
+            "Cannot create a file when that file already exists",
+            str(self),
+        )
+    return _REAL_RENAME(self, target)
+
+
+@pytest.fixture
+def windows_filesystem(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make Path.rename behave as it does on Windows, for one test.
+
+    monkeypatch rather than a bare ``Path.rename = ...`` so the attribute is
+    restored when the test ends. A leaked patch would break every test that ran
+    after it in the same process.
+    """
+    monkeypatch.setattr(Path, "rename", _win32_rename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,12 +208,15 @@ def _isolate_ferry_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> I
 # --- Windows filesystem semantics ---------------------------------------------
 # POSIX rename(2) is an atomic replace, so on Linux and macOS a swap onto an
 # existing file just works and no test can tell Path.rename from Path.replace.
-# Win32 MoveFile refuses, which is issue #172: every second migration into an
-# existing output directory died at the first checkpoint save.
+# Win32 MoveFile refuses, which is issue #172. save_state runs at every phase
+# boundary and every checkpoint_interval messages, so the SECOND save of any run
+# hit an existing destination and died, not only a second run into an existing
+# directory. test_repeated_checkpoints_overwrite_on_windows is the one that shows
+# this: it starts from an empty tmp_path.
 #
-# ci.yml runs the suite on ubuntu-latest only, so this fixture is the only way a
-# pull request can see that difference. The windows-atomic-write job runs the
-# same files on a real Windows runner, where no simulation is needed.
+# Every other job in ci.yml is ubuntu-only, so this fixture is the only way a pull
+# request can see that difference. The windows-atomic-write job runs the same two
+# files on a real Windows runner, where no simulation is needed.
 _REAL_RENAME = Path.rename
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -457,3 +457,30 @@ def test_rolemeta_legacy_json_defaults_name_color():
     restored = _dict_to_meta(legacy)
     assert restored.role_metadata["r1"].name == ""
     assert restored.role_metadata["r1"].color == ""
+
+
+def test_save_metadata_overwrites_existing_file_on_windows(
+    windows_filesystem: None, tmp_path: Path
+) -> None:
+    """Issue #172, the third swap site."""
+    first = DiscordMetadata(
+        guild_id="123",
+        fetched_at="2026-06-23T00:00:00+00:00",
+        server_default_permissions=7,
+        role_permissions={"role-a": PermissionPair(allow=1, deny=2)},
+        channel_metadata={"chan-a": ChannelMeta(nsfw=True)},
+    )
+    second = DiscordMetadata(
+        guild_id="456",
+        fetched_at="2026-06-24T00:00:00+00:00",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+    )
+
+    save_discord_metadata(first, tmp_path)
+    save_discord_metadata(second, tmp_path)
+
+    loaded = load_discord_metadata(tmp_path)
+    assert loaded is not None
+    assert loaded.guild_id == "456"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -481,6 +481,7 @@ def test_save_metadata_overwrites_existing_file_on_windows(
     save_discord_metadata(first, tmp_path)
     save_discord_metadata(second, tmp_path)
 
-    loaded = load_discord_metadata(tmp_path)
-    assert loaded is not None
-    assert loaded.guild_id == "456"
+    # Full-object equality, matching test_metadata_roundtrip_preserves_new_fields.
+    # Asserting guild_id alone would pass even if the second write landed only
+    # partially, because every other field would still read back as `first`'s.
+    assert load_discord_metadata(tmp_path) == second

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1037,3 +1037,42 @@ def test_every_classified_text_member_is_actually_used() -> None:
         "_TEXT_MEMBERS classifies a member key no append site uses: "
         f"{sorted(classified - observed)}"
     )
+
+
+def test_save_state_overwrites_existing_files_on_windows(
+    windows_filesystem: None, tmp_path: Path
+) -> None:
+    """Issue #172: a second run into an existing output directory must not crash.
+
+    One test covers both swap sites. save_state has no branch between them
+    (state.py:198-214), so reverting the message_map swap raises on the first and
+    reverting the state.json swap raises on the second.
+    """
+    save_state(MigrationState(stoat_server_id="first"), tmp_path)
+    save_state(MigrationState(stoat_server_id="second"), tmp_path)
+
+    assert load_state(tmp_path).stoat_server_id == "second"
+    assert (tmp_path / "message_map.json").exists()
+
+
+def test_save_state_first_write_succeeds_on_windows(
+    windows_filesystem: None, tmp_path: Path
+) -> None:
+    """The fixture must only refuse an EXISTING destination.
+
+    If it refused unconditionally, a genuine first-run break would look identical
+    to the bug under test and this suite could not tell them apart.
+    """
+    save_state(MigrationState(stoat_server_id="only"), tmp_path)
+
+    assert load_state(tmp_path).stoat_server_id == "only"
+
+
+def test_repeated_checkpoints_overwrite_on_windows(
+    windows_filesystem: None, tmp_path: Path
+) -> None:
+    """save_state runs every checkpoint_interval messages, 50 by default."""
+    for n in range(5):
+        save_state(MigrationState(stoat_server_id=f"run-{n}"), tmp_path)
+
+    assert load_state(tmp_path).stoat_server_id == "run-4"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.3"
+version = "2.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes a Windows-only crash reported in #172, and closes the gap that let it reach a user.

## The bug

`Path.rename()` calls `os.rename`. On POSIX that replaces the destination by definition. On Win32 it is `MoveFile`, which refuses when the destination exists; the overwrite variant is `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`, reached from Python through `os.replace` and so `Path.replace()`.

Three writers finished an atomic write with `Path.rename()`:

| File | Written |
|---|---|
| `state.py:202` | `message_map.json` |
| `state.py:214` | `state.json` |
| `discord/metadata.py:73` | `discord_metadata.json` |

`save_state` runs at every phase boundary and every 50 messages, so the destination exists from the second save onward. This is wider than it first looks, and the first draft of this PR got it wrong: it is **not** limited to repeat runs. A migration into a brand-new folder reached its second save inside the server and channel phase and died there. A run into a directory Ferry had already written to, which is what resume, `--incremental` and reusing an existing export all do, died at the first save instead.

The correction came from the whole-branch review and is commit `37de141`. The branch's own test had already demonstrated it: `test_repeated_checkpoints_overwrite_on_windows` saves five times into pytest's `tmp_path`, a fresh empty directory, and failed against the unfixed code.

Each of the three changes is one method name.

## Why the obvious test would not have caught it

The suite runs on `ubuntu-latest` only. POSIX `rename` already overwrites, so a test that saves twice passes against the broken code. That is measured, not assumed: the naive version was run against the unfixed source during design and went green.

`tests/conftest.py` gains a `windows_filesystem` fixture that replaces `Path.rename` with Win32 `MoveFile` semantics, refusing only an existing destination so the first write still exercises the real path. Four tests use it.

Verified by mutation rather than by assertion. Each of the three sites was reverted to `.rename()` in turn, in place, and the suite recorded red each time: 2, 2 and 1 failures respectively.

## Real Windows coverage

Nothing in this project's tests has ever run on Windows, which is the actual reason #172 reached a user. This adds a `windows-atomic-write` job to `ci.yml` running `tests/test_state.py` and `tests/test_metadata.py` on `windows-latest`.

Two named files rather than the whole suite. #174 tracks the full leg and is blocked on triaging an unknown number of unrelated first-run failures; naming two files sidesteps that blocker and covers the code this release changes. #174 is updated with what remains.

It went into `ci.yml` rather than `release.yml`'s existing Windows job, which already has pytest installed. That was rejected on inputs, not cost: `release.yml` filters pull requests to `ferry.spec`, `core/http.py` and itself, so a gate there would only fire at tag push for changes under `src/` or `tests/`. `auto-tag` pushes tags on merge, so a failure would leave a tag with no release.

**First run: green in 29s.** The risk going in was collection rather than the fix, because `tests/conftest.py:57` registers `nicegui.testing.user_plugin` for every run and that had never executed on Windows. It was fine. The rule stood either way: had it failed on something unrelated, that got fixed or the job's file list narrowed, never a skip.

## Wording

The changelog says the writers overwrite an existing destination on Windows. It deliberately does not say the write is atomic there: CPython scopes that guarantee to POSIX, `ReplaceFileW` rather than `MoveFileEx` is the stronger Win32 contract, and neither promises anything on FAT32 or over SMB.

## Scope, and what was filed instead of done

Nothing here is deferred without a tracking number.

- **#173** the thread archive writes Discord names straight to the filesystem, found while sweeping for Windows defects during this work. Same family, different root cause.
- **#174** a full Windows leg on the CI matrix.
- **#175** three writers that skip the atomic swap entirely, including the blueprint, which is read back by `import_blueprint`.
- **#176** `os.replace` still fails on Windows when the destination is held open, which OneDrive and antivirus both do. Unreproduced, four deferral fields recorded.

## Verification

```
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
1672 passed
```

Chunk reviews are on #187 and #188. The chunk-1 review confirmed two findings, both fixed in `20c104c`: redundant `--extra` flags on the CI job, and a single-field assertion in the metadata test that a partial write would have satisfied.

Success Metric 1 from the spec stays open after merge: it asks for a migration run twice on Windows, verified by the frozen executable or by the #172 reporter on the released build. The new job covers the swap primitive, not the run-twice case.

Closes #172
Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171SrxqNqV1k9BKHLrNdGCL
