### PR TITLE
feat: ferry check verifies a finished migration against the live server (v2.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-08-12
+
+### Added
+
+- A new `ferry check` command verifies a migration you have already run. Point it at
+  the output directory and it asks the Stoat server whether everything Ferry recorded
+  is still there: every channel, role, category and emoji, and each channel's most
+  recent messages. It is read-only and creates nothing. Run it after a migration, after
+  a resume, or weeks later. It exits non-zero if anything is missing, so it can be used
+  in a script (#107 batch 9).
+- Results come back as one of four answers, and the fourth matters. `ok` means found
+  and matching, `warn` means a category was renamed but its contents are intact, `fail`
+  means something is gone, and `unverifiable` means Ferry cannot answer and says why.
+  A `warn` on its own does not fail the command.
+
+### Changed
+
+- Nothing existing changed behaviour. `--validate-after` still does what it did, and
+  `ferry validate` still inspects an export before a migration rather than checking one
+  afterwards.
+
+### Notes
+
+- What `ferry check` cannot tell you is documented alongside what it can. It reads the
+  100 most recent messages in each channel, so a gap in the middle of a channel is
+  invisible and an `ok` means "the last message Ferry recorded is present" rather than
+  "this channel is complete". A channel that has gained more than 100 messages since the
+  migration reports `unverifiable` rather than guessing. A renamed channel or role is not
+  detected, because Ferry never recorded the names it gave them; renamed categories are.
+  See the Known Limitations guide.
+
 ## [2.15.0] - 2026-08-11
 
 ### Added

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -407,6 +407,68 @@ ferry stats ~/migrations/my-server-2026-05-15/
 
 ---
 
+## `ferry check`
+
+Verify a migration you have already run. Check reads the state file Ferry wrote and asks the live Stoat server whether everything it recorded is still there: every channel, role, category and emoji by id, and each channel's most recent messages. It is read-only, creating, editing and deleting nothing.
+
+```
+ferry check <output-dir> [OPTIONS]
+```
+
+Point it at the same output directory the migration used. Use it after a migration finishes, after a resume, or weeks later to confirm nothing has been lost.
+
+This is not the same command as [`ferry validate`](#ferry-validate), which inspects a Discord export before you migrate it and never contacts a server.
+
+### Options
+
+| Flag | Environment Variable | Description |
+|------|----------------------|-------------|
+| `--stoat-url TEXT` | `STOAT_URL` | Stoat API base URL *(required)* |
+| `--token TEXT` | `STOAT_TOKEN` | Your Stoat user token *(required)* |
+
+### What the four statuses mean
+
+| Status | Meaning |
+|--------|---------|
+| `ok` | Found, and it matches what Ferry recorded |
+| `warn` | It exists and its content is intact, but a name differs. Today this only ever means a category was renamed |
+| `fail` | Something Ferry recorded is gone, or a channel lost messages |
+| `unverifiable` | Ferry cannot answer, and says why. Not a pass and not a failure |
+
+`unverifiable` is worth reading rather than skimming past. It is the honest answer when Ferry never recorded what it would need to confirm something, which happens for good reasons: you migrated with `--thread-strategy=merge`, a send was accepted as a duplicate, or the token you gave Check cannot see a particular channel.
+
+### Exit codes
+
+| Code | When |
+|------|------|
+| `0` | Every result was `ok`, `warn` or `unverifiable` |
+| `1` | Any result was `fail`, or the migration could not be checked at all |
+
+A `warn` on its own does not fail the command, because nothing has been lost. Use the exit code in a script; there is no separate machine-readable flag.
+
+### What Check cannot tell you
+
+Check reads the most recent 100 messages in each channel and confirms the last one Ferry recorded sending is still among them. That is cheap enough to run on any server, and it is honest about what it misses:
+
+- **A gap in the middle of a channel is invisible.** An `ok` means the recorded last message is present. It does not mean the channel is complete.
+- **If more than 100 messages arrived after your migration**, Check can no longer see far enough back and reports `unverifiable` rather than guessing.
+- **A renamed channel or role is not detected.** Ferry never recorded the names it gave them, so there is nothing to compare against. Renamed *categories* are detected, because those names are recorded.
+- **A duplicate forum index** is not detected.
+- **Check will not run against a dry run.** A dry run records placeholders for things that were never created, so there is nothing on a server to compare with.
+
+### Examples
+
+```bash
+# Check a migration you have just run
+ferry check ./ferry-output --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN"
+
+# In a script: fail the job if anything is missing
+if ! ferry check ./ferry-output; then
+  echo "migration verification failed" >&2
+  exit 1
+fi
+```
+
 ## `ferry probe`
 
 Check what a live Stoat instance actually supports before you migrate to it. Probe measures upload size limits, checks whether voice channels can be created (Stoat Bug #194), checks webhook availability, and inspects rate-limit behaviour. It is most useful for self-hosted instances, where limits differ from the official service.

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -121,6 +121,24 @@ These limitations relate to platform-level features that either work differently
 
 ---
 
+## Verifying a Migration
+
+`ferry check` confirms a finished migration against the live server. What it proves is narrower than it might appear, and the limits below are deliberate rather than unfinished work.
+
+**A gap in the middle of a channel is invisible.** Check reads each channel's most recent 100 messages and confirms the last one Ferry recorded is still among them. If messages went missing earlier in the channel while the last one survived, Check reports `ok`. Read an `ok` as "the recorded last message is present", never as "this channel is complete".
+
+**A channel that gained more than 100 messages since the migration cannot be checked.** The window no longer reaches back to the message Ferry recorded, so Check reports `unverifiable` rather than guessing. This is common on an active server.
+
+**A renamed channel or role is not detected.** Ferry records the identifiers it created but not the names it gave them, so there is nothing to compare a current name against. Renamed *categories* are detected, because category names are recorded.
+
+**A message accepted as a duplicate cannot be confirmed.** When Stoat recognises a retry and refuses it, it does not say which message it already had, so Ferry has no identifier to check later. Channels affected this way report `unverifiable`.
+
+**A channel your token cannot read reports `unverifiable`.** Check can tell this apart from a deleted channel, because the server lists every channel's identifier even when it will not return the channel itself.
+
+**A duplicate forum index message is not detected.** Ferry records only the most recent index message it posted.
+
+**Check refuses to run against a dry run.** A dry run records placeholders for channels and messages that were never created, so there is nothing on a server to compare them with.
+
 ## See Also
 
 - [Troubleshooting](troubleshooting.md) — solutions for common migration errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.15.0"
+version = "2.16.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.15.0"
+__version__ = "2.16.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1434,6 +1434,19 @@ def _render_check_report(report: CheckReport) -> None:
     on a merge migration most tail results are unverifiable, and a bare count
     beside three green ones reads like approval of something never examined.
     """
+    # `detail` can embed a server-supplied error body, which this project treats
+    # as attacker-influenced in the general case. escape() neutralises Rich
+    # markup in it, and that is ALL it does: it leaves an ESC byte untouched.
+    #
+    # A raw ANSI sequence in that text is defanged anyway, but by the rendering
+    # rather than by escape(). Rich interleaves its own style codes between the
+    # ESC and the following '[', so "\x1b[2J" never reaches the terminal as one
+    # contiguous sequence. Measured, not assumed.
+    #
+    # That protection is incidental, so it disappears the moment this text is
+    # emitted any other way. If a --json mode is added (spec P1 S6), it must go
+    # through click.echo per the recorded rule, and click.echo would print the
+    # ESC verbatim. Strip control characters there rather than relying on this.
     colours = {"ok": "green", "warn": "yellow", "fail": "red", "unverifiable": "cyan"}
     table = Table(title="Migration Check")
     table.add_column("Check")

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1367,7 +1367,21 @@ def probe_cmd(
 @main.command(name="check")
 @click.argument("output_dir", type=click.Path(exists=True))
 @click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
-@click.option("--token", envvar="STOAT_TOKEN", default=None, help="Stoat user token")
+@click.option(
+    "--token",
+    envvar="STOAT_TOKEN",
+    default=None,
+    # Prefer the environment variable, and say so here rather than only in the
+    # guide: a token passed as an argument lands in shell history and in `ps`.
+    #
+    # A review proposed hide_input=True. Click consumes that in exactly one
+    # place, prompt_for_value, so on an option that never prompts it does
+    # nothing at all: it would read as a fix in the diff and change no
+    # behaviour. Making it real needs prompt=True, which breaks the
+    # non-interactive use the exit-code contract exists to serve, and would
+    # make this the only one of Ferry's four token options behaving that way.
+    help="Stoat user token. Prefer the STOAT_TOKEN environment variable",
+)
 def check_cmd(output_dir: str, stoat_url: str | None, token: str | None) -> None:
     """Verify a finished migration against the live Stoat server.
 

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -27,7 +27,7 @@ from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.core.http import format_proxy_notices, new_session
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
-from discord_ferry.errors import MigrationError, StateError
+from discord_ferry.errors import CheckError, MigrationError, StateError
 from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_role,
@@ -35,6 +35,7 @@ from discord_ferry.migrator.api import (
     api_edit_role,
     api_set_role_permissions,
     api_upsert_categories,
+    init_request_semaphore,
 )
 from discord_ferry.parser.dce_parser import (
     acknowledgement_required,
@@ -46,6 +47,7 @@ from discord_ferry.stats import summarize_state
 
 if TYPE_CHECKING:
     from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.migrator.verify import CheckReport
     from discord_ferry.parser.models import DCEExport
     from discord_ferry.review import RollbackSummary
     from discord_ferry.stats import StateSummary
@@ -1360,6 +1362,92 @@ def probe_cmd(
         colour = {"ok": "green", "warn": "yellow", "fail": "red"}.get(c.status, "white")
         table.add_row(c.name, f"[{colour}]{c.status}[/]", c.detail)
     console.print(table)
+
+
+@main.command(name="check")
+@click.argument("output_dir", type=click.Path(exists=True))
+@click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
+@click.option("--token", envvar="STOAT_TOKEN", default=None, help="Stoat user token")
+def check_cmd(output_dir: str, stoat_url: str | None, token: str | None) -> None:
+    """Verify a finished migration against the live Stoat server.
+
+    Reads the state file in OUTPUT_DIR and asks the server whether everything it
+    records is still there. Read-only: it creates, edits and deletes nothing.
+    """
+    load_dotenv()
+    if not stoat_url:
+        console.print("[bold red]Error:[/] --stoat-url is required (or set STOAT_URL)")
+        sys.exit(1)
+    if not token:
+        console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
+        sys.exit(1)
+
+    _print_proxy_notices(to_stderr=True)
+
+    # Same hazard probe_cmd documents: this command builds no FerryConfig, so
+    # the engine's _ensure_token_store hook never fires and the Stoat token has
+    # NO masking coverage for the whole run without this line. The regex
+    # backstop deliberately cannot match Stoat's opaque base64url values.
+    register_secret("stoat", token)
+
+    # Without this the module semaphore stays None, which _api_request treats as
+    # "no limit" rather than as an error. Nothing would report the omission.
+    init_request_semaphore(FerryConfig.max_concurrent_requests)
+
+    from discord_ferry.migrator.verify import run_check
+
+    try:
+        state = load_state(Path(output_dir))
+    except StateError as exc:
+        console.print(f"[bold red]Error:[/] {_safe(exc)}")
+        sys.exit(1)
+
+    try:
+        report = asyncio.run(run_check(stoat_url, token, state, lambda _e: None))
+    except (CheckError, MigrationError) as exc:
+        console.print(f"[bold red]Cannot check this migration:[/] {_safe(exc)}")
+        sys.exit(1)
+
+    _render_check_report(report)
+    sys.exit(1 if report.has_failures else 0)
+
+
+def _render_check_report(report: CheckReport) -> None:
+    """Print the results table and the summary line.
+
+    The summary leads with counts and states the exit code, so neither has to be
+    inferred. When anything could not be verified it also says so in a sentence:
+    on a merge migration most tail results are unverifiable, and a bare count
+    beside three green ones reads like approval of something never examined.
+    """
+    colours = {"ok": "green", "warn": "yellow", "fail": "red", "unverifiable": "cyan"}
+    table = Table(title="Migration Check")
+    table.add_column("Check")
+    table.add_column("Status")
+    table.add_column("Detail")
+    for result in report.results:
+        colour = colours.get(result.status, "white")
+        table.add_row(
+            escape(result.name),
+            f"[{colour}]{result.status}[/]",
+            escape(result.detail),
+        )
+    console.print(table)
+
+    counts = report.counts()
+    exit_code = 1 if report.has_failures else 0
+    console.print(
+        f"{counts['ok']} ok · {counts['fail']} failed · "
+        f"{counts['unverifiable']} unverifiable · {counts['warn']} warning"
+        f"   (exit {exit_code})"
+    )
+    if counts["unverifiable"]:
+        console.print(
+            f"[cyan]{counts['unverifiable']} checks could not be verified.[/] Ferry did "
+            "not record what it would need to confirm them, which is expected when "
+            "--thread-strategy=merge was used, after a duplicate send, or for a channel "
+            "this token cannot read."
+        )
 
 
 @main.command("tls-check")

--- a/src/discord_ferry/errors.py
+++ b/src/discord_ferry/errors.py
@@ -9,6 +9,16 @@ class ValidationError(FerryError):
     """Export validation failed."""
 
 
+class CheckError(FerryError):
+    """A finished migration cannot be checked against a live server.
+
+    Distinct from :class:`ValidationError`, which is about a DiscordChatExporter
+    export being unusable as INPUT. This is about a recorded migration being
+    unusable as a SUBJECT: a dry-run state, or one that never reached the
+    structure phase and so records no server.
+    """
+
+
 class StoatConnectionError(FerryError):
     """Stoat API connection failed."""
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -1017,3 +1017,31 @@ async def api_fetch_messages(
             f"Expected a JSON array of messages from {url}, got {type(raw).__name__}"
         )
     return raw
+
+
+async def api_fetch_server_with_channels(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    server_id: str,
+) -> dict[str, Any]:
+    """Fetch a server together with its channel objects.
+
+    ``GET /servers/{id}?include_channels=true``. Deliberately a separate
+    function from :func:`api_fetch_server` rather than a parameter on it.
+    Upstream answers this route with ``FetchServerResponse::JustServer`` when
+    the parameter is absent and ``ServerWithChannels`` when it is present, so
+    adding it to the existing function would change the response shape under the
+    ``validate_after`` block in ``run_migration`` and under rollback, neither of
+    which this work touches.
+
+    The response carries two lists, and the pair is the point. ``server`` is
+    returned unmodified, so its own ``channels`` field still names every channel
+    id on the server. The sibling ``channels`` array holds only the channel
+    objects the caller may ``ViewChannel``. Comparing the two is the only way to
+    tell a channel that was deleted from one this token simply cannot see.
+
+    Lands in the ``servers`` rate bucket, 5 per 10 seconds keyed per server id.
+    """
+    url = f"{stoat_url.rstrip('/')}/servers/{server_id}?include_channels=true"
+    return await _api_request(session, "GET", url, token)

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -1045,3 +1045,28 @@ async def api_fetch_server_with_channels(
     """
     url = f"{stoat_url.rstrip('/')}/servers/{server_id}?include_channels=true"
     return await _api_request(session, "GET", url, token)
+
+
+async def api_fetch_emoji_list(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    server_id: str,
+) -> list[dict[str, Any]]:
+    """List a server's custom emoji (GET /servers/{id}/emojis).
+
+    A separate request because the ``Server`` model carries no emoji field at
+    all. Upstream returns ``Vec<Emoji>`` and requires only server membership,
+    unlike the message route which requires ``ReadMessageHistory``.
+
+    Narrowed the same way as :func:`api_fetch_messages`, and for the same
+    reason: this route returns an array while the shared request helper is
+    declared to return a mapping.
+
+    Lands in the ``servers`` rate bucket, 5 per 10 seconds keyed per server id.
+    """
+    url = f"{stoat_url.rstrip('/')}/servers/{server_id}/emojis"
+    raw: object = await _api_request(session, "GET", url, token)
+    if not isinstance(raw, list):
+        raise MigrationError(f"Expected a JSON array of emoji from {url}, got {type(raw).__name__}")
+    return raw

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -1001,6 +1001,16 @@ async def api_fetch_messages(
     per 10 seconds keyed per channel id, because upstream routes to
     ``messaging`` only on POST.
     """
+    # ValueError, not MigrationError, and deliberately so. These two guards
+    # catch a CALLER passing arguments this route cannot accept, which is a
+    # programming error, not a migration failure. Both values are supplied by
+    # Ferry itself and no CLI flag feeds either, so neither is reachable from
+    # user input. Raising a FerryError here would let the CLI's per-command
+    # handler print a bad call as though the migration had failed, hiding the
+    # bug; an uncaught ValueError points a developer straight at the call site.
+    # A chunk review proposed converting these and the proposal was checked
+    # rather than taken: the CLI genuinely does not catch ValueError, but the
+    # path is unreachable by construction.
     if not 1 <= limit <= 100:
         raise ValueError(f"limit must be between 1 and 100, got {limit}")
     if sort not in ("Latest", "Oldest"):

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -970,3 +970,50 @@ async def api_delete_emoji(
     """
     url = f"{stoat_url.rstrip('/')}/custom/emoji/{emoji_id}"
     await _api_request(session, "DELETE", url, token, expected_404_ok=True)
+
+
+async def api_fetch_messages(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    channel_id: str,
+    *,
+    limit: int,
+    sort: str,
+) -> list[dict[str, Any]]:
+    """Read a channel's messages (GET /channels/{id}/messages).
+
+    ``limit`` and ``sort`` are keyword-only and required rather than defaulted,
+    which is deliberate on both counts. Upstream validates ``limit`` as
+    ``range(min = 1, max = 100)``, and its ``MessageSort`` default is
+    ``Relevance``, which this route explicitly rejects. A caller that could omit
+    ``sort`` would inherit a value the server refuses.
+
+    ``include_users`` is never sent. The response is an untagged enum: without
+    that parameter it is a bare array of messages, with it an object carrying
+    ``messages``, ``users`` and ``members``. Omitting it pins the shape.
+
+    A message id arrives as ``_id``, not ``id``. Ferry's webhook id field IS
+    ``id``, so the two are inconsistent upstream and neither can be inferred
+    from the other.
+
+    Requires ``ReadMessageHistory``. Lands in the ``channels`` rate bucket, 15
+    per 10 seconds keyed per channel id, because upstream routes to
+    ``messaging`` only on POST.
+    """
+    if not 1 <= limit <= 100:
+        raise ValueError(f"limit must be between 1 and 100, got {limit}")
+    if sort not in ("Latest", "Oldest"):
+        raise ValueError(f"sort must be 'Latest' or 'Oldest', got {sort!r}")
+    url = f"{stoat_url.rstrip('/')}/channels/{channel_id}/messages?limit={limit}&sort={sort}"
+    # Annotated `object` on purpose. _api_request is declared -> dict[str, Any]
+    # but its success path returns whatever JSON arrived, and this route returns
+    # an array. Widening that shared helper would cost 28 callers their typing,
+    # and a type: ignore here would hide a real shape mismatch, so the narrowing
+    # happens where the shape is actually known.
+    raw: object = await _api_request(session, "GET", url, token)
+    if not isinstance(raw, list):
+        raise MigrationError(
+            f"Expected a JSON array of messages from {url}, got {type(raw).__name__}"
+        )
+    return raw

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -20,6 +20,7 @@ check is a recorded result, not the absence of one.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, get_args
 
@@ -392,6 +393,14 @@ async def _check_structure(
         )
 
 
+#: How many channels the tail check reads at once.
+#:
+#: Matches the default `init_request_semaphore` uses for a migration. The
+#: per-channel bucket allows 15 requests per 10 seconds EACH, so this is
+#: nowhere near a limit; it exists to avoid opening 200 sockets at once.
+_MAX_CONCURRENT_TAILS = 5
+
+
 #: The prefix `structure.py` puts on a forum index channel's synthetic
 #: `channel_map` key. Its message id lives under the BARE key in
 #: `forum_index_message_ids`, so one of the two has to be translated.
@@ -430,29 +439,70 @@ async def _check_tails(
             message="Checking each channel's most recent messages...",
         )
     )
-    for discord_id, stoat_id in state.channel_map.items():
-        if discord_id not in verified:
-            # The structure pass could not read this channel, and has already
-            # said so. Fetching its messages would fail for the same cause and
-            # report it twice, doubling the apparent damage and sending a repair
-            # after a channel that may not exist.
-            continue
+    # Fanned out, not sequential. The rate-limit bucket is keyed
+    # ("channels", channel_id), so separate channels never contend with each
+    # other, and 200 channels in series would be 200 round trips of pure
+    # latency for no reason.
+    #
+    # Bounded by a LOCAL semaphore rather than the module-level one in api.py.
+    # That one is initialised by whoever drives a migration, and a caller using
+    # this module directly may not have done so, in which case it is None and
+    # imposes no limit at all. A local bound cannot be forgotten.
+    #
+    # `_one_tail` is written so it CANNOT raise, which is what makes gather safe
+    # here. The recorded hazard is `gather(..., return_exceptions=True)`
+    # discarding what it collected; a coroutine with nothing to throw leaves
+    # gather nothing to swallow, and the ordinary form preserves input order so
+    # the report stays deterministic.
+    limiter = asyncio.Semaphore(_MAX_CONCURRENT_TAILS)
+    targets = [
+        (discord_id, stoat_id)
+        for discord_id, stoat_id in state.channel_map.items()
+        # The structure pass could not read these, and has already said so.
+        # Fetching them would fail for the same cause and report it twice,
+        # doubling the apparent damage and sending a repair after a channel
+        # that may not exist.
+        if discord_id in verified
+    ]
+    results = await asyncio.gather(
+        *(
+            _one_tail(sess, stoat_url, token, state, discord_id, stoat_id, limiter)
+            for discord_id, stoat_id in targets
+        )
+    )
+    for result in results:
+        report.results.append(result)
+
+
+async def _one_tail(
+    sess: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    state: MigrationState,
+    discord_id: str,
+    stoat_id: str,
+    limiter: asyncio.Semaphore,
+) -> CheckResult:
+    """One channel's tail verdict. Never raises, by construction.
+
+    Every failure becomes a result. That is what lets the caller use a plain
+    ``gather`` without ``return_exceptions``, and it is the deliberate contrast
+    with the ``validate_after`` block in ``run_migration``, whose blanket
+    handler leaves its result dict empty so a check that failed reads exactly
+    like one that passed.
+    """
+    expected = _expected_tail(state, discord_id)
+    async with limiter:
         try:
             window = await api_fetch_messages(
                 sess, stoat_url, token, stoat_id, limit=_WINDOW, sort="Latest"
             )
         except FerryError as exc:
-            # One channel failing is a RESULT, not the end of the run. This is
-            # the deliberate contrast with the validate_after block in
-            # run_migration, whose blanket handler writes a warning and leaves
-            # its result dict empty, so a check that failed reads exactly like
-            # one that passed.
-            #
-            # unverifiable rather than fail: Ferry could not look, which is not
-            # the same as finding something wrong. Only FerryError is caught, so
-            # a programming error still surfaces as a crash rather than being
+            # unverifiable, not fail: Ferry could not look, which is not the
+            # same as finding something wrong. Only FerryError is caught, so a
+            # programming error still surfaces as a crash rather than being
             # filed as a server problem.
-            report.add(
+            return CheckResult(
                 name=f"tail:{discord_id}",
                 status="unverifiable",
                 kind="check_error",
@@ -460,22 +510,21 @@ async def _check_tails(
                 discord_id=discord_id,
                 stoat_id=stoat_id,
             )
-            continue
-        window_ids = [m["_id"] for m in window if isinstance(m, dict) and "_id" in m]
-        status, kind, detail = _classify_tail(
-            expected=_expected_tail(state, discord_id),
-            window_ids=window_ids,
-            recorded_count=state.channel_message_counts.get(discord_id, 0),
-        )
-        report.add(
-            name=f"tail:{discord_id}",
-            status=status,
-            kind=kind,
-            detail=detail,
-            discord_id=discord_id,
-            stoat_id=stoat_id,
-            expected=_expected_tail(state, discord_id),
-        )
+    window_ids = [m["_id"] for m in window if isinstance(m, dict) and "_id" in m]
+    status, kind, detail = _classify_tail(
+        expected=expected,
+        window_ids=window_ids,
+        recorded_count=state.channel_message_counts.get(discord_id, 0),
+    )
+    return CheckResult(
+        name=f"tail:{discord_id}",
+        status=status,
+        kind=kind,
+        detail=detail,
+        discord_id=discord_id,
+        stoat_id=stoat_id,
+        expected=expected,
+    )
 
 
 def _expected_tail(state: MigrationState, discord_id: str) -> str | None:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -493,4 +493,49 @@ def _classify_tail(
         )
     if expected in set(window_ids):
         return ("ok", "tail_present", "the last message Ferry recorded is still present")
-    return ("unverifiable", "tail_not_recorded", "placeholder, refined in task #257")
+
+    # The tail is absent. Two very different reasons, and telling them apart is
+    # what makes this check worth running.
+    #
+    # Stoat message ids are ULIDs, whose leading 48 bits are a millisecond
+    # timestamp in Crockford base32, so lexicographic order on equal-length ids
+    # IS time order. That lets the window's position be compared against the
+    # expected tail without any timestamps.
+    #
+    # min() and max(), never window[0] or window[-1]. MessageSort::Latest is
+    # doc!{"_id": -1} upstream and the vector is not reversed, so element zero
+    # is the NEWEST. Reading it as the oldest inverts both verdicts below: real
+    # loss would report unverifiable while ordinary post-migration activity
+    # would report fail. Taking the extremes by value also makes this
+    # independent of whatever order the server chooses to send.
+    newest = max(window_ids)
+    oldest = min(window_ids)
+    if newest < expected:
+        # Everything on the server predates the tail, so the tail and every
+        # message after it is gone while older content survives. Stronger
+        # evidence of loss than the branch below, where only the tail itself is
+        # missing, and separated because a repair would treat them differently.
+        return (
+            "fail",
+            "tail_and_after_absent",
+            "every recent message predates the last one Ferry recorded, so that "
+            "message and everything after it is missing",
+        )
+    if oldest < expected:
+        # The window spans the tail's own position in time and the tail is not
+        # in it. It was deleted.
+        return (
+            "fail",
+            "tail_absent",
+            "the last message Ferry recorded is missing, though messages from "
+            "both before and after it are present",
+        )
+    # The whole window is newer than the tail: more than the window's worth of
+    # messages arrived since. Not evidence of loss. This is the branch that
+    # keeps a large merge, and a busy channel, off the failure list.
+    return (
+        "unverifiable",
+        "tail_not_recorded",
+        f"more than {_WINDOW} messages have arrived since the last one Ferry "
+        "recorded, so the window does not reach far enough back to confirm it",
+    )

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -23,7 +23,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, get_args
 
+from discord_ferry.core.events import MigrationEvent
+from discord_ferry.core.http import new_session
 from discord_ferry.errors import CheckError
+from discord_ferry.migrator.api import (
+    api_fetch_emoji_list,
+    api_fetch_server_with_channels,
+)
 
 if TYPE_CHECKING:
     import aiohttp
@@ -169,5 +175,86 @@ async def run_check(
         )
 
     report = CheckReport()
-    _ = (stoat_url, token, session, on_event)  # wired up in the next chunks
+    own_session = session is None
+    sess = session or new_session()
+    try:
+        await _check_structure(sess, stoat_url, token, state, report, on_event)
+    finally:
+        if own_session:
+            await sess.close()
     return report
+
+
+async def _check_structure(
+    sess: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    state: MigrationState,
+    report: CheckReport,
+    on_event: EventCallback,
+) -> None:
+    """Compare every recorded entity against the server, by id.
+
+    Two requests for the whole family, whatever the entity count: the server
+    fetch carries roles and categories as full objects alongside the channels,
+    and emoji need one more because ``Server`` has no emoji field.
+    """
+    on_event(
+        MigrationEvent(
+            phase="check",
+            status="started",
+            message="Checking server structure...",
+        )
+    )
+    payload = await api_fetch_server_with_channels(sess, stoat_url, token, state.stoat_server_id)
+    await api_fetch_emoji_list(sess, stoat_url, token, state.stoat_server_id)
+
+    server = payload.get("server") or {}
+    # Two lists, and the pair is the discriminator. `server.channels` comes back
+    # UNFILTERED and names every channel id; the sibling array holds only the
+    # objects this token may ViewChannel. Consulting the objects alone cannot
+    # tell a deleted channel from one merely hidden, which would make
+    # `channel_missing` unreachable and lose the point of the tool.
+    all_channel_ids = set(server.get("channels") or [])
+    visible_ids = {
+        c["_id"] for c in (payload.get("channels") or []) if isinstance(c, dict) and "_id" in c
+    }
+
+    for discord_id, stoat_id in state.channel_map.items():
+        # `discord_id` is not always a Discord snowflake: the forum index writer
+        # stores a synthetic `forum-index-{key}`. Only the VALUE is sent to the
+        # server, so identity checking is valid for those entries too.
+        if stoat_id in visible_ids:
+            report.add(
+                name=f"channel:{discord_id}",
+                status="ok",
+                kind="channel_present",
+                detail="channel exists under its recorded id",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+        elif stoat_id in all_channel_ids:
+            report.add(
+                name=f"channel:{discord_id}",
+                status="unverifiable",
+                kind="channel_not_visible",
+                detail=(
+                    "the server lists this channel but did not return it, which "
+                    "means this token cannot view it. Its contents cannot be checked."
+                ),
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+        else:
+            report.add(
+                name=f"channel:{discord_id}",
+                status="fail",
+                kind="channel_missing",
+                detail="the server does not list this channel at all",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+
+    # No branch for a `dry-ch-` value. It is written only under config.dry_run,
+    # and the same run sets state.is_dry_run, which run_check refuses above. The
+    # branch is unreachable by construction, so it is not written.

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -207,7 +207,7 @@ async def _check_structure(
         )
     )
     payload = await api_fetch_server_with_channels(sess, stoat_url, token, state.stoat_server_id)
-    await api_fetch_emoji_list(sess, stoat_url, token, state.stoat_server_id)
+    emoji = await api_fetch_emoji_list(sess, stoat_url, token, state.stoat_server_id)
 
     server = payload.get("server") or {}
     # Two lists, and the pair is the discriminator. `server.channels` comes back
@@ -258,3 +258,38 @@ async def _check_structure(
     # No branch for a `dry-ch-` value. It is written only under config.dry_run,
     # and the same run sets state.is_dry_run, which run_check refuses above. The
     # branch is unreachable by construction, so it is not written.
+
+    # Roles arrive as a map keyed by role id, so membership is a key lookup.
+    # There is no second list and no permission filter here, unlike channels, so
+    # an absence is unambiguous and reports fail rather than unverifiable.
+    role_ids = set(server.get("roles") or {})
+    for discord_id, stoat_id in state.role_map.items():
+        present = stoat_id in role_ids
+        report.add(
+            name=f"role:{discord_id}",
+            status="ok" if present else "fail",
+            kind="role_present" if present else "role_missing",
+            detail=(
+                "role exists under its recorded id"
+                if present
+                else "the server does not list this role"
+            ),
+            discord_id=discord_id,
+            stoat_id=stoat_id,
+        )
+
+    emoji_ids = {e["_id"] for e in emoji if isinstance(e, dict) and "_id" in e}
+    for discord_id, stoat_id in state.emoji_map.items():
+        present = stoat_id in emoji_ids
+        report.add(
+            name=f"emoji:{discord_id}",
+            status="ok" if present else "fail",
+            kind="emoji_present" if present else "emoji_missing",
+            detail=(
+                "emoji exists under its recorded id"
+                if present
+                else "the server does not list this emoji"
+            ),
+            discord_id=discord_id,
+            stoat_id=stoat_id,
+        )

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -21,9 +21,9 @@ check is a recorded result, not the absence of one.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, get_args
 
-from discord_ferry.errors import ValidationError
+from discord_ferry.errors import CheckError
 
 if TYPE_CHECKING:
     import aiohttp
@@ -31,7 +31,18 @@ if TYPE_CHECKING:
     from discord_ferry.core.events import EventCallback
     from discord_ferry.state import MigrationState
 
-#: Every status the tool can report, in the order a summary line names them.
+#: Every status the tool can report.
+#:
+#: A ``Literal`` rather than a bare ``str`` so ``mypy --strict`` rejects a typo at
+#: the call site. This is not fussiness: a status of ``"faild"`` would leave
+#: :attr:`CheckReport.has_failures` False and the command exiting 0 while a real
+#: failure sat in the report. A runtime guard would catch it too, but only once
+#: the line actually runs, and the wrong branch may be the rare one.
+CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
+
+#: The same four, as a tuple, DERIVED from the type rather than restated beside
+#: it. A hand-maintained parallel list is how this project once let every
+#: extension of a permission map leave its expansion behind.
 #:
 #: ``warn`` exists for a cosmetic difference on an entity whose content is
 #: intact. Today the only such difference is a category title, because
@@ -39,7 +50,7 @@ if TYPE_CHECKING:
 #: design review found ``warn`` promised in two acceptance criteria and produced
 #: by no code path at all, so its single legitimate home is stated here rather
 #: than left implicit.
-STATUSES: tuple[str, ...] = ("ok", "warn", "fail", "unverifiable")
+STATUSES: tuple[CheckStatus, ...] = get_args(CheckStatus)
 
 
 @dataclass
@@ -53,7 +64,7 @@ class CheckResult:
     """
 
     name: str
-    status: str
+    status: CheckStatus
     kind: str
     detail: str
     discord_id: str | None = None
@@ -72,7 +83,7 @@ class CheckReport:
         self,
         *,
         name: str,
-        status: str,
+        status: CheckStatus,
         kind: str,
         detail: str,
         discord_id: str | None = None,
@@ -101,9 +112,13 @@ class CheckReport:
         there, so a summary line can always say "0 failed" out loud. A reader
         most wants that stated when it is zero.
         """
-        tally = dict.fromkeys(STATUSES, 0)
+        # Annotated dict[str, int] rather than inferred: dict.fromkeys over a
+        # Literal tuple infers dict[CheckStatus, int], which callers formatting a
+        # summary line would have to satisfy with literals. CheckStatus is a str,
+        # so the widening is free and the increment below still type-checks.
+        tally: dict[str, int] = dict.fromkeys(STATUSES, 0)
         for result in self.results:
-            tally[result.status] = tally.get(result.status, 0) + 1
+            tally[result.status] += 1
         return tally
 
     @property
@@ -139,16 +154,16 @@ async def run_check(
     name channels nobody ever created.
 
     Raises:
-        ValidationError: the state is from a dry run, or records no server.
+        CheckError: the state is from a dry run, or records no server.
     """
     if state.is_dry_run:
-        raise ValidationError(
+        raise CheckError(
             "Cannot check a dry-run state. A dry run records placeholder ids for "
             "channels and messages that were never created, so there is nothing on "
             "the server to verify against. Run a real migration first."
         )
     if not state.stoat_server_id:
-        raise ValidationError(
+        raise CheckError(
             "This state records no Stoat server id, so there is nothing to check "
             "against. The migration may not have reached the structure phase."
         )

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -69,6 +69,35 @@ class CheckResult:
     purpose. This report is the contract the repair tool consumes, and a status
     plus a sentence is not actionable: a repair needs the entity's ids and an
     enumerable defect category it can dispatch on, not prose to parse.
+
+    The complete ``kind`` vocabulary lives here rather than only in the design
+    document, because that directory is gitignored and this is the contract
+    another batch will be written against:
+
+    ==================  ====================================================
+    Family              Kinds
+    ==================  ====================================================
+    Channel identity    ``channel_present``, ``channel_missing``,
+                        ``channel_not_visible``
+    Role identity       ``role_present``, ``role_missing``
+    Category identity   ``category_present``, ``category_missing``,
+                        ``category_title_mismatch``, ``category_title_unknown``
+    Emoji identity      ``emoji_present``, ``emoji_missing``
+    Tail                ``nothing_expected``, ``tail_present``,
+                        ``channel_empty``,
+                        ``tail_absent``, ``tail_and_after_absent``,
+                        ``tail_not_recorded``, ``tail_window_exhausted``
+    Failure to look     ``check_error``
+    ==================  ====================================================
+
+    Two pairs are deliberately NOT collapsed, both for the same reason.
+    ``tail_absent`` against ``tail_and_after_absent``: one message gone, against
+    everything from that point on. ``tail_not_recorded`` against
+    ``tail_window_exhausted``: Ferry recorded no id and can never confirm it,
+    against the id being merely out of a 100-message window's reach, which a
+    tool willing to page further back could resolve. Collapsing either pair
+    forces a repair to parse the prose detail, which is what a ``kind`` exists
+    to avoid.
     """
 
     name: str
@@ -642,9 +671,16 @@ def _classify_tail(
     # The whole window is newer than the tail: more than the window's worth of
     # messages arrived since. Not evidence of loss. This is the branch that
     # keeps a large merge, and a busy channel, off the failure list.
+    # A DIFFERENT kind from the `expected is None` branch above, and the two are
+    # separated for the same reason the two fail kinds are. That one is
+    # permanently unanswerable: Ferry recorded no id, so no amount of looking
+    # will ever confirm it. This one is merely out of reach of a 100-message
+    # window, and a repair tool willing to page further back could resolve it.
+    # Collapsing them would force that tool to parse the prose detail, which is
+    # what having a kind exists to avoid.
     return (
         "unverifiable",
-        "tail_not_recorded",
+        "tail_window_exhausted",
         f"more than {_WINDOW} messages have arrived since the last one Ferry "
         "recorded, so the window does not reach far enough back to confirm it",
     )

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Literal, get_args
 
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.http import new_session
-from discord_ferry.errors import CheckError
+from discord_ferry.errors import CheckError, FerryError
 from discord_ferry.migrator.api import (
     api_fetch_emoji_list,
     api_fetch_messages,
@@ -437,9 +437,30 @@ async def _check_tails(
             # report it twice, doubling the apparent damage and sending a repair
             # after a channel that may not exist.
             continue
-        window = await api_fetch_messages(
-            sess, stoat_url, token, stoat_id, limit=_WINDOW, sort="Latest"
-        )
+        try:
+            window = await api_fetch_messages(
+                sess, stoat_url, token, stoat_id, limit=_WINDOW, sort="Latest"
+            )
+        except FerryError as exc:
+            # One channel failing is a RESULT, not the end of the run. This is
+            # the deliberate contrast with the validate_after block in
+            # run_migration, whose blanket handler writes a warning and leaves
+            # its result dict empty, so a check that failed reads exactly like
+            # one that passed.
+            #
+            # unverifiable rather than fail: Ferry could not look, which is not
+            # the same as finding something wrong. Only FerryError is caught, so
+            # a programming error still surfaces as a crash rather than being
+            # filed as a server problem.
+            report.add(
+                name=f"tail:{discord_id}",
+                status="unverifiable",
+                kind="check_error",
+                detail=f"could not read this channel's messages: {exc}",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+            continue
         window_ids = [m["_id"] for m in window if isinstance(m, dict) and "_id" in m]
         status, kind, detail = _classify_tail(
             expected=_expected_tail(state, discord_id),

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -1,0 +1,108 @@
+"""Verify a finished migration against a live Stoat server.
+
+Modelled on :mod:`discord_ferry.migrator.probe`: read-only, reports through an
+``on_event`` callback so nothing here imports a shell, and takes an injectable
+session so tests drive it without a network.
+
+Two check families. Structure compares every entity recorded in
+:class:`~discord_ferry.state.MigrationState` against the server **by id**, in
+two requests regardless of how many entities exist. The tail check asks each
+channel for its newest 100 messages and confirms the message state records as
+that channel's last is still present among them.
+
+The existing ``validate_after`` block in ``run_migration`` compares two
+cardinalities and sets ``passed`` on them alone, so two channels created with
+each other's names pass it. It also swallows every exception into a warning and
+leaves ``validation_results`` empty, which makes a check that failed
+indistinguishable from one that passed. Neither is repeated here: a failure to
+check is a recorded result, not the absence of one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+#: Every status the tool can report, in the order a summary line names them.
+#:
+#: ``warn`` exists for a cosmetic difference on an entity whose content is
+#: intact. Today the only such difference is a category title, because
+#: ``category_names`` is the only expected name ``MigrationState`` records. A
+#: design review found ``warn`` promised in two acceptance criteria and produced
+#: by no code path at all, so its single legitimate home is stated here rather
+#: than left implicit.
+STATUSES: tuple[str, ...] = ("ok", "warn", "fail", "unverifiable")
+
+
+@dataclass
+class CheckResult:
+    """One entity's verdict.
+
+    Carries more than :class:`~discord_ferry.migrator.probe.ProbeCheck` on
+    purpose. This report is the contract the repair tool consumes, and a status
+    plus a sentence is not actionable: a repair needs the entity's ids and an
+    enumerable defect category it can dispatch on, not prose to parse.
+    """
+
+    name: str
+    status: str
+    kind: str
+    detail: str
+    discord_id: str | None = None
+    stoat_id: str | None = None
+    expected: str | None = None
+    found: str | None = None
+
+
+@dataclass
+class CheckReport:
+    """Every verdict from one run."""
+
+    results: list[CheckResult] = field(default_factory=list)
+
+    def add(
+        self,
+        *,
+        name: str,
+        status: str,
+        kind: str,
+        detail: str,
+        discord_id: str | None = None,
+        stoat_id: str | None = None,
+        expected: str | None = None,
+        found: str | None = None,
+    ) -> None:
+        """Append a verdict. Mirrors ``ProbeReport.add``."""
+        self.results.append(
+            CheckResult(
+                name=name,
+                status=status,
+                kind=kind,
+                detail=detail,
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+                expected=expected,
+                found=found,
+            )
+        )
+
+    def counts(self) -> dict[str, int]:
+        """Count results per status, with **every** status present.
+
+        Seeded from :data:`STATUSES` rather than counting what happens to be
+        there, so a summary line can always say "0 failed" out loud. A reader
+        most wants that stated when it is zero.
+        """
+        tally = dict.fromkeys(STATUSES, 0)
+        for result in self.results:
+            tally[result.status] = tally.get(result.status, 0) + 1
+        return tally
+
+    @property
+    def has_failures(self) -> bool:
+        """True only when something is genuinely wrong.
+
+        ``warn`` and ``unverifiable`` do not count. Treating either as a failure
+        would exit non-zero on every merge migration and on every renamed
+        category, which is the fastest way to teach people to ignore the tool.
+        """
+        return any(r.status == "fail" for r in self.results)

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -278,6 +278,57 @@ async def _check_structure(
             stoat_id=stoat_id,
         )
 
+    # Categories are the ONE entity whose expected name Ferry records, in
+    # state.category_names, so this is the only name comparison in the tool. A
+    # channel or role rename is undetectable, which is stated as a limit rather
+    # than approximated (spec P2 S11).
+    #
+    # `categories` is Optional upstream: the key can be absent entirely on a
+    # server that never had one, not merely an empty list.
+    found_titles = {
+        c["id"]: c.get("title", "")
+        for c in (server.get("categories") or [])
+        if isinstance(c, dict) and "id" in c
+    }
+    for discord_id, stoat_id in state.category_map.items():
+        if stoat_id not in found_titles:
+            report.add(
+                name=f"category:{discord_id}",
+                status="fail",
+                kind="category_missing",
+                detail="the server does not list this category",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+            continue
+        expected_title = state.category_names.get(discord_id)
+        actual_title = found_titles[stoat_id]
+        if expected_title is not None and expected_title != actual_title:
+            # warn, not fail. The category exists and its channels are intact;
+            # only a heading differs. This is the single reachable warn in the
+            # tool, and it is why the status exists at all: a design review
+            # found warn promised in two acceptance criteria and produced by no
+            # code path.
+            report.add(
+                name=f"category:{discord_id}",
+                status="warn",
+                kind="category_title_mismatch",
+                detail="the category exists but its title differs from the recorded one",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+                expected=expected_title,
+                found=actual_title,
+            )
+        else:
+            report.add(
+                name=f"category:{discord_id}",
+                status="ok",
+                kind="category_present",
+                detail="category exists under its recorded id",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+
     emoji_ids = {e["_id"] for e in emoji if isinstance(e, dict) and "_id" in e}
     for discord_id, stoat_id in state.emoji_map.items():
         present = stoat_id in emoji_ids

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -28,6 +28,7 @@ from discord_ferry.core.http import new_session
 from discord_ferry.errors import CheckError
 from discord_ferry.migrator.api import (
     api_fetch_emoji_list,
+    api_fetch_messages,
     api_fetch_server_with_channels,
 )
 
@@ -179,6 +180,7 @@ async def run_check(
     sess = session or new_session()
     try:
         await _check_structure(sess, stoat_url, token, state, report, on_event)
+        await _check_tails(sess, stoat_url, token, state, report, on_event)
     finally:
         if own_session:
             await sess.close()
@@ -381,3 +383,114 @@ async def _check_structure(
             discord_id=discord_id,
             stoat_id=stoat_id,
         )
+
+
+#: How many messages the tail check asks for per channel.
+#:
+#: 100 is the upstream maximum and costs exactly what 1 costs, because the rate
+#: bucket counts REQUESTS. Asking for the whole window rather than the single
+#: newest message is what lets a merge parent, a forum index channel, and a
+#: channel someone posted in since all report ok instead of unverifiable.
+_WINDOW = 100
+
+
+async def _check_tails(
+    sess: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    state: MigrationState,
+    report: CheckReport,
+    on_event: EventCallback,
+) -> None:
+    """Confirm each channel still holds the last message Ferry recorded sending.
+
+    One request per channel, whatever the channel's size. Reads land in the
+    ``channels`` bucket, 15 per 10 seconds keyed per channel id, because
+    upstream routes to ``messaging`` only on POST, so separate channels do not
+    contend with each other.
+    """
+    on_event(
+        MigrationEvent(
+            phase="check",
+            status="started",
+            message="Checking each channel's most recent messages...",
+        )
+    )
+    for discord_id, stoat_id in state.channel_map.items():
+        window = await api_fetch_messages(
+            sess, stoat_url, token, stoat_id, limit=_WINDOW, sort="Latest"
+        )
+        window_ids = [m["_id"] for m in window if isinstance(m, dict) and "_id" in m]
+        status, kind, detail = _classify_tail(
+            expected=_expected_tail(state, discord_id),
+            window_ids=window_ids,
+            recorded_count=state.channel_message_counts.get(discord_id, 0),
+        )
+        report.add(
+            name=f"tail:{discord_id}",
+            status=status,
+            kind=kind,
+            detail=detail,
+            discord_id=discord_id,
+            stoat_id=stoat_id,
+            expected=_expected_tail(state, discord_id),
+        )
+
+
+def _expected_tail(state: MigrationState, discord_id: str) -> str | None:
+    """The Stoat id of the last message Ferry believes it sent to this channel.
+
+    TWO hops, and both can miss without either being an error.
+
+    ``channel_high_water`` is keyed by DISCORD channel id and holds a DISCORD
+    message id, so it must be resolved through ``message_map`` to become a Stoat
+    id. Comparing without that hop compares a Discord id against a Stoat one and
+    never matches.
+
+    A missing high-water entry means the channel sent nothing, which is ordinary
+    for an empty Discord channel. A missing map entry means the send returned
+    409 DuplicateNonce, where batch 7 deliberately records no id. Neither may
+    raise: an unconditional lookup reports the commonest correct case as a
+    crash.
+    """
+    high_water = state.channel_high_water.get(discord_id)
+    if high_water is None:
+        return None
+    return state.message_map.get(high_water)
+
+
+def _classify_tail(
+    *,
+    expected: str | None,
+    window_ids: list[str],
+    recorded_count: int,
+) -> tuple[CheckStatus, str, str]:
+    """Decide one channel's verdict. A pure function, deliberately.
+
+    Order matters and is not arbitrary. The zero-count rule runs FIRST so a
+    channel that legitimately received nothing is never dragged through the
+    lookups below it.
+    """
+    if recorded_count == 0:
+        return (
+            "ok",
+            "nothing_expected",
+            "no messages were migrated to this channel, and none were expected",
+        )
+    if not window_ids:
+        return (
+            "fail",
+            "channel_empty",
+            "state records messages for this channel but the server returned none",
+        )
+    if expected is None:
+        return (
+            "unverifiable",
+            "tail_not_recorded",
+            "Ferry recorded no id for this channel's last message, which happens "
+            "when a send was accepted as a duplicate. Its delivery cannot be "
+            "confirmed here (see issue #240).",
+        )
+    if expected in set(window_ids):
+        return ("ok", "tail_present", "the last message Ferry recorded is still present")
+    return ("unverifiable", "tail_not_recorded", "placeholder, refined in task #257")

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -179,8 +179,9 @@ async def run_check(
     own_session = session is None
     sess = session or new_session()
     try:
-        await _check_structure(sess, stoat_url, token, state, report, on_event)
-        await _check_tails(sess, stoat_url, token, state, report, on_event)
+        verified: set[str] = set()
+        await _check_structure(sess, stoat_url, token, state, report, on_event, verified)
+        await _check_tails(sess, stoat_url, token, state, report, on_event, verified)
     finally:
         if own_session:
             await sess.close()
@@ -194,8 +195,13 @@ async def _check_structure(
     state: MigrationState,
     report: CheckReport,
     on_event: EventCallback,
+    verified: set[str],
 ) -> None:
     """Compare every recorded entity against the server, by id.
+
+    ``verified`` is filled with the channel keys that came back readable. The
+    tail check consults it and skips the rest, so one deleted channel yields one
+    finding rather than two.
 
     Two requests for the whole family, whatever the entity count: the server
     fetch carries roles and categories as full objects alongside the channels,
@@ -238,6 +244,7 @@ async def _check_structure(
         # stores a synthetic `forum-index-{key}`. Only the VALUE is sent to the
         # server, so identity checking is valid for those entries too.
         if stoat_id in visible_ids:
+            verified.add(discord_id)
             report.add(
                 name=f"channel:{discord_id}",
                 status="ok",
@@ -385,6 +392,12 @@ async def _check_structure(
         )
 
 
+#: The prefix `structure.py` puts on a forum index channel's synthetic
+#: `channel_map` key. Its message id lives under the BARE key in
+#: `forum_index_message_ids`, so one of the two has to be translated.
+_FORUM_INDEX_PREFIX = "forum-index-"
+
+
 #: How many messages the tail check asks for per channel.
 #:
 #: 100 is the upstream maximum and costs exactly what 1 costs, because the rate
@@ -401,6 +414,7 @@ async def _check_tails(
     state: MigrationState,
     report: CheckReport,
     on_event: EventCallback,
+    verified: set[str],
 ) -> None:
     """Confirm each channel still holds the last message Ferry recorded sending.
 
@@ -417,6 +431,12 @@ async def _check_tails(
         )
     )
     for discord_id, stoat_id in state.channel_map.items():
+        if discord_id not in verified:
+            # The structure pass could not read this channel, and has already
+            # said so. Fetching its messages would fail for the same cause and
+            # report it twice, doubling the apparent damage and sending a repair
+            # after a channel that may not exist.
+            continue
         window = await api_fetch_messages(
             sess, stoat_url, token, stoat_id, limit=_WINDOW, sort="Latest"
         )
@@ -453,6 +473,18 @@ def _expected_tail(state: MigrationState, discord_id: str) -> str | None:
     raise: an unconditional lookup reports the commonest correct case as a
     crash.
     """
+    # A forum index channel's newest message is the index itself, posted by
+    # _rebuild_forum_indexes AFTER the messages phase, and recorded in its own
+    # map rather than in message_map.
+    #
+    # The two maps are keyed differently, which is the trap: channel_map holds
+    # `forum-index-{key}` while forum_index_message_ids holds the bare `{key}`.
+    # Looking the prefixed key up in the second map never matches and drops
+    # every forum index channel into unverifiable.
+    if discord_id.startswith(_FORUM_INDEX_PREFIX):
+        forum_key = discord_id[len(_FORUM_INDEX_PREFIX) :]
+        return state.forum_index_message_ids.get(forum_key)
+
     high_water = state.channel_high_water.get(discord_id)
     if high_water is None:
         return None
@@ -471,12 +503,19 @@ def _classify_tail(
     channel that legitimately received nothing is never dragged through the
     lookups below it.
     """
-    if recorded_count == 0:
+    if recorded_count == 0 and expected is None:
         return (
             "ok",
             "nothing_expected",
             "no messages were migrated to this channel, and none were expected",
         )
+    # The `and expected is None` half is not belt-and-braces. A forum index
+    # channel has NO channel_message_counts entry, because that map is keyed by
+    # real export channels and the index channel is synthetic. Its expected
+    # message is nonetheless known, from forum_index_message_ids. Firing the
+    # zero-count rule on count alone would report "nothing expected" for a
+    # channel whose one message Ferry can actually verify, and would leave the
+    # forum branch of _expected_tail permanently unreachable.
     if not window_ids:
         return (
             "fail",

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -21,6 +21,15 @@ check is a recorded result, not the absence of one.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from discord_ferry.errors import ValidationError
+
+if TYPE_CHECKING:
+    import aiohttp
+
+    from discord_ferry.core.events import EventCallback
+    from discord_ferry.state import MigrationState
 
 #: Every status the tool can report, in the order a summary line names them.
 #:
@@ -106,3 +115,44 @@ class CheckReport:
         category, which is the fastest way to teach people to ignore the tool.
         """
         return any(r.status == "fail" for r in self.results)
+
+
+async def run_check(
+    stoat_url: str,
+    token: str,
+    state: MigrationState,
+    on_event: EventCallback,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> CheckReport:
+    """Verify a finished migration against a live Stoat server.
+
+    Takes an already-loaded :class:`~discord_ferry.state.MigrationState` rather
+    than an output directory, so every test drives it with no filesystem. Takes
+    ``stoat_url`` and ``token`` directly and reports through ``on_event``,
+    matching ``run_probe``, so nothing here needs a ``FerryConfig`` and nothing
+    under ``migrator/`` imports a shell.
+
+    Both preconditions raise before any request is made. That ordering is the
+    behaviour under test: checking after the first fetch would spend a request
+    and, on a dry-run state, would go looking for ``dry-ch-`` sentinels that
+    name channels nobody ever created.
+
+    Raises:
+        ValidationError: the state is from a dry run, or records no server.
+    """
+    if state.is_dry_run:
+        raise ValidationError(
+            "Cannot check a dry-run state. A dry run records placeholder ids for "
+            "channels and messages that were never created, so there is nothing on "
+            "the server to verify against. Run a real migration first."
+        )
+    if not state.stoat_server_id:
+        raise ValidationError(
+            "This state records no Stoat server id, so there is nothing to check "
+            "against. The migration may not have reached the structure phase."
+        )
+
+    report = CheckReport()
+    _ = (stoat_url, token, session, on_event)  # wired up in the next chunks
+    return report

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -209,6 +209,17 @@ async def _check_structure(
     payload = await api_fetch_server_with_channels(sess, stoat_url, token, state.stoat_server_id)
     emoji = await api_fetch_emoji_list(sess, stoat_url, token, state.stoat_server_id)
 
+    # Three id conventions arrive in this ONE response, verified against
+    # upstream rather than assumed, because they do not agree with each other:
+    #
+    #   channel objects   ->  "_id"   (Channel carries serde(rename = "_id"))
+    #   category objects  ->  "id"    (Category has NO rename)
+    #   roles             ->  the KEY of a HashMap<String, Role>, so the map's
+    #                         keys are read, not each Role's inner "_id"
+    #
+    # A later pass that "makes these consistent" breaks two of the three. The
+    # sibling hazard is already recorded for messages, which use "_id" while
+    # Ferry's webhook id field uses "id".
     server = payload.get("server") or {}
     # Two lists, and the pair is the discriminator. `server.channels` comes back
     # UNFILTERED and names every channel id; the sibling array holds only the
@@ -262,6 +273,9 @@ async def _check_structure(
     # Roles arrive as a map keyed by role id, so membership is a key lookup.
     # There is no second list and no permission filter here, unlike channels, so
     # an absence is unambiguous and reports fail rather than unverifiable.
+    # set() over the MAP, so these are its KEYS. Roles are keyed by id upstream;
+    # each Role object also carries an inner "_id", which is deliberately not
+    # what is read here. See the three-conventions note above.
     role_ids = set(server.get("roles") or {})
     for discord_id, stoat_id in state.role_map.items():
         present = stoat_id in role_ids
@@ -303,7 +317,30 @@ async def _check_structure(
             continue
         expected_title = state.category_names.get(discord_id)
         actual_title = found_titles[stoat_id]
-        if expected_title is not None and expected_title != actual_title:
+        if expected_title is None:
+            # The category exists, but nothing records what it should be called,
+            # so the title half of this check cannot be answered. Reporting ok
+            # would claim more than was verified.
+            #
+            # Unreachable for a state written by a current Ferry: structure.py
+            # writes category_map and category_names on the same line, twice
+            # over, and the only unpaired writes are the dry-run ones the
+            # precondition refuses. It IS reachable for a state.json written
+            # before category_names existed, which is exactly the population
+            # the degrade-rather-than-refuse rule exists for.
+            report.add(
+                name=f"category:{discord_id}",
+                status="unverifiable",
+                kind="category_title_unknown",
+                detail=(
+                    "the category exists, but this state records no expected title "
+                    "for it, so the title cannot be compared"
+                ),
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+                found=actual_title,
+            )
+        elif expected_title != actual_title:
             # warn, not fail. The category exists and its channels are intact;
             # only a heading differs. This is the single reachable warn in the
             # tool, and it is why the status exists at all: a design review

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,6 +35,7 @@ from discord_ferry.migrator.api import (
     api_edit_server,
     api_execute_webhook,
     api_fetch_channel,
+    api_fetch_emoji_list,
     api_fetch_messages,
     api_fetch_server,
     api_fetch_server_with_channels,
@@ -1907,3 +1908,44 @@ async def test_api_fetch_server_still_sends_no_include_channels(
         out = await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
     assert out["_id"] == "srv1"
     assert "channels" not in out
+
+
+# ---------------------------------------------------------------------------
+# api_fetch_emoji_list (#107 batch 9, task #249)
+# ---------------------------------------------------------------------------
+
+
+async def test_emoji_list_reads_the_server_emoji_route(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Emoji are their own route because the Server model carries no emoji field.
+
+    GET /servers/{id}/emojis returns Vec<Emoji> and needs only server
+    membership, unlike the message route which needs ReadMessageHistory.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1/emojis",
+        payload=[{"_id": "01JAUTUMNEMOJI000000000A", "name": "party"}],
+    )
+    async with aiohttp.ClientSession() as session:
+        out = await api_fetch_emoji_list(session, BASE_URL, TOKEN, "srv1")
+    assert isinstance(out, list)
+    assert out[0]["name"] == "party"
+
+
+async def test_emoji_list_raises_on_403(mock_aiohttp: aioresponses) -> None:
+    """A non-member gets 404 or 403. Either must raise rather than reporting an
+    empty emoji set, which the check tool would read as "every emoji is gone"."""
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1/emojis", status=403, payload={})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError):
+            await api_fetch_emoji_list(session, BASE_URL, TOKEN, "srv1")
+
+
+async def test_emoji_list_rejects_a_non_list_body(mock_aiohttp: aioresponses) -> None:
+    """Same narrowing as the message fetch, for the same reason: _api_request is
+    declared -> dict[str, Any] and this route returns an array."""
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1/emojis", payload={"emoji": []})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError, match="JSON array"):
+            await api_fetch_emoji_list(session, BASE_URL, TOKEN, "srv1")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,6 +35,7 @@ from discord_ferry.migrator.api import (
     api_edit_server,
     api_execute_webhook,
     api_fetch_channel,
+    api_fetch_messages,
     api_fetch_server,
     api_pin_message,
     api_send_message,
@@ -1737,3 +1738,119 @@ async def test_uncatching_call_site_still_sees_a_migration_error(
         except MigrationError as exc:  # the pre-existing handler shape
             caught = type(exc).__name__
     assert caught == "DuplicateSendError"
+
+
+# ---------------------------------------------------------------------------
+# api_fetch_messages (#107 batch 9, task #247)
+# ---------------------------------------------------------------------------
+
+
+async def test_message_fetch_rejects_a_limit_below_the_range() -> None:
+    """Kills an implementation that forwards the limit and lets Stoat reject it.
+
+    Upstream validates the query as range(min = 1, max = 100). Ferry rejects it
+    locally so a caller never spends a request on an opaque 400. No route is
+    registered here, so an attempted request would raise a different error and
+    the test could not pass by accident.
+    """
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(ValueError, match="limit"):
+                await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=0, sort="Latest")
+
+
+async def test_message_fetch_rejects_a_limit_above_the_range() -> None:
+    """The upper half of the same guard. Upstream caps limit at 100."""
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(ValueError, match="limit"):
+                await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=101, sort="Latest")
+
+
+async def test_message_fetch_rejects_an_unknown_sort() -> None:
+    """Stoat's MessageSort is Relevance, Latest, Oldest, and this route REJECTS
+    Relevance. Ferry only ever sends the two the route accepts."""
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(ValueError, match="sort"):
+                await api_fetch_messages(
+                    session, BASE_URL, TOKEN, "ch1", limit=10, sort="Relevance"
+                )
+
+
+async def test_message_fetch_sends_limit_and_sort_and_no_include_users(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Pins the exact query string.
+
+    aioresponses matches on the full URL, so registering it with exactly
+    ``?limit=100&sort=Latest`` means an implementation that omits sort, or that
+    adds include_users, fails to match and errors rather than passing.
+
+    include_users matters because BulkMessageResponse is an UNTAGGED enum:
+    omitting it yields a bare array, sending it yields {messages, users}. An
+    implementation that sends it and then indexes ["messages"] works against a
+    mock built the same wrong way and fails against the real server.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/ch1/messages?limit=100&sort=Latest",
+        payload=[{"_id": "01JSTOATMSG000000000000AA"}],
+    )
+    async with aiohttp.ClientSession() as session:
+        out = await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=100, sort="Latest")
+    assert isinstance(out, list)
+    assert out[0]["_id"] == "01JSTOATMSG000000000000AA"
+
+
+async def test_message_fetch_reads_the_underscore_id_key(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Stoat serialises a message id as ``_id`` (serde rename on Message).
+
+    Ferry's WEBHOOK id field is ``id``, so the two are inconsistent upstream and
+    copying the working webhook code is the likeliest way this gets written
+    wrong. The fixture carries NO ``id`` key at all, so a wrong read cannot pass
+    by accident.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/ch1/messages?limit=1&sort=Latest",
+        payload=[{"_id": "01JSTOATMSG000000000000AA", "content": "hi"}],
+    )
+    async with aiohttp.ClientSession() as session:
+        out = await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=1, sort="Latest")
+    assert "id" not in out[0]
+    assert out[0]["_id"] == "01JSTOATMSG000000000000AA"
+
+
+async def test_message_fetch_raises_on_403_rather_than_returning_empty(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The route requires ReadMessageHistory, so 403 is the realistic failure.
+
+    It must RAISE. Returning an empty list would turn a permission problem into
+    a false "this channel is empty" verdict in the check tool downstream, which
+    is the worst possible way for this to fail.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/ch1/messages?limit=100&sort=Latest",
+        status=403,
+        payload={"type": "MissingPermission"},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError):
+            await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=100, sort="Latest")
+
+
+async def test_message_fetch_rejects_a_non_list_body(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """_api_request is declared -> dict[str, Any] but returns whatever JSON
+    arrived. This route returns an array, so the narrowing is what keeps the
+    declared return type honest rather than a cast that lies."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/ch1/messages?limit=5&sort=Oldest",
+        payload={"messages": [], "users": []},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError, match="JSON array"):
+            await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=5, sort="Oldest")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,7 @@ from discord_ferry.migrator.api import (
     api_fetch_channel,
     api_fetch_messages,
     api_fetch_server,
+    api_fetch_server_with_channels,
     api_pin_message,
     api_send_message,
     api_set_channel_default_permissions,
@@ -1854,3 +1855,55 @@ async def test_message_fetch_rejects_a_non_list_body(
     async with aiohttp.ClientSession() as session:
         with pytest.raises(MigrationError, match="JSON array"):
             await api_fetch_messages(session, BASE_URL, TOKEN, "ch1", limit=5, sort="Oldest")
+
+
+# ---------------------------------------------------------------------------
+# api_fetch_server_with_channels (#107 batch 9, task #248)
+# ---------------------------------------------------------------------------
+
+
+async def test_server_with_channels_requests_channel_objects(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Pins include_channels=true and both lists in the response.
+
+    Upstream returns FetchServerResponse::JustServer without the parameter and
+    ServerWithChannels with it. Two different top-level shapes from one route,
+    so the parameter is what decides which one arrives.
+
+    Both lists matter downstream: server.channels is UNFILTERED and lists every
+    channel id, while the sibling channels array holds only objects the caller
+    may ViewChannel. That pair is the only way to tell a deleted channel from an
+    invisible one.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1?include_channels=true",
+        payload={
+            "server": {"_id": "srv1", "channels": ["01JSTOATCH00000000000AAA"]},
+            "channels": [{"_id": "01JSTOATCH00000000000AAA", "name": "general"}],
+        },
+    )
+    async with aiohttp.ClientSession() as session:
+        out = await api_fetch_server_with_channels(session, BASE_URL, TOKEN, "srv1")
+    assert out["server"]["channels"] == ["01JSTOATCH00000000000AAA"]
+    assert out["channels"][0]["name"] == "general"
+
+
+async def test_api_fetch_server_still_sends_no_include_channels(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Regression. The pre-existing api_fetch_server must not gain the parameter.
+
+    Adding include_channels to it instead of adding a new function would change
+    the response shape under two callers this batch does not touch: the
+    --validate-after block in run_migration, and rollback. aioresponses matches
+    the full URL, so a query string appearing here fails to match and errors.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        payload={"_id": "srv1", "name": "My Server"},
+    )
+    async with aiohttp.ClientSession() as session:
+        out = await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert out["_id"] == "srv1"
+    assert "channels" not in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 import certifi
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 from discord_ferry.cli import main
 from discord_ferry.core.http import reset_http_state
 from discord_ferry.errors import MigrationError
+from discord_ferry.migrator.verify import CheckReport
 from discord_ferry.state import MigrationState
 
 if TYPE_CHECKING:
@@ -1873,3 +1874,190 @@ def test_tls_check_never_prints_userinfo_on_the_failure_path(proxy_env) -> None:
 
     assert "secret" not in out
     assert "user" not in out
+
+
+# ---------------------------------------------------------------------------
+# ferry check (#107 batch 9, tasks #261 and #262)
+# ---------------------------------------------------------------------------
+
+
+def _check_report(*results: tuple[str, str]) -> CheckReport:
+    report = CheckReport()
+    for status, kind in results:
+        report.add(name=f"x:{kind}", status=status, kind=kind, detail="detail")  # type: ignore[arg-type]
+    return report
+
+
+def _patched(order: list[str], report: CheckReport | None = None) -> Any:
+    """Patch the three things check_cmd must do, recording call order."""
+    return (
+        patch(
+            "discord_ferry.cli.register_secret",
+            side_effect=lambda *_a: order.append("register_secret"),
+        ),
+        patch(
+            "discord_ferry.cli.init_request_semaphore",
+            side_effect=lambda *_a: order.append("semaphore"),
+        ),
+        patch(
+            "discord_ferry.cli.load_state",
+            return_value=MigrationState(stoat_server_id="srv1"),
+        ),
+        patch(
+            "discord_ferry.migrator.verify.run_check",
+            new=AsyncMock(
+                side_effect=lambda *a, **k: (
+                    order.append("request") or (report if report is not None else _check_report())
+                )
+            ),
+        ),
+    )
+
+
+def test_check_registers_the_stoat_token_before_any_request(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Asserts the CALL, deliberately, and never the absence of a token in a
+    sample string.
+
+    An absence assertion passes against a value that simply did not appear in
+    that particular string. Ferry shipped unmasked Stoat tokens to its log file
+    for two releases behind exactly that shape of check.
+
+    probe_cmd's own comment records why the call is needed at all: a command
+    that bypasses FerryConfig never fires the engine's store hook, and the regex
+    backstop deliberately cannot match Stoat's opaque base64url values, so
+    without this line the whole command has no coverage.
+    """
+    order: list[str] = []
+    a, b, c, d = _patched(order)
+    with a, b, c, d:
+        runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert "register_secret" in order, "never registered for masking"
+    assert order.index("register_secret") < order.index("request")
+
+
+def test_check_initialises_the_request_semaphore_before_any_request(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Omitting this gives UNBOUNDED concurrency and no error at all.
+
+    _request_semaphore starts None and _api_request treats that as no limit, so
+    nothing anywhere reports the omission. On a 200-channel server that is 200
+    simultaneous sockets. Asserted as a call, for the same reason as above.
+    """
+    order: list[str] = []
+    a, b, c, d = _patched(order)
+    with a, b, c, d:
+        runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert "semaphore" in order, "the concurrency semaphore was never initialised"
+    assert order.index("semaphore") < order.index("request")
+
+
+def test_validate_still_resolves_to_the_export_validator(runner: CliRunner) -> None:
+    """`ferry validate` is TAKEN and means something else: parse and validate an
+    export, with no API calls. The new command had to be named `check`.
+
+    Kills registering the new command under the existing name, which would
+    silently replace a released one.
+    """
+    result = runner.invoke(main, ["validate", "--help"])
+    assert result.exit_code == 0
+    assert "export" in result.output.lower()
+    assert "--stoat-url" not in result.output
+
+
+def test_check_requires_a_url(runner: CliRunner, tmp_path: Path) -> None:
+    """Matches probe_cmd: a clear message rather than a traceback."""
+    result = runner.invoke(main, ["check", str(tmp_path), "--token", "t"], env={"STOAT_URL": ""})
+    assert result.exit_code != 0
+    assert "stoat-url" in result.output.lower()
+
+
+def test_check_exits_zero_when_everything_passed(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.4."""
+    order: list[str] = []
+    a, b, c, d = _patched(order, _check_report(("ok", "tail_present")))
+    with a, b, c, d:
+        result = runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert result.exit_code == 0
+
+
+def test_check_exits_non_zero_on_any_failure(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.5. The exit code IS the machine-readable interface, which is why no
+    --json is needed to ship."""
+    order: list[str] = []
+    report = _check_report(("ok", "tail_present"), ("fail", "channel_missing"))
+    a, b, c, d = _patched(order, report)
+    with a, b, c, d:
+        result = runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert result.exit_code != 0
+
+
+def test_a_warning_alone_still_exits_zero(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.7. A renamed category is cosmetic: the entity exists and its content
+    is intact. Exiting non-zero for it would fail a migration that is fine."""
+    order: list[str] = []
+    a, b, c, d = _patched(order, _check_report(("warn", "category_title_mismatch")))
+    with a, b, c, d:
+        result = runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert result.exit_code == 0
+
+
+def test_a_report_of_only_unverifiable_exits_zero_and_says_so(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-5.6. Exit 0, AND the summary must not read as a clean pass.
+
+    The exit code alone cannot separate "all fine" from "could not check any of
+    it", because both exit 0. On a merge migration most tail results are
+    unverifiable, so the count has to be visible or the tool looks like it
+    approved something it never examined.
+    """
+    order: list[str] = []
+    report = _check_report(
+        ("unverifiable", "tail_not_recorded"), ("unverifiable", "channel_not_visible")
+    )
+    a, b, c, d = _patched(order, report)
+    with a, b, c, d:
+        result = runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    assert result.exit_code == 0
+    assert "2 unverifiable" in result.output
+    assert "could not be verified" in result.output
+
+
+def test_the_summary_names_every_count_and_the_exit_code(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.6. Counts lead, and the exit code is stated rather than inferred."""
+    order: list[str] = []
+    report = _check_report(
+        ("ok", "tail_present"),
+        ("warn", "category_title_mismatch"),
+        ("fail", "channel_missing"),
+        ("unverifiable", "tail_not_recorded"),
+    )
+    a, b, c, d = _patched(order, report)
+    with a, b, c, d:
+        result = runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"],
+        )
+    for fragment in ("1 ok", "1 failed", "1 unverifiable", "1 warning"):
+        assert fragment in result.output, f"summary omitted {fragment!r}"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -427,9 +427,7 @@ async def test_a_renamed_category_warns_rather_than_failing(
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
-    report = await run_check(
-        BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event
-    )
+    report = await run_check(BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event)
     result = next(r for r in report.results if r.discord_id == "d-cat-1")
     assert result.status == "warn"
     assert result.kind == "category_title_mismatch"
@@ -453,9 +451,7 @@ async def test_a_matching_category_title_is_ok(mock_aiohttp: aioresponses) -> No
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
-    report = await run_check(
-        BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event
-    )
+    report = await run_check(BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event)
     assert next(r for r in report.results if r.discord_id == "d-cat-1").status == "ok"
 
 
@@ -492,3 +488,70 @@ async def test_an_absent_categories_key_does_not_crash(
         BASE_URL, TOKEN, _state_with_category("01JSTOATCAT00000000000A", "Original"), _noop_event
     )
     assert next(r for r in report.results if r.discord_id == "d-cat-1").status == "fail"
+
+
+# ---------------------------------------------------------------------------
+# structure: the request budget (task #255)
+# ---------------------------------------------------------------------------
+
+
+async def test_the_structure_family_costs_exactly_two_requests(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Cost is a separate property from correctness and needs its own assertion.
+
+    Kills a per-entity implementation: a loop calling api_fetch_channel per
+    channel produces entirely CORRECT verdicts and 91 requests here, so any
+    test checking only outcomes passes against it. On a 200-channel server that
+    is 200 extra round trips against a 5-per-10-second bucket.
+
+    Deliberately oversized fixture, 91 entities against 2 requests, so the two
+    numbers cannot be confused for each other.
+    """
+    channels = {f"d-c{i}": f"01JSTOATCH{i:013d}" for i in range(40)}
+    roles = {f"d-r{i}": f"01JSTOATRL{i:013d}" for i in range(15)}
+    cats = {f"d-k{i}": f"01JSTOATCT{i:013d}" for i in range(6)}
+    emoji = {f"d-e{i}": f"01JAUTUMNEM{i:012d}" for i in range(30)}
+    assert len(channels) + len(roles) + len(cats) + len(emoji) == 91
+
+    # repeat=True on BOTH routes is load-bearing for this test's honesty.
+    # aioresponses serves a registered route once by default, so an
+    # implementation making extra calls would die on ClientConnectionError
+    # before the count assertion below ever ran, and the test would "pass"
+    # against the mutant for entirely the wrong reason. Serving repeats lets
+    # the over-fetching implementation succeed, so the count is the only thing
+    # that can catch it. Verified by mutation: a duplicated server fetch now
+    # fails on the count line, not on a connection error.
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        repeat=True,
+        payload={
+            "server": {
+                "_id": SRV,
+                "channels": list(channels.values()),
+                "roles": dict.fromkeys(roles.values(), {"name": "r"}),
+                "categories": [{"id": cid, "title": "t", "channels": []} for cid in cats.values()],
+            },
+            "channels": [{"_id": c, "name": "n"} for c in channels.values()],
+        },
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        repeat=True,
+        payload=[{"_id": e, "name": "e"} for e in emoji.values()],
+    )
+
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = channels
+    state.role_map = roles
+    state.category_map = cats
+    state.category_names = dict.fromkeys(cats, "t")
+    state.emoji_map = emoji
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    requests_made = sum(len(v) for v in mock_aiohttp.requests.values())
+    assert requests_made == 2, f"expected 2 requests for 91 entities, made {requests_made}"
+    assert len(report.results) == 91
+    assert report.has_failures is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -979,3 +979,93 @@ async def test_the_tail_check_never_emits_warn(
     tail_statuses = {r.status for r in report.results if r.name.startswith("tail:")}
     assert "warn" not in tail_statuses
     assert tail_statuses <= {"ok", "fail", "unverifiable"}
+
+
+async def test_a_forum_index_channel_resolves_through_its_own_map(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.5. The two maps are keyed DIFFERENTLY, and that is the whole test.
+
+    _rebuild_forum_indexes reads state.channel_map.get(f"forum-index-{key}") but
+    writes state.forum_index_message_ids[key], bare. So the check must strip the
+    prefix before the second lookup.
+
+    Kills looking up forum_index_message_ids[channel_map_key], which never
+    matches and drops every forum index channel into unverifiable. Only a
+    fixture using the literal prefixed key makes that visible, which is why the
+    key here is spelled out rather than built from a variable.
+
+    The index message is legitimately the newest in its channel, because
+    _rebuild_forum_indexes runs AFTER the messages phase.
+    """
+    index_channel = "01JSTOATIDX00000000000AA"
+    index_message = "01JSTOATIDXMSG0000000AA"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {"_id": SRV, "channels": [index_channel]},
+            "channels": [{"_id": index_channel, "name": "forum-index"}],
+        },
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/{index_channel}/messages?limit=100&sort=Latest",
+        payload=[{"_id": index_message}],
+    )
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {"forum-index-cat-9": index_channel}
+    # NO channel_message_counts entry, deliberately. That map is keyed by real
+    # export channels and a forum index channel is synthetic, so a real state
+    # never has one. An earlier version of this test set a count of 1, which
+    # fabricated a shape that does not occur and let the zero-count rule hide
+    # the fact that the forum branch was never reached.
+    state.forum_index_message_ids = {"cat-9": index_message}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = _tail_result(report)
+    assert result.status == "ok"
+    assert result.kind == "tail_present"
+
+
+async def test_a_channel_that_failed_the_structure_check_is_not_checked_again(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-I2. One deleted channel should yield ONE finding, not two.
+
+    No message route is registered for the missing channel, so the absence of a
+    request is what proves the skip rather than only the result count: an
+    implementation that fetched anyway would raise here.
+
+    Kills reporting both channel_missing and channel_empty for the same cause,
+    which doubles the apparent damage and sends a repair tool after a channel
+    that does not exist.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    for_channel = [r for r in report.results if r.discord_id == "d-100"]
+    assert len(for_channel) == 1
+    assert for_channel[0].kind == "channel_missing"
+
+
+async def test_an_unverifiable_channel_is_also_skipped(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A channel this token cannot view cannot have its messages read either.
+
+    Kills skipping only on fail: an invisible channel would then be fetched,
+    get a 403, and surface a second, confusing result for a cause already
+    reported.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": [CH1]}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    for_channel = [r for r in report.results if r.discord_id == "d-100"]
+    assert len(for_channel) == 1
+    assert for_channel[0].kind == "channel_not_visible"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -386,3 +386,109 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
     state.emoji_map = {"d-e1": emoji_id}
     report = await run_check(BASE_URL, TOKEN, state, _noop_event)
     assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# structure: categories, and the only warn in the tool (task #254)
+# ---------------------------------------------------------------------------
+
+
+def _state_with_category(stoat_cat_id: str, expected_title: str) -> MigrationState:
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.category_map = {"d-cat-1": stoat_cat_id}
+    state.category_names = {"d-cat-1": expected_title}
+    return state
+
+
+async def test_a_renamed_category_warns_rather_than_failing(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The ONLY place warn is reachable in the whole tool.
+
+    category_names is the one expected name MigrationState records, so a
+    category title is the one name comparison possible. It warns rather than
+    fails because the entity exists and its content is intact: someone renamed
+    a heading, nothing was lost.
+
+    Kills an implementation reporting a cosmetic rename as fail, which would
+    exit non-zero on a migration that is entirely intact.
+    """
+    cat_id = "01JSTOATCAT00000000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {
+                "_id": SRV,
+                "channels": [],
+                "categories": [{"id": cat_id, "title": "Renamed", "channels": []}],
+            },
+            "channels": [],
+        },
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event
+    )
+    result = next(r for r in report.results if r.discord_id == "d-cat-1")
+    assert result.status == "warn"
+    assert result.kind == "category_title_mismatch"
+    assert result.expected == "Original"
+    assert result.found == "Renamed"
+    assert report.has_failures is False
+
+
+async def test_a_matching_category_title_is_ok(mock_aiohttp: aioresponses) -> None:
+    """Kills an implementation that warns on every category regardless."""
+    cat_id = "01JSTOATCAT00000000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {
+                "_id": SRV,
+                "channels": [],
+                "categories": [{"id": cat_id, "title": "Original", "channels": []}],
+            },
+            "channels": [],
+        },
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event
+    )
+    assert next(r for r in report.results if r.discord_id == "d-cat-1").status == "ok"
+
+
+async def test_a_missing_category_is_a_failure(mock_aiohttp: aioresponses) -> None:
+    """A category absent from the server is a real loss, not a cosmetic one."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": [], "categories": []}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_category("01JSTOATCAT00000000000A", "Original"), _noop_event
+    )
+    result = next(r for r in report.results if r.discord_id == "d-cat-1")
+    assert result.status == "fail"
+    assert result.kind == "category_missing"
+
+
+async def test_an_absent_categories_key_does_not_crash(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Server.categories is Optional upstream, so the key can be absent entirely
+    rather than an empty list.
+
+    Kills an implementation doing server["categories"] or assuming a list,
+    which would raise on a server that has never had a category.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_category("01JSTOATCAT00000000000A", "Original"), _noop_event
+    )
+    assert next(r for r in report.results if r.discord_id == "d-cat-1").status == "fail"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import pytest
 from aioresponses import aioresponses
 
-from discord_ferry.errors import ValidationError
+from discord_ferry.errors import CheckError
 from discord_ferry.migrator.verify import CheckReport, CheckResult, run_check
 from discord_ferry.state import MigrationState
 
@@ -126,7 +126,7 @@ async def test_a_dry_run_state_is_refused_before_any_request() -> None:
     state = MigrationState()
     state.is_dry_run = True
     state.stoat_server_id = "01JSTOATSRV0000000000AAA"
-    with aioresponses(), pytest.raises(ValidationError, match="dry-run"):
+    with aioresponses(), pytest.raises(CheckError, match="dry-run"):
         await run_check(BASE_URL, TOKEN, state, _noop_event)
 
 
@@ -135,7 +135,7 @@ async def test_an_empty_server_id_is_refused_before_any_request() -> None:
     be built with an empty path segment rather than failing honestly."""
     state = MigrationState()
     state.stoat_server_id = ""
-    with aioresponses(), pytest.raises(ValidationError, match="server"):
+    with aioresponses(), pytest.raises(CheckError, match="server"):
         await run_check(BASE_URL, TOKEN, state, _noop_event)
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -919,7 +919,7 @@ async def test_a_merge_parent_whose_tail_overflowed_the_window_is_unverifiable(
     report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
     result = _tail_result(report)
     assert result.status == "unverifiable"
-    assert result.kind == "tail_not_recorded"
+    assert result.kind == "tail_window_exhausted"
 
 
 async def test_post_migration_activity_over_the_window_is_unverifiable(
@@ -1151,7 +1151,7 @@ async def test_a_whole_merge_migration_produces_zero_failures(
     assert tails["d-plain"] == ("ok", "tail_present")
     assert tails["forum-index-cat-9"] == ("ok", "tail_present")
     assert tails["d-empty"] == ("ok", "nothing_expected")
-    assert tails["d-big"] == ("unverifiable", "tail_not_recorded")
+    assert tails["d-big"] == ("unverifiable", "tail_window_exhausted")
 
 
 async def test_one_channel_failing_does_not_abort_the_others(
@@ -1312,7 +1312,9 @@ async def test_all_seven_populations_in_one_run(mock_aiohttp: aioresponses) -> N
 
     assert tails["d-flat"] == ("ok", "tail_present")
     assert tails["d-merge-small"] == ("ok", "tail_present")
-    assert tails["d-merge-big"] == ("unverifiable", "tail_not_recorded")
+    # A DIFFERENT kind from d-dupe below, deliberately: this one is merely out
+    # of the window's reach, while that one can never be confirmed at all.
+    assert tails["d-merge-big"] == ("unverifiable", "tail_window_exhausted")
     assert tails["forum-index-cat-9"] == ("ok", "tail_present")
     assert tails["d-dupe"] == ("unverifiable", "tail_not_recorded")
     assert tails["d-silent"] == ("ok", "nothing_expected")

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1069,3 +1069,253 @@ async def test_an_unverifiable_channel_is_also_skipped(
     for_channel = [r for r in report.results if r.discord_id == "d-100"]
     assert len(for_channel) == 1
     assert for_channel[0].kind == "channel_not_visible"
+
+
+# ---------------------------------------------------------------------------
+# Integration (chunk 4 gate)
+# ---------------------------------------------------------------------------
+
+
+def _multi_server(visible: list[str], all_ids: list[str] | None = None) -> dict[str, object]:
+    return {
+        "server": {"_id": SRV, "channels": all_ids if all_ids is not None else visible},
+        "channels": [{"_id": c, "name": f"ch-{c[-3:]}"} for c in visible],
+    }
+
+
+async def test_a_whole_merge_migration_produces_zero_failures(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-I1. Spec S3 criterion 5, and the single most important outcome here.
+
+    Three merge parents whose own tails sit UNDER later merged thread content,
+    one of them so far under that the window cannot reach it, plus a forum index
+    channel and an empty channel. Every one of these is a correct migration.
+
+    Kills any regression to newest-message equality, which fails every merge
+    parent, and any classifier change routing a window overflow to fail. A tool
+    that cries wolf on a correct migration gets switched off, and then it
+    protects nothing.
+    """
+    small, big, plain = (
+        "01JSTOATCH00000000000001",
+        "01JSTOATCH00000000000002",
+        "01JSTOATCH00000000000003",
+    )
+    idx, empty = "01JSTOATIDX00000000000AA", "01JSTOATCH00000000000004"
+    visible = [small, big, plain, idx, empty]
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=_multi_server(visible)
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+
+    def window(cid: str, ns: list[int]) -> None:
+        mock_aiohttp.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[{"_id": _sid(n)} for n in sorted(ns, reverse=True)],
+        )
+
+    window(small, list(range(40)))  # tail at 9, 30 merged after it
+    window(big, list(range(400, 500)))  # tail at 9, far out of reach
+    window(plain, list(range(12)))  # ordinary flatten channel
+    window(idx, [900])  # the index message
+    window(empty, [])  # never received anything
+
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {
+        "d-small": small,
+        "d-big": big,
+        "d-plain": plain,
+        "forum-index-cat-9": idx,
+        "d-empty": empty,
+    }
+    for key, hw, count in (("d-small", 9, 10), ("d-big", 9, 10), ("d-plain", 11, 12)):
+        state.channel_high_water[key] = _did(hw)
+        state.message_map[_did(hw)] = _sid(hw)
+        state.channel_message_counts[key] = count
+    state.forum_index_message_ids = {"cat-9": _sid(900)}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    failures = [r for r in report.results if r.status == "fail"]
+    assert failures == [], f"a correct merge migration reported {len(failures)} failures"
+    assert report.has_failures is False
+
+    # "Zero failures" alone would also be satisfied by an implementation that
+    # reported unverifiable for everything, which would be useless while
+    # technically meeting the criterion. Pin the actual verdicts so this cannot
+    # pass by giving up.
+    tails = {r.discord_id: (r.status, r.kind) for r in report.results if r.name.startswith("tail:")}
+    assert tails["d-small"] == ("ok", "tail_present")
+    assert tails["d-plain"] == ("ok", "tail_present")
+    assert tails["forum-index-cat-9"] == ("ok", "tail_present")
+    assert tails["d-empty"] == ("ok", "nothing_expected")
+    assert tails["d-big"] == ("unverifiable", "tail_not_recorded")
+
+
+async def test_one_channel_failing_does_not_abort_the_others(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-I3. A per-channel error is a RESULT, not the end of the run.
+
+    This is the deliberate contrast with the existing validate_after block,
+    which catches everything into a warning and leaves its result dict empty, so
+    a check that failed is indistinguishable from one that passed. Here a
+    failure to check is recorded.
+
+    Kills an asyncio.gather that propagates the first exception, and equally one
+    using return_exceptions=True that then discards what it collected, which is
+    a recorded silent-failure pattern in this project.
+    """
+    good1, bad, good2 = (
+        "01JSTOATCH00000000000001",
+        "01JSTOATCH00000000000002",
+        "01JSTOATCH00000000000003",
+    )
+    visible = [good1, bad, good2]
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=_multi_server(visible)
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    for cid in (good1, good2):
+        mock_aiohttp.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[{"_id": _sid(9)}],
+        )
+    mock_aiohttp.get(
+        f"{BASE_URL}/channels/{bad}/messages?limit=100&sort=Latest",
+        status=500,
+        payload={},
+        repeat=True,
+    )
+
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {"d-1": good1, "d-2": bad, "d-3": good2}
+    for key in ("d-1", "d-2", "d-3"):
+        state.channel_high_water[key] = _did(9)
+        state.channel_message_counts[key] = 10
+    state.message_map[_did(9)] = _sid(9)
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    tails = {r.discord_id: r for r in report.results if r.name.startswith("tail:")}
+    assert set(tails) == {"d-1", "d-2", "d-3"}
+    assert tails["d-1"].status == "ok"
+    assert tails["d-3"].status == "ok"
+    assert tails["d-2"].status == "unverifiable"
+    assert tails["d-2"].kind == "check_error"
+    # check_error is unverifiable, not fail, so it does not fail the command:
+    # Ferry could not look, which is not the same as finding something wrong.
+    assert report.has_failures is False
+
+
+async def test_a_flatten_migration_with_later_activity_is_all_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-I5. The third strategy, with humans having posted since."""
+    a, b = "01JSTOATCH00000000000001", "01JSTOATCH00000000000002"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=_multi_server([a, b])
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    for cid, extra in ((a, 30), (b, 5)):
+        mock_aiohttp.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[{"_id": _sid(n)} for n in range(9 + extra, -1, -1)],
+        )
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {"d-a": a, "d-b": b}
+    for key in ("d-a", "d-b"):
+        state.channel_high_water[key] = _did(9)
+        state.channel_message_counts[key] = 10
+    state.message_map[_did(9)] = _sid(9)
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    assert {r.status for r in report.results} == {"ok"}
+
+
+async def test_all_seven_populations_in_one_run(mock_aiohttp: aioresponses) -> None:
+    """SC-I6. Every population the design names, together, in one report.
+
+    Kills a fix for one population that breaks another, which per-population
+    tests structurally cannot see. The eighth population, a dry-run state, is
+    absent on purpose: the precondition refuses that whole state before this
+    point is reached, which is why its spec criterion was struck as unreachable
+    rather than implemented.
+    """
+    flat = "01JSTOATCH00000000000001"
+    merge_small = "01JSTOATCH00000000000002"
+    merge_big = "01JSTOATCH00000000000003"
+    idx = "01JSTOATIDX00000000000AA"
+    dupe = "01JSTOATCH00000000000004"
+    hidden = "01JSTOATCH00000000000005"
+    silent = "01JSTOATCH00000000000006"
+
+    visible = [flat, merge_small, merge_big, idx, dupe, silent]
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        # `hidden` is in the unfiltered id list but NOT among the objects: the
+        # shape ViewChannel filtering produces.
+        payload=_multi_server(visible, all_ids=[*visible, hidden]),
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+
+    def window(cid: str, ns: list[int]) -> None:
+        mock_aiohttp.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[{"_id": _sid(n)} for n in sorted(ns, reverse=True)],
+        )
+
+    window(flat, list(range(10)))
+    window(merge_small, list(range(40)))
+    window(merge_big, list(range(400, 500)))
+    window(idx, [900])
+    window(dupe, list(range(10)))
+    window(silent, [])
+    # No window for `hidden`: the tail pass must skip it. If it fetched anyway
+    # this test fails on a missing mock, which is the point.
+
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {
+        "d-flat": flat,
+        "d-merge-small": merge_small,
+        "d-merge-big": merge_big,
+        "forum-index-cat-9": idx,
+        "d-dupe": dupe,
+        "d-hidden": hidden,
+        "d-silent": silent,
+    }
+    for key in ("d-flat", "d-merge-small", "d-merge-big", "d-dupe", "d-hidden"):
+        state.channel_high_water[key] = _did(9)
+        state.channel_message_counts[key] = 10
+    # message_map maps the Discord id to a DIFFERENT-looking Stoat id, which is
+    # what makes a comparison against the wrong one impossible to pass.
+    state.message_map[_did(9)] = _sid(9)
+    # d-dupe's tail landed under a 409 DuplicateNonce, so batch 7 recorded no id
+    # for it. Give it its own unmapped high-water.
+    state.channel_high_water["d-dupe"] = _did(99)
+    state.forum_index_message_ids = {"cat-9": _sid(900)}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    structure = {
+        r.discord_id: (r.status, r.kind) for r in report.results if r.name.startswith("channel:")
+    }
+    tails = {r.discord_id: (r.status, r.kind) for r in report.results if r.name.startswith("tail:")}
+
+    assert structure["d-hidden"] == ("unverifiable", "channel_not_visible")
+    assert "d-hidden" not in tails, "an unreadable channel must not be reported twice"
+
+    assert tails["d-flat"] == ("ok", "tail_present")
+    assert tails["d-merge-small"] == ("ok", "tail_present")
+    assert tails["d-merge-big"] == ("unverifiable", "tail_not_recorded")
+    assert tails["forum-index-cat-9"] == ("ok", "tail_present")
+    assert tails["d-dupe"] == ("unverifiable", "tail_not_recorded")
+    assert tails["d-silent"] == ("ok", "nothing_expected")
+
+    assert report.has_failures is False
+    assert report.counts()["fail"] == 0

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1351,3 +1351,55 @@ async def test_tail_results_keep_channel_map_order_despite_the_fan_out(
     report = await run_check(BASE_URL, TOKEN, state, _noop_event)
     tail_order = [r.discord_id for r in report.results if r.name.startswith("tail:")]
     assert tail_order == [f"d-{n}" for n in range(6)]
+
+
+@pytest.mark.parametrize(
+    ("label", "window", "high_water", "count", "expected_status"),
+    [
+        pytest.param(
+            "hole in the middle, tail intact",
+            [0, 1, 2, 7, 8, 9],
+            9,
+            10,
+            "ok",
+            id="hole-in-the-middle",
+        ),
+        pytest.param(
+            "tail deleted, then 100 newer messages arrived",
+            list(range(200, 300)),
+            9,
+            10,
+            "unverifiable",
+            id="tail-deleted-then-overflowed",
+        ),
+    ],
+)
+async def test_two_shapes_of_real_loss_this_check_cannot_see(
+    mock_aiohttp: aioresponses,
+    label: str,
+    window: list[int],
+    high_water: int,
+    count: int,
+    expected_status: str,
+) -> None:
+    """KNOWN LIMITS, pinned so nobody later claims the tool catches these.
+
+    Both inputs describe a channel that genuinely lost content, and neither is
+    reported as a failure. That is accepted, documented in the design, and the
+    direct consequence of checking a tail rather than reconciling every message.
+
+    A chunk review asserted there were NO such inputs. There are exactly these
+    two, which is why the claim is pinned in executable form rather than left
+    to prose that can drift.
+
+    An ok result here means "the recorded tail is present". It must never be
+    read, or worded, as "this channel is complete". Full per-message
+    reconciliation is batch 10's territory (spec P2 S9).
+    """
+    _register_tail(mock_aiohttp, window)
+    report = await run_check(
+        BASE_URL, TOKEN, _tail_state(high_water=high_water, count=count), _noop_event
+    )
+    result = _tail_result(report)
+    assert result.status == expected_status
+    assert report.has_failures is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1319,3 +1319,35 @@ async def test_all_seven_populations_in_one_run(mock_aiohttp: aioresponses) -> N
 
     assert report.has_failures is False
     assert report.counts()["fail"] == 0
+
+
+async def test_tail_results_keep_channel_map_order_despite_the_fan_out(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The tail checks run concurrently, so their ORDER is a property worth
+    pinning rather than an accident.
+
+    asyncio.gather returns in INPUT order regardless of completion order, so a
+    slow channel does not shuffle the report. Kills an append-as-completed
+    implementation, which would render the CLI table in a different order on
+    every run and make two reports of the same server impossible to diff.
+    """
+    ids = [f"01JSTOATCH0000000000000{n}" for n in range(6)]
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=_multi_server(ids))
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    for cid in ids:
+        mock_aiohttp.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[{"_id": _sid(9)}],
+        )
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {f"d-{n}": cid for n, cid in enumerate(ids)}
+    for n in range(6):
+        state.channel_high_water[f"d-{n}"] = _did(9)
+        state.channel_message_counts[f"d-{n}"] = 1
+    state.message_map[_did(9)] = _sid(9)
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    tail_order = [r.discord_id for r in report.results if r.name.startswith("tail:")]
+    assert tail_order == [f"d-{n}" for n in range(6)]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,88 @@
+"""Tests for the migration check tool (#107 batch 9).
+
+Fixture rule for this whole module: Discord ids and Stoat ids are LITERAL and
+visibly different, ``"d-100"`` against ``"01JSTOAT..."``. They are never derived
+from one variable and never equal. Seeding both sides of a comparison from a
+single value is what lets a check test pass against an implementation comparing
+the wrong one, and this project has shipped five assertions that could not fail
+against what they guarded.
+"""
+
+from __future__ import annotations
+
+from discord_ferry.migrator.verify import CheckReport, CheckResult
+
+# ---------------------------------------------------------------------------
+# CheckResult / CheckReport (task #250)
+# ---------------------------------------------------------------------------
+
+
+def test_a_report_of_only_unverifiable_counts_zero_ok() -> None:
+    """Kills an implementation that folds unverifiable into ok.
+
+    The exit code cannot separate those two, because a report of only
+    unverifiable and a report of all ok BOTH exit 0. Only the count can tell
+    them apart, which is why the count is asserted here rather than only the
+    command's status.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="unverifiable",
+        kind="tail_not_recorded",
+        detail="newest message was not recorded by Ferry",
+    )
+    counts = report.counts()
+    assert counts["ok"] == 0
+    assert counts["unverifiable"] == 1
+    assert report.has_failures is False
+
+
+def test_counts_reports_every_status_even_at_zero() -> None:
+    """A caller rendering a summary line needs all four keys present.
+
+    Kills a Counter-based implementation that omits statuses with no results,
+    which would make the summary line drop "0 failed" exactly when a reader
+    most wants to see it stated.
+    """
+    report = CheckReport()
+    report.add(name="a", status="ok", kind="tail_present", detail="")
+    counts = report.counts()
+    assert set(counts) == {"ok", "warn", "fail", "unverifiable"}
+    assert counts["fail"] == 0
+    assert counts["warn"] == 0
+
+
+def test_has_failures_is_true_only_for_a_fail() -> None:
+    """warn and unverifiable must NOT make the command exit non-zero.
+
+    Kills an implementation treating anything non-ok as a failure, which would
+    exit non-zero on every merge migration and on every renamed category.
+    """
+    report = CheckReport()
+    report.add(name="a", status="warn", kind="category_title_mismatch", detail="")
+    report.add(name="b", status="unverifiable", kind="tail_not_recorded", detail="")
+    assert report.has_failures is False
+    report.add(name="c", status="fail", kind="channel_missing", detail="")
+    assert report.has_failures is True
+
+
+def test_a_result_carries_the_entity_ids_a_repair_would_need() -> None:
+    """The report is the contract batch 10's repair tool consumes.
+
+    A status plus prose is not actionable. Kills a shape carrying only the
+    ProbeCheck fields (name, status, detail), which would force a repair tool
+    to parse ids back out of a sentence.
+    """
+    result = CheckResult(
+        name="channel:d-100",
+        status="fail",
+        kind="channel_missing",
+        detail="recorded channel is absent from the server",
+        discord_id="d-100",
+        stoat_id="01JSTOATCH00000000000AAA",
+    )
+    assert result.discord_id == "d-100"
+    assert result.stoat_id == "01JSTOATCH00000000000AAA"
+    assert result.expected is None
+    assert result.found is None

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -853,3 +853,129 @@ async def test_run_check_does_not_close_an_injected_session(
             session=injected,
         )
         assert injected.closed is False
+
+
+async def test_a_deleted_tail_inside_the_window_is_a_failure(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.6. THE MANDATORY DISCRIMINATOR. Do not delete this test.
+
+    A five-message channel whose recorded tail was deleted, with messages still
+    present on BOTH sides of where it should be. So the window's oldest id sorts
+    BELOW the expected tail and its newest sorts ABOVE it.
+
+    This is the only one of the twelve tail scenarios that kills either ordering
+    mutant, measured on the runnable prototype at
+    docs/plans/designs/2026-08-11-check-tool-classifier-prototype.py:
+
+        read the NEWEST id where the oldest belongs (max)   -> only this one
+        take the oldest positionally as window[0]           -> only this one
+
+    Every other scenario either contains the tail, so the oldest id is never
+    consulted, or overflows the window, where both ends sort above the expected
+    id and min and max agree. This is the only input where the two ends of the
+    window disagree.
+
+    Omitting it ships the ordering bug green while the suite looks thorough, and
+    that bug inverts the verdicts: real data loss reported as unverifiable,
+    ordinary post-migration activity reported as fail.
+    """
+    _register_tail(mock_aiohttp, [0, 1, 2, 3, 5, 6, 7, 8, 9])
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=4, count=5), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "fail"
+    assert result.kind == "tail_absent"
+
+
+async def test_the_whole_window_predating_the_tail_is_a_failure(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.11. Every id in the window sorts below the expected tail, so the
+    tail AND everything after it is gone while older content survives.
+
+    An earlier acceptance criterion asked for warn here. Running the classifier
+    across its whole input space showed warn was reachable from no path at all,
+    and working out the meaning inverts the severity: this is STRONGER evidence
+    of loss than SC-3.6, where only the tail itself is missing. It is a fail
+    with its own kind, because a repair tool would treat the two differently.
+    """
+    _register_tail(mock_aiohttp, list(range(50)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=200, count=201), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "fail"
+    assert result.kind == "tail_and_after_absent"
+
+
+async def test_a_merge_parent_whose_tail_overflowed_the_window_is_unverifiable(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.4. Three hundred merged messages pushed the parent's own tail out.
+
+    The window is entirely NEWER than the expected tail, so it simply does not
+    reach far enough back. That is not evidence of loss, and calling it fail
+    would break spec S3 criterion 5: a merge migration must produce zero fail.
+    """
+    _register_tail(mock_aiohttp, list(range(210, 310)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "unverifiable"
+    assert result.kind == "tail_not_recorded"
+
+
+async def test_post_migration_activity_over_the_window_is_unverifiable(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.12. Same shape as the merge overflow, different cause.
+
+    Both are "the window does not reach the tail", and neither is a defect.
+    """
+    _register_tail(mock_aiohttp, list(range(150, 250)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    assert _tail_result(report).status == "unverifiable"
+
+
+async def test_an_empty_channel_that_should_have_messages_is_a_failure(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.7. State records ten migrated messages; the server returns none."""
+    _register_tail(mock_aiohttp, [])
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "fail"
+    assert result.kind == "channel_empty"
+
+
+@pytest.mark.parametrize(
+    ("window", "high_water", "count"),
+    [
+        pytest.param(list(range(10)), 9, 10, id="tail-is-newest"),
+        pytest.param(list(range(5)), 4, 5, id="channel-shorter-than-window"),
+        pytest.param(list(range(50)), 9, 10, id="merge-parent-small"),
+        pytest.param(list(range(210, 310)), 9, 10, id="merge-parent-overflow"),
+        pytest.param([0, 1, 2, 3, 5, 6, 7, 8, 9], 4, 5, id="deleted-tail"),
+        pytest.param([], 9, 10, id="empty-channel"),
+        pytest.param([], None, 0, id="nothing-expected"),
+        pytest.param(list(range(60)), 9, 10, id="human-activity-small"),
+        pytest.param(list(range(150, 250)), 9, 10, id="human-activity-overflow"),
+        pytest.param(list(range(50)), 200, 201, id="whole-window-predates-tail"),
+    ],
+)
+async def test_the_tail_check_never_emits_warn(
+    mock_aiohttp: aioresponses,
+    window: list[int],
+    high_water: int | None,
+    count: int,
+) -> None:
+    """SC-3.13. warn belongs to the category title check, and nowhere else.
+
+    Driven across every tail scenario. Kills reintroducing the inverted-severity
+    warn that critique round 2 removed, and documents in executable form that a
+    warn appearing in a report can only have come from a renamed category.
+    """
+    _register_tail(mock_aiohttp, window)
+    report = await run_check(
+        BASE_URL, TOKEN, _tail_state(high_water=high_water, count=count), _noop_event
+    )
+    tail_statuses = {r.status for r in report.results if r.name.startswith("tail:")}
+    assert "warn" not in tail_statuses
+    assert tail_statuses <= {"ok", "fail", "unverifiable"}

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -107,6 +107,31 @@ def test_a_result_carries_the_entity_ids_a_repair_would_need() -> None:
     assert result.found is None
 
 
+SRV = "01JSTOATSRV0000000000AAA"
+
+
+def _state_with_channels(channel_map: dict[str, str]) -> MigrationState:
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = dict(channel_map)
+    return state
+
+
+def _server_payload(all_ids: list[str], visible: list[dict[str, str]]) -> dict[str, object]:
+    """A ServerWithChannels body.
+
+    The two lists are separate on purpose and that is the whole point of this
+    route: ``server.channels`` is returned unfiltered and names every channel
+    id, while the sibling array holds only objects the caller may ViewChannel.
+    """
+    return {"server": {"_id": SRV, "channels": all_ids}, "channels": visible}
+
+
+def _register(mock: aioresponses, payload: dict[str, object]) -> None:
+    mock.get(f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=payload)
+    mock.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+
+
 # ---------------------------------------------------------------------------
 # run_check preconditions (task #251)
 # ---------------------------------------------------------------------------
@@ -139,7 +164,9 @@ async def test_an_empty_server_id_is_refused_before_any_request() -> None:
         await run_check(BASE_URL, TOKEN, state, _noop_event)
 
 
-async def test_a_state_predating_this_feature_is_not_refused() -> None:
+async def test_a_state_predating_this_feature_degrades_rather_than_refusing(
+    mock_aiohttp: aioresponses,
+) -> None:
     """An older state.json loads with its newer optional fields defaulted,
     because load_state reads every one through data.get.
 
@@ -147,16 +174,137 @@ async def test_a_state_predating_this_feature_is_not_refused() -> None:
     does not carry, which would make the tool useless for exactly the
     migrations it exists to inspect.
 
-    Scoped to what this layer can actually prove: the preconditions do not
-    reject it. The fuller claim, that the CHECKS degrade and report what they
-    cannot determine, needs checks to exist and is pinned in chunk 3 and chunk
-    4. Registering mock routes here would have made this look like an
-    integration test while asserting nothing, because the skeleton makes no
-    requests yet.
+    Scoped to the preconditions in chunk 2, where run_check made no requests
+    and this could assert nothing more. Chunk 3 gave it something to degrade,
+    so it now drives the real structure pass over an empty state and asserts
+    the run completes with nothing to report rather than raising.
     """
     state = MigrationState()
-    state.stoat_server_id = "01JSTOATSRV0000000000AAA"
+    state.stoat_server_id = SRV
     # No channel_map, no message_map, no channel_high_water, no
     # channel_message_counts: the shape an early state.json presents.
+    _register(mock_aiohttp, _server_payload([], []))
     report = await run_check(BASE_URL, TOKEN, state, _noop_event)
     assert report.counts()["fail"] == 0
+    assert report.results == []
+
+
+# ---------------------------------------------------------------------------
+# structure: channel identity, the three-way rule (task #252)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_channel_present_in_both_lists_is_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The ordinary case."""
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(
+        mock_aiohttp,
+        _server_payload([stoat_id], [{"_id": stoat_id, "name": "general"}]),
+    )
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
+    )
+    channel_results = [r for r in report.results if r.discord_id == "d-100"]
+    assert [r.status for r in channel_results] == ["ok"]
+    assert channel_results[0].stoat_id == stoat_id
+
+
+async def test_a_channel_absent_from_the_id_list_is_a_failure(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Deleted, and reportable as such.
+
+    Kills an implementation that consults only the visible-objects array. That
+    one cannot tell deletion from a permission filter, so it would have to
+    report unverifiable here, and `channel_missing` would be unreachable.
+    Reporting a deleted channel is the point of the tool.
+    """
+    _register(mock_aiohttp, _server_payload([], []))
+    report = await run_check(
+        BASE_URL,
+        TOKEN,
+        _state_with_channels({"d-100": "01JSTOATCH00000000000AAA"}),
+        _noop_event,
+    )
+    result = next(r for r in report.results if r.discord_id == "d-100")
+    assert result.status == "fail"
+    assert result.kind == "channel_missing"
+    assert report.has_failures is True
+
+
+async def test_a_channel_the_token_cannot_see_is_unverifiable_not_a_failure(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Present in the unfiltered id list, absent from the permission-filtered
+    objects: the channel exists and this token simply may not view it.
+
+    Kills an implementation treating any absence from the objects array as
+    deletion, which would report fail on every private channel and teach users
+    to ignore the tool. The two fixtures differ ONLY in the objects array, so
+    this test and the one above cannot both pass against a one-list
+    implementation.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(mock_aiohttp, _server_payload([stoat_id], []))
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
+    )
+    result = next(r for r in report.results if r.discord_id == "d-100")
+    assert result.status == "unverifiable"
+    assert result.kind == "channel_not_visible"
+    assert report.has_failures is False
+
+
+async def test_a_renamed_channel_is_not_reported(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """KNOWN LIMIT, pinned deliberately. This is NOT coverage of an intended check.
+
+    MigrationState records no channel name. Its only name fields are
+    category_names, forum_category_names and author_names, and every write to
+    channel_map is id to id. So there is no expected name to compare a found
+    name against, and a renamed channel is undetectable.
+
+    Tracked as spec P2 S11, which would record the names for FUTURE migrations.
+    It cannot help any migration that already exists, which is the population
+    this tool serves, so it was deferred rather than built.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(
+        mock_aiohttp,
+        _server_payload([stoat_id], [{"_id": stoat_id, "name": "renamed-by-someone"}]),
+    )
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
+    )
+    result = next(r for r in report.results if r.discord_id == "d-100")
+    assert result.status == "ok"
+
+
+async def test_a_forum_index_entry_is_checked_as_an_ordinary_channel(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """channel_map keys are not all Discord channel ids.
+
+    The forum index writer stores a SYNTHETIC key, `forum-index-{forum_key}`,
+    whose value is nonetheless a real Stoat channel id. Identity checking is
+    valid for it because only the value is sent to the server.
+
+    Kills an implementation that assumes every key is a Discord snowflake and
+    skips, or crashes on, the ones that are not.
+    """
+    stoat_id = "01JSTOATIDX00000000000AA"
+    _register(
+        mock_aiohttp,
+        _server_payload([stoat_id], [{"_id": stoat_id, "name": "forum-index"}]),
+    )
+    report = await run_check(
+        BASE_URL,
+        TOKEN,
+        _state_with_channels({"forum-index-cat-9": stoat_id}),
+        _noop_event,
+    )
+    result = next(r for r in report.results if r.discord_id == "forum-index-cat-9")
+    assert result.status == "ok"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -308,3 +308,81 @@ async def test_a_forum_index_entry_is_checked_as_an_ordinary_channel(
     )
     result = next(r for r in report.results if r.discord_id == "forum-index-cat-9")
     assert result.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# structure: roles and emoji (task #253)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_missing_role_is_a_failure(mock_aiohttp: aioresponses) -> None:
+    """Server.roles is a map keyed by role id, so membership is a key lookup.
+
+    Unlike channels there is no second list and no permission filter, so an
+    absence here is unambiguous and reports fail rather than unverifiable.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": [], "roles": {}}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-r1": "01JSTOATROLE0000000000A"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-r1")
+    assert result.status == "fail"
+    assert result.kind == "role_missing"
+
+
+async def test_a_present_role_is_ok(mock_aiohttp: aioresponses) -> None:
+    """Kills an implementation reporting every role missing, which the failure
+    test above cannot catch on its own."""
+    role_id = "01JSTOATROLE0000000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {"_id": SRV, "channels": [], "roles": {role_id: {"name": "mods"}}},
+            "channels": [],
+        },
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-r1": role_id}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    assert next(r for r in report.results if r.discord_id == "d-r1").status == "ok"
+
+
+async def test_a_missing_emoji_is_a_failure(mock_aiohttp: aioresponses) -> None:
+    """Emoji come from their own route, because Server carries no emoji field."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": "01JAUTUMNEMOJI00000000A"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "fail"
+    assert result.kind == "emoji_missing"
+
+
+async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
+    """The emoji list is a list of objects keyed by _id, not a map."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "party"}],
+    )
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -555,3 +555,74 @@ async def test_the_structure_family_costs_exactly_two_requests(
     assert requests_made == 2, f"expected 2 requests for 91 entities, made {requests_made}"
     assert len(report.results) == 91
     assert report.has_failures is False
+
+
+async def test_a_category_with_no_recorded_title_is_unverifiable_not_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The category exists but nothing says what it should be called.
+
+    Kills reporting ok here, which would claim the title was verified when it
+    was never compared. Unreachable for a state a current Ferry writes, because
+    category_map and category_names are written on adjacent lines; reachable for
+    a state.json written before category_names existed, which is the population
+    the degrade-rather-than-refuse rule serves.
+    """
+    cat_id = "01JSTOATCAT00000000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {
+                "_id": SRV,
+                "channels": [],
+                "categories": [{"id": cat_id, "title": "Whatever", "channels": []}],
+            },
+            "channels": [],
+        },
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.category_map = {"d-cat-1": cat_id}
+    # category_names deliberately left empty: an older state.json.
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-cat-1")
+    assert result.status == "unverifiable"
+    assert result.kind == "category_title_unknown"
+    assert result.found == "Whatever"
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        pytest.param(["not-a-dict"], id="element-is-not-a-dict"),
+        pytest.param([{"name": "general"}], id="element-lacks-_id"),
+        pytest.param([{"id": "01JSTOATCH00000000000AAA"}], id="element-uses-id-not-_id"),
+    ],
+)
+async def test_a_malformed_channel_object_never_reports_a_false_deletion(
+    mock_aiohttp: aioresponses, malformed: list[object]
+) -> None:
+    """A property the three-way rule gives for free, pinned so it stays.
+
+    A chunk review predicted that the isinstance filter would make a real
+    channel look deleted. It cannot: the unfiltered server.channels id list is a
+    SECOND, independent witness, and a fail needs both witnesses to agree the
+    channel is absent. Whatever goes wrong with the object array degrades to
+    unverifiable instead.
+
+    Kills any refactor that drops the id list and decides from the objects
+    alone, which would turn every one of these into a false report of deletion.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": [stoat_id]}, "channels": malformed},
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    report = await run_check(
+        BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
+    )
+    result = report.results[0]
+    assert result.status == "unverifiable"
+    assert report.has_failures is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -10,6 +10,9 @@ against what they guarded.
 
 from __future__ import annotations
 
+import re
+
+import aiohttp
 import pytest
 from aioresponses import aioresponses
 
@@ -127,9 +130,41 @@ def _server_payload(all_ids: list[str], visible: list[dict[str, str]]) -> dict[s
     return {"server": {"_id": SRV, "channels": all_ids}, "channels": visible}
 
 
+def _allow_any_message_window(mock: aioresponses) -> None:
+    """Serve an empty message window for ANY channel.
+
+    For tests whose subject is the structure pass: the tail check still runs and
+    needs somewhere to send its request.
+    """
+    mock.get(re.compile(r".*/channels/.*/messages.*"), payload=[], repeat=True)
+
+
 def _register(mock: aioresponses, payload: dict[str, object]) -> None:
+    """Register the two structure routes, plus an empty message window for every
+    channel id the payload mentions.
+
+    The tail check runs for every entry in channel_map, so a structure-focused
+    test still needs a message route or it fails on a missing mock rather than
+    on what it is testing. An empty window with a zero recorded count reports
+    ok/nothing_expected, which these tests ignore.
+    """
     mock.get(f"{BASE_URL}/servers/{SRV}?include_channels=true", payload=payload)
     mock.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    server = payload.get("server") or {}
+    ids = set(server.get("channels") or [])
+    ids.update(
+        c["_id"] for c in (payload.get("channels") or []) if isinstance(c, dict) and "_id" in c
+    )
+    for cid in ids:
+        mock.get(
+            f"{BASE_URL}/channels/{cid}/messages?limit=100&sort=Latest",
+            payload=[],
+            repeat=True,
+        )
+    # Also cover a channel the payload does not list. Until task #259 lands, the
+    # tail check runs for every channel_map entry even when the structure pass
+    # already failed it, so the request still has to go somewhere.
+    _allow_any_message_window(mock)
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +241,7 @@ async def test_a_channel_present_in_both_lists_is_ok(
     report = await run_check(
         BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
     )
-    channel_results = [r for r in report.results if r.discord_id == "d-100"]
+    channel_results = [r for r in report.results if r.name == "channel:d-100"]
     assert [r.status for r in channel_results] == ["ok"]
     assert channel_results[0].stoat_id == stoat_id
 
@@ -228,7 +263,7 @@ async def test_a_channel_absent_from_the_id_list_is_a_failure(
         _state_with_channels({"d-100": "01JSTOATCH00000000000AAA"}),
         _noop_event,
     )
-    result = next(r for r in report.results if r.discord_id == "d-100")
+    result = next(r for r in report.results if r.name == "channel:d-100")
     assert result.status == "fail"
     assert result.kind == "channel_missing"
     assert report.has_failures is True
@@ -251,7 +286,7 @@ async def test_a_channel_the_token_cannot_see_is_unverifiable_not_a_failure(
     report = await run_check(
         BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
     )
-    result = next(r for r in report.results if r.discord_id == "d-100")
+    result = next(r for r in report.results if r.name == "channel:d-100")
     assert result.status == "unverifiable"
     assert result.kind == "channel_not_visible"
     assert report.has_failures is False
@@ -279,7 +314,7 @@ async def test_a_renamed_channel_is_not_reported(
     report = await run_check(
         BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
     )
-    result = next(r for r in report.results if r.discord_id == "d-100")
+    result = next(r for r in report.results if r.name == "channel:d-100")
     assert result.status == "ok"
 
 
@@ -306,7 +341,7 @@ async def test_a_forum_index_entry_is_checked_as_an_ordinary_channel(
         _state_with_channels({"forum-index-cat-9": stoat_id}),
         _noop_event,
     )
-    result = next(r for r in report.results if r.discord_id == "forum-index-cat-9")
+    result = next(r for r in report.results if r.name == "channel:forum-index-cat-9")
     assert result.status == "ok"
 
 
@@ -326,6 +361,7 @@ async def test_a_missing_role_is_a_failure(mock_aiohttp: aioresponses) -> None:
         payload={"server": {"_id": SRV, "channels": [], "roles": {}}, "channels": []},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     state = MigrationState()
     state.stoat_server_id = SRV
     state.role_map = {"d-r1": "01JSTOATROLE0000000000A"}
@@ -347,6 +383,7 @@ async def test_a_present_role_is_ok(mock_aiohttp: aioresponses) -> None:
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     state = MigrationState()
     state.stoat_server_id = SRV
     state.role_map = {"d-r1": role_id}
@@ -361,6 +398,7 @@ async def test_a_missing_emoji_is_a_failure(mock_aiohttp: aioresponses) -> None:
         payload={"server": {"_id": SRV, "channels": []}, "channels": []},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     state = MigrationState()
     state.stoat_server_id = SRV
     state.emoji_map = {"d-e1": "01JAUTUMNEMOJI00000000A"}
@@ -381,6 +419,7 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
         f"{BASE_URL}/servers/{SRV}/emojis",
         payload=[{"_id": emoji_id, "name": "party"}],
     )
+    _allow_any_message_window(mock_aiohttp)
     state = MigrationState()
     state.stoat_server_id = SRV
     state.emoji_map = {"d-e1": emoji_id}
@@ -427,6 +466,7 @@ async def test_a_renamed_category_warns_rather_than_failing(
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     report = await run_check(BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event)
     result = next(r for r in report.results if r.discord_id == "d-cat-1")
     assert result.status == "warn"
@@ -451,6 +491,7 @@ async def test_a_matching_category_title_is_ok(mock_aiohttp: aioresponses) -> No
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     report = await run_check(BASE_URL, TOKEN, _state_with_category(cat_id, "Original"), _noop_event)
     assert next(r for r in report.results if r.discord_id == "d-cat-1").status == "ok"
 
@@ -462,6 +503,7 @@ async def test_a_missing_category_is_a_failure(mock_aiohttp: aioresponses) -> No
         payload={"server": {"_id": SRV, "channels": [], "categories": []}, "channels": []},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     report = await run_check(
         BASE_URL, TOKEN, _state_with_category("01JSTOATCAT00000000000A", "Original"), _noop_event
     )
@@ -484,6 +526,7 @@ async def test_an_absent_categories_key_does_not_crash(
         payload={"server": {"_id": SRV, "channels": []}, "channels": []},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     report = await run_check(
         BASE_URL, TOKEN, _state_with_category("01JSTOATCAT00000000000A", "Original"), _noop_event
     )
@@ -540,6 +583,7 @@ async def test_the_structure_family_costs_exactly_two_requests(
         repeat=True,
         payload=[{"_id": e, "name": "e"} for e in emoji.values()],
     )
+    _allow_any_message_window(mock_aiohttp)
 
     state = MigrationState()
     state.stoat_server_id = SRV
@@ -551,9 +595,17 @@ async def test_the_structure_family_costs_exactly_two_requests(
 
     report = await run_check(BASE_URL, TOKEN, state, _noop_event)
 
-    requests_made = sum(len(v) for v in mock_aiohttp.requests.values())
-    assert requests_made == 2, f"expected 2 requests for 91 entities, made {requests_made}"
-    assert len(report.results) == 91
+    # Count the STRUCTURE requests only. The tail check deliberately costs one
+    # request per channel and is budgeted separately; counting everything here
+    # was only accidentally right while the tail check did not exist yet.
+    structure_calls = sum(
+        len(v) for k, v in mock_aiohttp.requests.items() if "/servers/" in str(k[1])
+    )
+    assert structure_calls == 2, (
+        f"expected 2 structure requests for 91 entities, made {structure_calls}"
+    )
+    structure_results = [r for r in report.results if not r.name.startswith("tail:")]
+    assert len(structure_results) == 91
     assert report.has_failures is False
 
 
@@ -581,6 +633,7 @@ async def test_a_category_with_no_recorded_title_is_unverifiable_not_ok(
         },
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     state = MigrationState()
     state.stoat_server_id = SRV
     state.category_map = {"d-cat-1": cat_id}
@@ -620,9 +673,183 @@ async def test_a_malformed_channel_object_never_reports_a_false_deletion(
         payload={"server": {"_id": SRV, "channels": [stoat_id]}, "channels": malformed},
     )
     mock_aiohttp.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    _allow_any_message_window(mock_aiohttp)
     report = await run_check(
         BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
     )
-    result = report.results[0]
+    result = next(r for r in report.results if r.name == "channel:d-100")
     assert result.status == "unverifiable"
     assert report.has_failures is False
+
+
+# ---------------------------------------------------------------------------
+# the tail check (tasks #256, #257, #258, #259)
+# ---------------------------------------------------------------------------
+
+CH1 = "01JSTOATCH00000000000AAA"
+
+
+def _sid(n: int) -> str:
+    """A 26-char Stoat message id, monotonic in n.
+
+    Stoat ids are ULIDs whose leading bits are a millisecond timestamp in
+    Crockford base32, so lexicographic order on equal-length ids is time order.
+    These are not real ULIDs but they share the two properties the classifier
+    depends on: fixed width, and sorting in creation order.
+    """
+    return f"01JSTOATMSG{n:015d}"
+
+
+def _did(n: int) -> str:
+    """A Discord message id. Visibly different from the Stoat id for the same
+    message, so a comparison against the wrong one cannot pass by accident."""
+    return f"d-msg-{n}"
+
+
+def _tail_state(
+    *,
+    high_water: int | None,
+    count: int,
+    mapped: bool = True,
+    channel: str = "d-100",
+) -> MigrationState:
+    """A state describing one migrated channel.
+
+    ``high_water`` is the index of the last message Ferry believes it sent.
+    ``mapped`` False leaves message_map without an entry for it, which is the
+    409 DuplicateNonce shape: the send landed but batch 7 deliberately records
+    no id for it.
+    """
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.channel_map = {channel: CH1}
+    state.channel_message_counts = {channel: count}
+    if high_water is not None:
+        state.channel_high_water[channel] = _did(high_water)
+        if mapped:
+            state.message_map[_did(high_water)] = _sid(high_water)
+    return state
+
+
+def _register_tail(mock: aioresponses, window: list[int], *, channel_id: str = CH1) -> None:
+    """Register the structure routes plus one channel's message window.
+
+    The window is served NEWEST FIRST, which is what MessageSort::Latest
+    produces upstream: doc!{"_id": -1}, not reversed downstream.
+    """
+    mock.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={
+            "server": {"_id": SRV, "channels": [channel_id]},
+            "channels": [{"_id": channel_id, "name": "general"}],
+        },
+    )
+    mock.get(f"{BASE_URL}/servers/{SRV}/emojis", payload=[])
+    mock.get(
+        f"{BASE_URL}/channels/{channel_id}/messages?limit=100&sort=Latest",
+        payload=[{"_id": _sid(n)} for n in sorted(window, reverse=True)],
+    )
+
+
+def _tail_result(report: CheckReport) -> CheckResult:
+    return next(r for r in report.results if r.name.startswith("tail:"))
+
+
+async def test_the_tail_is_the_newest_message(mock_aiohttp: aioresponses) -> None:
+    """SC-3.1. The ordinary flatten case."""
+    _register_tail(mock_aiohttp, list(range(10)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "ok"
+    assert result.kind == "tail_present"
+
+
+async def test_a_channel_shorter_than_the_window_is_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.2. The window is the whole channel."""
+    _register_tail(mock_aiohttp, list(range(5)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=4, count=5), _noop_event)
+    assert _tail_result(report).status == "ok"
+
+
+async def test_a_merge_parent_with_content_after_the_tail_is_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.3. Forty merged thread messages sit after the parent's own tail.
+
+    This is the case the window approach exists for. An equality test asking
+    "is the recorded tail the NEWEST message" fails here, and would fail on
+    every merge parent, which is spec S3 criterion 5.
+    """
+    _register_tail(mock_aiohttp, list(range(50)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    assert _tail_result(report).status == "ok"
+
+
+async def test_a_channel_that_migrated_nothing_is_ok_and_does_not_raise(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.8. An ordinary empty Discord channel.
+
+    channel_high_water is written only under `if _channel_max_id:`, so a channel
+    that sent nothing has NO entry. Kills the unconditional two-hop lookup,
+    which raises KeyError here and reports the commonest correct case as a check
+    error. Added by critique round 1.
+    """
+    _register_tail(mock_aiohttp, [])
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=None, count=0), _noop_event)
+    result = _tail_result(report)
+    assert result.status == "ok"
+    assert result.kind == "nothing_expected"
+
+
+async def test_a_high_water_id_with_no_map_entry_is_unverifiable(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.9. KNOWN GAP, pinned deliberately, tracked as #240.
+
+    A send that returned 409 DuplicateNonce landed on the server, but batch 7
+    deliberately writes no message_map entry for it because an empty-valued
+    entry is worse than none. So the expected Stoat id cannot be resolved.
+
+    unverifiable is the honest answer, and it must not raise. This asserts
+    CURRENT behaviour and is not coverage of an intended outcome; #240 would
+    close it by recording those sends durably.
+    """
+    _register_tail(mock_aiohttp, list(range(10)))
+    report = await run_check(
+        BASE_URL, TOKEN, _tail_state(high_water=9, count=10, mapped=False), _noop_event
+    )
+    result = _tail_result(report)
+    assert result.status == "unverifiable"
+    assert result.kind == "tail_not_recorded"
+
+
+async def test_post_migration_activity_under_the_window_is_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.10. Someone posted after the migration. Not a defect."""
+    _register_tail(mock_aiohttp, list(range(60)))
+    report = await run_check(BASE_URL, TOKEN, _tail_state(high_water=9, count=10), _noop_event)
+    assert _tail_result(report).status == "ok"
+
+
+async def test_run_check_does_not_close_an_injected_session(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-I4. Mirrors test_probe_does_not_close_an_injected_session.
+
+    A caller that supplied the session owns it. Closing it would break a caller
+    reusing one across calls, which batch 10's repair tool will do.
+    """
+    _register_tail(mock_aiohttp, list(range(3)))
+    async with aiohttp.ClientSession() as injected:
+        await run_check(
+            BASE_URL,
+            TOKEN,
+            _tail_state(high_water=2, count=3),
+            _noop_event,
+            session=injected,
+        )
+        assert injected.closed is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -10,7 +10,26 @@ against what they guarded.
 
 from __future__ import annotations
 
-from discord_ferry.migrator.verify import CheckReport, CheckResult
+import pytest
+from aioresponses import aioresponses
+
+from discord_ferry.errors import ValidationError
+from discord_ferry.migrator.verify import CheckReport, CheckResult, run_check
+from discord_ferry.state import MigrationState
+
+BASE_URL = "https://api.test"
+TOKEN = "test-session-token"
+
+
+@pytest.fixture()
+def mock_aiohttp() -> object:
+    with aioresponses() as m:
+        yield m
+
+
+def _noop_event(_event: object) -> None:
+    return None
+
 
 # ---------------------------------------------------------------------------
 # CheckResult / CheckReport (task #250)
@@ -86,3 +105,58 @@ def test_a_result_carries_the_entity_ids_a_repair_would_need() -> None:
     assert result.stoat_id == "01JSTOATCH00000000000AAA"
     assert result.expected is None
     assert result.found is None
+
+
+# ---------------------------------------------------------------------------
+# run_check preconditions (task #251)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_dry_run_state_is_refused_before_any_request() -> None:
+    """A dry run records dry-ch- and dry-msg- sentinels for entities that were
+    never created, so there is nothing on a server to check against.
+
+    --resume has refused a dry-run state since it was written and --incremental
+    gained the same refusal in v2.15.0. This is the third sibling.
+
+    No route is registered, so the refusal is proven by the absence of a
+    request rather than only by the exception: an implementation checking the
+    flag AFTER its first fetch would raise a different error here.
+    """
+    state = MigrationState()
+    state.is_dry_run = True
+    state.stoat_server_id = "01JSTOATSRV0000000000AAA"
+    with aioresponses(), pytest.raises(ValidationError, match="dry-run"):
+        await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+
+async def test_an_empty_server_id_is_refused_before_any_request() -> None:
+    """Without a server id there is nothing to check against, and the URL would
+    be built with an empty path segment rather than failing honestly."""
+    state = MigrationState()
+    state.stoat_server_id = ""
+    with aioresponses(), pytest.raises(ValidationError, match="server"):
+        await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+
+async def test_a_state_predating_this_feature_is_not_refused() -> None:
+    """An older state.json loads with its newer optional fields defaulted,
+    because load_state reads every one through data.get.
+
+    Kills an implementation that hard-requires a field a released state file
+    does not carry, which would make the tool useless for exactly the
+    migrations it exists to inspect.
+
+    Scoped to what this layer can actually prove: the preconditions do not
+    reject it. The fuller claim, that the CHECKS degrade and report what they
+    cannot determine, needs checks to exist and is pinned in chunk 3 and chunk
+    4. Registering mock routes here would have made this look like an
+    integration test while asserting nothing, because the skeleton makes no
+    requests yet.
+    """
+    state = MigrationState()
+    state.stoat_server_id = "01JSTOATSRV0000000000AAA"
+    # No channel_map, no message_map, no channel_high_water, no
+    # channel_message_counts: the shape an early state.json presents.
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    assert report.counts()["fail"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.15.0"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
#107 batch 9. Releases **2.16.0**.

Adds `ferry check`, a read-only command that verifies a migration you have already run. Point it at the output directory and it asks the Stoat server whether everything Ferry recorded is still there.

## Why this shape

Ferry's only verification today is the `--validate-after` block, which compares two cardinalities:

```python
"passed": actual_channels == expected_channels and actual_roles == expected_roles,
```

A cardinality check passes whenever the *number* of objects is right, whichever objects those are. Two channels created with each other's names pass it. It also swallows every exception into a warning and leaves `validation_results` empty, so a check that failed reads exactly like one that passed. And it can only run at the end of a migration, never against one that already finished, which is the main thing anyone would want.

## What it does, and what it costs

| Family | Cost | Method |
|---|---|---|
| Structure | **2 requests at any server size** | Every channel, role, category and emoji compared **by id** |
| Tail | **1 request per channel** | The newest 100 messages, asking whether the recorded tail is *present* |

Reads land in the `channels` bucket (15 per 10 s, keyed **per channel**), not `messaging`, because upstream routes to `messaging` only on POST. So `limit=100` costs exactly what `limit=1` costs, and channels do not contend.

## The design decision that matters

The tail check asks whether the recorded last message is **present** in the window, not whether it is the **newest**. Equality is brittle: two populations produce a newer message by construction on every run, so an equality test fails every `merge` parent and every forum index channel. Membership is robust and still catches the loss it exists to catch.

Stoat ids are ULIDs, so lexicographic order is time order. That splits an absence three ways at no extra cost:

```
tail in the window                    -> ok
window entirely older than the tail   -> fail   tail_and_after_absent
window straddles the tail's position  -> fail   tail_absent
window entirely newer than the tail   -> unverifiable
```

## Four statuses, and the fourth is the point

`unverifiable` is neither a pass nor a failure. It is the honest answer when Ferry never recorded what it would need. A design review found `warn` promised in two acceptance criteria and **produced by no code path at all**, verified by running the classifier across its whole input space. It now has exactly one home, a renamed category, which is the only name Ferry records.

## What it cannot tell you, stated in the docs and the changelog

- A gap in the **middle** of a channel is invisible. An `ok` means the recorded tail is present, never that the channel is complete.
- More than 100 messages since the migration and the window cannot reach back: `unverifiable`.
- A renamed **channel or role** is undetectable. Ferry never recorded those names (#269).
- A duplicate-nonce send leaves no id, so its channel is `unverifiable` (#240).

Both shapes of undetectable loss are pinned as tests, because a ship review claimed there were none.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src/` clean. **1829 passed**, up from 1751 at the branch point. Five deletions against the merge-base, all in tests being tightened.

**`core/engine.py`, `state.py`, `config.py` and `parser/models.py` are untouched.** That is the batch's whole risk argument, and it is audit target 3 in the change manifest.

## Chunks

| Chunk | Tasks |
|---|---|
| #242 the three API reads | #247, #248, #249 |
| #243 the module foundation | #250, #251 |
| #244 structure by identity | #252, #253, #254, #255 |
| #245 the tail check | #256, #257, #258, #259, #260 |
| #246 the shell and the release | #261, #262, #263, #264 |

All closed, each chunk carrying its `/df-chunk-review` marker, zero critical findings anywhere.

## What the process caught, recorded because it repeats

- **A mistyped status was a hidden pass.** `add()` took a bare `str`, so `status="faild"` created a new key and left `has_failures` False. Fixed with a `Literal`, which catches it at the call site rather than when the branch runs, and immediately surfaced a second real type error.
- **A test passed against a state shape that cannot exist.** The forum index fixture set `channel_message_counts` for a synthetic channel; that map is keyed by real export channels, so the branch was unreachable in production. Mutation could not catch it, because mutant and test shared the false premise. Reading the writer did.
- **A budget test was a kill for the wrong reason.** The over-fetch mutant died on a connection error before the count assertion ran, so a pass/fail mutation run would have scored it green while the assertion had never executed.
- **A mutant that never applied read as a survivor.** `ruff` had collapsed the target onto one line. Harnesses now assert their anchor first. A *mislabelled* mutant is worse: one produced a confident wrong conclusion that a correct prediction was wrong.
- **The design said "fan out concurrently" twice and the code was a sequential loop.** Found by re-reading the design, not by any test.
- **Two spec criteria were struck as unreachable rather than implemented**, a `dry-ch-` branch and an earlier `warn`, for the same reason: a line no input can reach is a diagnosis, not something to add.

## Ten mutants, all applied, all died

Every anchor asserted before applying. Both ordering mutants die to **one scenario and nothing else**, the deleted-tail-inside-the-window case, measured first on a runnable prototype and then confirmed against the real module. Its test docstring says not to delete it.

## Deferrals, filed rather than mentioned

**#266** `--json`, **#267** record `thread_strategy`, **#268** retire `--validate-after`, **#269** record channel and role names. All four carry the four ADR-005 fields. One earlier deferral, distinguishing a deleted channel from an invisible one, was **closed rather than filed**: it existed because a signal was unverified, and reading `server_fetch.rs` showed the response carries both an unfiltered id list and a permission-filtered object array, so the discriminator is free.

## Note for whoever merges second

Another worktree on this machine, `fix/server-create-response-shape`, has uncommitted work on #265 touching `api.py` and `cli.py`. No version collision, and its hunks sit mid-file where this branch appends, but a rebase will be needed. Its bug is a **third** instance of the same upstream trap this batch documented: `api_create_server` reads `_id` off the top level while the route answers with `CreateServerLegacyResponse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotVV9xXbWp9oR2JdF9Vkm
