### PR TITLE
fix(messages): stop a duplicate send becoming a real duplicate, and land the batch 8 merge guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.14.7] - 2026-08-11
+
+### Fixed
+
+- A message that Stoat had already accepted could be reported as failed, and a later
+  `--incremental` run would then send it a second time, leaving two copies in the
+  channel. This happened when a send succeeded but its reply was lost on the way
+  back, for example on a flaky connection: Ferry retried, Stoat recognised the retry
+  and refused it as a duplicate, and Ferry read that refusal as a failure. Ferry now
+  recognises it as "already delivered", so the message is not recorded as failed and
+  nothing re-sends it. Stoat does not say which message it was, so a message affected
+  this way cannot be used as a reply target, and its pin and reactions are skipped; a
+  warning names it in the report (#107 batch 7).
+- The forum index message is no longer reported as a failure when it turns out to have
+  been posted already, and the index channel keeps its place in the migrated server
+  rather than being left unlinked.
+
+### Changed
+
+- When a thread and its parent channel both refer to the same source message, the
+  parent's copy is now the one Ferry records, consistently rather than depending on
+  which channel happened to finish first. Replies and pins inside a channel now
+  resolve against that channel's own messages first. This has no effect on the
+  current DiscordChatExporter version and is groundwork for updating it (#110).
+
 ## [2.14.6] - 2026-08-11
 
 ### Fixed

--- a/docs/reference/stoat-api-notes.md
+++ b/docs/reference/stoat-api-notes.md
@@ -302,6 +302,28 @@ mechanism:
 Treat the idempotency key as a cheap guard against an immediate double-send within one run — a
 retried request, a duplicated task — and nothing more.
 
+### Ferry acts on the 409 as of v2.14.7
+
+Before v2.14.7 the guard fired and Ferry treated the answer as a failure. A 409 reached the generic
+error handler at every send site, which recorded the message in `state.failed_messages`. An
+`--incremental` run then re-attempted it, by which point the key had left the cache, so the re-send
+succeeded and the channel held the message twice. The mechanism meant to prevent a duplicate was
+producing one.
+
+A 409 whose body is `{"type": "DuplicateNonce"}` now raises `DuplicateSendError`, and every send
+site treats it as delivered. Nothing is recorded as failed, so nothing re-sends it. Any other 409,
+and any body that is not a JSON object, still raises the generic error.
+
+What it costs, because the 409 carries no message id:
+
+- A duplicate on a message's **first part** loses its `message_map` entry. Replies to that one
+  message will not resolve, its pin is skipped and its reactions are skipped. A warning of type
+  `duplicate_send_unmapped` names the message.
+- A duplicate on a **later part** costs nothing. Only the first part feeds the map, and the
+  remaining parts still send, because each part carries its own key.
+- A duplicate on the **forum index** means the index message cannot be pinned. The channel wiring
+  does not need that id and still happens.
+
 !!! note "Deprecated: nonce body field"
     The old `nonce` body field on message sends is deprecated. Use the `Idempotency-Key` HTTP header
     instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.14.6"
+version = "2.14.7"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.14.6"
+__version__ = "2.14.7"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -22,7 +22,7 @@ from discord_ferry.discord import (
     load_discord_metadata,
     save_discord_metadata,
 )
-from discord_ferry.errors import DotNetMissingError, MigrationError
+from discord_ferry.errors import DotNetMissingError, DuplicateSendError, MigrationError
 from discord_ferry.exporter import (
     detect_dotnet,
     download_dce,
@@ -933,26 +933,37 @@ async def _rebuild_forum_indexes(
                     )
                     index_msg_id: str = existing_msg_id
                 else:
-                    msg_result = await api_send_message(
-                        session,
-                        config.stoat_url,
-                        config.token,
-                        index_channel_id,
-                        content=content,
-                        masquerade={"name": "Discord Ferry"},
-                        idempotency_key=f"ferry-forum-index-rebuilt-{forum_key}",
-                    )
+                    try:
+                        msg_result = await api_send_message(
+                            session,
+                            config.stoat_url,
+                            config.token,
+                            index_channel_id,
+                            content=content,
+                            masquerade={"name": "Discord Ferry"},
+                            idempotency_key=f"ferry-forum-index-rebuilt-{forum_key}",
+                        )
+                        index_msg_id = msg_result["_id"]
+                    except DuplicateSendError:
+                        # Already on the server with no recoverable id. Write NOTHING to
+                        # forum_index_message_ids: an entry there persists into
+                        # state.json and drives an api_edit_message against an id that
+                        # does not exist on the next run. Letting the broad handler take
+                        # this instead would report a rebuild failure that did not
+                        # happen, which is the same defect as the FailedMessage on the
+                        # message path.
+                        index_msg_id = ""
                     await asyncio.sleep(config.upload_delay)
-                    index_msg_id = msg_result["_id"]
-                    state.forum_index_message_ids[forum_key] = index_msg_id
-                    await api_pin_message(
-                        session,
-                        config.stoat_url,
-                        config.token,
-                        index_channel_id,
-                        index_msg_id,
-                    )
-                    await asyncio.sleep(config.upload_delay)
+                    if index_msg_id:
+                        state.forum_index_message_ids[forum_key] = index_msg_id
+                        await api_pin_message(
+                            session,
+                            config.stoat_url,
+                            config.token,
+                            index_channel_id,
+                            index_msg_id,
+                        )
+                        await asyncio.sleep(config.upload_delay)
                 on_event(
                     MigrationEvent(
                         phase="report",

--- a/src/discord_ferry/errors.py
+++ b/src/discord_ferry/errors.py
@@ -21,6 +21,15 @@ class MigrationError(FerryError):
     """Error during migration phase."""
 
 
+class DuplicateSendError(MigrationError):
+    """Stoat rejected a send because its Idempotency-Key was still cached.
+
+    The message IS on the server. Stoat does not return it, so the caller has no
+    Stoat message id. Subclasses MigrationError so a call site that does not catch
+    this behaves exactly as it did before the class existed.
+    """
+
+
 class StateError(FerryError):
     """State file read/write error."""
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -307,7 +307,7 @@ async def _api_request_inner(
                     # falling through to the catch-all below.
                     try:
                         dup_body = await resp.json(content_type=None)
-                    except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError):
+                    except (json.JSONDecodeError, ValueError):
                         dup_body = None
                     if isinstance(dup_body, dict) and dup_body.get("type") == "DuplicateNonce":
                         # A delivered message, so this must not prime the breaker. Same

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp  # noqa: TCH002
 
 from discord_ferry.core.http import new_session, proxy_error_is_permanent, proxy_hint, tls_hint
-from discord_ferry.errors import MigrationError
+from discord_ferry.errors import DuplicateSendError, MigrationError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping
@@ -293,6 +293,34 @@ async def _api_request_inner(
                         await asyncio.sleep(delay)
                         _circuit_state.consecutive_failures += 1
                     continue
+
+                if resp.status == 409:
+                    # A still-cached Idempotency-Key. The message IS on the server;
+                    # Stoat answers DuplicateNonce and does not return it, so the caller
+                    # gets no message id. Only a request that CARRIED a key can reach
+                    # this, so "the caller opted in" and "the caller sent a key" are the
+                    # same condition and no opt-in flag is needed.
+                    #
+                    # isinstance-guarded exactly like the 429 body parse at :203: a
+                    # syntactically valid 409 body that is a list, a number or a string
+                    # would otherwise raise AttributeError out of this branch instead of
+                    # falling through to the catch-all below.
+                    try:
+                        dup_body = await resp.json(content_type=None)
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError):
+                        dup_body = None
+                    if isinstance(dup_body, dict) and dup_body.get("type") == "DuplicateNonce":
+                        # A delivered message, so this must not prime the breaker. Same
+                        # bookkeeping as the 204 branch above.
+                        _circuit_state.consecutive_failures = 0
+                        if _rate_multiplier > 1.0 and not any(
+                            time.monotonic() - t < 30 for t in _rate_429_window
+                        ):
+                            _rate_multiplier = max(_rate_multiplier * 0.75, 1.0)
+                        raise DuplicateSendError(
+                            "Stoat rejected a duplicate Idempotency-Key; the message "
+                            "is already on the server"
+                        )
 
                 text = await resp.text()
                 raise MigrationError(f"API error {resp.status}: {text}")

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1517,6 +1517,12 @@ async def _process_message(
         # the retry loop accounts correctly and terminates. The parallel per-channel path
         # (channel_result set) keeps degrade-in-loop. Guard is provably retry-path-only:
         # only engine.py's retry loop passes channel_result=None.
+        #
+        # Batch 7: a DuplicateSendError never reaches here. It is caught per part inside
+        # the send loop above, because a duplicate means the message landed and there is
+        # no re-failure to mark. Re-raising it would leave the message in
+        # failed_messages, which is exactly the defect batch 7 removes. Pinned by
+        # test_retry_path_does_not_reraise_on_a_duplicate.
         if channel_result is None:
             raise
         return

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1368,23 +1368,37 @@ async def _process_message(
 
     # Step 8: Send the message (all parts).
     stoat_msg_id: str = ""
+    duplicate_unmapped = False
     try:
         for part_idx, part_content in enumerate(parts):
             is_first = part_idx == 0
             idem_key = f"ferry-{msg.id}" if len(parts) == 1 else f"ferry-{msg.id}_p{part_idx + 1}"
-            result = await api_send_message(
-                session,
-                config.stoat_url,
-                config.token,
-                stoat_channel_id,
-                content=part_content,
-                # Attachments, embeds, and replies only on the first part.
-                attachments=(autumn_ids if autumn_ids and is_first else None),
-                embeds=(stoat_embeds if stoat_embeds and is_first else None),
-                masquerade=masquerade,
-                replies=(replies if replies and is_first else None),
-                idempotency_key=idem_key,
-            )
+            try:
+                result = await api_send_message(
+                    session,
+                    config.stoat_url,
+                    config.token,
+                    stoat_channel_id,
+                    content=part_content,
+                    # Attachments, embeds, and replies only on the first part.
+                    attachments=(autumn_ids if autumn_ids and is_first else None),
+                    embeds=(stoat_embeds if stoat_embeds and is_first else None),
+                    masquerade=masquerade,
+                    replies=(replies if replies and is_first else None),
+                    idempotency_key=idem_key,
+                )
+            except DuplicateSendError:
+                # This part is already on the server. The catch is PER PART, not around
+                # the loop: every part carries its own Idempotency-Key, so the parts
+                # after a duplicate are NOT duplicates and must still be sent. Catching
+                # at the loop truncates the message and loses their content with no
+                # warning, which is worse than the bug this batch fixes.
+                #
+                # Only the first part's id reaches message_map, so only it is worth
+                # noting. Stoat returns no id with the 409, so that entry is lost.
+                if is_first:
+                    duplicate_unmapped = True
+                continue
             part_stoat_id: str = result["_id"]
             if is_first:
                 stoat_msg_id = part_stoat_id

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1403,12 +1403,23 @@ async def _process_message(
             if is_first:
                 stoat_msg_id = part_stoat_id
 
+        # Only the statements that CONSUME the id are guarded. The counters and the
+        # reference-set updates run either way, because the message IS on the server.
+        #
+        # Do NOT fold `stoat_msg_id` into the branch condition above. `else` means "not
+        # the condition above", not "the retry path", so a parallel-path message with an
+        # empty id would fall into the retry branch and write state.message_map directly,
+        # bypassing ChannelResult and the save_lock discipline. Both branches leave the
+        # same channel_message_counts, so no state-level test can see that mistake.
+        # Pinned by test_duplicate_runs_the_parallel_branch_not_the_retry_branch.
         if channel_result is not None:
-            channel_result.message_map_updates[msg.id] = stoat_msg_id
+            if stoat_msg_id:
+                channel_result.message_map_updates[msg.id] = stoat_msg_id
             channel_result.referenced_autumn_ids.update(autumn_ids, embed_media_ids)
             channel_result.messages_migrated += 1  # S15: track for forum index rebuild
         else:
-            state.message_map[msg.id] = stoat_msg_id
+            if stoat_msg_id:
+                state.message_map[msg.id] = stoat_msg_id
             state.referenced_autumn_ids.update(autumn_ids, embed_media_ids)
             # S15: Track per-channel message count (direct-state path, e.g. retry).
             if export_channel_id:
@@ -1416,11 +1427,12 @@ async def _process_message(
                     state.channel_message_counts.get(export_channel_id, 0) + 1
                 )
 
-        if msg.is_pinned:
+        if msg.is_pinned and stoat_msg_id:
             acc_pins.append((stoat_channel_id, stoat_msg_id))
 
-        # Step 8b: Queue reactions (only in native mode).
-        if _effective_mode == "native":
+        # Step 8b: Queue reactions (only in native mode). Guarded at the block, which
+        # covers BOTH append sites, the custom-emoji one and the Unicode one.
+        if _effective_mode == "native" and stoat_msg_id:
             for reaction in msg.reactions:
                 if reaction.emoji.id:  # Custom emoji.
                     stoat_emoji = state.emoji_map.get(reaction.emoji.id)

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -137,6 +137,13 @@ class ChannelResult:
     warnings: list[dict[str, str]] = field(default_factory=list)
     errors: list[dict[str, str]] = field(default_factory=list)
     failed_messages: list[FailedMessage] = field(default_factory=list)
+    #: Source message id to Stoat message id, for this channel only.
+    #:
+    #: INVARIANT: never write an empty value here. The reply and pin lookups in
+    #: ``_process_message`` decide whether to fall back to the shared ``state.message_map``
+    #: with ``is None``, not with falsiness, so an empty string would read as "found" and
+    #: suppress the fallback, resolving the reference to nothing. The write site is
+    #: guarded on ``if stoat_msg_id:`` for exactly this reason.
     message_map_updates: dict[str, str] = field(default_factory=dict)
     pending_pins: list[tuple[str, str]] = field(default_factory=list)
     pending_reactions: list[dict[str, object]] = field(default_factory=list)
@@ -1441,6 +1448,9 @@ async def _process_message(
         # same channel_message_counts, so no state-level test can see that mistake.
         # Pinned by test_duplicate_runs_the_parallel_branch_not_the_retry_branch.
         if channel_result is not None:
+            # This guard is load-bearing twice over: it keeps an empty id out of the map,
+            # and it upholds the ChannelResult.message_map_updates invariant that the
+            # reply and pin lookups rely on. See the field's own comment.
             if stoat_msg_id:
                 channel_result.message_map_updates[msg.id] = stoat_msg_id
             channel_result.referenced_autumn_ids.update(autumn_ids, embed_media_ids)

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -157,7 +157,24 @@ def _merge_channel_result(state: MigrationState, result: ChannelResult) -> None:
     state.warnings.extend(result.warnings)
     state.errors.extend(result.errors)
     state.failed_messages.extend(result.failed_messages)
-    state.message_map.update(result.message_map_updates)
+    # Parent-wins on a thread-starter collision. Prerequisite for batch 8 (#110): after
+    # DCE 2.47.3 a thread's starter carries the ORIGIN message's id, and a thread's
+    # channel id EQUALS that origin id, so the parent channel and the thread channel
+    # write the same key. save_lock serialises these merges but does not ORDER them, and
+    # a small thread routinely finishes before its large parent, so first-wins and
+    # last-wins are both wrong.
+    #
+    # The discriminator is exact: a thread's map key equals its own channel_id, and a
+    # parent's never does. Both halves are required. Dropping `in state.message_map`
+    # would lose a thread's only entry when its parent has not merged yet; dropping the
+    # key comparison would suppress an ordinary re-merge.
+    #
+    # Inert at the current 2.47.1 pin, where the starter carries a synthetic id that
+    # collides with nothing. Pinned in both arrival orders by test_parent_wins_*.
+    for _key, _stoat_id in result.message_map_updates.items():
+        if _key == result.channel_id and _key in state.message_map:
+            continue
+        state.message_map[_key] = _stoat_id
     state.pending_pins.extend(result.pending_pins)
     state.pending_reactions.extend(result.pending_reactions)
     state.attachments_uploaded += result.attachments_uploaded

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1129,10 +1129,15 @@ async def _process_message(
     # ChannelPinnedMessage: mark the referenced message for re-pinning, don't send.
     if msg.type == "ChannelPinnedMessage":
         if msg.reference and msg.reference.message_id:
-            # Check both the main state map and the channel result's local map.
-            ref_stoat_id = state.message_map.get(msg.reference.message_id)
-            if ref_stoat_id is None and channel_result is not None:
+            # Channel-local FIRST, then the shared map. After the DCE bump a parent and
+            # a thread can hold the same key with different values, and a pin in this
+            # channel must resolve to this channel's copy. Same rule as the reply
+            # lookup below.
+            ref_stoat_id = None
+            if channel_result is not None:
                 ref_stoat_id = channel_result.message_map_updates.get(msg.reference.message_id)
+            if ref_stoat_id is None:
+                ref_stoat_id = state.message_map.get(msg.reference.message_id)
             if ref_stoat_id:
                 acc_pins.append((stoat_channel_id, ref_stoat_id))
             else:
@@ -1307,9 +1312,15 @@ async def _process_message(
             channel_result.replies_total += 1
         else:
             state.replies_total += 1
-        ref_stoat_id = state.message_map.get(msg.reference.message_id)
-        if ref_stoat_id is None and channel_result is not None:
+        # Channel-local FIRST, then the shared map. Without this, a reply in the parent
+        # channel can resolve to the thread's copy of the same key once DCE 2.47.3 makes
+        # the two collide, and a sent reply cannot be unsent. Pairs with the parent-wins
+        # guard in _merge_channel_result: neither half works alone.
+        ref_stoat_id = None
+        if channel_result is not None:
             ref_stoat_id = channel_result.message_map_updates.get(msg.reference.message_id)
+        if ref_stoat_id is None:
+            ref_stoat_id = state.message_map.get(msg.reference.message_id)
         if ref_stoat_id:
             replies.append({"id": ref_stoat_id, "mention": False})
             if channel_result is not None:

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1427,6 +1427,22 @@ async def _process_message(
                     state.channel_message_counts.get(export_channel_id, 0) + 1
                 )
 
+        if duplicate_unmapped:
+            # The message is on the server but Stoat returned no id with the 409, so
+            # nothing can reference it: replies to it will not resolve, and its pin and
+            # reactions are skipped above. Say so rather than reporting a clean run.
+            acc_warnings.append(
+                {
+                    "phase": "messages",
+                    "type": "duplicate_send_unmapped",
+                    "message": (
+                        f"Message {msg.id} was already on the server (duplicate send); "
+                        "its Stoat id could not be recovered, so replies to it and its "
+                        "pins and reactions were skipped"
+                    ),
+                }
+            )
+
         if msg.is_pinned and stoat_msg_id:
             acc_pins.append((stoat_channel_id, stoat_msg_id))
 

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.security import safe_sanitize
+from discord_ferry.errors import DuplicateSendError
 from discord_ferry.migrator.api import api_send_message, get_rate_multiplier, get_session
 from discord_ferry.migrator.sanitize import truncate_name
 from discord_ferry.parser.dce_parser import check_cdn_url_expiry, stream_messages
@@ -580,6 +581,10 @@ async def _merge_threads(
                         masquerade={"name": "Discord Ferry"},
                         idempotency_key=f"ferry-thread-sep-{export.channel.id}",
                     )
+                except DuplicateSendError:
+                    # Already on the server. The return value is discarded here, so a
+                    # duplicate is indistinguishable from a success.
+                    pass
                 except Exception as exc:  # noqa: BLE001
                     safe_exc = safe_sanitize(config.token_store, str(exc))
                     state.warnings.append(
@@ -641,6 +646,14 @@ async def _merge_threads(
                             masquerade=masquerade,
                             idempotency_key=idem_key,
                         )
+                    except DuplicateSendError:
+                        # Already on the server. _msg_failed deliberately stays False so
+                        # the message still reaches _succeeded_ids and drives
+                        # reconciliation. Recording a FailedMessage here is the defect
+                        # this batch fixes: --incremental re-attempts previously-failed
+                        # ids, the idempotency LRU has evicted the key by then, and the
+                        # re-send succeeds, leaving a real duplicate in the channel.
+                        continue
                     except Exception as exc:  # noqa: BLE001
                         safe_exc = safe_sanitize(config.token_store, str(exc))
                         state.warnings.append(
@@ -848,6 +861,9 @@ async def _process_single_channel(
                     masquerade={"name": "Discord Ferry"},
                     idempotency_key=f"ferry-header-{export.channel.id}",
                 )
+            except DuplicateSendError:
+                # Already on the server. The return value is discarded here.
+                pass
             except Exception as exc:  # noqa: BLE001
                 result.warnings.append(
                     {

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -14,7 +14,7 @@ from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
 from discord_ferry.discord.metadata import RoleMeta, load_discord_metadata
-from discord_ferry.errors import AutumnUploadError, MigrationError
+from discord_ferry.errors import AutumnUploadError, DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_role,
@@ -1256,26 +1256,36 @@ async def run_channels(
                 else:
                     content = "No posts migrated."
 
-                msg_result = await api_send_message(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    index_channel_id,
-                    content=content,
-                    masquerade={"name": "Discord Ferry"},
-                    idempotency_key=f"ferry-forum-index-{forum_key}",
-                )
+                index_msg_id: str = ""
+                try:
+                    msg_result = await api_send_message(
+                        session,
+                        config.stoat_url,
+                        config.token,
+                        index_channel_id,
+                        content=content,
+                        masquerade={"name": "Discord Ferry"},
+                        idempotency_key=f"ferry-forum-index-{forum_key}",
+                    )
+                    index_msg_id = msg_result["_id"]
+                except DuplicateSendError:
+                    # The index message is already on the server. Stoat returns no id
+                    # with the 409, so it cannot be pinned. Everything below uses
+                    # index_channel_id rather than the message id, so the channel wiring
+                    # must still run: letting the broad handler swallow it would lose
+                    # the channel_map entry for a channel that exists.
+                    pass
                 await asyncio.sleep(config.upload_delay)
 
-                index_msg_id: str = msg_result["_id"]
-                await api_pin_message(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    index_channel_id,
-                    index_msg_id,
-                )
-                await asyncio.sleep(config.upload_delay)
+                if index_msg_id:
+                    await api_pin_message(
+                        session,
+                        config.stoat_url,
+                        config.token,
+                        index_channel_id,
+                        index_msg_id,
+                    )
+                    await asyncio.sleep(config.upload_delay)
 
                 # Insert at position 0 so it appears at the top of the category.
                 category_channels.setdefault(forum_cat_stoat_id, []).insert(0, index_channel_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1652,6 +1652,13 @@ async def test_other_409_variant_raises_generic_error(mock_aiohttp: aioresponses
             )
     assert not isinstance(ei.value, DuplicateSendError)
     assert "409" in str(ei.value)
+    # The 409 branch calls resp.json() before falling through to resp.text(). aiohttp
+    # caches the body on first read, so the catch-all still reports it. Asserted rather
+    # than assumed: if the stream were consumed the message would end at "409: ".
+    assert "SomethingElse" in str(ei.value), (
+        "the response body was lost, so resp.json() consumed the stream and the "
+        "catch-all now reports an empty body"
+    )
 
 
 @pytest.mark.parametrize("payload", [["not", "an", "object"], 42, "bare string"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.http import new_session
-from discord_ferry.errors import MigrationError
+from discord_ferry.errors import DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
     _circuit_state,
@@ -1609,3 +1609,124 @@ async def test_a_certificate_error_against_an_https_proxy_names_the_proxy_not_th
         "proxy wins and REPLACES the certificate hint; appending both sends the "
         "user to a CA bundle for a host they never configured"
     )
+
+
+# ---------------------------------------------------------------------------
+# DuplicateNonce 409 (#107 batch 7, chunk #195, task #201)
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_nonce_raises_duplicate_send_error(mock_aiohttp: aioresponses) -> None:
+    """SC-1.1: a DuplicateNonce body raises the distinct subclass.
+
+    Body shape read from revoltchat/backend crates/core/result/src/lib.rs: ErrorType
+    carries serde(tag = "type") and Error.error_type carries serde(flatten), so the
+    variant tag is a top-level key.
+    """
+    mock_aiohttp.post(
+        f"{BASE_URL}/channels/c1/messages",
+        status=409,
+        payload={"type": "DuplicateNonce", "location": "crates/x/src/lib.rs:12:3"},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(DuplicateSendError) as ei:
+            await api_send_message(
+                session, BASE_URL, TOKEN, "c1", content="x", idempotency_key="ferry-1"
+            )
+    assert isinstance(ei.value, MigrationError), (
+        "must subclass MigrationError so an uncatching call site is unaffected"
+    )
+
+
+async def test_other_409_variant_raises_generic_error(mock_aiohttp: aioresponses) -> None:
+    """SC-1.2: a different 409 variant is NOT a duplicate. Kills mutant M6."""
+    mock_aiohttp.post(
+        f"{BASE_URL}/channels/c1/messages",
+        status=409,
+        payload={"type": "SomethingElse", "location": "x.rs:1:1"},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as ei:
+            await api_send_message(
+                session, BASE_URL, TOKEN, "c1", content="x", idempotency_key="ferry-1"
+            )
+    assert not isinstance(ei.value, DuplicateSendError)
+    assert "409" in str(ei.value)
+
+
+@pytest.mark.parametrize("payload", [["not", "an", "object"], 42, "bare string"])
+async def test_non_object_409_body_does_not_crash(payload: object) -> None:
+    """SC-1.3: a JSON 409 body that is not a dict must not raise AttributeError.
+
+    Kills mutant M5, dropping the isinstance guard the 429 branch already applies.
+    """
+    with aioresponses() as m:
+        m.post(f"{BASE_URL}/channels/c1/messages", status=409, payload=payload)
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(MigrationError) as ei:
+                await api_send_message(
+                    session, BASE_URL, TOKEN, "c1", content="x", idempotency_key="ferry-1"
+                )
+    assert not isinstance(ei.value, DuplicateSendError)
+
+
+async def test_409_with_no_idempotency_key_is_unchanged(mock_aiohttp: aioresponses) -> None:
+    """SC-1.4: an endpoint that sends no key still sees the generic error.
+
+    A DuplicateNonce is only reachable when a key was sent, which is what makes the
+    opt-in flag redundant. This pins that an unrelated 409 elsewhere is untouched.
+    """
+    mock_aiohttp.post(
+        f"{BASE_URL}/servers/srv1/roles", status=409, payload={"type": "AlreadyInGroup"}
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as ei:
+            await api_create_role(session, BASE_URL, TOKEN, "srv1", "role")
+    assert not isinstance(ei.value, DuplicateSendError)
+
+
+async def test_duplicate_path_resets_the_circuit_breaker(mock_aiohttp: aioresponses) -> None:
+    """SC-1.5: a duplicate is a delivered message, so it must not prime the breaker.
+
+    No functional test would notice if this bookkeeping were dropped, which is why it
+    gets its own test.
+    """
+    _circuit_state.consecutive_failures = 3
+    try:
+        mock_aiohttp.post(
+            f"{BASE_URL}/channels/c1/messages",
+            status=409,
+            payload={"type": "DuplicateNonce", "location": "x.rs:1:1"},
+        )
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(DuplicateSendError):
+                await api_send_message(
+                    session, BASE_URL, TOKEN, "c1", content="x", idempotency_key="ferry-1"
+                )
+        assert _circuit_state.consecutive_failures == 0
+    finally:
+        _reset_circuit_state()
+
+
+async def test_uncatching_call_site_still_sees_a_migration_error(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-1.6: the property that removes the need for an opt-in flag.
+
+    A caller written before this class existed catches MigrationError or Exception.
+    Both must still catch a duplicate.
+    """
+    mock_aiohttp.post(
+        f"{BASE_URL}/channels/c1/messages",
+        status=409,
+        payload={"type": "DuplicateNonce", "location": "x.rs:1:1"},
+    )
+    caught: str = ""
+    async with aiohttp.ClientSession() as session:
+        try:
+            await api_send_message(
+                session, BASE_URL, TOKEN, "c1", content="x", idempotency_key="ferry-1"
+            )
+        except MigrationError as exc:  # the pre-existing handler shape
+            caught = type(exc).__name__
+    assert caught == "DuplicateSendError"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2111,3 +2111,60 @@ async def test_retry_path_does_not_reraise_on_a_duplicate(tmp_path: Path) -> Non
     assert "msg_dup" not in state.message_map, (
         "Stoat returns no id with a 409, so nothing may be mapped for it"
     )
+
+
+async def test_index_rebuild_duplicate_writes_no_state_entry(tmp_path: Path) -> None:
+    """SC-2.7: three id consumers here, and the state write is the one that matters.
+
+    A bad forum_index_message_ids entry persists into state.json and is read back on
+    the next run, where it drives an api_edit_message against an id that does not
+    exist. Nothing may be written when Stoat returned no id.
+    """
+    from discord_ferry.core.engine import _rebuild_forum_indexes
+
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="stoat-srv",
+        forum_channel_members={"forum-news": ["disc-ch1"]},
+        forum_category_names={"forum-news": "News"},
+        channel_map={
+            "disc-ch1": "stoat-ch1",
+            "forum-index-forum-news": "stoat-idx-news",
+        },
+        channel_message_counts={"disc-ch1": 42},
+    )
+
+    pins: list[str] = []
+
+    with aioresponses() as mock:
+        mock.post(
+            "https://api.test/channels/stoat-idx-news/messages",
+            status=409,
+            payload={"type": "DuplicateNonce", "location": "crates/x/src/lib.rs:1:1"},
+        )
+        # Registered so a stray pin is recorded rather than erroring out.
+        mock.put(
+            "https://api.test/channels/stoat-idx-news/messages/new-idx-msg/pin",
+            payload={},
+            callback=lambda url, **kwargs: pins.append(str(url)),  # type: ignore[misc]
+        )
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            config.session = session
+            await _rebuild_forum_indexes(config, state, events.append)
+
+    assert pins == [], "a pin was attempted against an id that was never returned"
+    assert not state.forum_index_message_ids, (
+        "an index message id was recorded for a message whose id Stoat never returned; "
+        "this persists into state.json and drives an edit against a nonexistent id "
+        f"on the next run. got: {state.forum_index_message_ids}"
+    )
+    # The two above already hold, because the broad handler catches the duplicate before
+    # either statement runs. This one does not: it is the reason the task exists.
+    assert not [w for w in state.warnings if w.get("type") == "forum_index_rebuild_failed"], (
+        "the rebuild was reported as failed, but the index message is on the server. "
+        "Reporting a failure that did not happen is the same defect as the FailedMessage "
+        "on the message path, in a different place"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -14,6 +14,7 @@ from aioresponses import aioresponses
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import PHASE_ORDER, PhaseFunction, run_migration, run_retry_failed
 from discord_ferry.core.events import EventCallback, MigrationEvent
+from discord_ferry.errors import DuplicateSendError
 from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
 from discord_ferry.state import FailedMessage, MigrationState
 
@@ -2063,3 +2064,50 @@ async def test_preflight_emits_and_persists_a_proxy_notice(
 
     assert any(e.status == "notice" and e.phase == "preflight" for e in events)
     assert any(w.get("type", "").startswith("proxy_") for w in state.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate on the retry path (#107 batch 7, chunk #197, task #206)
+# ---------------------------------------------------------------------------
+
+
+async def test_retry_path_does_not_reraise_on_a_duplicate(tmp_path: Path) -> None:
+    """SC-2.9: a duplicate means the message landed, so the retry loop must terminate.
+
+    _process_message re-raises when channel_result is None, which is this path, because
+    the retry loop relies on an exception to mark a re-failure. A DuplicateSendError is
+    NOT a re-failure: the message is on the server. It never reaches that re-raise,
+    because the catch sits inside the send loop.
+
+    This test passes without a source change in this task. Its value is that it stays
+    true: moving the catch from inside the loop to around it makes it fail.
+    """
+    config = _make_retry_config(tmp_path)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    _write_dce_json(config.export_dir, "ch_dup", [_dce_msg_dict("msg_dup")])
+    exports = _make_exports_from_dir(config.export_dir)
+    state = MigrationState(
+        channel_map={"ch_dup": "stoat_ch_dup"},
+        autumn_url=AUTUMN_URL,
+        failed_messages=[
+            FailedMessage(discord_msg_id="msg_dup", stoat_channel_id="stoat_ch_dup", error="e"),
+        ],
+    )
+
+    async def always_duplicate(
+        session: Any, stoat_url: Any, token: Any, channel_id: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        await asyncio.sleep(0.01)  # yield so wait_for can bound a regression
+        raise DuplicateSendError("already on the server")
+
+    events: list[MigrationEvent] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", always_duplicate):
+        await asyncio.wait_for(run_retry_failed(config, state, exports, events.append), timeout=5.0)
+
+    assert not any(fm.discord_msg_id == "msg_dup" for fm in state.failed_messages), (
+        "a message already on the server was left in failed_messages, so it stays "
+        "reported as a failure and --incremental will re-send it"
+    )
+    assert "msg_dup" not in state.message_map, (
+        "Stoat returns no id with a 409, so nothing may be mapped for it"
+    )

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -8,6 +8,7 @@ SC-6, SC-7, SC-9.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from aioresponses import aioresponses
@@ -20,8 +21,8 @@ from discord_ferry.discord.metadata import (
     RoleMeta,
     save_discord_metadata,
 )
-from discord_ferry.errors import MigrationError
-from discord_ferry.migrator.messages import ChannelResult, _merge_channel_result
+from discord_ferry.errors import DuplicateSendError, MigrationError
+from discord_ferry.migrator.messages import ChannelResult, _merge_channel_result, run_messages
 from discord_ferry.migrator.structure import (
     run_categories,
     run_channels,
@@ -1049,3 +1050,67 @@ async def test_incremental_gate_does_not_touch_dry_run(tmp_path: Path) -> None:
     with aioresponses():  # any HTTP would raise (none registered)
         await run_categories(config, state, exports, lambda e: None)
     assert state.category_map["catNew"] == "dry-cat-catNew"
+
+
+# ---------------------------------------------------------------------------
+# SC-I1: the defect end to end (#107 batch 7, chunk #197, task #209)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_duplicate_does_not_become_a_real_duplicate_next_run(tmp_path: Path) -> None:
+    """SC-I1: the whole chain, and the only test that reaches the user-visible harm.
+
+    Run 1: a send's response is lost, the retry hits the still-cached Idempotency-Key,
+    and Stoat answers 409 DuplicateNonce. The message IS on the server.
+
+    Run 2 with --incremental: the self-heal set is built from state.failed_messages
+    (messages.py:914-919). If run 1 recorded the message as failed, run 2 re-sends it.
+    By then the 1000-entry LRU has evicted the key, so the re-send SUCCEEDS and the
+    user's channel holds the message twice.
+
+    Every other test in this batch checks one link. This one checks that the chain
+    cannot close.
+    """
+    msg = DCEMessage(
+        id="1506019505778987190",
+        type="Default",
+        timestamp="2024-01-15T12:00:00+00:00",
+        content="hello",
+        author=DCEAuthor(id="u1", name="Alice"),
+        is_pinned=False,
+        attachments=[],
+        embeds=[],
+        stickers=[],
+        reactions=[],
+        reference=None,
+    )
+    exports = [_make_export(channel_id="222", messages=[msg], message_count=1)]
+
+    state = MigrationState(channel_map={"222": "stoat-222"}, autumn_url="https://autumn.test")
+
+    async def always_duplicate(*a: object, **k: object) -> dict[str, object]:
+        raise DuplicateSendError("already on the server")
+
+    config1 = _make_config(tmp_path, message_rate_limit=0.0, upload_delay=0.0)
+    with patch("discord_ferry.migrator.messages.api_send_message", always_duplicate):
+        await run_messages(config1, state, exports, lambda e: None)
+
+    # The mechanism. Everything below depends on this being empty.
+    assert not state.failed_messages, (
+        "run 1 recorded a landed message as failed, which is what run 2 re-sends"
+    )
+
+    sent_second_run: list[str] = []
+
+    async def capture(*a: object, **k: object) -> dict[str, object]:
+        sent_second_run.append(str(k.get("idempotency_key", "")))
+        return {"_id": "stoat-msg1"}
+
+    config2 = _make_config(tmp_path, incremental=True, message_rate_limit=0.0, upload_delay=0.0)
+    with patch("discord_ferry.migrator.messages.api_send_message", capture):
+        await run_messages(config2, state, exports, lambda e: None)
+
+    assert not any("1506019505778987190" in key for key in sent_second_run), (
+        "the incremental run re-sent a message that was already on the server, "
+        f"creating a real duplicate in the user's channel. sent: {sent_second_run}"
+    )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3763,3 +3763,107 @@ async def test_duplicate_runs_the_parallel_branch_not_the_retry_branch(tmp_path:
         "the retry branch wrote directly to state.message_map, bypassing ChannelResult "
         "and the save_lock discipline the parallel merge design depends on"
     )
+
+
+# ---------------------------------------------------------------------------
+# Channel-local lookup precedence (#107 batch 7, chunk #198, task #211)
+# ---------------------------------------------------------------------------
+#
+# The two maps must hold DIFFERING values for the same key. A fixture where they agree
+# cannot distinguish the two orders and does not test anything.
+
+
+async def test_a_reply_resolves_against_the_channel_local_map_first(tmp_path: Path) -> None:
+    """SC-4.1: a differing local entry wins over the shared one.
+
+    After the DCE bump a parent and a thread can hold the same key with different
+    values. A reply inside the parent must resolve to the parent's copy, not the
+    thread's, and a sent reply cannot be unsent.
+    """
+    state = _make_state()
+    state.message_map["ref_id"] = "SHARED"
+    config = _make_config(tmp_path)
+    result = ChannelResult(channel_id="ch1", message_map_updates={"ref_id": "LOCAL"})
+    sent: list[dict[str, Any]] = []
+
+    async def capture(*a: Any, **k: Any) -> dict[str, Any]:
+        sent.append(k)
+        return {"_id": "stoat_new"}
+
+    msg = _make_message(id="m2", content="a reply")
+    msg.reference = DCEReference(message_id="ref_id")
+
+    async with aiohttp.ClientSession() as session:
+        with patch("discord_ferry.migrator.messages.api_send_message", capture):
+            await _process_message(
+                msg=msg,
+                stoat_channel_id="stoat_ch1",
+                config=config,
+                state=state,
+                session=session,
+                on_event=lambda e: None,
+                channel_result=result,
+            )
+
+    assert sent[0]["replies"] == [{"id": "LOCAL", "mention": False}], (
+        f"the reply resolved against the shared map, not the channel's own. got {sent[0]['replies']}"
+    )
+
+
+async def test_a_pin_resolves_against_the_channel_local_map_first(tmp_path: Path) -> None:
+    """SC-4.2: same rule for a ChannelPinnedMessage reference."""
+    state = _make_state()
+    state.message_map["ref_id"] = "SHARED"
+    config = _make_config(tmp_path)
+    result = ChannelResult(channel_id="ch1", message_map_updates={"ref_id": "LOCAL"})
+
+    msg = _make_message(id="m3", content="", msg_type="ChannelPinnedMessage")
+    msg.reference = DCEReference(message_id="ref_id")
+
+    async def capture(*a: Any, **k: Any) -> dict[str, Any]:
+        return {"_id": "stoat_new"}
+
+    async with aiohttp.ClientSession() as session:
+        with patch("discord_ferry.migrator.messages.api_send_message", capture):
+            await _process_message(
+                msg=msg,
+                stoat_channel_id="stoat_ch1",
+                config=config,
+                state=state,
+                session=session,
+                on_event=lambda e: None,
+                channel_result=result,
+            )
+
+    assert result.pending_pins == [("stoat_ch1", "LOCAL")], (
+        f"the pin resolved against the shared map, not the channel's own. got {result.pending_pins}"
+    )
+
+
+async def test_lookups_are_unchanged_with_no_channel_result(tmp_path: Path) -> None:
+    """SC-4.3: the retry path has no local map, so the shared one still answers."""
+    state = _make_state()
+    state.message_map["ref_id"] = "SHARED"
+    config = _make_config(tmp_path)
+    sent: list[dict[str, Any]] = []
+
+    async def capture(*a: Any, **k: Any) -> dict[str, Any]:
+        sent.append(k)
+        return {"_id": "stoat_new"}
+
+    msg = _make_message(id="m4", content="a reply")
+    msg.reference = DCEReference(message_id="ref_id")
+
+    async with aiohttp.ClientSession() as session:
+        with patch("discord_ferry.migrator.messages.api_send_message", capture):
+            await _process_message(
+                msg=msg,
+                stoat_channel_id="stoat_ch1",
+                config=config,
+                state=state,
+                session=session,
+                on_event=lambda e: None,
+                channel_result=None,
+            )
+
+    assert sent[0]["replies"] == [{"id": "SHARED", "mention": False}]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3690,3 +3690,76 @@ async def test_duplicate_on_first_part_still_sends_the_rest(tmp_path: Path) -> N
     assert state.message_map.get("msg1") != "stoat-ferry-msg1_p2", (
         "a later part's id must never stand in for the first part's"
     )
+
+
+async def test_single_part_duplicate_leaves_clean_state(tmp_path: Path) -> None:
+    """SC-2.1: no empty map entry, no failure, no pin, no reaction, counters intact."""
+    state = _make_state()
+    config = _make_config(tmp_path, reaction_mode="native")
+    msg = _make_message(id="msg1", content="hello", is_pinned=True)
+    msg.reactions = [DCEReaction(emoji=DCEEmoji(id=None, name="thumbsup"), count=2)]
+    exp = _make_export(messages=[msg])
+
+    async def always_duplicate(*a: Any, **k: Any) -> dict[str, Any]:
+        raise DuplicateSendError("already on the server")
+
+    with patch("discord_ferry.migrator.messages.api_send_message", always_duplicate):
+        await run_messages(config, state, [exp], lambda e: None)
+
+    assert "msg1" not in state.message_map, (
+        "an empty-valued map entry was written; a reply resolving to '' is worse than "
+        "one that does not resolve at all"
+    )
+    assert not state.failed_messages
+    assert not state.pending_pins, "a pin was queued against an empty message id"
+    assert not state.pending_reactions, "a reaction was queued against an empty message id"
+    assert "duplicate_send_unmapped" in [w.get("type") for w in state.warnings]
+
+
+async def test_duplicate_runs_the_parallel_branch_not_the_retry_branch(tmp_path: Path) -> None:
+    """SC-2.2: MANDATORY. The only check that catches the folded-condition mistake.
+
+    Guarding `if channel_result is not None and stoat_msg_id:` looks equivalent to
+    guarding the map write inside the branch. It is not. `else` means "not the
+    condition above", so an empty id sends a parallel-path message down the RETRY
+    path, which writes state.message_map directly and bypasses ChannelResult and the
+    save_lock discipline.
+
+    State-level assertions cannot see this: both branches leave
+    channel_message_counts == 1, by different routes. Only the real ChannelResult,
+    captured at the merge, distinguishes them. This mutant survived five other probes.
+    """
+    import discord_ferry.migrator.messages as mm
+
+    state = _make_state()
+    config = _make_config(tmp_path)
+    exp = _make_export(messages=[_make_message(id="msg1", content="hello")])
+
+    seen: list[tuple[int, dict[str, str]]] = []
+    real_merge = mm._merge_channel_result
+
+    def spy_merge(st: Any, result: Any) -> None:
+        seen.append((result.messages_migrated, dict(result.message_map_updates)))
+        real_merge(st, result)
+
+    async def always_duplicate(*a: Any, **k: Any) -> dict[str, Any]:
+        raise DuplicateSendError("already on the server")
+
+    with (
+        patch("discord_ferry.migrator.messages.api_send_message", always_duplicate),
+        patch("discord_ferry.migrator.messages._merge_channel_result", spy_merge),
+    ):
+        await run_messages(config, state, [exp], lambda e: None)
+
+    assert max((m for m, _ in seen), default=0) == 1, (
+        "the parallel branch did not run. The id check was folded into the "
+        "`channel_result is not None` condition, so control fell into the retry else "
+        f"and ChannelResult never saw the message. merges observed: {seen}"
+    )
+    assert not {k: v for _, d in seen for k, v in d.items()}, (
+        "an empty-valued map entry was accumulated on the ChannelResult"
+    )
+    assert not state.message_map, (
+        "the retry branch wrote directly to state.message_map, bypassing ChannelResult "
+        "and the save_lock discipline the parallel merge design depends on"
+    )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3806,7 +3806,8 @@ async def test_a_reply_resolves_against_the_channel_local_map_first(tmp_path: Pa
             )
 
     assert sent[0]["replies"] == [{"id": "LOCAL", "mention": False}], (
-        f"the reply resolved against the shared map, not the channel's own. got {sent[0]['replies']}"
+        f"the reply resolved against the shared map, not the channel's own. "
+        f"got {sent[0]['replies']}"
     )
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -10,6 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.errors import DuplicateSendError
 from discord_ferry.migrator.messages import (
     ChannelResult,
     _build_content,
@@ -3622,3 +3623,70 @@ async def test_pre_247_export_still_skips_and_warns(tmp_path: Path) -> None:
 
     assert "fwd_old" not in state.message_map
     assert any("fwd_old" in e.message for e in events if e.status == "warning")
+
+
+# ---------------------------------------------------------------------------
+# Duplicate sends on the main path (#107 batch 7, chunk #196)
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_on_later_part_does_not_truncate(tmp_path: Path) -> None:
+    """SC-2.3: every part after a duplicate must still be sent.
+
+    The catch has to be PER PART. A catch around the loop aborts it, so the parts
+    after the duplicate are never sent and their content is lost with no warning.
+    Each part carries its own Idempotency-Key, so they are not duplicates.
+    """
+    state = _make_state()
+    config = _make_config(tmp_path)
+    exp = _make_export(messages=[_make_message(id="msg1", content="B" * 5000)])
+    seen: list[str] = []
+
+    async def dup_on_second(*a: Any, **k: Any) -> dict[str, Any]:
+        key = str(k.get("idempotency_key", ""))
+        seen.append(key)
+        if key.endswith("_p2"):
+            raise DuplicateSendError("already on the server")
+        return {"_id": f"stoat-{key}"}
+
+    with patch("discord_ferry.migrator.messages.api_send_message", dup_on_second):
+        await run_messages(config, state, [exp], lambda e: None)
+
+    # Assert "everything after the duplicate was attempted", not a hardcoded count:
+    # the sent content is longer than the raw body once continuation markers are added.
+    assert any(k.endswith("_p3") for k in seen), (
+        f"part 3 was never attempted, so the duplicate truncated the message. keys={seen}"
+    )
+    assert state.message_map["msg1"] == "stoat-ferry-msg1_p1"
+    assert not state.failed_messages
+    assert "duplicate_send_unmapped" not in [w.get("type") for w in state.warnings], (
+        "a later-part duplicate must not claim the message is unmapped: part 1 mapped fine"
+    )
+
+
+async def test_duplicate_on_first_part_still_sends_the_rest(tmp_path: Path) -> None:
+    """SC-2.4: a duplicate on part 1 costs the map entry, not the remaining parts."""
+    state = _make_state()
+    config = _make_config(tmp_path)
+    exp = _make_export(messages=[_make_message(id="msg1", content="C" * 5000)])
+    seen: list[str] = []
+
+    async def dup_on_first(*a: Any, **k: Any) -> dict[str, Any]:
+        key = str(k.get("idempotency_key", ""))
+        seen.append(key)
+        if key.endswith("_p1"):
+            raise DuplicateSendError("already on the server")
+        return {"_id": f"stoat-{key}"}
+
+    with patch("discord_ferry.migrator.messages.api_send_message", dup_on_first):
+        await run_messages(config, state, [exp], lambda e: None)
+
+    assert any(k.endswith("_p2") for k in seen), (
+        f"a duplicate on part 1 stopped the remaining parts being sent. keys={seen}"
+    )
+    assert not state.failed_messages
+    # The map entry is task #204's concern: part 1 produced no id, so nothing may be
+    # written. Asserted in test_single_part_duplicate_leaves_clean_state.
+    assert state.message_map.get("msg1") != "stoat-ferry-msg1_p2", (
+        "a later part's id must never stand in for the first part's"
+    )

--- a/tests/test_parallel_messages.py
+++ b/tests/test_parallel_messages.py
@@ -819,3 +819,83 @@ async def test_unmapped_emoji_reaction_warning_token_safe(tmp_path: Path) -> Non
 
     assert state.reactions_dropped == 1
     assert all(secret not in w["message"] for w in state.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Parent-wins on a thread-starter collision (#107 batch 7, chunk #198, task #210)
+# ---------------------------------------------------------------------------
+#
+# Prerequisite work for batch 8 (#110). No symptom at the current DCE 2.47.1 pin.
+#
+# After DCE 2.47.3 a thread's starter carries the ORIGIN message's id, and a thread's
+# channel id EQUALS that origin id, so the parent channel and the thread channel write
+# the same message_map key. save_lock serialises the two merges but does not order them,
+# and with max_concurrent_channels defaulting to 3 a small thread routinely finishes
+# before its large parent. First-wins and last-wins are therefore both wrong.
+#
+# The discriminator: a thread's map key equals its own channel_id; a parent's never does.
+
+
+def _collision_pair() -> tuple[ChannelResult, ChannelResult]:
+    """A parent and a thread that both write the same key, as DCE 2.47.3 produces."""
+    origin_id = "1506019505778987190"
+    parent = ChannelResult(
+        channel_id="parent_ch",
+        message_map_updates={origin_id: "stoat_parent_copy"},
+    )
+    thread = ChannelResult(
+        channel_id=origin_id,  # a thread's channel id IS its origin message id
+        message_map_updates={origin_id: "stoat_thread_copy"},
+    )
+    return parent, thread
+
+
+def test_parent_wins_when_the_parent_merges_first() -> None:
+    """SC-3.1."""
+    state = MigrationState()
+    parent, thread = _collision_pair()
+    _merge_channel_result(state, parent)
+    _merge_channel_result(state, thread)
+    assert state.message_map["1506019505778987190"] == "stoat_parent_copy"
+
+
+def test_parent_wins_when_the_thread_merges_first() -> None:
+    """SC-3.2. Both orders are required.
+
+    A test running only one order cannot distinguish parent-wins from last-wins, and
+    last-wins is one of the two wrong answers this guard exists to rule out.
+    """
+    state = MigrationState()
+    parent, thread = _collision_pair()
+    _merge_channel_result(state, thread)
+    _merge_channel_result(state, parent)
+    assert state.message_map["1506019505778987190"] == "stoat_parent_copy"
+
+
+def test_a_key_already_present_but_not_the_channel_id_is_still_written() -> None:
+    """SC-3.4: the skip needs BOTH halves of the condition.
+
+    An ordinary re-merge of an existing key must not be suppressed. Only the exact
+    thread-starter shape is skipped.
+    """
+    state = MigrationState()
+    state.message_map["msg1"] = "old"
+    _merge_channel_result(
+        state, ChannelResult(channel_id="ch1", message_map_updates={"msg1": "new"})
+    )
+    assert state.message_map["msg1"] == "new"
+
+
+def test_a_thread_key_is_written_when_the_parent_has_not_merged_yet() -> None:
+    """SC-3.4, the other half: the skip needs the key to be PRESENT already.
+
+    A thread whose parent has not merged is not a collision. Suppressing it would lose
+    the only entry the message has.
+    """
+    state = MigrationState()
+    origin_id = "1506019505778987190"
+    _merge_channel_result(
+        state,
+        ChannelResult(channel_id=origin_id, message_map_updates={origin_id: "stoat_thread_copy"}),
+    )
+    assert state.message_map[origin_id] == "stoat_thread_copy"

--- a/tests/test_parallel_messages.py
+++ b/tests/test_parallel_messages.py
@@ -899,3 +899,74 @@ def test_a_thread_key_is_written_when_the_parent_has_not_merged_yet() -> None:
         ChannelResult(channel_id=origin_id, message_map_updates={origin_id: "stoat_thread_copy"}),
     )
     assert state.message_map[origin_id] == "stoat_thread_copy"
+
+
+# ---------------------------------------------------------------------------
+# The batch 8 precondition (#107 batch 7, chunk #198, task #212)
+# ---------------------------------------------------------------------------
+#
+# Batch 7 gates batch 8 (#110, the DCE 2.47.1 -> 2.47.3 bump) on exactly two properties:
+# the guard changes nothing at the current pin, and it resolves the collision the bump
+# introduces. Both are asserted here so batch 8 has evidence rather than an assurance.
+
+
+def test_the_guard_is_inert_at_the_2_47_1_pin() -> None:
+    """SC-5.1: at the current pin nothing collides, so nothing is skipped.
+
+    Ground truth from the shipped fixture
+    'Discord Ferry Test - general - Cool Thread [1506019505778987190].json':
+    the thread's channel id is 1506019505778987190 and its starter placeholder carries
+    the DIFFERENT synthetic id 1506019526855360593, under type 21.
+    """
+    thread_channel_id = "1506019505778987190"
+    synthetic_starter_id = "1506019526855360593"
+    assert thread_channel_id != synthetic_starter_id, (
+        "the premise of this test: at 2.47.1 the starter id is synthetic, not the origin id"
+    )
+
+    state = MigrationState()
+    parent = ChannelResult(
+        channel_id="parent_ch",
+        message_map_updates={synthetic_starter_id: "stoat_placeholder"},
+    )
+    thread = ChannelResult(
+        channel_id=thread_channel_id,
+        message_map_updates={thread_channel_id: "stoat_thread_first"},
+    )
+    _merge_channel_result(state, parent)
+    _merge_channel_result(state, thread)
+
+    # Every key written, nothing suppressed. This is what "batch 7 changes nothing
+    # before the bump" means concretely.
+    assert state.message_map == {
+        synthetic_starter_id: "stoat_placeholder",
+        thread_channel_id: "stoat_thread_first",
+    }
+
+
+def test_the_guard_is_active_in_the_post_bump_shape() -> None:
+    """SC-5.2: after 2.47.3 the starter carries the origin id, and the parent must win.
+
+    Built now rather than waiting for the bump. The whole point of batch 7 gating
+    batch 8 is that this is proven before the pin moves.
+    """
+    origin_id = "1506019505778987190"  # a thread's channel id IS its origin message id
+
+    for order in ("parent_first", "thread_first"):
+        state = MigrationState()
+        parent = ChannelResult(
+            channel_id="parent_ch",
+            message_map_updates={origin_id: "stoat_parent_copy"},
+        )
+        thread = ChannelResult(
+            channel_id=origin_id,
+            message_map_updates={origin_id: "stoat_thread_copy"},
+        )
+        pair = (parent, thread) if order == "parent_first" else (thread, parent)
+        for result in pair:
+            _merge_channel_result(state, result)
+
+        assert state.message_map[origin_id] == "stoat_parent_copy", (
+            f"the thread's copy won in the {order} order; a reply in the parent would "
+            "then be sent against the wrong message, and a sent reply cannot be unsent"
+        )

--- a/tests/test_parallel_messages.py
+++ b/tests/test_parallel_messages.py
@@ -970,3 +970,47 @@ def test_the_guard_is_active_in_the_post_bump_shape() -> None:
             f"the thread's copy won in the {order} order; a reply in the parent would "
             "then be sent against the wrong message, and a sent reply cannot be unsent"
         )
+
+
+def test_a_forum_post_already_has_key_equal_to_its_channel_id_today() -> None:
+    """The key == channel_id shape is NOT hypothetical: a forum post has it at 2.47.1.
+
+    Found by chunk 4's review, which claimed the discriminator was inexact. The
+    mechanism it named was wrong, but the shape is real. Ground truth from the shipped
+    fixture 'Discord Ferry Test - feedback-forum - Bug Report [1506019530294562938]':
+    the channel id and the first message id are the SAME, because a forum post is a
+    thread and its starter is a real message rather than a placeholder.
+
+    A forum post is still a thread, so the discriminator's premise holds. What must be
+    proven is that the guard never drops the post's own starter: the skip fires only
+    when the key is already present, and for a forum post the only writer of that key
+    is the post itself, so the value never changes.
+    """
+    post_id = "1506019530294562938"
+    state = MigrationState()
+
+    # Checkpoint merge: the starter, plus a later message in the same post.
+    _merge_channel_result(
+        state,
+        ChannelResult(
+            channel_id=post_id,
+            message_map_updates={post_id: "stoat_starter", "999": "stoat_second"},
+        ),
+    )
+    assert state.message_map[post_id] == "stoat_starter"
+
+    # Completion merge. Workers reset their own result, so this carries only new keys.
+    _merge_channel_result(
+        state, ChannelResult(channel_id=post_id, message_map_updates={"1000": "stoat_third"})
+    )
+
+    # Re-merging the SAME result is the harsher case: the key repeats and is now present.
+    _merge_channel_result(
+        state, ChannelResult(channel_id=post_id, message_map_updates={post_id: "stoat_starter"})
+    )
+
+    assert state.message_map[post_id] == "stoat_starter", (
+        "the forum post's own starter entry was dropped by the guard"
+    )
+    assert state.message_map["999"] == "stoat_second"
+    assert state.message_map["1000"] == "stoat_third"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3232,3 +3232,59 @@ async def test_a_refused_proxy_names_the_proxy(
     assert "Role icon upload failed" in message
     assert f"The request to autumn.test went through the proxy at 127.0.0.1:{port}" in message
     assert "FERRY_DISABLE_PROXY" in message
+
+
+async def test_forum_index_duplicate_skips_the_pin(tmp_path: Path) -> None:
+    """SC-2.6: a duplicate index send leaves no id, so there is nothing to pin.
+
+    Driven through real HTTP so the whole stack runs, including api.py's
+    DuplicateNonce branch. The channel wiring below the send uses index_channel_id,
+    not the message id, so it must still happen.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    exports = [
+        _make_export(
+            channel_id="fp1",
+            channel_name="first-post",
+            channel_type=15,
+            is_thread=True,
+            parent_channel_name="my-forum",
+            category_id="cat1",
+            category="General",
+            message_count=42,
+        ),
+    ]
+
+    pins: list[str] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-fp1", "name": "my-forum-first-post"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-idx1", "name": "my-forum-index"},
+        )
+        # The index message send answers with a still-cached Idempotency-Key.
+        m.post(
+            f"{STOAT_URL}/channels/stoat-idx1/messages",
+            status=409,
+            payload={"type": "DuplicateNonce", "location": "crates/x/src/lib.rs:1:1"},
+        )
+        # Registered so a stray pin is recorded rather than erroring out.
+        m.put(
+            f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg1/pin",
+            payload={},
+            callback=lambda url, **kwargs: pins.append(str(url)),  # type: ignore[misc]
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
+
+        await run_channels(config, state, exports, events.append)
+
+    assert pins == [], "a pin was attempted against a message id that was never returned"
+    # The channel wiring does not depend on the message id and must still have run.
+    assert state.channel_map["forum-index-forum-my-forum"] == "stoat-idx1"

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.security import SecureTokenStore
+from discord_ferry.errors import DuplicateSendError
 from discord_ferry.migrator.messages import run_messages
 from discord_ferry.migrator.structure import run_channels
 from discord_ferry.parser.models import (
@@ -1125,3 +1127,96 @@ async def test_incremental_still_reattempts_a_failed_merge_message(tmp_path: Pat
     assert "ferry-merge-20" in keys, "incremental must still self-heal"
     # Re-sent successfully, so the stale failure record is reconciled away.
     assert [fm.discord_msg_id for fm in state.failed_messages] == []
+
+
+# ---------------------------------------------------------------------------
+# Duplicate sends at the result-discarding sites (#107 batch 7, task #202)
+# ---------------------------------------------------------------------------
+
+
+def _dup_on(prefix: str) -> object:
+    """Patch target: raise DuplicateSendError for keys with *prefix*, else succeed."""
+
+    async def _send(
+        session: object, stoat_url: object, token: object, channel_id: object, **kwargs: object
+    ) -> dict[str, object]:
+        key = str(kwargs.get("idempotency_key", ""))
+        if key.startswith(prefix):
+            raise DuplicateSendError("already on the server")
+        return {"_id": f"stoat-{key}"}
+
+    return _send
+
+
+async def test_merge_duplicate_records_no_failed_message(tmp_path: Path) -> None:
+    """SC-2.5: the merge path must not record a landed message as failed.
+
+    This is the defect itself. A FailedMessage here is what --incremental later
+    re-sends, producing a real duplicate in the user's channel.
+    """
+    config = _make_config(tmp_path, thread_strategy="merge", message_rate_limit=0.0)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+
+    parent = _make_export(channel_id="100", channel_name="general", message_count=0)
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("m2", "thread msg")],
+        message_count=1,
+    )
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _dup_on("ferry-merge-")):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+
+    assert not state.failed_messages, (
+        "a message already on the server was recorded as failed; --incremental will "
+        "re-send it and create a real duplicate"
+    )
+    assert not [w for w in state.warnings if w.get("type") == "merge_message_failed"]
+
+
+async def test_merge_separator_duplicate_records_no_warning(tmp_path: Path) -> None:
+    """SC-2.8, separator half: a duplicate separator is not a failure."""
+    config = _make_config(tmp_path, thread_strategy="merge", message_rate_limit=0.0)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+
+    parent = _make_export(channel_id="100", channel_name="general", message_count=0)
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("m2", "thread msg")],
+        message_count=1,
+    )
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _dup_on("ferry-thread-sep-")):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+
+    assert not [w for w in state.warnings if w.get("type") == "merge_separator_failed"]
+
+
+async def test_thread_header_duplicate_records_no_warning(tmp_path: Path) -> None:
+    """SC-2.8, header half: a duplicate flatten-mode header is not a failure."""
+    config = _make_config(tmp_path, thread_strategy="flatten", message_rate_limit=0.0)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    state.channel_map["200"] = "stoat-ch-200"
+
+    thread = _make_export(
+        channel_id="200",
+        channel_name="my-thread",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("m2", "thread msg")],
+        message_count=1,
+    )
+
+    with patch("discord_ferry.migrator.messages.api_send_message", _dup_on("ferry-header-")):
+        await run_messages(config, state, [thread], lambda e: None)
+
+    assert not [w for w in state.warnings if w.get("type") == "thread_header_failed"]

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.14.6"
+version = "2.14.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
#107 batch 7. Gates batch 8 (#110, the DiscordChatExporter 2.47.1 to 2.47.3 bump).

Two halves, described differently on purpose.

## Half A: a live defect

Stoat answers 409 `DuplicateNonce` when an `Idempotency-Key` is still in its 1000-entry in-memory
LRU. The message **is** on the server, and Stoat returns no id for it.

Every send site absorbed that into a broad `except Exception` and recorded a `FailedMessage`.
`--incremental` deliberately re-attempts previously-failed ids; by then the LRU has evicted the
key, so the re-send **succeeds** and the user's channel holds the message twice. The mechanism that
exists to prevent a duplicate was producing one.

The codebase already named the hazard and accepted it (`messages.py:911-913`, before this branch):

> Re-sending under resume would risk duplicating a message that actually landed before the response
> was lost, which is a trade-off only the opt-in delta mode makes.

`_api_request_inner` now raises `DuplicateSendError(MigrationError)` for that one body shape, and
six send sites treat it as delivered. There is **no opt-in flag**: a `DuplicateNonce` is only
reachable when the request carried a key, and the new class subclasses `MigrationError`, so a call
site that does not catch it behaves exactly as before.

What it costs, stated in the CHANGELOG rather than glossed: the 409 carries no id, so a duplicate
on a message's first part loses its `message_map` entry. Replies to that one message will not
resolve, its pin and reactions are skipped, and a `duplicate_send_unmapped` warning names it.

## Half B: prerequisite work, not a fix

A parent-wins guard on the `message_map` merge and an inversion of the reply and pin lookup
precedence. **No symptom at the current 2.47.1 pin**, verified against the shipped fixture, where a
thread's starter carries a synthetic id that collides with nothing.

After 2.47.3 the starter carries the origin message's id, and a thread's channel id equals that
id, so the parent and the thread write the same key. `save_lock` serialises the merges but does not
order them, so first-wins and last-wins are both wrong.

## Chunks

| Chunk | Tasks |
|---|---|
| #195 the request layer | #200, #201 |
| #196 the messages.py send sites | #202, #203, #204, #205 |
| #197 the remaining call sites | #206, #207, #208, #209 |
| #198 merge guard and batch 8 precondition | #210, #211, #212 |
| #199 the record and the release | #213, #214 |

All closed, each chunk carrying its `/df-chunk-review` marker.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src/` clean. **1726 passed**, up from 1697 at the
branch point. **No pre-existing test was edited**: the only deletions against the merge-base are
import-line extensions. That mattered here, because 79 tests patch
`discord_ferry.migrator.messages.api_send_message` by name, and it is what killed an earlier design
that would have renamed it.

A 9-mutant matrix runs 9 of 9 caught, using a harness that writes a deliberately failing probe test
and refuses to report unless it sees that probe die.

## What the process caught, recorded because it repeats

- The **design was wrong four times** about one function's control flow. A runnable prototype
  settled it in one run: a catch around the parts loop truncated multi-part messages, and a
  plausible block guard dropped counters for a message that was delivered.
- **One mutant survived five of six probes.** Folding the id check into
  `if channel_result is not None:` routes a parallel-path message into the retry branch, where it
  writes `state.message_map` directly and bypasses `save_lock`. Both routes leave identical
  counters, so only an assertion on the real `ChannelResult` can tell them apart.
- **Three of my own checks could not fail** and were fixed: a mutation harness passing `-x`, one
  passing `-q` (so it reported 0 of 9 against mutants known to be lethal), and an assertion reading
  a fixture-seeded value.
- **Two tests first failed for the wrong reason**: one on a `NameError` from an import guard that
  matched function-local imports, and one on a fixture artefact, a non-numeric message id, which
  looked exactly like a second duplication route and was not one.

## Related

- Triaged out during chunk 3: #215, a duplicate forum index rebuild posts a second index message on
  the next run. Pre-existing, and the obvious sentinel fix is harmful.
- Spec P2 items S6 and S7 carry all four deferral fields and are not built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotVV9xXbWp9oR2JdF9Vkm
