### PR TITLE
fix: read the server id from Stoat's wrapped create response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.16.1] - 2026-08-12
+
+### Fixed
+
+- **Creating a new Stoat server no longer fails immediately.** Any migration that did not
+  reuse an existing server stopped at the start of the server phase with
+  `Phase server failed: '_id'`, before a single channel was made. Stoat replies to the
+  create-server call with the server nested beside the channels it makes alongside it,
+  and Ferry read the reply as though the server were at the top level. Point Ferry at a
+  fresh server and it now proceeds. Migrations run with `--server-id`, and resumed or
+  incremental runs carrying a server id, were never affected (#265).
+- `ferry build`, which creates a server from a blueprint or a preset template, read the
+  same reply the same wrong way and failed the same way. Fixed with it.
+
 ## [2.16.0] - 2026-08-12
 
 ### Added

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -490,7 +490,7 @@ writing a new callback — no engine changes needed.
 
 | Function | HTTP | Purpose |
 |----------|------|---------|
-| `api_create_server` | `POST /servers` | Create new Stoat server |
+| `api_create_server` | `POST /servers/create` | Create new Stoat server, returns its id |
 | `api_fetch_server` | `GET /servers/:id` | Verify server exists |
 | `api_edit_server` | `PATCH /servers/:id` | Update server settings |
 | `api_create_role` | `POST /servers/:id/roles` | Create role |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.16.0"
+version = "2.16.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -860,8 +860,7 @@ def build(
     async def _build() -> None:
         async with new_session() as session:
             # Create server
-            result = await api_create_server(session, stoat_url, token, bp.name)
-            server_id = result["_id"]
+            server_id = await api_create_server(session, stoat_url, token, bp.name)
             console.print(f"  Created server '{_safe(bp.name)}' ({server_id})")
 
             # Create roles

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -361,8 +361,18 @@ async def api_create_server(
     stoat_url: str,
     token: str,
     name: str,
-) -> dict[str, Any]:
-    """Create a new server on the Stoat instance.
+) -> str:
+    """Create a new server on the Stoat instance and return its id.
+
+    The route answers with ``CreateServerLegacyResponse`` (``create_server`` in upstream
+    ``routes/servers/server_create.rs``), which nests the server beside the channels
+    Stoat creates with it::
+
+        {"server": {"_id": ..., ...}, "channels": [...]}
+
+    There is no ``serde(flatten)``, so reading ``_id`` off the top level raised
+    ``KeyError`` and killed the server phase (#265). The ``channels`` member is
+    discarded: Ferry creates its own channels and does not adopt the default one.
 
     Args:
         session: An active aiohttp ClientSession.
@@ -371,10 +381,42 @@ async def api_create_server(
         name: Display name for the new server.
 
     Returns:
-        Server object dict from the API (includes ``_id``).
+        The new server's id.
+
+    Raises:
+        MigrationError: If the response carries no recognisable server id. The message
+            names the route and the key names received, never a value: on the
+            ``ferry build`` path nothing downstream redacts it.
     """
     url = f"{stoat_url.rstrip('/')}/servers/create"
-    return await _api_request(session, "POST", url, token, {"name": name})
+    version_hint = "The Stoat instance may be running an incompatible API version."
+    # ``object`` local: _api_request is declared -> dict[str, Any] but returns whatever
+    # JSON arrived, so isinstance narrowing is required rather than optional.
+    raw: object = await _api_request(session, "POST", url, token, {"name": name})
+    if not isinstance(raw, dict):
+        # Never sorted(raw) here: on a list that sorts the elements into the message.
+        raise MigrationError(
+            f"Stoat returned {type(raw).__name__} from {url}, expected an object. {version_hint}"
+        )
+    server = raw.get("server")
+    if server is None:
+        raise MigrationError(
+            f"Stoat returned no 'server' member from {url}; keys were {sorted(raw)}. {version_hint}"
+        )
+    if not isinstance(server, dict):
+        raise MigrationError(
+            f"Stoat returned a {type(server).__name__} as 'server' from {url}, "
+            f"expected an object. {version_hint}"
+        )
+    server_id = server.get("_id")
+    if not isinstance(server_id, str) or not server_id:
+        # Nested keys, not top-level: an upstream rename of _id leaves the top level
+        # looking exactly as Ferry expects, so naming it would read like success.
+        raise MigrationError(
+            f"Stoat returned no server id from {url}; 'server' keys were "
+            f"{sorted(server)}. {version_hint}"
+        )
+    return server_id
 
 
 async def api_fetch_server(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -167,8 +167,9 @@ async def run_server(
             else:
                 name = "Ferry Server"
 
-            result = await api_create_server(session, config.stoat_url, config.token, name)
-            state.stoat_server_id = result["_id"]
+            state.stoat_server_id = await api_create_server(
+                session, config.stoat_url, config.token, name
+            )
             # S2: persist immediately so a kill before the post-phase save still records the
             # server id — on --resume the reuse branch fires instead of creating a duplicate.
             save_state(state, config.output_dir)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,13 +203,22 @@ def mock_aiohttp() -> aioresponses:
 # ---------------------------------------------------------------------------
 
 
-async def test_api_create_server(mock_aiohttp: aioresponses) -> None:
-    """POST /servers/create returns the new server dict including _id."""
-    mock_aiohttp.post(f"{BASE_URL}/servers/create", payload={"_id": "srv123", "name": "Test"})
+async def test_api_create_server_wrapped_response(mock_aiohttp: aioresponses) -> None:
+    """SC-1.1. The live shape nests the server beside the channels created with it.
+
+    Regression guard for #265: every fixture in the suite used to mock a bare
+    ``{"_id": ...}``, which no current Stoat returns.
+    """
+    mock_aiohttp.post(
+        f"{BASE_URL}/servers/create",
+        payload={
+            "server": {"_id": "srv123", "name": "Test"},
+            "channels": [{"_id": "ch_default"}],
+        },
+    )
     async with aiohttp.ClientSession() as session:
-        result = await api_create_server(session, BASE_URL, TOKEN, "Test")
-    assert result["_id"] == "srv123"
-    assert result["name"] == "Test"
+        server_id = await api_create_server(session, BASE_URL, TOKEN, "Test")
+    assert server_id == "srv123"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -221,6 +221,71 @@ async def test_api_create_server_wrapped_response(mock_aiohttp: aioresponses) ->
     assert server_id == "srv123"
 
 
+async def test_api_create_server_array_body(mock_aiohttp: aioresponses) -> None:
+    """SC-2.1. A JSON array is named by type, and its elements never reach the message.
+
+    ``sorted()`` on a list sorts its contents, so a single shared ``sorted(raw)``
+    would put response data into the error text.
+    """
+    mock_aiohttp.post(f"{BASE_URL}/servers/create", payload=[{"_id": "srv123"}])
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, BASE_URL, TOKEN, "Test")
+    assert "list" in str(exc.value)
+    assert "srv123" not in str(exc.value)
+
+
+async def test_api_create_server_no_server_member(mock_aiohttp: aioresponses) -> None:
+    """SC-2.2. The flat pre-2023 shape is rejected, naming the top-level keys."""
+    mock_aiohttp.post(f"{BASE_URL}/servers/create", payload={"id": "srv123", "name": "Test"})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, BASE_URL, TOKEN, "Test")
+    assert "servers/create" in str(exc.value)
+    assert "'id'" in str(exc.value)
+    assert "'name'" in str(exc.value)
+
+
+async def test_api_create_server_server_not_an_object(mock_aiohttp: aioresponses) -> None:
+    """SC-2.3. A non-object 'server' member is named by type, not by value."""
+    mock_aiohttp.post(f"{BASE_URL}/servers/create", payload={"server": "srv1", "channels": []})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, BASE_URL, TOKEN, "Test")
+    assert "str" in str(exc.value)
+    assert "srv1" not in str(exc.value)
+
+
+async def test_api_create_server_renamed_id_names_nested_keys(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-2.4. If upstream renamed _id, the message must name the NESTED keys.
+
+    The top level still reads ``{"server": ..., "channels": ...}``, exactly what Ferry
+    expects, so a message naming only the top-level keys would describe a body that
+    looks healthy while the parse had in fact failed.
+    """
+    mock_aiohttp.post(
+        f"{BASE_URL}/servers/create",
+        payload={"server": {"id": "srv1", "name": "Test"}, "channels": []},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, BASE_URL, TOKEN, "Test")
+    message = str(exc.value)
+    assert "'id'" in message
+    assert "'name'" in message
+    assert "channels" not in message
+
+
+async def test_api_create_server_empty_id(mock_aiohttp: aioresponses) -> None:
+    """SC-2.5. An empty id would become a GET /servers/ URL on the next resume."""
+    mock_aiohttp.post(f"{BASE_URL}/servers/create", payload={"server": {"_id": ""}, "channels": []})
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError):
+            await api_create_server(session, BASE_URL, TOKEN, "Test")
+
+
 # ---------------------------------------------------------------------------
 # api_fetch_server
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -465,7 +465,7 @@ def test_build_prints_proxy_notice(runner: CliRunner, tmp_path: Path, proxy_env,
     with (
         os_proxy({}),
         proxy_env(ALL_PROXY="socks5://sock:1080"),
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
     ):
         result = runner.invoke(
             main,
@@ -1231,7 +1231,7 @@ def test_build_categorized_voice_preserves_id(runner: CliRunner, tmp_path: Path)
     create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
     upsert = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_channel", create),
         patch("discord_ferry.cli.api_upsert_categories", upsert),
     ):
@@ -1254,7 +1254,7 @@ def test_build_uncategorized_voice_fallback(runner: CliRunner, tmp_path: Path) -
     p = _write_bp(tmp_path, bp)
     create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_channel", create),
     ):
         result = runner.invoke(
@@ -1274,7 +1274,7 @@ def test_build_non_voice_failure_aborts(runner: CliRunner, tmp_path: Path) -> No
     )
     p = _write_bp(tmp_path, bp)
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch(
             "discord_ferry.cli.api_create_channel", AsyncMock(side_effect=MigrationError("boom"))
         ),
@@ -1294,7 +1294,7 @@ def test_build_empty_blueprint(runner: CliRunner, tmp_path: Path) -> None:  # SC
     p = _write_bp(tmp_path, bp)
     create = AsyncMock(return_value={"_id": "ch"})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_channel", create),
     ):
         result = runner.invoke(
@@ -1324,7 +1324,7 @@ def test_build_applies_distinct_ranks(runner: CliRunner, tmp_path: Path) -> None
     p = _write_bp(tmp_path, bp)
     edit = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
         patch("discord_ferry.cli.api_edit_role", edit),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
@@ -1346,7 +1346,7 @@ def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC
     p = _write_bp(tmp_path, bp)
     edit = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
         patch("discord_ferry.cli.api_edit_role", edit),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
@@ -1366,7 +1366,7 @@ def test_build_folds_colour_and_rank_one_patch(runner: CliRunner, tmp_path: Path
     p = _write_bp(tmp_path, bp)
     edit = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
         patch("discord_ferry.cli.api_edit_role", edit),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
@@ -1389,7 +1389,7 @@ def test_build_preserves_permissions(runner: CliRunner, tmp_path: Path) -> None:
     p = _write_bp(tmp_path, bp)
     perms = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value={"_id": "srv"})),
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
         patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
         patch("discord_ferry.cli.api_set_role_permissions", perms),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2061,3 +2061,73 @@ def test_the_summary_names_every_count_and_the_exit_code(runner: CliRunner, tmp_
         )
     for fragment in ("1 ok", "1 failed", "1 unverifiable", "1 warning"):
         assert fragment in result.output, f"summary omitted {fragment!r}"
+
+
+# ---------------------------------------------------------------------------
+# ferry build, driven through the real api_create_server wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_build_parses_the_real_create_response(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-3.1. Drive ferry build through the real wrapper, not a patched one.
+
+    Every other build test patches api_create_server out, so none of them touches the
+    response parsing. This one serves the wrapped body over aioresponses instead, which
+    is what spec story S3 actually asks for.
+    """
+    from aioresponses import aioresponses
+
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(name="Rebuilt", roles=[BlueprintRole(name="Mod")])
+    p = _write_bp(tmp_path, bp)
+
+    with aioresponses() as m:
+        # Register the whole chain. Leaving the roles route out would make aioresponses
+        # raise a connection error, which _api_request retries three times with backoff:
+        # seconds of runtime, ending in a MigrationError resembling the bug under test.
+        m.post(
+            "http://x/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Rebuilt"}, "channels": []},
+            repeat=True,
+        )
+        m.post(
+            "http://x/servers/srv1/roles",
+            payload={"id": "role1", "role": {"name": "Mod"}},
+            repeat=True,
+        )
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert "Created role" in result.output
+
+
+def test_build_reports_an_unrecognised_create_response(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-3.2. This path prints the error with no redaction available.
+
+    cli.py catches MigrationError and prints it through _safe, which is Rich markup
+    escaping rather than redaction, and build registers no secret. The message has to be
+    safe on its own, so it carries key names and never a value.
+    """
+    from aioresponses import aioresponses
+
+    from discord_ferry.blueprint import ServerBlueprint
+
+    bp = ServerBlueprint(name="Rebuilt")
+    p = _write_bp(tmp_path, bp)
+
+    with aioresponses() as m:
+        m.post("http://x/servers/create", payload={"id": "srv1"}, repeat=True)
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1
+    assert "Build failed:" in result.output
+    assert "srv1" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2130,4 +2130,9 @@ def test_build_reports_an_unrecognised_create_response(runner: CliRunner, tmp_pa
 
     assert result.exit_code == 1
     assert "Build failed:" in result.output
+    # Assert the diagnostic reached the user, not only that the value did not. Without
+    # this the test passes against MigrationError(""), which is the shape this project
+    # keeps shipping: a condition that cannot fail. Match a short fragment, because the
+    # module-level Rich Console wraps at 80 columns off a TTY and would split a longer one.
+    assert "'id'" in result.output
     assert "srv1" not in result.output

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -183,7 +183,7 @@ async def test_permission_bootstrap_failure_is_warned_not_fatal(tmp_path: Path) 
         # Server creation succeeds.
         m.post(
             f"{config.stoat_url}/servers/create",
-            payload={"_id": "stoat-server-001"},
+            payload={"server": {"_id": "stoat-server-001"}, "channels": []},
         )
         # Icon upload and PATCH icon — skip (no icon in fixture guild without a real file).
         # First PATCH (icon) is never reached since guild_icon.png doesn't exist locally.

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -131,7 +131,10 @@ async def test_run_server_creates_server(tmp_path: Path) -> None:
     exports = [_make_export()]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
 
         await run_server(config, state, exports, events.append)
 
@@ -161,7 +164,10 @@ async def test_run_server_applies_description_and_nsfw(tmp_path: Path) -> None:
     patch_bodies: list[dict[str, object]] = []
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         m.patch(
             f"{STOAT_URL}/servers/srv1",
             payload={},
@@ -198,7 +204,10 @@ async def test_run_server_omits_empty_description(tmp_path: Path) -> None:
     patch_bodies: list[dict[str, object]] = []
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         m.patch(
             f"{STOAT_URL}/servers/srv1",
             payload={},
@@ -221,7 +230,10 @@ async def test_run_server_meta_skipped_without_metadata(tmp_path: Path) -> None:
     exports = [_make_export()]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         m.patch(f"{STOAT_URL}/servers/srv1", payload={}, repeat=True)
 
         await run_server(config, state, exports, events.append)
@@ -257,7 +269,10 @@ async def test_run_server_uploads_icon(tmp_path: Path) -> None:
     exports = [_make_export(guild_icon_url=str(icon_file))]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         m.post(f"{AUTUMN_URL}/icons", payload={"id": "icon-autumn-id"})
         m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
 
@@ -279,7 +294,10 @@ async def test_run_server_icon_upload_failure_is_non_fatal(tmp_path: Path) -> No
     exports = [_make_export(guild_icon_url=str(icon_file))]
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         m.post(f"{AUTUMN_URL}/icons", status=500)  # Autumn failure
 
         # Should NOT raise — icon failure is non-fatal.
@@ -2122,7 +2140,10 @@ async def test_banner_uploaded_and_applied(tmp_path: Path) -> None:
     patch_bodies: list[dict[str, object]] = []
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         # CDN banner download.
         m.get(
             f"{BANNER_CDN}/111/abc123banner.png?size=1024",
@@ -2166,7 +2187,10 @@ async def test_banner_download_fails_graceful(tmp_path: Path) -> None:
     save_discord_metadata(meta, tmp_path)
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         # CDN returns 404.
         m.get(
             f"{BANNER_CDN}/111/abc123banner.png?size=1024",
@@ -2199,7 +2223,10 @@ async def test_no_banner_skipped(tmp_path: Path) -> None:
     save_discord_metadata(meta, tmp_path)
 
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "srv1", "name": "Test"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "srv1", "name": "Test"}, "channels": []},
+        )
         # No CDN mock — if banner download were attempted, aioresponses would raise.
 
         await run_server(config, state, exports, events.append)
@@ -2866,7 +2893,10 @@ async def test_create_path_description_has_no_lock_marker(tmp_path: Path) -> Non
     save_discord_metadata(_meta_with_description("Cosy"), tmp_path)
     bodies: list[dict[str, object]] = []
     with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "new1", "name": "S"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "new1", "name": "S"}, "channels": []},
+        )
         m.patch(
             f"{STOAT_URL}/servers/new1",
             payload={},
@@ -2896,7 +2926,10 @@ async def test_server_id_persisted_right_after_create(tmp_path: Path) -> None:
             side_effect=lambda s, d: recorded.append(s.stoat_server_id),
         ),
     ):
-        m.post(f"{STOAT_URL}/servers/create", payload={"_id": "new1", "name": "S"})
+        m.post(
+            f"{STOAT_URL}/servers/create",
+            payload={"server": {"_id": "new1", "name": "S"}, "channels": []},
+        )
         m.patch(f"{STOAT_URL}/servers/new1", payload={}, repeat=True)
         await run_server(config, state, [_make_export()], lambda e: None)
     assert recorded and recorded[0] == "new1"  # persisted immediately after create

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.16.0"
+version = "2.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Every migration that creates a fresh Stoat server has always died at the start of the server
phase. `POST /servers/create` answers with the new server nested beside the channels Stoat creates
alongside it, and Ferry read the id off the top level, so the phase raised `KeyError('_id')` before
making anything.

```
[validate] completed: Parsed 22 exports, 36609 messages
[connect] completed: Completed connect
[server] started: Starting server
[server] error: Error in server: '_id'
[ERROR] Migration failed: Phase server failed: '_id'
```

## Why it took two years to surface

Two reasons, and the second is the uncomfortable one.

The reuse branch in `run_server` resolves `config.server_id or state.stoat_server_id` first, so
`--server-id`, `--resume` and `--incremental` all take a different path and never reach the create
call. Anyone reusing a server was fine.

And every one of the 13 `servers/create` fixtures in the suite mocked a flat `{"_id": ...}` body,
a shape Stoat has never sent. The tests agreed with the code, and both were wrong about the outside
world. A green suite was evidence of nothing on this path.

## What changed

The response parsing moved into `api_create_server`, which now returns the id as a `str` rather
than the raw body. Both call sites assign it, so a third caller cannot repeat the mistake.

**`ferry build` had the identical bug** and is fixed by the same change. It was found by mypy, not
by searching: changing the return type turned the second call site into a type error. Blueprints
and all three preset templates were equally broken; nobody reported it because the migration path
fails first.

An unrecognised response now raises `MigrationError` naming the route and the key names received,
never a value. That last part is a requirement rather than a nicety: `ferry build` catches
`MigrationError` and prints it through `_safe`, which is Rich markup escaping rather than
redaction, and that command registers no secret, so nothing downstream can make an unsafe message
safe.

The error is built per branch. A body that is not an object reports its type, never its elements,
because `sorted()` on a list sorts its contents into the message. A `server` object missing `_id`
reports the **nested** keys, because on the likeliest future drift, upstream renaming `_id` to
`id`, the top level still reads exactly as Ferry expects and a top-level message would describe a
healthy-looking body while the parse had failed.

## Verification

Full gate green: `ruff check`, `ruff format --check`, `mypy src/` strict, 1836 tests.

Evidence beyond the suite, since the fixtures are what hid this:

- The contract was read from `stoatchat/stoatchat` at `crates/delta/src/routes/servers/server_create.rs`
  and `crates/core/models/src/v0/servers.rs`, not recalled. The four sibling create routes were read
  in the same pass and are correct as Ferry reads them, which is why this change is one route wide.
- Reverting the parse kills 12 named tests across `tests/test_api.py` and `tests/test_structure.py`.
- Every new assertion was checked against a mutation that should break it. Removing the type name
  kills the type test; reporting top-level keys kills the nested-keys test; blanking the message
  kills the CLI diagnostic test.
- `test_non_json_201_clear_error` is untouched and still passing. `tests/test_incremental_structure.py`
  still registers no create route, deliberately.

Design critique ran two rounds (ITERATE then PASS), a chunk review and a whole-branch review.

## Follow-ups, filed rather than mentioned

- #276 — a credential embedded in `--stoat-url` prints unredacted in API error messages. Confirmed
  by running it. Pre-existing and shared with two messages already on `main`, so a fix belongs in
  one helper applied at every site.
- #277 — Stoat's auto-created default channel is left stranded in a migrated server.

Plan chunk #271, tasks #272 to #275, all closed with their evidence.

Fixes #265
