### PR TITLE
fix: make the proxy resolver's never-raises promise true (v2.14.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.5] - 2026-08-11
+
+### Fixed
+
+- `ferry tls-check` could fail with a traceback instead of reporting, on a machine
+  where the system proxy configuration could not be read. It now reports
+  `proxy-source: unreadable` and exits normally. Reading the configuration involves
+  the operating system, and Ferry does not control what that can return.
+
+  It also no longer reports a clean machine when it means it could not look. Those
+  two are worth telling apart: one says there is no proxy, the other says the
+  question could not be answered, and treating the second as the first is a
+  diagnostic that lies. When one protocol resolves and the other cannot be read,
+  the working one is still reported and the failing one is marked `unreadable`, so
+  neither answer hides the other.
+
+- An export could stop before DiscordChatExporter started, for the same reason.
+  Ferry passes the system proxy through to the exporter as a convenience, and a
+  failure to read it now leaves the export running without it rather than ending
+  it. If that happens the export log says so, so an export that quietly ignored a
+  proxy no longer looks like an export that never needed one.
+
+  Nothing changes on a machine where the proxy configuration reads normally, and a
+  proxy set through an environment variable is still passed through untouched.
+
 ## [2.14.4] - 2026-08-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.4"
+version = "2.14.5"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.4"
+__version__ = "2.14.5"

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -397,9 +397,24 @@ def _is_bypassed(host: str, source: str, env: dict[str, str]) -> bool:
     return _bypass_memo[key]
 
 
-def resolve_proxy(url: str | URL) -> ProxyChoice | None:
-    """The proxy for `url`, or None. NEVER raises: this runs inside
-    ClientRequest.__init__, so a raise kills the first request of a migration.
+def resolve_proxy_or_raise(url: str | URL) -> ProxyChoice | None:
+    """The proxy for `url`, or None. RAISES whatever the platform raises.
+
+    The guards below cover this function's own URL parses only. `_scheme_map`
+    and `_is_bypassed` reach platform code Ferry does not control, and stdlib can
+    raise there outside (ValueError, TypeError).
+
+    Call this only when you need to tell "could not read the configuration" apart
+    from "no proxy is configured", and catch it yourself. `describe_proxy` and
+    `run_dce_export` do, because reporting the first as the second is a
+    diagnostic that lies. Everything else calls `resolve_proxy`.
+
+    The raise is deliberate and load-bearing. `_scheme_map` assigns its cache
+    AFTER the call that can fail, so letting the exception through leaves the
+    cache cold and the next call retries the platform. Swallowing it lower down,
+    inside `_os_proxies`, was tried and rejected: the assignment then runs with an
+    empty result and freezes "no OS proxy" for the life of the process, so one
+    transient fault stops every later request using the proxy. Issue #148.
     """
     if os.environ.get("FERRY_DISABLE_PROXY"):
         return None
@@ -428,6 +443,26 @@ def resolve_proxy(url: str | URL) -> ProxyChoice | None:
     if _is_bypassed(target.host or "", source, env):
         return None
     return ProxyChoice(url=stripped, authorization=authorization, source=source)
+
+
+def resolve_proxy(url: str | URL) -> ProxyChoice | None:
+    """The proxy for `url`, or None. NEVER raises: this runs inside
+    ClientRequest.__init__, so a raise kills the first request of a migration.
+
+    A thin wrapper over `resolve_proxy_or_raise`, so the promise is a property of
+    this function rather than of whichever caller happens to sit behind a
+    boundary. Before #148 it was delivered by one of three callers, and the other
+    two inherited only the narrow guards, which is how `ferry tls-check` could
+    traceback on a machine where the platform misbehaved.
+    """
+    try:
+        return resolve_proxy_or_raise(url)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not read the proxy configuration; connecting direct.",
+            exc_info=True,
+        )
+        return None
 
 
 def proxy_notices() -> tuple[ProxyNotice, ...]:

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -764,13 +764,35 @@ def describe_proxy() -> dict[str, str]:
             "proxy-disabled": "true",
         }
     out = {"proxy-disabled": "false", "proxy-source": "none"}
+    any_failed = False
     for scheme in ("http", "https"):
-        choice = resolve_proxy(f"{scheme}://example.invalid/")
+        # The RAISING sibling, deliberately. resolve_proxy returns None for a read
+        # failure and for a clean machine alike, so calling it here would report
+        # "none" for both, and CI would not notice: release.yml asserts only that
+        # the proxy-source key is present, whatever its value. A diagnostic that
+        # reports "no proxy" when it means "could not look" is the failure this
+        # function's own docstring is about. Issue #148.
+        try:
+            choice = resolve_proxy_or_raise(f"{scheme}://example.invalid/")
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Could not read the proxy configuration for %s.", scheme, exc_info=True
+            )
+            out[f"proxy-{scheme}"] = "unreadable"
+            any_failed = True
+            continue
         if choice is None:
             out[f"proxy-{scheme}"] = "none"
         else:
             out[f"proxy-{scheme}"] = f"{choice.url.host}:{choice.url.port}"
             out["proxy-source"] = choice.source
+    # A real resolved source wins the summary. Overwriting it with "unreadable"
+    # because the OTHER scheme failed prints a live proxy next to a line denying
+    # it, which is the contradiction this design rejected an alternative for. The
+    # failing scheme still reports its own failure in its own key, so nothing is
+    # hidden.
+    if any_failed and out["proxy-source"] == "none":
+        out["proxy-source"] = "unreadable"
     return out
 
 

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -775,9 +775,7 @@ def describe_proxy() -> dict[str, str]:
         try:
             choice = resolve_proxy_or_raise(f"{scheme}://example.invalid/")
         except Exception:  # noqa: BLE001
-            logger.warning(
-                "Could not read the proxy configuration for %s.", scheme, exc_info=True
-            )
+            logger.warning("Could not read the proxy configuration for %s.", scheme, exc_info=True)
             out[f"proxy-{scheme}"] = "unreadable"
             any_failed = True
             continue

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -483,10 +483,16 @@ def proxy_notices() -> tuple[ProxyNotice, ...]:
     The scan underneath (`_scheme_map`) is cached either way, so the repeat
     costs a dict walk rather than a syscall.
 
-    NEVER raises, mirroring `_FerryRequest._resolve_or_direct`. `_scheme_map()`
+    NEVER raises, like `resolve_proxy`, which since #148 is the function that
+    defines this contract rather than inheriting it from a caller. `_scheme_map()`
     reaches the platform getters `getproxies_macosx_sysconf` and
     `getproxies_registry` through `_os_proxies`, and stdlib can raise there
     outside (ValueError, TypeError).
+
+    This function keeps its own boundary rather than calling `resolve_proxy`,
+    because it evaluates the configuration itself and must run before the first
+    request. It also degrades differently, to a visible `unreadable` notice
+    rather than a silent direct connection.
 
     This paragraph has now been wrong twice, in opposite directions, so it is
     worth stating what is actually true. It first claimed a concrete `re.error`
@@ -845,13 +851,17 @@ class _FerryRequest(aiohttp.ClientRequest):
     def _resolve_or_direct(url: object) -> ProxyChoice | None:
         """Resolve, or fall through to a direct connection. NEVER raises.
 
-        This is the boundary where the design's "resolution never raises"
-        invariant actually has to hold, because a raise here kills the first
-        request of a migration from inside ClientRequest.__init__.
+        This WAS the boundary where the "resolution never raises" invariant
+        actually held, which was the defect #148 fixed: the invariant belonged to
+        a caller rather than to the function that promised it, so the other two
+        callers inherited only the narrow guards. `resolve_proxy` now holds it.
 
-        `resolve_proxy`'s own guards catch ValueError and TypeError, which is
-        not enough, because `_is_bypassed` and `_scheme_map` reach platform code
-        Ferry does not control.
+        The boundary stays, for two reasons rather than as habit. It is defense
+        in depth over platform code Ferry does not control. And it still covers a
+        case `resolve_proxy`'s boundary does not reach in the same way:
+        `resolve_proxy(None)` raises `AttributeError` from Ferry's own frame, and
+        the `if url is None` guard above is what stops that, with the test below
+        pinning it.
 
         An earlier version of this docstring justified the boundary with a
         specific mechanism: that `_proxy_bypass_winreg_override` calls

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -856,12 +856,18 @@ class _FerryRequest(aiohttp.ClientRequest):
         a caller rather than to the function that promised it, so the other two
         callers inherited only the narrow guards. `resolve_proxy` now holds it.
 
-        The boundary stays, for two reasons rather than as habit. It is defense
-        in depth over platform code Ferry does not control. And it still covers a
-        case `resolve_proxy`'s boundary does not reach in the same way:
-        `resolve_proxy(None)` raises `AttributeError` from Ferry's own frame, and
-        the `if url is None` guard above is what stops that, with the test below
-        pinning it.
+        The boundary stays as defense in depth over platform code Ferry does not
+        control, not as habit.
+
+        What the `if url is None` guard above buys is worth stating precisely,
+        because #148 changed it. `resolve_proxy_or_raise(None)` raises
+        `AttributeError` at `target.scheme`, from Ferry's own frame rather than
+        from a platform seam. `resolve_proxy` now catches that itself and returns
+        None, so dropping the guard would no longer produce an exception here.
+        It would produce a logged warning with a full traceback on every request
+        that never had a url to resolve. The guard prevents the noise, not a
+        crash, and the test below pins it by asserting the resolver is never
+        called rather than by asserting on a symptom.
 
         An earlier version of this docstring justified the boundary with a
         specific mechanism: that `_proxy_bypass_winreg_override` calls

--- a/src/discord_ferry/exporter/runner.py
+++ b/src/discord_ferry/exporter/runner.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import new_session, proxy_hint, resolve_proxy, tls_hint
+from discord_ferry.core.http import new_session, proxy_hint, resolve_proxy_or_raise, tls_hint
 from discord_ferry.errors import DiscordAuthError, ExportError
 from discord_ferry.exporter.dce_output import (
     Banner,
@@ -374,7 +374,26 @@ async def run_dce_export(
     config.export_dir.mkdir(parents=True, exist_ok=True)
 
     child_env = dict(os.environ)  # full copy: dropping SYSTEMROOT or PATH breaks .NET on Windows
-    choice = resolve_proxy("https://discord.com/")
+    # The RAISING sibling, with a boundary here. resolve_proxy would swallow and
+    # return None, which is indistinguishable from "this machine has no proxy",
+    # and there would be nothing to tell the user. The variable below is an
+    # optimisation, so a failure to resolve it must never abort an export, but it
+    # must not pass silently either: a user behind a proxy whose export runs
+    # without one deserves to know why. Issue #148.
+    try:
+        choice = resolve_proxy_or_raise("https://discord.com/")
+    except Exception:  # noqa: BLE001
+        logger.warning("Could not read the proxy configuration for the export.", exc_info=True)
+        on_event(
+            MigrationEvent(
+                phase="export",
+                status="warning",
+                message=(
+                    "Could not read the system proxy configuration. The export will run without it."
+                ),
+            )
+        )
+        choice = None
     if choice is not None and choice.source == "os" and "HTTPS_PROXY" not in child_env:
         # Only when the OS supplied it. If the user set the variable themselves,
         # DCE already inherits it, and overwriting a deliberate setting is a

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1816,3 +1816,60 @@ def test_the_rollback_tracker_also_handles_notice() -> None:
             MigrationEvent(phase="preflight", status="notice", message="ROLLBACK-NOTICE")
         )
     assert "ROLLBACK-NOTICE" in buf.getvalue()
+
+
+def test_tls_check_reports_unreadable_without_crashing(proxy_env) -> None:
+    """The library call being guarded is not the same as the command surviving.
+
+    Killing: a boundary that covers describe_proxy but lets the CLI wrapper
+    traceback. The command must exit zero and still print the four describe_trust
+    keys release.yml pins, or the #134 gate breaks.
+    """
+    with (
+        proxy_env(),
+        patch("discord_ferry.core.http._os_proxies", side_effect=KeyError("boom")),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        result = CliRunner().invoke(main, ["tls-check"])
+
+    assert result.exit_code == 0
+    assert "proxy-source: unreadable" in result.output
+    for key in ("ca-bundle:", "ca-bundle-readable:", "trust-source:", "ca-visible:"):
+        assert key in result.output
+
+
+def test_tls_check_says_nothing_about_unreadable_on_a_healthy_machine(proxy_env) -> None:
+    """A diagnostic that cries wolf is the same defect in the other direction.
+
+    test_tls_check_reports_the_proxy_keys calls reporting configuration rather
+    than resolution "what makes a diagnostic lie". Reporting a failure that did
+    not happen lies just as loudly.
+    """
+    with (
+        proxy_env(HTTPS_PROXY="http://corp:8080"),
+        patch("discord_ferry.core.http._os_proxies", return_value={}),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+
+    assert "proxy-source: env" in out
+    assert "proxy-https: corp:8080" in out
+    assert "unreadable" not in out
+
+
+def test_tls_check_never_prints_userinfo_on_the_failure_path(proxy_env) -> None:
+    """A new code path is a new chance to leak.
+
+    test_tls_check_never_prints_userinfo measured that str(URL), repr(URL) and
+    URL.human_repr() all render userinfo. This drives the same command down the
+    branch that did not exist when that test was written.
+    """
+    with (
+        proxy_env(HTTPS_PROXY="http://user:secret@corp:8080"),
+        patch("discord_ferry.core.http._os_proxies", return_value={"http": "http://os:3128"}),
+        patch("discord_ferry.core.http._os_proxy_bypass", side_effect=OSError("registry")),
+    ):
+        out = CliRunner().invoke(main, ["tls-check"]).output
+
+    assert "secret" not in out
+    assert "user" not in out

--- a/tests/test_exporter_runner.py
+++ b/tests/test_exporter_runner.py
@@ -991,3 +991,80 @@ class TestDceChildProxyEnvironment:
             await run_dce_export(cfg, tmp_path / "dce", lambda _e: None)
 
         assert captured_env["HTTPS_PROXY"] == "http://mine:9999"
+
+
+# ---------------------------------------------------------------------------
+# Proxy resolution must never abort an export (issue #148)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_launches_when_proxy_resolution_fails(tmp_path: Path) -> None:
+    """Today the raise aborts the export before DCE starts.
+
+    The HTTPS_PROXY variable this block injects is an optimisation: DCE works
+    without it, and a user who set the variable themselves already has it. Losing
+    the whole export over a failure to read the OS proxy configuration is a bad
+    trade, so the export must launch anyway with the variable absent rather than
+    present and wrong.
+    """
+    process = _make_process([b"Successfully exported 1 channel(s).\n"])
+    exec_mock = AsyncMock(return_value=process)
+    events: list[MigrationEvent] = []
+
+    with (
+        patch("discord_ferry.exporter.runner.asyncio.create_subprocess_exec", new=exec_mock),
+        patch("discord_ferry.core.http._os_proxies", side_effect=KeyError("boom")),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        await run_dce_export(_make_config(tmp_path), tmp_path / "dce", events.append)
+
+    assert exec_mock.await_count == 1, "the subprocess must still be created"
+    assert "HTTPS_PROXY" not in exec_mock.await_args.kwargs["env"]
+
+
+@pytest.mark.asyncio
+async def test_a_user_set_proxy_variable_survives_a_resolution_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The comment beside this block says overwriting a deliberate setting is a
+    surprise rather than a feature. A boundary that clears the variable on
+    failure would do exactly that."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://mine:8080")
+    process = _make_process([b"Successfully exported 1 channel(s).\n"])
+    exec_mock = AsyncMock(return_value=process)
+    events: list[MigrationEvent] = []
+
+    with (
+        patch("discord_ferry.exporter.runner.asyncio.create_subprocess_exec", new=exec_mock),
+        patch("discord_ferry.core.http._os_proxies", side_effect=KeyError("boom")),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        await run_dce_export(_make_config(tmp_path), tmp_path / "dce", events.append)
+
+    assert exec_mock.await_args.kwargs["env"]["HTTPS_PROXY"] == "http://mine:8080"
+
+
+@pytest.mark.asyncio
+async def test_a_resolution_failure_reaches_the_event_stream(tmp_path: Path) -> None:
+    """Without this, the two tests above both pass against an empty except block.
+
+    An export that silently runs without the proxy the user configured is the
+    shape recorded in lesson_a_command_that_does_nothing_is_worse_than_no_command:
+    a code path that looks like it delivers something and structurally cannot.
+    """
+    process = _make_process([b"Successfully exported 1 channel(s).\n"])
+    events: list[MigrationEvent] = []
+
+    with (
+        patch(
+            "discord_ferry.exporter.runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ),
+        patch("discord_ferry.core.http._os_proxies", side_effect=KeyError("boom")),
+        patch("discord_ferry.core.http._os_proxy_bypass", return_value=False),
+    ):
+        await run_dce_export(_make_config(tmp_path), tmp_path / "dce", events.append)
+
+    warnings = [e for e in events if e.status == "warning" and "proxy" in e.message.lower()]
+    assert len(warnings) == 1

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -778,9 +778,12 @@ async def test_a_missing_url_raises_type_error_not_index_error(proxy_env, os_pro
 
     It does NOT cover `_resolve_or_direct`'s `if url is None` guard. That guard
     stopped being observable here the moment the resolver call was wrapped in
-    `except Exception`: without it, resolve_proxy(None) raises AttributeError,
-    the wrapper swallows it, and this test still sees its TypeError. The test
-    below is what pins that guard.
+    `except Exception`: without it, `resolve_proxy_or_raise(None)` raises
+    AttributeError, a boundary swallows it, and this test still sees its
+    TypeError. The test below is what pins that guard.
+
+    Naming the raising function matters since #148 split the resolver in two.
+    `resolve_proxy` no longer raises on None; it catches and returns None.
     """
     with os_proxy({}), proxy_env(HTTPS_PROXY="http://corp:8080"), pytest.raises(TypeError):
         http._FerryRequest("GET", loop=asyncio.get_running_loop())
@@ -790,10 +793,11 @@ async def test_a_missing_url_never_reaches_the_resolver(proxy_env, os_proxy) -> 
     """`_resolve_or_direct`'s `if url is None: return None`.
 
     Killing: dropping that guard. The visible cost is no longer an exception,
-    because `except Exception` catches the AttributeError resolve_proxy(None)
-    raises; it is a warning logged with a full traceback on a request that never
-    had a url to resolve. Asserting the resolver is not called pins the guard
-    itself rather than one of its downstream symptoms.
+    because `resolve_proxy` catches the AttributeError that
+    `resolve_proxy_or_raise(None)` raises at `target.scheme`; it is a warning
+    logged with a full traceback on a request that never had a url to resolve.
+    Asserting the resolver is not called pins the guard itself rather than one of
+    its downstream symptoms.
     """
     with (
         os_proxy({}),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1692,3 +1692,35 @@ def test_a_failed_scan_leaves_the_cache_cold(proxy_env) -> None:
     ):
         http.resolve_proxy("https://a.test/")
         assert http._proxy_scan is None
+
+
+def test_a_transient_platform_failure_self_heals(proxy_env) -> None:
+    """One bad reading must not cost the whole process its proxy.
+
+    Fails against the design rejected at critique round 1, which put the boundary
+    inside _os_proxies. Under that shape call 1 caches an empty scan and call 2
+    still returns None after the platform has recovered, for the life of the
+    process. Measured during design: exactly that.
+
+    Both seams are patched even though only one is exercised, so the test does not
+    reach the real _scproxy C extension on a macOS machine.
+    """
+    calls = {"n": 0}
+
+    def flaky() -> dict[str, str]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise KeyError("transient")
+        return {"https": "http://corp:8080"}
+
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=flaky),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        assert http.resolve_proxy("https://a.test/") is None
+        recovered = http.resolve_proxy("https://a.test/")
+
+    assert recovered is not None
+    assert recovered.url.host == "corp"
+    assert calls["n"] == 2, "the second call must reach the platform again"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1599,3 +1599,96 @@ def test_describe_proxy_never_prints_userinfo_even_if_resolve_stops_stripping(
         out = http.describe_proxy()
     assert all("secret" not in v for v in out.values())
     assert all("user" not in v for v in out.values())
+
+
+# ---------------------------------------------------------------------------
+# The never-raises contract (issue #148)
+# ---------------------------------------------------------------------------
+#
+# Four rules apply to every test below, and three of them exist because this
+# work already got them wrong once.
+#
+# 1. The os_proxy fixture cannot inject a raise: it patches both seams with
+#    return_value and side_effect=lambda, which only produce successful returns.
+#    A raise has to be patched in directly.
+# 2. Patch BOTH seams anyway. Patching only _os_proxies leaves _os_proxy_bypass
+#    real, and on a macOS machine that calls the _scproxy C extension.
+# 3. Wrap in proxy_env(), which clears ambient *_proxy variables and neutralises
+#    FERRY_DISABLE_PROXY.
+# 4. Raise something outside (ValueError, TypeError). resolve_proxy_or_raise
+#    still guards those around its own URL parses, so using one proves nothing
+#    about the boundary under test.
+
+
+def test_resolve_proxy_returns_none_when_the_scan_seam_raises(proxy_env) -> None:
+    """The docstring has promised this since v2.14.0, and the function raised.
+
+    KeyError rather than ValueError on purpose: see rule 4 above.
+    """
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("exclude_simple")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        assert http.resolve_proxy("https://a.test/") is None
+
+
+def test_resolve_proxy_returns_none_when_the_bypass_seam_raises(proxy_env) -> None:
+    """The bypass call sits after the scan and is reached only when a proxy
+    matched from the OS half, so a fix that guards only the scan passes the test
+    above and fails this one."""
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", return_value={"https": "http://oscorp:3128"}),
+        patch.object(http, "_os_proxy_bypass", side_effect=OSError("registry")),
+    ):
+        assert http.resolve_proxy("https://a.test/") is None
+
+
+def test_resolve_proxy_or_raise_still_raises(proxy_env) -> None:
+    """The split has to be real, not cosmetic.
+
+    If the boundary went into the sibling too, describe_proxy and run_dce_export
+    would receive None for a read failure and for a clean machine alike, which is
+    the silent inversion this change exists to prevent.
+    """
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("exclude_simple")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+        pytest.raises(KeyError),
+    ):
+        http.resolve_proxy_or_raise("https://a.test/")
+
+
+def test_resolve_proxy_logs_the_failure_once(proxy_env, caplog) -> None:
+    """A silent swallow makes a persistent platform failure invisible."""
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("exclude_simple")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+        caplog.at_level(logging.WARNING, logger="discord_ferry.core.http"),
+    ):
+        http.resolve_proxy("https://a.test/")
+
+    records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
+
+
+def test_a_failed_scan_leaves_the_cache_cold(proxy_env) -> None:
+    """The assertion that separates this design from the one that was rejected.
+
+    _scheme_map assigns _proxy_scan AFTER the comprehension that calls
+    _os_proxies, so letting the raise through leaves the cache None and the next
+    call retries the platform. A boundary inside the seam would let the
+    assignment run with an empty os_side and freeze "no OS proxy" for the life of
+    the process, which is worse than the bug it replaces.
+    """
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("exclude_simple")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        http.resolve_proxy("https://a.test/")
+        assert http._proxy_scan is None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1724,3 +1724,106 @@ def test_a_transient_platform_failure_self_heals(proxy_env) -> None:
     assert recovered is not None
     assert recovered.url.host == "corp"
     assert calls["n"] == 2, "the second call must reach the platform again"
+
+
+def test_describe_proxy_reports_unreadable_when_the_platform_fails(proxy_env) -> None:
+    """Killing: calling the SAFE wrapper here instead of the raising sibling.
+
+    resolve_proxy returns None for a read failure and for a clean machine alike,
+    so a describe_proxy built on it reports "none" for both. CI cannot catch
+    that: release.yml asserts only that the proxy-source key exists, whatever its
+    value. A unit test is the only guard.
+    """
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("exclude_simple")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        out = http.describe_proxy()
+
+    assert out["proxy-source"] == "unreadable"
+    assert out["proxy-http"] == "unreadable"
+    assert out["proxy-https"] == "unreadable"
+
+
+def test_describe_proxy_distinguishes_all_three_states(proxy_env) -> None:
+    """Asserted pairwise. Three individually plausible values are not the same
+    as three distinguishable ones, and distinguishable is the requirement."""
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", side_effect=KeyError("boom")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        failed = http.describe_proxy()["proxy-source"]
+    http.reset_http_state()
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", return_value={}),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        clean = http.describe_proxy()["proxy-source"]
+    http.reset_http_state()
+    with (
+        proxy_env(HTTPS_PROXY="http://corp:8080"),
+        patch.object(http, "_os_proxies", return_value={}),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        configured = http.describe_proxy()["proxy-source"]
+
+    assert failed == "unreadable"
+    assert clean == "none"
+    assert configured == "env"
+    assert len({failed, clean, configured}) == 3
+
+
+def test_a_resolved_source_wins_over_a_failing_sibling_scheme(proxy_env) -> None:
+    """http resolves from the environment while the https OS bypass read fails.
+
+    Killing: an unconditional `out["proxy-source"] = "unreadable"` in the except
+    branch, which prints a live proxy beside a summary denying it. Verified
+    reachable during design: this exact configuration produced
+    proxy-http: envcorp:8080 next to proxy-source: unreadable.
+    """
+    with (
+        proxy_env(HTTP_PROXY="http://envcorp:8080"),
+        patch.object(http, "_os_proxies", return_value={"https": "http://oscorp:3128"}),
+        patch.object(http, "_os_proxy_bypass", side_effect=OSError("registry")),
+    ):
+        out = http.describe_proxy()
+
+    assert out["proxy-http"] == "envcorp:8080"
+    assert out["proxy-https"] == "unreadable"
+    assert out["proxy-source"] == "env"
+
+
+def test_describe_proxy_happy_path_is_unchanged(proxy_env) -> None:
+    """release.yml pins these key names on Windows and macOS (cli.py:1367), so a
+    changed or dropped key breaks the #134 gate. Asserted as a whole dict rather
+    than key by key, so an ADDED key fails too."""
+    with (
+        proxy_env(),
+        patch.object(http, "_os_proxies", return_value={}),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        assert http.describe_proxy() == {
+            "proxy-disabled": "false",
+            "proxy-source": "none",
+            "proxy-http": "none",
+            "proxy-https": "none",
+        }
+
+
+def test_the_kill_switch_short_circuits_before_the_platform(proxy_env) -> None:
+    """Killing: a boundary placed above describe_proxy's own FERRY_DISABLE_PROXY
+    return, which would report unreadable on a machine where the user explicitly
+    turned proxying off. The seam is patched to raise, so reaching it at all
+    would be visible."""
+    with (
+        proxy_env(FERRY_DISABLE_PROXY="1"),
+        patch.object(http, "_os_proxies", side_effect=KeyError("never reached")),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        out = http.describe_proxy()
+
+    assert out["proxy-disabled"] == "true"
+    assert out["proxy-source"] == "none"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -809,13 +809,18 @@ async def test_a_raising_resolver_connects_direct(proxy_env, os_proxy, caplog) -
     """SC-135 constraint 12, meant totally. Killing: narrowing the wrapper to
     `except (ValueError, TypeError)`.
 
-    re.error is the concrete case. `_is_bypassed` reaches proxy_bypass_registry,
-    which hands a registry-controlled ProxyOverride entry to
-    `_proxy_bypass_winreg_override`, and `re.match(test, host)` raises re.error
-    on an entry like `internal[`. re.error subclasses Exception directly, so it
-    escapes resolve_proxy's own ValueError/TypeError guards and would kill the
-    first request of a migration from inside ClientRequest.__init__ on exactly
-    the Windows corporate machines this feature exists for.
+    `re.error` is the injected class, chosen because it subclasses Exception
+    directly and so escapes the narrow guards. It is NOT a claim about a real
+    path: an earlier version of this docstring said `_proxy_bypass_winreg_override`
+    calls `re.match(test, host)` and raises `re.error` on a ProxyOverride entry
+    like `internal[`. That is wrong on every Python Ferry supports, which uses
+    `fnmatch` there, and both source docstrings have since retracted it. The
+    `re.match` form lives in `requests`, not the standard library.
+
+    What is real is the class of failure, not that one instance of it: the
+    platform getters beneath `_scheme_map` and `_is_bypassed` are code Ferry does
+    not control, and a raise from either would kill the first request of a
+    migration from inside ClientRequest.__init__.
     """
     boom = re.error("unterminated character set at position 8")
     with (
@@ -1327,12 +1332,14 @@ def test_an_unreadable_configuration_degrades_visibly(proxy_env, os_proxy) -> No
 
     `_scheme_map()` reaches the platform getters `getproxies_macosx_sysconf` and
     `getproxies_registry` through `_os_proxies`, and stdlib can raise there
-    outside (ValueError, TypeError). `re.error` is used here because it
-    subclasses Exception directly and so escapes both narrow guards; the
-    documented `re.error` path in this module belongs to the SIBLING boundary
-    (`proxy_bypass_registry`, reached only from resolve_proxy), not to this one.
-    An earlier version of this docstring inherited that attribution verbatim and
-    was wrong about it.
+    outside (ValueError, TypeError). `re.error` is used here only because it
+    subclasses Exception directly and so escapes both narrow guards.
+
+    Earlier versions of this docstring argued about which boundary owned a
+    concrete `re.error` path. No such path exists on any Python Ferry supports:
+    `_proxy_bypass_winreg_override` uses `fnmatch`, not `re.match`. The argument
+    is dropped rather than re-attributed, and it would be ambiguous now in any
+    case, since #148 gave `resolve_proxy` a boundary of its own.
     """
     with (
         os_proxy({}),

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.4"
+version = "2.14.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #148. Releases v2.14.5.

`resolve_proxy` runs inside `aiohttp.ClientRequest.__init__`, where a raise kills the first request of a migration. Its docstring promised "NEVER raises" and it raised: it guarded only `(ValueError, TypeError)` around its own URL parses, while `_scheme_map()` and `_is_bypassed()` beneath it reach OS proxy getters that can raise anything. The promise was delivered by an `except Exception` in one of three callers, so the other two inherited only the narrow guards.

Reproduced by making the platform getter raise a `KeyError`:

```
RAISES    describe_proxy()          [ferry tls-check]
SURVIVES  _resolve_or_direct()      [every HTTP request]
RAISES    resolve_proxy()           [the function whose docstring makes the promise]
```

## Two corrections to the issue as filed

**Its reproduction case is unreachable from the callers it names.** The issue cites `_proxy_bypass_macosx_sysconf` indexing `proxy_settings['exclude_simple']`. That line is real (`urllib/request.py:2620`, bracket-indexed, no guard) but sits behind `if '.' not in host`, and both unguarded callers pass dotted hosts. It can only fire from the caller that was already protected.

**Windows was never exposed.** `getproxies_registry` catches `(OSError, ValueError, TypeError)` internally at `urllib/request.py:2758`, and `proxy_bypass_registry` catches `OSError` at `:2789`. The live exposure is the macOS `_scproxy` C extension.

## What it does

The body becomes `resolve_proxy_or_raise` and still raises. `resolve_proxy` is a thin wrapper that catches, logs once, and returns `None`, so the promise belongs to the function rather than to whichever caller sits behind a boundary.

`describe_proxy` and `run_dce_export` call the raising sibling and catch it themselves, because they must tell "could not read the configuration" from "no proxy is configured". `ferry tls-check` now reports `proxy-source: unreadable` instead of `none`, and an export that cannot read the proxy launches anyway and says so.

**The raise stays intact through `_scheme_map`, deliberately.** That function assigns its cache after the call that can fail, so letting the exception through keeps the cache cold and a transient fault self-heals. Guarding lower down, inside the platform seam, was measured to freeze "no OS proxy" for the life of the process:

| | Call 1 | Cache after | Call 2, platform recovered |
|---|---|---|---|
| Boundary at the seam | returns `None` | `({}, {})` frozen | still `None`, direct for the process |
| This branch | returns `None` | cold | **recovers**, uses the proxy |

## Why a unit test and not CI

`release.yml:173` asserts `proxy-source:\s*` and `:324` globs `*"proxy-source: "*`. Both match the key with any value, so a diagnostic reporting a clean machine when it had failed to look would pass CI unchanged. The pairwise-distinct assertion in `test_describe_proxy_distinguishes_all_three_states` is the only thing that can catch it.

The happy-path output is byte-identical, so `release.yml` is untouched.

## Review

Two critique rounds on the design, both returning ITERATE, both finding defects the fix itself would have introduced:

- **Round 1** killed a chokepoint design that cached "no OS proxy" permanently, turning a self-healing fault into a session-long proxy outage.
- **Round 2** found that wrapping `resolve_proxy` in place would leave `describe_proxy` unable to see the failure at all, recreating the silent inversion by another route. Its prototype had hidden that by holding a pre-patch function reference production would not have.
- **Round 2** also found a reachable contradiction: with `HTTP_PROXY` set and the HTTPS bypass read failing, an unconditional overwrite printed `proxy-http: envcorp:8080` beside `proxy-source: unreadable`.

The whole-branch review found one more, fixed in the final commit: the split falsified a claim in a docstring this same branch edited. `resolve_proxy(None)` no longer raises, `resolve_proxy_or_raise(None)` does.

A second opinion raised four findings, all verified and none acted on: credential leakage through the traceback (refuted, the Formatter masks it, `http://user:****etpw@corp:8080`), log volume (refuted, exactly one warning per request, unchanged from today), `CancelledError` being swallowed (refuted, its MRO never includes `Exception`), and a proposed `"os (partial)"` value (a design change, not a defect).

Every guard was mutation-tested: five mutants on the resolver split, four on `describe_proxy`, four on the export path. Thirteen of thirteen caught. Two mutations initially read as survivors and were not, both because the mutation itself changed nothing.

## Verification

`uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest`

**1689 passed** on top of the rebased main. No pre-existing test edited. Version 2.14.5 across all four files.

## Note on the release number

Two sessions were working this repository in parallel and both had claimed 2.14.4. The Windows
atomic-write fix (#172, PR #192) merged and tagged first, so this branch rebased onto it and took
2.14.5.

Had both shipped as 2.14.4, `auto-tag.yml` would have compared the version against the existing tag,
correctly decided no tag was needed, and published nothing while going green. That is
`gotcha_auto_tag_rebase_merge_skips_release` in a different costume: the failure is silent and
surfaces as a missing release rather than a red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkHteonqfTKhfVVcuY4fkT
