### PR TITLE
fix: an interrupted write can no longer destroy a document Ferry reads back (v2.14.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev --extra native
 
-      - name: Run the state and metadata suites
-        run: uv run pytest tests/test_state.py tests/test_metadata.py -v
+      - name: Run the atomic-write suites
+        # test_atomicio and test_blueprint joined the list in v2.14.6. Every
+        # document write now goes through one helper, and the blueprint is the
+        # case that matters most, since import_blueprint reads that file back.
+        # The conftest fixture only simulates Win32 rename semantics; this is the
+        # real thing.
+        run: >-
+          uv run pytest tests/test_atomicio.py tests/test_state.py
+          tests/test_metadata.py tests/test_blueprint.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.6] - 2026-08-11
+
+### Fixed
+
+- A crash, a full disk, or a killed process partway through writing one of
+  Ferry's own files could leave a half-written file where a complete one was
+  expected, with the previous good copy already gone. The server blueprint is the
+  one that mattered: Ferry reads that file back when you import it, so an
+  incomplete export survived the run that produced it, and there was no way to
+  tell it apart from a good one until the import failed or built a partial
+  server. Every file Ferry writes and later reads is now written to a temporary
+  file first and swapped into place, so a failure leaves the previous version
+  readable. This also covers the backup taken before a state file is upgraded to
+  the current format, which is the only copy of the old one (#175).
+
 ## [2.14.5] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   one that mattered: Ferry reads that file back when you import it, so an
   incomplete export survived the run that produced it, and there was no way to
   tell it apart from a good one until the import failed or built a partial
-  server. Every file Ferry writes and later reads is now written to a temporary
-  file first and swapped into place, so a failure leaves the previous version
-  readable. This also covers the backup taken before a state file is upgraded to
-  the current format, which is the only copy of the old one (#175).
+  server. The files holding your migration's progress, the Discord server details
+  it collected, its report and an exported blueprint are now written to a
+  temporary file first and swapped into place, so a failure leaves the previous
+  version readable. This also covers the backup Ferry takes before upgrading an
+  older state file, which becomes the only copy of the original (#175).
 
 ## [2.14.5] - 2026-08-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.5"
+version = "2.14.6"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.5"
+__version__ = "2.14.6"

--- a/src/discord_ferry/blueprint.py
+++ b/src/discord_ferry/blueprint.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from discord_ferry.core.atomicio import atomic_write_text
+
 
 @dataclass
 class BlueprintRole:
@@ -53,7 +55,10 @@ def export_blueprint(blueprint: ServerBlueprint, output_path: Path) -> None:
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     data = _blueprint_to_dict(blueprint)
-    output_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    # Atomic: import_blueprint reads this file back, so a truncated export outlives
+    # the run that produced it and there is no way to tell it apart from a good one
+    # until the import fails or builds a partial server (#175).
+    atomic_write_text(output_path, json.dumps(data, indent=2))
 
 
 def import_blueprint(input_path: Path) -> ServerBlueprint:

--- a/src/discord_ferry/core/atomicio.py
+++ b/src/discord_ferry/core/atomicio.py
@@ -1,0 +1,48 @@
+"""Atomic text writes for the documents Ferry has to be able to read back.
+
+Two defects live here, and both are cheap to reintroduce by writing the obvious
+thing at a new call site.
+
+``write_text`` truncates its target the moment it opens it, so a crash, a full
+disk or a killed process partway through leaves a half-written file where a
+complete one is expected, and the previous good copy is already gone. That was
+issue #175. The blueprint was the case that mattered: ``export_blueprint`` and
+``import_blueprint`` are a matched pair, so a truncated export is read back by a
+later run and the damage outlives the run that caused it.
+
+``Path.rename`` looks like the fix and is not, on Windows. It calls ``os.rename``,
+which replaces the destination on POSIX and refuses it on Win32, where the
+overwrite is ``MoveFileEx`` with ``MOVEFILE_REPLACE_EXISTING``. Reaching that
+from Python means ``os.replace``, so ``Path.replace``. That was issue #172, and
+because the destination only exists from the second write onward, it killed the
+second checkpoint save of every migration on Windows.
+
+Both are guarded. ``tests/test_atomicio.py`` asserts the previous file survives a
+failed write and a failed swap, exercises the swap under simulated Win32
+semantics, and walks the four document-owning modules with ``ast`` to fail the
+build if one of them writes directly again.
+"""
+
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path*, replacing any existing file, with no truncation window.
+
+    The parent directory must already exist. Every caller creates it as part of
+    its own work, and creating it here would change their behaviour rather than
+    tidy it.
+
+    The temporary file is *path* with ``.tmp`` appended, so a document at
+    ``state.json`` stages through ``state.json.tmp``. Nothing in Ferry reads a
+    ``.tmp`` path, so one left behind by a crash is inert and the next write
+    overwrites it.
+
+    Args:
+        path: Final location of the document.
+        text: Complete contents. Any redaction has already been applied by the
+            caller, which is where ADR-014 puts it.
+    """
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    tmp_path.replace(path)

--- a/src/discord_ferry/core/atomicio.py
+++ b/src/discord_ferry/core/atomicio.py
@@ -18,9 +18,14 @@ because the destination only exists from the second write onward, it killed the
 second checkpoint save of every migration on Windows.
 
 Both are guarded. ``tests/test_atomicio.py`` asserts the previous file survives a
-failed write and a failed swap, exercises the swap under simulated Win32
-semantics, and walks the four document-owning modules with ``ast`` to fail the
-build if one of them writes directly again.
+partial write and a failed swap, and exercises the swap under simulated Win32
+semantics.
+
+It also walks the four document-owning modules with ``ast`` and fails the build
+on a direct ``write_text`` call in any of them. That catches the mistake someone
+is actually likely to make, and no more: it does not see ``open(path, "w")``, an
+aliased method, ``getattr``, or a fifth module that starts owning a document. It
+is a tripwire on the obvious path, not proof of coverage.
 """
 
 from pathlib import Path

--- a/src/discord_ferry/discord/metadata.py
+++ b/src/discord_ferry/discord/metadata.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from discord_ferry.core.atomicio import atomic_write_text
+
 
 @dataclass
 class PermissionPair:
@@ -67,11 +69,7 @@ def save_discord_metadata(meta: DiscordMetadata, output_dir: Path) -> None:
     """Save to output_dir/discord_metadata.json using atomic write."""
     output_dir.mkdir(parents=True, exist_ok=True)
     data = _meta_to_dict(meta)
-    tmp_path = output_dir / "discord_metadata.json.tmp"
-    final_path = output_dir / "discord_metadata.json"
-    tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    # replace, not rename: see state.py and issue #172.
-    tmp_path.replace(final_path)
+    atomic_write_text(output_dir / "discord_metadata.json", json.dumps(data, indent=2))
 
 
 def load_discord_metadata(output_dir: Path) -> DiscordMetadata | None:

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from discord_ferry.core.atomicio import atomic_write_text
 from discord_ferry.core.security import safe_sanitize, sanitize_secrets, scrub_document
 from discord_ferry.discord.metadata import load_discord_metadata
 
@@ -444,8 +445,7 @@ def generate_markdown_report(
             )
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = config.output_dir / "migration_report.md"
-    output_path.write_text("\n".join(lines), encoding="utf-8")
+    atomic_write_text(config.output_dir / "migration_report.md", "\n".join(lines))
 
 
 def _write_report(
@@ -458,10 +458,9 @@ def _write_report(
     simply forgot the argument would otherwise get weaker redaction and no error.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    report_path = output_dir / "migration_report.json"
     # Redact here rather than at the ~59 append sites feeding warnings and errors: a
     # call site cannot forget a scrub it never has to make, and forgetting was the
     # defect. This file is what the bug report template asks users to attach, so
     # anything in it is effectively published. Issue #140, ADR-014.
     scrubbed = scrub_document(report, token_store)
-    report_path.write_text(json.dumps(scrubbed, indent=2), encoding="utf-8")
+    atomic_write_text(output_dir / "migration_report.json", json.dumps(scrubbed, indent=2))

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -409,9 +409,10 @@ def _migrate_v1_to_v2(data: dict[str, Any], output_dir: Path) -> dict[str, Any]:
     Returns:
         Modified dict with v2 resume fields and v1 fields removed.
     """
-    # Back up the original state.json before migrating. Atomic like the rest: this is
-    # the only copy of the pre-migration state, so a truncated backup is a safety net
-    # with a hole in it (#175). The path is named because the warning below reports it.
+    # Back up the original state.json before migrating. Atomic like the rest: state.json
+    # still holds the v1 content at this moment, but the run's first save_state overwrites
+    # it, so this backup becomes the only copy. A truncated one is a safety net with a
+    # hole in it (#175). The path is named because the warning below reports it.
     backup_path = output_dir / "state.json.v1.bak"
     atomic_write_text(backup_path, json.dumps(data, indent=2))
 

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from discord_ferry.core.atomicio import atomic_write_text
 from discord_ferry.core.security import scrub_document
 from discord_ferry.errors import StateError
 
@@ -194,19 +195,10 @@ def save_state(state: MigrationState, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     data = _state_to_dict(state)
 
-    # Extract message_map and write it to its own file atomically.
+    # Extract message_map and write it to its own file.
     message_map = data.pop("message_map", {})
-    mm_tmp = output_dir / "message_map.json.tmp"
-    mm_final = output_dir / "message_map.json"
-    mm_tmp.write_text(json.dumps(message_map, indent=2), encoding="utf-8")
-    # replace, not rename: os.rename refuses an existing destination on Windows and
-    # replaces it everywhere else. save_state runs at every phase boundary and every
-    # checkpoint_interval messages, so the SECOND save of any run died here, not only
-    # a second run into an existing directory (#172).
-    mm_tmp.replace(mm_final)
+    atomic_write_text(output_dir / "message_map.json", json.dumps(message_map, indent=2))
 
-    tmp_path = output_dir / "state.json.tmp"
-    final_path = output_dir / "state.json"
     # Redact free-text fields on the way out, never in place: state.warnings must keep
     # its raw text in memory. save_state takes no config, so this relies on the
     # process-wide registry, which is where the proxy secrets live.
@@ -214,8 +206,7 @@ def save_state(state: MigrationState, output_dir: Path) -> None:
     # message_map was popped above and is deliberately NOT scrubbed. It holds identifier
     # pairs and no free text, and walking it measured ~290ms at 100k entries against
     # ~3ms for everything else, on a path that runs every 50 messages. Issue #140, ADR-014.
-    tmp_path.write_text(json.dumps(scrub_document(data), indent=2), encoding="utf-8")
-    tmp_path.replace(final_path)
+    atomic_write_text(output_dir / "state.json", json.dumps(scrub_document(data), indent=2))
 
 
 def load_state(output_dir: Path) -> MigrationState:
@@ -418,9 +409,11 @@ def _migrate_v1_to_v2(data: dict[str, Any], output_dir: Path) -> dict[str, Any]:
     Returns:
         Modified dict with v2 resume fields and v1 fields removed.
     """
-    # Back up the original state.json before migrating.
+    # Back up the original state.json before migrating. Atomic like the rest: this is
+    # the only copy of the pre-migration state, so a truncated backup is a safety net
+    # with a hole in it (#175). The path is named because the warning below reports it.
     backup_path = output_dir / "state.json.v1.bak"
-    backup_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    atomic_write_text(backup_path, json.dumps(data, indent=2))
 
     lcc: str = data.get("last_completed_channel", "")
     lcm: str = data.get("last_completed_message", "")

--- a/tests/test_atomicio.py
+++ b/tests/test_atomicio.py
@@ -1,0 +1,146 @@
+"""Tests for the shared atomic text writer.
+
+Issue #175. Three writers put a document straight at its final path, so an
+interrupted write truncated it and the previous good copy was already gone. The
+blueprint mattered most: export_blueprint and import_blueprint are a matched
+pair, so a truncated export outlived the run that produced it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from discord_ferry.core.atomicio import atomic_write_text
+
+
+def test_writes_a_new_file(tmp_path: Path) -> None:
+    target = tmp_path / "doc.json"
+
+    atomic_write_text(target, '{"a": 1}')
+
+    assert target.read_text(encoding="utf-8") == '{"a": 1}'
+
+
+def test_leaves_no_temp_file_behind(tmp_path: Path) -> None:
+    target = tmp_path / "doc.json"
+
+    atomic_write_text(target, "x")
+
+    assert not (tmp_path / "doc.json.tmp").exists()
+    assert [p.name for p in tmp_path.iterdir()] == ["doc.json"]
+
+
+def test_overwrites_an_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "doc.json"
+    atomic_write_text(target, "first")
+
+    atomic_write_text(target, "second")
+
+    assert target.read_text(encoding="utf-8") == "second"
+
+
+def test_overwrites_under_windows_rename_semantics(
+    windows_filesystem: None, tmp_path: Path
+) -> None:
+    """The helper must not reintroduce #172.
+
+    windows_filesystem makes Path.rename refuse an existing destination, the way
+    Win32 MoveFile does. A helper written with rename rather than replace fails
+    here and passes everywhere else, which is the whole reason the fixture exists.
+    """
+    target = tmp_path / "doc.json"
+    atomic_write_text(target, "first")
+
+    atomic_write_text(target, "second")
+
+    assert target.read_text(encoding="utf-8") == "second"
+
+
+def test_a_partial_write_leaves_the_previous_file_intact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """This is the property #175 is actually about.
+
+    The failure has to *truncate*, not merely raise. An earlier version of this
+    test patched write_text to raise before writing anything, and a direct write
+    then left the target untouched too, so it passed against the exact defect it
+    was written to catch. The mutation harness caught that. This one writes half
+    the new content and then fails, which is what a full disk does.
+    """
+    target = tmp_path / "doc.json"
+    atomic_write_text(target, '{"good": true}')
+    real_write_text = Path.write_text
+
+    def half_then_fail(self: Path, data: str, *args: object, **kwargs: object) -> None:
+        real_write_text(self, data[: len(data) // 2], encoding="utf-8")
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(Path, "write_text", half_then_fail)
+    with pytest.raises(OSError):
+        atomic_write_text(target, '{"replacement": true}')
+
+    monkeypatch.undo()
+    assert target.read_text(encoding="utf-8") == '{"good": true}'
+
+
+def test_a_failed_swap_leaves_the_previous_file_intact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The other half: the write succeeds and the swap is what fails."""
+    target = tmp_path / "doc.json"
+    atomic_write_text(target, '{"good": true}')
+
+    def refuse(self: Path, *args: object, **kwargs: object) -> None:
+        raise PermissionError(13, "destination held open")
+
+    monkeypatch.setattr(Path, "replace", refuse)
+    with pytest.raises(PermissionError):
+        atomic_write_text(target, '{"new": true}')
+
+    monkeypatch.undo()
+    assert target.read_text(encoding="utf-8") == '{"good": true}'
+
+
+# --- The guard --------------------------------------------------------------
+# The #172 review noted that nothing stopped a new writer using Path.rename
+# again: the grep was a one-time check and the simulated fixture only patches
+# Path.rename. This runs on every pull request instead.
+
+_DOCUMENT_MODULES = (
+    "state.py",
+    "discord/metadata.py",
+    "reporter.py",
+    "blueprint.py",
+)
+
+
+def test_document_modules_never_write_text_directly() -> None:
+    """The four modules owning Ferry's durable documents must go through the helper.
+
+    Scoped to four named modules rather than all of src/ on purpose. A repo-wide
+    ban would fire on the avatar, banner, role-icon and thread-archive writers,
+    which are legitimately direct, and would then need an allowlist that grows
+    until the rule means nothing.
+    """
+    src_root = Path(__file__).resolve().parents[1] / "src" / "discord_ferry"
+    offenders: list[str] = []
+
+    for rel in _DOCUMENT_MODULES:
+        path = src_root / rel
+        assert path.exists(), f"{rel} moved; update _DOCUMENT_MODULES"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "write_text"
+            ):
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "these modules own durable documents and must call atomic_write_text "
+        f"rather than write_text directly: {offenders}"
+    )

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -3,6 +3,8 @@
 import importlib.resources
 from pathlib import Path
 
+import pytest
+
 from discord_ferry.blueprint import (
     BlueprintCategory,
     BlueprintChannel,
@@ -150,3 +152,35 @@ def test_education_template_parses() -> None:
     assert bp.name == "Education Server"
     assert len(bp.roles) >= 2
     assert any("course" in cat.name.lower() for cat in bp.categories)
+
+
+def test_a_failed_export_leaves_the_previous_blueprint_importable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #175, the case that made this worth fixing.
+
+    ``export_blueprint`` and ``import_blueprint`` are a matched pair, so a
+    truncated file is read back by a later run. Before the atomic write, the
+    direct ``write_text`` truncated the target as soon as it opened it, which
+    destroyed a good blueprint the moment a second write failed partway through.
+    A user who then lost the source server had no way to tell the file was
+    incomplete until the import failed or built a partial server.
+    """
+    target = tmp_path / "server.json"
+    export_blueprint(_make_blueprint(), target)
+    real_write_text = Path.write_text
+
+    def half_then_fail(self: Path, data: str, *args: object, **kwargs: object) -> None:
+        # Half the content, then fail. A failure that writes nothing leaves the
+        # target intact even without the temp file, so it would not detect the bug.
+        real_write_text(self, data[: len(data) // 2], encoding="utf-8")
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(Path, "write_text", half_then_fail)
+    with pytest.raises(OSError):
+        export_blueprint(ServerBlueprint(name="Replacement"), target)
+    monkeypatch.undo()
+
+    recovered = import_blueprint(target)
+    assert recovered.name == "Test Server"
+    assert [r.name for r in recovered.roles] == ["Admin", "Member"]

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.5"
+version = "2.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #175. Picked up because that issue's own deferral trigger fired: "the release after #172 ships", and v2.14.5 shipped.

## The bug

Three writers put a document straight at its final path. `write_text` truncates its target the moment it opens it, so a crash, a full disk or a killed process partway through left a half-written file where a complete one was expected, and the previous good copy was already gone.

The blueprint is why this was worth doing. `export_blueprint` and `import_blueprint` (`blueprint.py:47` and `:59`) are a matched pair, so a truncated export is read back by a later run and the damage outlives the run that produced it. A user who then lost the source server had no way to tell an incomplete file from a good one until the import failed or built a partial server. The two reporter outputs are lower stakes, both regenerable and neither consumed by Ferry.

## The change

`src/discord_ferry/core/atomicio.py`, one function, and seven sites routed through it.

| Site | Before |
|---|---|
| `reporter.py` markdown | direct write |
| `reporter.py` JSON | direct write |
| `blueprint.py` | direct write |
| `state.py` `state.json.v1.bak` | direct write |
| `state.py` `message_map.json` | inline temp then swap |
| `state.py` `state.json` | inline temp then swap |
| `discord/metadata.py` | inline temp then swap |

**Seven, not the three the issue named.** A sweep for every writing call in `src/` turned up `state.json.v1.bak`, the backup taken immediately before a v1 to v2 state migration rewrites `state.json`. It was ruled out of scope during #172 because it performs no swap, which was right for that issue and wrong here. `state.json` still holds the old content while the backup is written, since `load_state` does not rewrite it, but the run's first `save_state` does, and from that point the backup is the only copy. A truncated one is a safety net with a hole in it.

Redaction does not move. The helper takes finished text, so `scrub_document` stays at the writer where ADR-014 put it, with the same call sites and the same arguments. `message_map` is still popped before scrubbing and still not walked.

Temp names for the three existing sites are byte-identical to before (`state.json.tmp`, `message_map.json.tmp`, `discord_metadata.json.tmp`). Nothing in `src/` reads a `.tmp` path.

## The four writers left alone, on evidence

All binary, and none is a document that outlives its run. The role icon, banner and avatar are all written and then read straight back to upload from, so a partial write surfaces immediately as an upload failure rather than as a file that looks fine until much later; the role icon is `unlink`ed in a `finally` besides. `messages.py:782` is the thread archive, which is #173's own site and regenerable, left out so this branch carries one root cause.

That distinction is the reason the changelog names four documents rather than claiming every file is covered.

## A guard, because the last one was one-time

The #172 whole-branch review noted that nothing stopped a new writer using `Path.rename` again: the check there was a grep run once during the build. This adds an `ast` walk over the four modules that own Ferry's durable documents, failing the build if any of them writes directly.

Scoped to four named modules on purpose. A repo-wide ban would fire on the avatar, banner, role-icon and thread-archive writers, which are legitimately direct, and would need an allowlist that grows until the rule means nothing.

## Verification

```
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
1697 passed
```

Mutation harness, run and recorded rather than assumed. Both defects the helper exists to prevent are covered:

| Mutation | Result |
|---|---|
| direct write, no temp file (reintroduces #175) | 3 tests fail |
| `rename` instead of `replace` (reintroduces #172) | 5 tests fail, including the Windows ones |

**One of those tests was vacuous until the harness caught it.** It patched `write_text` to raise before writing anything, so a direct write left the target intact too and it passed against the exact defect it was written for. It now writes half the content and then fails, which is what a full disk does. That change is why mutation A kills three tests rather than one.

CI's `windows-atomic-write` job, added in v2.14.4, now also runs `tests/test_atomicio.py` and `tests/test_blueprint.py` alongside the state and metadata suites on `windows-latest`. The whole-branch review pointed out that the blueprint, the case this release leads with, would otherwise never execute on a real Win32 runner: the conftest fixture only simulates rename semantics. Green in 23s.

That review also caught a sentence in the changelog claiming every file Ferry writes and reads is now atomic. It is not, and this branch's own guard test says so: the avatar and banner writers put bytes straight at their final path and read them back to upload from. Narrowed in `0322778` to name the four documents that actually changed.

## Related issues, and why they are not here

- **#173** thread archive filesystem names. Investigated during this work and the findings are posted on the issue: real DCE captures show thread names are free-form display text, and only the filename half is exposed because `parent_channel_name` comes from a filename stem DCE already made legal. Still gated on which characters Discord permits in a thread name, which is not answerable from this repo.
- **#174** full Windows CI leg. Trigger is a third Windows-only defect or a newly reported one. Neither has happened.
- **#176** `os.replace` on a held-open destination. Trigger is a user report. None.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171SrxqNqV1k9BKHLrNdGCL
