### PR TITLE
Finish the CheckReport contract: detect renames, name the cause, and emit JSON (2.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-08-12
+
+### Added
+
+- **`ferry check` now detects a renamed channel or role.** Ferry records the name it gives
+  each channel and role as it creates them, so Check can compare that against the current
+  name on the server and report a rename as a warning rather than passing it silently. A
+  rename does not fail the command, because nothing has been lost. This works for
+  migrations run under 2.17.0 or later: an earlier migration recorded no such names, and
+  nothing can recover them after the fact, so a rename there stays invisible (#269).
+- **`ferry check --json`** prints the whole report as a single JSON document instead of a
+  table, for a script that wants the individual results rather than a pass or fail. Every
+  free-text value has control characters stripped, because a consumer that parses the
+  document and prints a value would otherwise inherit whatever the server sent (#266).
+
+### Changed
+
+- **`ferry check` now names why a result could not be verified**, instead of listing every
+  possible cause. Ferry records which thread strategy a migration ran under, so a merge
+  parent is reported as expected rather than as one of three possibilities. A migration run
+  by an earlier version recorded no strategy, and Check still lists the possibilities for
+  those (#267).
+
+### Fixed
+
+- The recorded thread strategy is the one that actually ran. A configuration carrying a
+  value outside `flatten`, `merge` and `archive` runs as `flatten`, and the state file now
+  says so rather than repeating what was asked for. The CLI rejects such a value outright;
+  the GUI reads its setting back from a file it does not re-validate.
+
 ## [2.16.1] - 2026-08-12
 
 ### Fixed

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -425,17 +425,20 @@ This is not the same command as [`ferry validate`](#ferry-validate), which inspe
 |------|----------------------|-------------|
 | `--stoat-url TEXT` | `STOAT_URL` | Stoat API base URL *(required)* |
 | `--token TEXT` | `STOAT_TOKEN` | Your Stoat user token *(required)* |
+| `--json` | | Print the report as a single JSON document instead of a table |
 
 ### What the four statuses mean
 
 | Status | Meaning |
 |--------|---------|
 | `ok` | Found, and it matches what Ferry recorded |
-| `warn` | It exists and its content is intact, but a name differs. Today this only ever means a category was renamed |
+| `warn` | It exists and its content is intact, but a name differs: a channel, a role or a category was renamed on the server |
 | `fail` | Something Ferry recorded is gone, or a channel lost messages |
 | `unverifiable` | Ferry cannot answer, and says why. Not a pass and not a failure |
 
 `unverifiable` is worth reading rather than skimming past. It is the honest answer when Ferry never recorded what it would need to confirm something, which happens for good reasons: you migrated with `--thread-strategy=merge`, a send was accepted as a duplicate, or the token you gave Check cannot see a particular channel.
+
+From 2.17.0 Ferry records which thread strategy a migration ran under, so Check names the cause that applies rather than listing all three. A migration run by an earlier version recorded no strategy, and Check still lists the possibilities for those.
 
 ### Exit codes
 
@@ -444,7 +447,7 @@ This is not the same command as [`ferry validate`](#ferry-validate), which inspe
 | `0` | Every result was `ok`, `warn` or `unverifiable` |
 | `1` | Any result was `fail`, or the migration could not be checked at all |
 
-A `warn` on its own does not fail the command, because nothing has been lost. Use the exit code in a script; there is no separate machine-readable flag.
+A `warn` on its own does not fail the command, because nothing has been lost. Use the exit code in a script, and `--json` when you want the individual results rather than a pass or fail.
 
 ### What Check cannot tell you
 
@@ -452,7 +455,7 @@ Check reads the most recent 100 messages in each channel and confirms the last o
 
 - **A gap in the middle of a channel is invisible.** An `ok` means the recorded last message is present. It does not mean the channel is complete.
 - **If more than 100 messages arrived after your migration**, Check can no longer see far enough back and reports `unverifiable` rather than guessing.
-- **A renamed channel or role is not detected.** Ferry never recorded the names it gave them, so there is nothing to compare against. Renamed *categories* are detected, because those names are recorded.
+- **A renamed channel or role is only detected for migrations run under 2.17.0 or later.** Ferry records the names it gives channels and roles from that release on. A migration run by an earlier version recorded none, so there is nothing to compare against and a rename there stays invisible. Renamed *categories* have always been detected.
 - **A duplicate forum index** is not detected.
 - **Check will not run against a dry run.** A dry run records placeholders for things that were never created, so there is nothing on a server to compare with.
 

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -129,7 +129,7 @@ These limitations relate to platform-level features that either work differently
 
 **A channel that gained more than 100 messages since the migration cannot be checked.** The window no longer reaches back to the message Ferry recorded, so Check reports `unverifiable` rather than guessing. This is common on an active server.
 
-**A renamed channel or role is not detected.** Ferry records the identifiers it created but not the names it gave them, so there is nothing to compare a current name against. Renamed *categories* are detected, because category names are recorded.
+**A renamed channel or role is only detected for migrations run under 2.17.0 or later.** From that release Ferry records the name it gave each channel and role, so `ferry check` can compare it against the current one and reports a rename as a warning. A migration run by an earlier version recorded no such names, and nothing can recover them after the fact, so a rename there stays invisible. Renamed *categories* have always been detected, because category names were recorded from the start.
 
 **A message accepted as a duplicate cannot be confirmed.** When Stoat recognises a retry and refuses it, it does not say which message it already had, so Ferry has no identifier to check later. Channels affected this way report `unverifiable`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.16.1"
+version = "2.17.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.16.1"
+__version__ = "2.17.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1554,17 +1554,26 @@ def _render_check_report(report: CheckReport, thread_strategy: str = "") -> None
         # serialises and what the repair tool reads in-process. This is what a
         # human reads, and fixing one without the other leaves half the audience
         # with the wrong explanation.
+        # Each branch points at the per-result detail rather than enumerating,
+        # because `unverifiable` has FIVE producers: channel_not_visible,
+        # category_title_unknown, check_error, tail_not_recorded and
+        # tail_window_exhausted. An earlier draft of this sentence said a
+        # non-merge migration "means a duplicate send, or a channel this token
+        # cannot read", which claimed exclusivity and omitted three of them. A
+        # wrong claim in prose is a defect, and the whole-branch review caught it.
         if thread_strategy == "merge":
             cause = (
-                "which is expected under --thread-strategy=merge, after a duplicate "
-                "send, or for a channel this token cannot read"
+                "and under --thread-strategy=merge that is expected for any channel "
+                "that absorbed thread content. Each result above says which cause applies"
             )
         elif thread_strategy:
             cause = (
-                f"which for a --thread-strategy={thread_strategy} migration means a "
-                "duplicate send, or a channel this token cannot read"
+                f"which a --thread-strategy={thread_strategy} migration does not cause "
+                "on its own. Each result above says which cause applies"
             )
         else:
+            # The exact wording v2.16.0 shipped, kept for a state file that
+            # records no strategy, which is every migration predating 2.17.0.
             cause = (
                 "which is expected when --thread-strategy=merge was used, after a "
                 "duplicate send, or for a channel this token cannot read"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1381,7 +1381,13 @@ def probe_cmd(
     # make this the only one of Ferry's four token options behaving that way.
     help="Stoat user token. Prefer the STOAT_TOKEN environment variable",
 )
-def check_cmd(output_dir: str, stoat_url: str | None, token: str | None) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit the report as JSON instead of a table",
+)
+def check_cmd(output_dir: str, stoat_url: str | None, token: str | None, as_json: bool) -> None:
     """Verify a finished migration against the live Stoat server.
 
     Reads the state file in OUTPUT_DIR and asks the server whether everything it
@@ -1421,8 +1427,61 @@ def check_cmd(output_dir: str, stoat_url: str | None, token: str | None) -> None
         console.print(f"[bold red]Cannot check this migration:[/] {_safe(exc)}")
         sys.exit(1)
 
-    _render_check_report(report, state.thread_strategy)
+    if as_json:
+        # click.echo, not console.print: the module-level Console has
+        # soft_wrap=False and falls back to 80 columns off a terminal, so it
+        # inserts a real newline wherever the wrap lands, including inside a
+        # string value, which makes the output unparseable (issue #145).
+        click.echo(json.dumps(_check_report_as_dict(report)))
+    else:
+        _render_check_report(report, state.thread_strategy)
     sys.exit(1 if report.has_failures else 0)
+
+
+def _strip_control(text: str) -> str:
+    """Remove every C0 and C1 control character except tab.
+
+    Applied on the JSON path ONLY. ``CheckResult.detail`` can embed a
+    server-supplied error body, which this project treats as attacker-influenced.
+    On the Rich path an escape sequence is defanged incidentally, because Rich
+    interleaves its own style codes between the ESC and the following ``[`` so it
+    never reaches the terminal contiguously. ``click.echo`` does no such thing and
+    would print the ESC verbatim.
+
+    Stripping at the dataclass, or in ``report.add``, would also change what the
+    Rich table prints, and that output shipped in v2.16.0.
+
+    Newlines go too. A JSON string escapes them safely, but a consumer that
+    prints a ``detail`` straight to a terminal would otherwise inherit whatever
+    line breaks the server chose.
+    """
+    return "".join(ch for ch in text if ch == "\t" or (ord(ch) >= 32 and ord(ch) != 127))
+
+
+def _check_report_as_dict(report: CheckReport) -> dict[str, Any]:
+    """The report as a JSON-ready document.
+
+    An explicit serialiser rather than ``dataclasses.asdict``, so a field added
+    to ``CheckResult`` later does not enter the published output without someone
+    deciding it should. The repair tool consumes the dataclass in process; this
+    is the surface a script sees, and the two can move independently.
+    """
+    return {
+        "results": [
+            {
+                "name": _strip_control(r.name),
+                "status": r.status,
+                "kind": r.kind,
+                "detail": _strip_control(r.detail),
+                "discord_id": r.discord_id,
+                "stoat_id": r.stoat_id,
+                "expected": _strip_control(r.expected) if r.expected is not None else None,
+                "found": _strip_control(r.found) if r.found is not None else None,
+            }
+            for r in report.results
+        ],
+        "counts": report.counts(),
+    }
 
 
 def _render_check_report(report: CheckReport, thread_strategy: str = "") -> None:

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import sys
 import textwrap
+import unicodedata
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -1454,8 +1455,18 @@ def _strip_control(text: str) -> str:
     Newlines go too. A JSON string escapes them safely, but a consumer that
     prints a ``detail`` straight to a terminal would otherwise inherit whatever
     line breaks the server chose.
+
+    "It parses" was never the right test, and the first version of this function
+    failed on that mistake. ``json.dumps`` escapes a control character in the
+    JSON **text**, so the document always parses, and then hands the raw byte
+    back to whoever parses it. The threat is downstream of parsing.
+
+    ``unicodedata`` category ``Cc`` rather than a hand-rolled range, because the
+    hand-rolled one missed the C1 block: ``\\x9b`` is CSI, the single-byte
+    equivalent of ``ESC[``, and its ordinal is 155, so an ``ord(ch) >= 32``
+    filter passes it straight through. ``Cc`` covers C0, DEL and C1 exactly.
     """
-    return "".join(ch for ch in text if ch == "\t" or (ord(ch) >= 32 and ord(ch) != 127))
+    return "".join(ch for ch in text if ch == "\t" or unicodedata.category(ch) != "Cc")
 
 
 def _check_report_as_dict(report: CheckReport) -> dict[str, Any]:
@@ -1473,8 +1484,15 @@ def _check_report_as_dict(report: CheckReport) -> dict[str, Any]:
                 "status": r.status,
                 "kind": r.kind,
                 "detail": _strip_control(r.detail),
-                "discord_id": r.discord_id,
-                "stoat_id": r.stoat_id,
+                # Stripped too, and not obviously: discord_id is not always a
+                # Discord snowflake. The forum index writer stores a synthetic
+                # `forum-index-forum-{parent_channel_name}`, and that name comes
+                # from the export, so a forum named with an ESC byte puts it
+                # straight into this key. stoat_id comes from an API response,
+                # which this project also treats as attacker-influenced.
+                # `status` and `kind` are internal literals and need nothing.
+                "discord_id": _strip_control(r.discord_id) if r.discord_id else r.discord_id,
+                "stoat_id": _strip_control(r.stoat_id) if r.stoat_id else r.stoat_id,
                 "expected": _strip_control(r.expected) if r.expected is not None else None,
                 "found": _strip_control(r.found) if r.found is not None else None,
             }

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1421,11 +1421,11 @@ def check_cmd(output_dir: str, stoat_url: str | None, token: str | None) -> None
         console.print(f"[bold red]Cannot check this migration:[/] {_safe(exc)}")
         sys.exit(1)
 
-    _render_check_report(report)
+    _render_check_report(report, state.thread_strategy)
     sys.exit(1 if report.has_failures else 0)
 
 
-def _render_check_report(report: CheckReport) -> None:
+def _render_check_report(report: CheckReport, thread_strategy: str = "") -> None:
     """Print the results table and the summary line.
 
     The summary leads with counts and states the exit code, so neither has to be
@@ -1468,11 +1468,33 @@ def _render_check_report(report: CheckReport) -> None:
         f"   (exit {exit_code})"
     )
     if counts["unverifiable"]:
+        # The causes worth naming depend on what the migration actually did, and
+        # since 2.17.0 state.json records that. Before it did, this sentence
+        # offered merge to every user including the ones who never used it,
+        # which is the wording issue #267 exists to correct.
+        #
+        # verify.py carries the matching per-result detail, which is what --json
+        # serialises and what the repair tool reads in-process. This is what a
+        # human reads, and fixing one without the other leaves half the audience
+        # with the wrong explanation.
+        if thread_strategy == "merge":
+            cause = (
+                "which is expected under --thread-strategy=merge, after a duplicate "
+                "send, or for a channel this token cannot read"
+            )
+        elif thread_strategy:
+            cause = (
+                f"which for a --thread-strategy={thread_strategy} migration means a "
+                "duplicate send, or a channel this token cannot read"
+            )
+        else:
+            cause = (
+                "which is expected when --thread-strategy=merge was used, after a "
+                "duplicate send, or for a channel this token cannot read"
+            )
         console.print(
             f"[cyan]{counts['unverifiable']} checks could not be verified.[/] Ferry did "
-            "not record what it would need to confirm them, which is expected when "
-            "--thread-strategy=merge was used, after a duplicate send, or for a channel "
-            "this token cannot read."
+            f"not record what it would need to confirm them, {cause}."
         )
 
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -298,6 +298,22 @@ async def run_migration(
         state.started_at = datetime.now(UTC).isoformat()
         state.is_dry_run = config.dry_run
 
+    # Set AFTER the four state paths converge, deliberately, and not inside any
+    # of them. --resume loads, --incremental either carries from a prior state or
+    # constructs fresh, and neither flag constructs fresh. A fifth path must also
+    # reach here to run the phases, so it inherits this without anyone having to
+    # remember. Measured rather than assumed: moving this line beside
+    # `state = MigrationState()` kills four of the five tests covering it and
+    # leaves the fresh-run test passing, which is what makes that placement look
+    # correct to whoever writes it.
+    #
+    # This records the strategy of the MOST RECENT run. A resume under a
+    # different --thread-strategy than the original therefore describes the
+    # resuming run while most of the content was migrated under the first, which
+    # is why verify.py words its detail as the recorded strategy rather than as
+    # the strategy every message in the channel was migrated under.
+    state.thread_strategy = config.thread_strategy
+
     # Preflight: surface any proxy configuration Ferry found but cannot use.
     # core/http.py returns data and never emits; the engine decides. Emitted at
     # "notice" rather than "warning" because cli.py gates warnings behind

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -207,6 +207,14 @@ async def run_migration(
             # Carry over ID maps so structure phases are skipped / reused
             state.channel_map = dict(prior.channel_map)
             state.role_map = dict(prior.role_map)
+            # Beside their id maps, and mandatory rather than tidy. A carried
+            # channel skips creation entirely (run_channels snapshots
+            # pre_existing_channel_ids before its create loop), and roles do the
+            # same, so nothing re-records a name on an incremental run. Without
+            # these two lines every incremental run ends with an empty name map
+            # and ferry check reports ok for a renamed channel.
+            state.created_channel_names = dict(prior.created_channel_names)
+            state.created_role_names = dict(prior.created_role_names)
             # C1: carry finalized-roles so incremental skips re-editing (load_state seeds `prior`
             # for old-ferry states). Without this every incremental run re-PATCHes all roles.
             state.roles_finalized = set(prior.roles_finalized)
@@ -250,6 +258,9 @@ async def run_migration(
             state.native_fidelity_counts = dict(prior.native_fidelity_counts)
             # Carry-over audit (every MigrationState field classified):
             #   CARRY: role_map / channel_map / category_map / emoji_map,
+            #     created_channel_names / created_role_names (a carried entity
+            #     skips creation, so nothing re-records its name; omitting these
+            #     makes ferry check report ok for a renamed channel),
             #     category_names, channel_categories, message_map, avatar_cache,
             #     upload_cache, author_names, stoat_server_id, autumn_url,
             #     invite_code / invite_url, channel_message_offsets,
@@ -267,7 +278,10 @@ async def run_migration(
             #     reactions/pins phases — carrying a stale list would re-pin/re-react);
             #     warnings / errors, validation_results, embeds_* / replies_*
             #     (per-run fidelity counters); current_phase, started_at,
-            #     completed_at, export_completed, rollback_progress, is_dry_run.
+            #     completed_at, export_completed, rollback_progress, is_dry_run;
+            #     thread_strategy, which describes THIS run and is set from
+            #     config after this block, at the point the four state paths
+            #     converge.
             #   DECISION: autumn_uploads / referenced_autumn_ids stay reset —
             #     orphan-sweep is per-run; carrying matters only if a cross-run
             #     sweep is added (none today).

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -47,7 +47,7 @@ from discord_ferry.migrator.api import (
 from discord_ferry.migrator.avatars import run_avatars
 from discord_ferry.migrator.connect import run_connect
 from discord_ferry.migrator.emoji import run_emoji
-from discord_ferry.migrator.messages import _process_message, run_messages
+from discord_ferry.migrator.messages import _THREAD_STRATEGIES, _process_message, run_messages
 from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
 from discord_ferry.migrator.structure import run_categories, run_channels, run_roles, run_server
@@ -326,7 +326,17 @@ async def run_migration(
     # resuming run while most of the content was migrated under the first, which
     # is why verify.py words its detail as the recorded strategy rather than as
     # the strategy every message in the channel was migrated under.
-    state.thread_strategy = config.thread_strategy
+    #
+    # The EFFECTIVE strategy, not the requested one. run_messages falls back to
+    # "flatten" for any value outside _THREAD_STRATEGIES, so recording
+    # config.thread_strategy raw would let state.json name a strategy the run
+    # never used, and ferry check would then report that as the cause. --resume
+    # and the CLI cannot reach it, because click.Choice validates there, but the
+    # GUI reads its value back from a storage file it does not re-validate and a
+    # programmatic FerryConfig is unconstrained. Found by a chunk review.
+    state.thread_strategy = (
+        config.thread_strategy if config.thread_strategy in _THREAD_STRATEGIES else "flatten"
+    )
 
     # Preflight: surface any proxy configuration Ferry found but cannot use.
     # core/http.py returns data and never emits; the engine decides. Emitted at

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -1102,6 +1102,14 @@ async def run_channels(
                 # what the server stored, so any normalisation upstream cannot
                 # show up later as a rename nobody made. The fallback covers a
                 # response that omits the key.
+                #
+                # `or` rather than `.get("name", unique_name)`, and a review
+                # proposed the swap. Measured across the four response shapes:
+                # they differ only on an empty-string name, which Stoat's 1-to-32
+                # create validation makes unreachable, and `.get` with a default
+                # returns None on an explicit `"name": null`, putting None into a
+                # dict[str, str]. `or` is the safer of the two here. The same
+                # applies to the role and forum index sites below.
                 state.created_channel_names[ch.id] = result.get("name") or unique_name
 
                 # Apply channel permission overrides from Discord metadata.

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -566,6 +566,11 @@ async def run_roles(
                 raise
             stoat_role_id: str = result["id"]
             state.role_map[role.id] = stoat_role_id
+            # Beside the id write, and from the RESPONSE, matching the channel
+            # site. The fallback repeats truncate_name because that is the value
+            # actually sent: recording role.name would report a rename for every
+            # role whose Discord name exceeds the cap.
+            state.created_role_names[role.id] = result.get("name") or truncate_name(role.name)
             # S3: persist periodically so a hard-kill mid-create leaves role_map durable
             # (resume then skips already-created roles instead of duplicating them).
             if idx % 10 == 0:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -1086,6 +1086,18 @@ async def run_channels(
                         raise
 
                 state.channel_map[ch.id] = stoat_channel_id
+                # Beside the id write, and OUTSIDE the try, deliberately. The
+                # voice-to-text retry above reassigns `result` inside its except
+                # block, so `result` here is whichever attempt succeeded. A name
+                # recorded next to the first `result["_id"]` read would never run
+                # on the retry path, because the exception jumps past it, and
+                # every voice channel would end up with no recorded name.
+                #
+                # From the RESPONSE rather than from unique_name: this records
+                # what the server stored, so any normalisation upstream cannot
+                # show up later as a rename nobody made. The fallback covers a
+                # response that omits the key.
+                state.created_channel_names[ch.id] = result.get("name") or unique_name
 
                 # Apply channel permission overrides from Discord metadata.
                 if ch_meta and not config.dry_run:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -1303,6 +1303,13 @@ async def run_channels(
                 # Insert at position 0 so it appears at the top of the category.
                 category_channels.setdefault(forum_cat_stoat_id, []).insert(0, index_channel_id)
                 state.channel_map[f"forum-index-{forum_key}"] = index_channel_id
+                # Keyed identically to the id above, synthetic prefix and all, so
+                # the rename check needs no special case for it. index_name came
+                # from make_unique_channel_name, so it is truncated exactly as an
+                # ordinary channel's is.
+                state.created_channel_names[f"forum-index-{forum_key}"] = (
+                    idx_result.get("name") or index_name
+                )
 
                 on_event(
                     MigrationEvent(

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -274,7 +274,7 @@ async def _check_structure(
     # derived from this dict has exactly the membership the previous set
     # comprehension produced, malformed entries dropped identically.
     visible_names = {
-        c["_id"]: c.get("name", "")
+        c["_id"]: _readable_name(c)
         for c in (payload.get("channels") or [])
         if isinstance(c, dict) and "_id" in c
     }
@@ -297,8 +297,11 @@ async def _check_structure(
             # before 2.17.0 honest rather than noisy, and it is a documented
             # limit rather than a missing check.
             recorded = state.created_channel_names.get(discord_id)
-            found_name = visible_names.get(stoat_id, "")
-            if recorded is not None and recorded != found_name:
+            found_name = visible_names.get(stoat_id)
+            # `found_name is not None` is doing real work: an object Ferry could
+            # not read a name from must not be compared, or every such channel
+            # reports a rename nobody made.
+            if recorded is not None and found_name is not None and recorded != found_name:
                 report.add(
                     name=f"channel:{discord_id}",
                     status="warn",
@@ -362,6 +365,35 @@ async def _check_structure(
     role_ids = set(roles_map)
     for discord_id, stoat_id in state.role_map.items():
         present = stoat_id in role_ids
+        if present:
+            recorded_role = state.created_role_names.get(discord_id)
+            # Guard the VALUE, matching what the channel and category branches
+            # already do. Until this comparison existed the roles map was
+            # consumed with set(), which takes the KEYS and never touches a
+            # value, so a None or a bare string was harmless. Reading a name off
+            # one raises AttributeError, and mypy --strict cannot catch it
+            # because the payload is typed dict[str, Any]. A malformed value
+            # degrades to no-name-found rather than aborting the whole check.
+            found_role_name = _readable_name(roles_map.get(stoat_id))
+            if (
+                recorded_role is not None
+                and found_role_name is not None
+                and recorded_role != found_role_name
+            ):
+                report.add(
+                    name=f"role:{discord_id}",
+                    status="warn",
+                    kind="role_renamed",
+                    detail=(
+                        "the role exists and its permissions are intact, but it "
+                        "has been renamed on the server since the migration"
+                    ),
+                    discord_id=discord_id,
+                    stoat_id=stoat_id,
+                    expected=recorded_role,
+                    found=found_role_name,
+                )
+                continue
         report.add(
             name=f"role:{discord_id}",
             status="ok" if present else "fail",
@@ -633,6 +665,25 @@ def _expected_tail(state: MigrationState, discord_id: str) -> str | None:
     if high_water is None:
         return None
     return state.message_map.get(high_water)
+
+
+def _readable_name(obj: object) -> str | None:
+    """The ``name`` of an entity object, or None when it cannot be read.
+
+    None means "no name found", which is NOT the same as an empty name and must
+    not be compared against a recorded one. A malformed entry, or an object with
+    no ``name`` key, would otherwise read as ``""`` and differ from every
+    recorded name, reporting a rename nobody made on a response Ferry simply
+    could not parse.
+
+    The isinstance guards are hand-written because ``mypy --strict`` cannot help
+    here: the payload arrives as ``dict[str, Any]``, so every value off it is
+    ``Any``. The channel and category branches guard the same way.
+    """
+    if not isinstance(obj, dict):
+        return None
+    name = obj.get("name")
+    return name if isinstance(name, str) else None
 
 
 def _tail_not_recorded_detail(thread_strategy: str) -> str:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -286,6 +286,33 @@ async def _check_structure(
         # server, so identity checking is valid for those entries too.
         if stoat_id in visible_ids:
             verified.add(discord_id)
+            # The rename comparison lives INSIDE this arm, which has already
+            # decided the channel is present. That satisfies "one cause, one
+            # result" structurally rather than by a guard: a channel taking
+            # either arm below cannot reach this code, so a missing or invisible
+            # channel can never also be reported as renamed.
+            #
+            # A channel with no recorded name skips the comparison entirely and
+            # keeps `channel_present`. That is what makes a state file written
+            # before 2.17.0 honest rather than noisy, and it is a documented
+            # limit rather than a missing check.
+            recorded = state.created_channel_names.get(discord_id)
+            found_name = visible_names.get(stoat_id, "")
+            if recorded is not None and recorded != found_name:
+                report.add(
+                    name=f"channel:{discord_id}",
+                    status="warn",
+                    kind="channel_renamed",
+                    detail=(
+                        "the channel exists and its content is intact, but it has "
+                        "been renamed on the server since the migration"
+                    ),
+                    discord_id=discord_id,
+                    stoat_id=stoat_id,
+                    expected=recorded,
+                    found=found_name,
+                )
+                continue
             report.add(
                 name=f"channel:{discord_id}",
                 status="ok",

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -265,9 +265,20 @@ async def _check_structure(
     # tell a deleted channel from one merely hidden, which would make
     # `channel_missing` unreachable and lose the point of the tool.
     all_channel_ids = set(server.get("channels") or [])
-    visible_ids = {
-        c["_id"] for c in (payload.get("channels") or []) if isinstance(c, dict) and "_id" in c
+    # An id-to-name dict, mirroring `found_titles` in the category branch below.
+    # The name is needed for the rename comparison and is already in this
+    # response, so keeping it costs no request and the two-request budget for the
+    # whole structure family is unchanged.
+    #
+    # The isinstance and `"_id" in c` guards are unchanged, so `visible_ids`
+    # derived from this dict has exactly the membership the previous set
+    # comprehension produced, malformed entries dropped identically.
+    visible_names = {
+        c["_id"]: c.get("name", "")
+        for c in (payload.get("channels") or [])
+        if isinstance(c, dict) and "_id" in c
     }
+    visible_ids = set(visible_names)
 
     for discord_id, stoat_id in state.channel_map.items():
         # `discord_id` is not always a Discord snowflake: the forum index writer
@@ -315,7 +326,13 @@ async def _check_structure(
     # set() over the MAP, so these are its KEYS. Roles are keyed by id upstream;
     # each Role object also carries an inner "_id", which is deliberately not
     # what is read here. See the three-conventions note above.
-    role_ids = set(server.get("roles") or {})
+    #
+    # Kept whole rather than collapsed straight to its keys, because the rename
+    # comparison needs the Role objects the values hold. `set()` over a dict
+    # takes its keys, so `role_ids` is exactly what the previous one-liner
+    # produced.
+    roles_map = server.get("roles") or {}
+    role_ids = set(roles_map)
     for discord_id, stoat_id in state.role_map.items():
         present = stoat_id in role_ids
         report.add(

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -53,11 +53,18 @@ CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
 #: extension of a permission map leave its expansion behind.
 #:
 #: ``warn`` exists for a cosmetic difference on an entity whose content is
-#: intact. Today the only such difference is a category title, because
-#: ``category_names`` is the only expected name ``MigrationState`` records. A
-#: design review found ``warn`` promised in two acceptance criteria and produced
-#: by no code path at all, so its single legitimate home is stated here rather
-#: than left implicit.
+#: intact. It has exactly **three** producers, all name comparisons, and they are
+#: enumerated here rather than left implicit because a design review once found
+#: ``warn`` promised in two acceptance criteria and produced by no code path at
+#: all:
+#:
+#: * ``category_title_mismatch``, since v2.16.0
+#: * ``channel_renamed`` and ``role_renamed``, since 2.17.0, once
+#:   ``created_channel_names`` and ``created_role_names`` gave the check an
+#:   expected name to compare against
+#:
+#: The tail check emits no ``warn`` at all, which
+#: ``test_the_tail_check_never_emits_warn`` pins across every tail scenario.
 STATUSES: tuple[CheckStatus, ...] = get_args(CheckStatus)
 
 
@@ -78,8 +85,8 @@ class CheckResult:
     Family              Kinds
     ==================  ====================================================
     Channel identity    ``channel_present``, ``channel_missing``,
-                        ``channel_not_visible``
-    Role identity       ``role_present``, ``role_missing``
+                        ``channel_not_visible``, ``channel_renamed``
+    Role identity       ``role_present``, ``role_missing``, ``role_renamed``
     Category identity   ``category_present``, ``category_missing``,
                         ``category_title_mismatch``, ``category_title_unknown``
     Emoji identity      ``emoji_present``, ``emoji_missing``

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -544,6 +544,7 @@ async def _one_tail(
         expected=expected,
         window_ids=window_ids,
         recorded_count=state.channel_message_counts.get(discord_id, 0),
+        thread_strategy=state.thread_strategy,
     )
     return CheckResult(
         name=f"tail:{discord_id}",
@@ -590,11 +591,45 @@ def _expected_tail(state: MigrationState, discord_id: str) -> str | None:
     return state.message_map.get(high_water)
 
 
+def _tail_not_recorded_detail(thread_strategy: str) -> str:
+    """Word the one unverifiable case whose cause Ferry can sometimes name.
+
+    ``thread_strategy`` is ``""`` for every migration that predates the field,
+    and that is the only case where the possibilities have to be listed rather
+    than named. Keeping the v2.16.0 wording there is deliberate: naming an empty
+    or unknown strategy would read as a defect rather than as an old state file.
+
+    Under ``merge`` the cause is usually structural rather than a failure.
+    ``_merge_threads`` never writes ``message_map``, so a parent channel that
+    absorbed thread content legitimately has no recorded last message.
+    """
+    if not thread_strategy:
+        return (
+            "Ferry recorded no id for this channel's last message, which happens "
+            "when a send was accepted as a duplicate. Its delivery cannot be "
+            "confirmed here (see issue #240)."
+        )
+    if thread_strategy == "merge":
+        return (
+            "Ferry recorded no id for this channel's last message. The migration "
+            "ran with --thread-strategy=merge, under which a parent channel that "
+            "absorbed thread content records no id for what it sent, so this is "
+            "expected rather than a failure. A duplicate send produces the same "
+            "result (see issue #240)."
+        )
+    return (
+        "Ferry recorded no id for this channel's last message. The migration ran "
+        f"with --thread-strategy={thread_strategy}, which does not produce this "
+        "on its own, so a send was accepted as a duplicate (see issue #240)."
+    )
+
+
 def _classify_tail(
     *,
     expected: str | None,
     window_ids: list[str],
     recorded_count: int,
+    thread_strategy: str,
 ) -> tuple[CheckStatus, str, str]:
     """Decide one channel's verdict. A pure function, deliberately.
 
@@ -622,13 +657,7 @@ def _classify_tail(
             "state records messages for this channel but the server returned none",
         )
     if expected is None:
-        return (
-            "unverifiable",
-            "tail_not_recorded",
-            "Ferry recorded no id for this channel's last message, which happens "
-            "when a send was accepted as a duplicate. Its delivery cannot be "
-            "confirmed here (see issue #240).",
-        )
+        return ("unverifiable", "tail_not_recorded", _tail_not_recorded_detail(thread_strategy))
     if expected in set(window_ids):
         return ("ok", "tail_present", "the last message Ferry recorded is still present")
 

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -62,6 +62,22 @@ class MigrationState:
     channel_map: dict[str, str] = field(default_factory=dict)
     category_map: dict[str, str] = field(default_factory=dict)
     category_names: dict[str, str] = field(default_factory=dict)  # discord_cat_id -> title
+    # The names Ferry SENT to Stoat, keyed exactly as the id maps above.
+    #
+    # NOT the Discord name, and the difference is not cosmetic.
+    # make_unique_channel_name truncates to 32 characters and appends "-1" on a
+    # collision; roles pass through truncate_name. Recording the Discord name
+    # would report a rename for every channel whose name exceeds 32 characters
+    # and every collision-suffixed duplicate, against a server nobody edited.
+    #
+    # The value is taken from the create RESPONSE, so it is what the server
+    # stored rather than what Ferry believes it sent.
+    #
+    # Contrast category_names directly above, which records the DISCORD title.
+    # Same suffix, opposite meaning, which is why these are not called
+    # channel_names.
+    created_channel_names: dict[str, str] = field(default_factory=dict)
+    created_role_names: dict[str, str] = field(default_factory=dict)
     # discord_ch_id -> effective discord_cat_id (the forum key for forum channels).
     # Persisted so incremental re-runs can re-attach carried channels to the
     # CORRECT category in the full-replace upsert, even with multiple
@@ -123,6 +139,14 @@ class MigrationState:
 
     # Dry-run flag — persisted so resume logic can reject dry-run states
     is_dry_run: bool = False
+
+    # The thread strategy of the MOST RECENT run. "" means never recorded, which
+    # is what every migration predating this field reports.
+    #
+    # "" and "flatten" are different claims: unknown, against chosen. A default
+    # of "flatten" would assert a strategy nobody selected, and ferry check
+    # would then name a cause it cannot know.
+    thread_strategy: str = ""
 
     # Export phase tracking (for smart resume)
     export_completed: bool = False
@@ -260,6 +284,9 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "channel_map": state.channel_map,
         "category_map": state.category_map,
         "category_names": state.category_names,
+        "created_channel_names": state.created_channel_names,
+        "created_role_names": state.created_role_names,
+        "thread_strategy": state.thread_strategy,
         "channel_categories": state.channel_categories,
         "message_map": state.message_map,
         "emoji_map": state.emoji_map,
@@ -334,6 +361,9 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             channel_map=data.get("channel_map", {}),
             category_map=data.get("category_map", {}),
             category_names=data.get("category_names", {}),
+            created_channel_names=data.get("created_channel_names", {}),
+            created_role_names=data.get("created_role_names", {}),
+            thread_strategy=data.get("thread_strategy", ""),
             channel_categories=data.get("channel_categories", {}),
             message_map=data.get("message_map", {}),
             emoji_map=data.get("emoji_map", {}),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2447,3 +2447,31 @@ def test_check_json_keeps_a_tab_and_ordinary_unicode(runner: CliRunner, tmp_path
 
     detail = json.loads(result.output)["results"][0]["detail"]
     assert detail == "col\tumn   café 日本語"
+
+
+def test_the_summary_does_not_claim_an_exclusive_cause(runner: CliRunner, tmp_path: Path) -> None:
+    """`unverifiable` has FIVE producers, and the summary must not imply fewer.
+
+    channel_not_visible, category_title_unknown, check_error, tail_not_recorded
+    and tail_window_exhausted all produce it. An earlier draft of this sentence
+    said a non-merge migration "means a duplicate send, or a channel this token
+    cannot read", which claimed exclusivity and omitted three. The whole-branch
+    review caught it.
+
+    Each branch now points at the per-result detail instead of enumerating, so
+    this asserts the pointer is there rather than trying to list five causes in
+    a summary line.
+    """
+    for strategy in ("flatten", "merge", "archive"):
+        state = MigrationState(stoat_server_id="srv1")
+        state.thread_strategy = strategy
+        report = _check_report(("unverifiable", "tail_window_exhausted"))
+        order: list[str] = []
+        a, b, _c, d = _patched(order, report)
+        with a, b, patch("discord_ferry.cli.load_state", return_value=state), d:
+            result = runner.invoke(
+                main, ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"]
+            )
+        assert "Each result above says which cause applies" in result.output, (
+            f"the {strategy} summary does not point at the per-result detail"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -2191,3 +2192,199 @@ def test_check_summary_keeps_the_old_wording_when_no_strategy_was_recorded(
     assert result.exit_code == 0
     assert "merge" in result.output
     assert "duplicate send" in result.output
+
+
+# ---------------------------------------------------------------------------
+# ferry check --json (#300, SC-4.1 to SC-4.7)
+# ---------------------------------------------------------------------------
+
+
+def _invoke_check(runner: CliRunner, tmp_path: Path, report: CheckReport, *extra: str) -> Any:
+    """Drive check_cmd with a given report, optionally with extra flags."""
+    order: list[str] = []
+    a, b, c, d = _patched(order, report)
+    with a, b, c, d:
+        return runner.invoke(
+            main,
+            ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t", *extra],
+        )
+
+
+def test_check_json_output_parses(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.1. Asserted BY PARSING, never by inspecting the string.
+
+    A substring assertion passes against output that is not valid JSON at all,
+    which is the whole failure mode issue #145 records: the module-level Console
+    falls back to 80 columns off a terminal and inserts a real newline wherever
+    the wrap lands, including inside a string value.
+    """
+    report = _check_report(("ok", "channel_present"), ("warn", "channel_renamed"))
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, dict)
+
+
+def test_check_json_mirrors_the_report(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.2. Every CheckResult field, plus the counts summary."""
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="warn",
+        kind="channel_renamed",
+        detail="renamed on the server",
+        discord_id="d-100",
+        stoat_id="01JSTOATCH00000000000AAA",
+        expected="general",
+        found="renamed-here",
+    )
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    parsed = json.loads(result.output)
+    assert parsed["counts"]["warn"] == 1
+    (row,) = parsed["results"]
+    assert row == {
+        "name": "channel:d-100",
+        "status": "warn",
+        "kind": "channel_renamed",
+        "detail": "renamed on the server",
+        "discord_id": "d-100",
+        "stoat_id": "01JSTOATCH00000000000AAA",
+        "expected": "general",
+        "found": "renamed-here",
+    }
+
+
+def test_check_json_survives_a_control_character_in_a_detail(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-4.3. The discriminator for this story.
+
+    CheckResult.detail can embed a server-supplied error body. The protection
+    that exists on the Rich path is incidental: Rich interleaves its own style
+    codes between an ESC and the following '[', so the sequence never reaches the
+    terminal contiguously. click.echo does no such thing and would print the ESC
+    verbatim.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="fail",
+        kind="check_error",
+        detail="server said: \x1b[2J\x07 wiped\nyour screen\r",
+    )
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    parsed = json.loads(result.output)
+    detail = parsed["results"][0]["detail"]
+    assert "\x1b" not in detail
+    assert "\x07" not in detail
+    assert "\r" not in detail
+    assert "wiped" in detail and "your screen" in detail
+
+
+def test_check_json_suppresses_the_table(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.4. Stdout is one JSON document and nothing else."""
+    report = _check_report(("ok", "channel_present"))
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    assert "Migration Check" not in result.output
+    assert "ok ·" not in result.output
+    json.loads(result.output)
+
+
+def test_the_rich_path_is_unchanged_by_the_stripping(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.5. Stripping at the wrong layer would alter shipped behaviour.
+
+    Applying it in CheckResult or in report.add would change what the Rich table
+    prints, which is output v2.16.0 already produces. Only this test catches
+    that, because every other assertion here reads the JSON path.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="fail",
+        kind="check_error",
+        detail="server said: \x1b[2J oops",
+    )
+    result = _invoke_check(runner, tmp_path, report)
+
+    assert result.exit_code == 1
+    assert "Migration Check" in result.output
+    # The dataclass itself must still hold the raw text: the stripping belongs
+    # to the JSON path alone.
+    assert report.results[0].detail == "server said: \x1b[2J oops"
+
+
+def test_check_json_does_not_change_the_exit_code(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.6. The v2.16.0 contract: non-zero only when something failed."""
+    failing = _check_report(("fail", "channel_missing"))
+    passing = _check_report(("warn", "channel_renamed"), ("unverifiable", "tail_not_recorded"))
+
+    assert _invoke_check(runner, tmp_path, failing, "--json").exit_code == 1
+    assert _invoke_check(runner, tmp_path, failing).exit_code == 1
+    assert _invoke_check(runner, tmp_path, passing, "--json").exit_code == 0
+    assert _invoke_check(runner, tmp_path, passing).exit_code == 0
+
+
+def test_check_json_still_registers_the_token_and_the_semaphore(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-4.7. Asserts the CALLS, never an absence.
+
+    A test asserting a token is missing from some sample string passes against a
+    token that simply did not appear there, and Ferry shipped unmasked Stoat
+    tokens to its log file for two releases behind exactly that shape of check.
+    Both calls must still happen before the request on the --json path.
+    """
+    order: list[str] = []
+    a, b, c, d = _patched(order, _check_report(("ok", "channel_present")))
+    with a, b, c, d:
+        runner.invoke(
+            main,
+            [
+                "check",
+                str(tmp_path),
+                "--stoat-url",
+                "https://api.test",
+                "--token",
+                "t",
+                "--json",
+            ],
+        )
+
+    assert "register_secret" in order
+    assert "semaphore" in order
+    assert order.index("register_secret") < order.index("request")
+    assert order.index("semaphore") < order.index("request")
+
+
+def test_check_json_does_not_wrap_a_long_detail(runner: CliRunner, tmp_path: Path) -> None:
+    """The test that actually enforces issue #145, and the first seven did not.
+
+    Every other --json test here uses a short payload, and a short payload fits
+    inside 80 columns, so all seven passed against console.print as readily as
+    against click.echo. The rule was documented in a comment and guarded by
+    nothing.
+
+    Measured: a 275-character JSON line printed through the module-level Console
+    comes back with five newlines and fails to parse, because Console has
+    soft_wrap=False and falls back to 80 columns off a terminal. The wrap lands
+    inside a string value.
+
+    So the detail here is deliberately long enough to force that. If this test
+    is ever shortened it stops testing anything.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="fail",
+        kind="check_error",
+        detail="could not read this channel's messages: " + ("verylongword" * 20),
+    )
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    assert len(result.output) > 200, "payload too short to force a wrap; this test is inert"
+    parsed = json.loads(result.output)
+    assert parsed["results"][0]["detail"].endswith("verylongword")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2388,3 +2388,62 @@ def test_check_json_does_not_wrap_a_long_detail(runner: CliRunner, tmp_path: Pat
     assert len(result.output) > 200, "payload too short to force a wrap; this test is inert"
     parsed = json.loads(result.output)
     assert parsed["results"][0]["detail"].endswith("verylongword")
+
+
+def test_check_json_strips_c1_controls_and_the_synthetic_id(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Two gaps the first version of the stripping had, both measured.
+
+    "It parses" was never the right test. json.dumps escapes a control character
+    in the JSON TEXT, so the document always parses and then hands the raw byte
+    back to whoever parses it. The threat is downstream of parsing, which is why
+    these assertions read the PARSED values.
+
+    C1: \\x9b is CSI, the single-byte equivalent of ESC[. Its ordinal is 155, so
+    an `ord(ch) >= 32` filter passes it straight through. The first version of
+    _strip_control used exactly that filter.
+
+    discord_id: not always a Discord snowflake. The forum index writer stores a
+    synthetic `forum-index-forum-{parent_channel_name}`, and that name comes from
+    the export, so a forum named with an escape byte puts it into this key. It
+    was not stripped at all.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:forum-index-forum-my\x1b[2Jforum",
+        status="ok",
+        kind="channel_present",
+        detail="fine\x9b2J here",
+        discord_id="forum-index-forum-my\x1b[2Jforum",
+        stoat_id="01JSTOAT\x9bCH000000000AAA",
+    )
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    row = json.loads(result.output)["results"][0]
+    for field in ("name", "detail", "discord_id", "stoat_id"):
+        assert "\x1b" not in row[field], f"{field} still carries an ESC after parsing"
+        assert "\x9b" not in row[field], f"{field} still carries a C1 CSI after parsing"
+    # The surrounding text survives, so this is stripping and not blanking.
+    assert row["discord_id"] == "forum-index-forum-my[2Jforum"
+    assert row["detail"] == "fine2J here"
+
+
+def test_check_json_keeps_a_tab_and_ordinary_unicode(runner: CliRunner, tmp_path: Path) -> None:
+    """The strip must not be a blunt ASCII filter.
+
+    A tab is deliberately kept, and U+00A0 is category Zs rather than Cc, so a
+    non-breaking space and any ordinary non-ASCII text must survive. A filter
+    written as `ch.isprintable()` would drop both.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:d-100",
+        status="ok",
+        kind="channel_present",
+        detail="col\tumn   café 日本語",
+    )
+    result = _invoke_check(runner, tmp_path, report, "--json")
+
+    detail = json.loads(result.output)["results"][0]["detail"]
+    assert detail == "col\tumn   café 日本語"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2136,3 +2136,58 @@ def test_build_reports_an_unrecognised_create_response(runner: CliRunner, tmp_pa
     # module-level Rich Console wraps at 80 columns off a TTY and would split a longer one.
     assert "'id'" in result.output
     assert "srv1" not in result.output
+
+
+def test_check_summary_does_not_offer_merge_on_a_flatten_migration(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """#267's problem sentence, and it lives here rather than in verify.py.
+
+    The summary told every user an unverifiable result is "expected when
+    --thread-strategy=merge was used, after a duplicate send, or for a channel
+    this token cannot read". On a flatten migration the first of those three is
+    false, and Ferry now records which strategy actually ran.
+
+    verify.py's per-result detail was fixed in #293. That is what --json
+    serialises and what the repair tool reads in-process. This is what a human
+    reads, and fixing one without the other leaves half the audience wrong.
+    """
+    order: list[str] = []
+    state = MigrationState(stoat_server_id="srv1")
+    state.thread_strategy = "flatten"
+    report = _check_report(("unverifiable", "tail_not_recorded"))
+
+    a, _b, _c, d = _patched(order, report)
+    with a, _b, patch("discord_ferry.cli.load_state", return_value=state), d:
+        result = runner.invoke(
+            main, ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"]
+        )
+
+    assert result.exit_code == 0
+    assert "could not be verified" in result.output
+    assert "merge" not in result.output
+
+
+def test_check_summary_keeps_the_old_wording_when_no_strategy_was_recorded(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A state.json written before 2.17.0 records no strategy.
+
+    It must keep the v2.16.0 sentence listing the possibilities, because that is
+    genuinely all Ferry knows about that migration. Naming an unknown strategy
+    would read as a defect rather than as an old file.
+    """
+    order: list[str] = []
+    state = MigrationState(stoat_server_id="srv1")
+    assert state.thread_strategy == ""
+    report = _check_report(("unverifiable", "tail_not_recorded"))
+
+    a, _b, _c, d = _patched(order, report)
+    with a, _b, patch("discord_ferry.cli.load_state", return_value=state), d:
+        result = runner.invoke(
+            main, ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"]
+        )
+
+    assert result.exit_code == 0
+    assert "merge" in result.output
+    assert "duplicate send" in result.output

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2253,3 +2253,32 @@ async def test_a_resume_records_the_resuming_runs_strategy(tmp_path: Path) -> No
     config = _make_config(tmp_path, resume=True, thread_strategy="merge")
     state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
     assert state.thread_strategy == "merge"
+
+
+async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
+    """SC-5.7. Omitting these two carries degrades rename detection to silence.
+
+    A carried channel SKIPS creation entirely: run_channels snapshots
+    pre_existing_channel_ids before its create loop and reuses the mapped id
+    without calling the API, and roles do the same through
+    pre_existing_role_ids. So nothing re-records a name on an incremental run.
+
+    Without the carry, every incremental run ends with an empty name map, and
+    ferry check then reports ok for a renamed channel. No existing test sees it,
+    which is why this one drives the ids and the names as distinct literals.
+    """
+    from discord_ferry.state import save_state
+
+    prior = MigrationState(
+        channel_map={"d-100": "01JSTOATCH00000000000AAA"},
+        created_channel_names={"d-100": "general"},
+        role_map={"d-role-1": "01JSTOATRL0000000000AAA"},
+        created_role_names={"d-role-1": "mods"},
+    )
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+
+    assert state.created_channel_names == {"d-100": "general"}
+    assert state.created_role_names == {"d-role-1": "mods"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2418,3 +2418,23 @@ def test_completeness_is_deliberately_not_applied_to_an_incremental_state() -> N
         "tests/test_structure.py. Applying it to an incremental state reports a "
         "false alarm on a legitimate pre-2.17.0 upgrade. See SC-5.8."
     )
+
+
+async def test_an_invalid_thread_strategy_is_recorded_as_the_effective_one(
+    tmp_path: Path,
+) -> None:
+    """The recorded strategy must describe what RAN, not what was asked for.
+
+    run_messages falls back to "flatten" for any value outside
+    _THREAD_STRATEGIES. Recording config.thread_strategy raw would let state.json
+    name a strategy the run never used, and ferry check would then report that as
+    the cause of an unverifiable result, which is the exact failure this field
+    exists to prevent.
+
+    The CLI cannot reach this, because click.Choice validates there. The GUI
+    reads its value back from a storage file it does not re-validate, and a
+    programmatic FerryConfig is unconstrained. Found by the chunk 1 review.
+    """
+    config = _make_config(tmp_path, thread_strategy="not-a-strategy")
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "flatten"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2282,3 +2282,139 @@ async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
 
     assert state.created_channel_names == {"d-100": "general"}
     assert state.created_role_names == {"d-role-1": "mods"}
+
+
+# ---------------------------------------------------------------------------
+# Predicate 2: nothing dropped by the carry-over (#288, SC-5.6 to SC-5.11)
+# ---------------------------------------------------------------------------
+
+
+def assert_nothing_dropped(prior: MigrationState, carried: MigrationState) -> None:
+    """Every name the PRIOR state held is still held, and still equal.
+
+    NOT a completeness check, and the difference was measured on a prototype
+    rather than reasoned about. A completeness predicate over the carried state
+    alone cannot tell a dropped carry-over from a legitimate pre-2.17.0 upgrade:
+    both leave channel_map populated and created_channel_names empty, which is
+    byte-identical. Only taking the prior as an input separates them. Applying
+    completeness here would report incomplete on a correct run, which is a false
+    alarm against every existing user's first upgrade.
+
+    The `key in carried.channel_map` filter is UNREACHABLE today, because the
+    carry-over copies channel_map wholesale, so every prior key is present. It is
+    defensive against a future carry-over that selects rather than copies. Do not
+    delete it as a dead branch: a surviving mutant is not always a delete
+    instruction. test_the_carried_map_filter_is_unreachable_today pins it.
+    """
+    for key, name in prior.created_channel_names.items():
+        if key in carried.channel_map:
+            assert carried.created_channel_names.get(key) == name, (
+                f"channel {key}: prior recorded {name!r}, carried has "
+                f"{carried.created_channel_names.get(key)!r}"
+            )
+    for key, name in prior.created_role_names.items():
+        if key in carried.role_map:
+            assert carried.created_role_names.get(key) == name, (
+                f"role {key}: prior recorded {name!r}, carried has "
+                f"{carried.created_role_names.get(key)!r}"
+            )
+
+
+async def _incremental_from(tmp_path: Path, prior: MigrationState) -> MigrationState:
+    """Save *prior*, then run an --incremental migration against it."""
+    from discord_ferry.state import save_state
+
+    save_state(prior, tmp_path)
+    config = _make_config(tmp_path, incremental=True)
+    return await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+
+
+async def test_a_2_17_prior_is_carried_intact(tmp_path: Path) -> None:
+    """SC-5.6. The ordinary case: names recorded, names carried."""
+    prior = MigrationState(
+        channel_map={"d-100": "01JSTOATCH00000000000AAA"},
+        created_channel_names={"d-100": "general"},
+    )
+    state = await _incremental_from(tmp_path, prior)
+    assert_nothing_dropped(prior, state)
+    assert state.created_channel_names == {"d-100": "general"}
+
+
+async def test_an_incremental_from_a_pre_2_17_state_is_not_flagged(tmp_path: Path) -> None:
+    """SC-5.8. THE mandatory discriminator, and the reason there are two predicates.
+
+    A 2.16.1 state has channel_map entries and no names, because the fields did
+    not exist. That is byte-identical to a carry-over that DROPPED the names, and
+    a completeness predicate cannot separate them: it reports incomplete here,
+    which is a false alarm on a completely correct run.
+
+    Measured on the prototype at docs/plans/designs, which is gitignored: the
+    completeness predicate is wrong on 2 of 8 cases and this is one of them.
+    Applying it to an incremental state ships a spurious failure against every
+    existing user's first upgrade, while the suite looks thorough.
+
+    DO NOT DELETE THIS TEST, and do not "simplify" the two predicates into one.
+    """
+    prior = MigrationState(channel_map={"d-100": "01JSTOATCH00000000000AAA"})
+    state = await _incremental_from(tmp_path, prior)
+
+    assert_nothing_dropped(prior, state)  # passes: no names recorded, no obligation
+    assert state.channel_map == {"d-100": "01JSTOATCH00000000000AAA"}
+    assert state.created_channel_names == {}
+
+
+async def test_a_mixed_carried_and_nameless_prior_is_not_flagged(tmp_path: Path) -> None:
+    """SC-5.9. Half a pre-2.17.0 prior, half recorded under 2.17.0.
+
+    The carried nameless entry imposes no obligation and the recorded one is
+    honoured. The completeness predicate is wrong here too, which is the second
+    of its two measured failures.
+    """
+    prior = MigrationState(
+        channel_map={
+            "d-100": "01JSTOATCH00000000000AAA",  # from the old run, no name
+            "d-101": "01JSTOATCH00000000000BBB",  # recorded under 2.17.0
+        },
+        created_channel_names={"d-101": "announcements"},
+    )
+    state = await _incremental_from(tmp_path, prior)
+
+    assert_nothing_dropped(prior, state)
+    assert state.created_channel_names == {"d-101": "announcements"}
+
+
+def test_the_carried_map_filter_is_unreachable_today() -> None:
+    """SC-5.10. Diagnosis, not deletion.
+
+    The `key in carried.channel_map` filter has no input that reaches it today,
+    because the carry-over copies channel_map wholesale, so every prior key
+    survives. This drives the filter directly to prove it functions, and records
+    that nothing in production reaches it, so a later reader sees a diagnosed
+    defensive branch rather than an uncovered one to delete.
+    """
+    prior = MigrationState(
+        channel_map={"d-100": "01JSTOATCH00000000000AAA"},
+        created_channel_names={"d-100": "general"},
+    )
+    carried = MigrationState()  # a carry-over that brought nothing forward
+    assert_nothing_dropped(prior, carried)  # the filter excludes the absent key
+
+
+def test_completeness_is_deliberately_not_applied_to_an_incremental_state() -> None:
+    """SC-5.11. The omission is a decision, recorded so it is not "fixed".
+
+    assert_names_complete lives in tests/test_structure.py and is applied after a
+    FRESH structure run only. It must not be imported here. Applying it to an
+    incremental state was measured to raise a false alarm on a legitimate
+    pre-2.17.0 upgrade, which is what SC-5.8 above pins.
+
+    This asserts the separation itself: the completeness helper is not reachable
+    from this module.
+    """
+    import tests.test_engine as this_module
+
+    assert not hasattr(this_module, "assert_names_complete"), (
+        "assert_names_complete belongs to the fresh-run guard in "
+        "tests/test_structure.py. Applying it to an incremental state reports a "
+        "false alarm on a legitimate pre-2.17.0 upgrade. See SC-5.8."
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2168,3 +2168,88 @@ async def test_index_rebuild_duplicate_writes_no_state_entry(tmp_path: Path) -> 
         "Reporting a failure that did not happen is the same defect as the FailedMessage "
         "on the message path, in a different place"
     )
+
+
+# ---------------------------------------------------------------------------
+# thread_strategy is recorded on every state path (#286, SC-1.3 to SC-1.7)
+# ---------------------------------------------------------------------------
+#
+# run_migration resolves state four ways and they all rejoin before the proxy
+# preflight loop. The assignment sits at that rejoin point rather than in any
+# branch, so a fifth path added later inherits it. Each path gets its own test
+# because the natural implementation, setting it beside `state = MigrationState()`,
+# covers the fresh path and passes every test of it.
+
+
+async def test_a_fresh_run_records_the_thread_strategy(tmp_path: Path) -> None:
+    """SC-1.3. Neither --resume nor --incremental."""
+    config = _make_config(tmp_path, thread_strategy="merge")
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "merge"
+
+
+async def test_a_resume_records_the_thread_strategy(tmp_path: Path) -> None:
+    """SC-1.4. The mutant this kills is the natural implementation.
+
+    Placing the assignment beside `state = MigrationState()` covers the fresh
+    path, and every test of that path passes. Only a resume sees the omission,
+    because --resume calls load_state and never constructs. A resumed migration
+    would then keep the vague unverifiable wording forever.
+    """
+    from discord_ferry.state import save_state
+
+    prior = MigrationState(current_phase="channels", started_at="2024-01-01T00:00:00+00:00")
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, resume=True, thread_strategy="archive")
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "archive"
+
+
+async def test_an_incremental_with_a_prior_records_the_thread_strategy(tmp_path: Path) -> None:
+    """SC-1.5. The carry-over branch constructs, then copies fields forward.
+
+    The strategy is NOT among them: it describes this run, not the prior one.
+    """
+    from discord_ferry.state import save_state
+
+    prior = MigrationState(
+        channel_map={"d-100": "01JSTOATCH00000000000AAA"},
+        thread_strategy="flatten",
+    )
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, incremental=True, thread_strategy="merge")
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "merge"
+
+
+async def test_an_incremental_with_no_prior_records_the_thread_strategy(tmp_path: Path) -> None:
+    """SC-1.6. The fallback branch, which constructs fresh and warns."""
+    config = _make_config(tmp_path, incremental=True, thread_strategy="archive")
+    events: list[MigrationEvent] = []
+    state = await run_migration(config, events.append, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "archive"
+    assert any("no prior state" in e.message for e in events)
+
+
+async def test_a_resume_records_the_resuming_runs_strategy(tmp_path: Path) -> None:
+    """SC-1.7. The field describes the MOST RECENT run, deliberately.
+
+    A resume under a different --thread-strategy than the original therefore
+    describes the resuming run while most of the content was migrated under the
+    first. This spec makes that mismatch legible for the first time; it does not
+    create it. verify.py's wording must not overclaim on the strength of it.
+    """
+    from discord_ferry.state import save_state
+
+    prior = MigrationState(
+        current_phase="channels",
+        started_at="2024-01-01T00:00:00+00:00",
+        thread_strategy="flatten",
+    )
+    save_state(prior, tmp_path)
+
+    config = _make_config(tmp_path, resume=True, thread_strategy="merge")
+    state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.thread_strategy == "merge"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -844,6 +844,28 @@ _KNOWN_STATE_FIELDS = frozenset(
         "channel_map",
         "category_map",
         "category_names",
+        # All three below are STRUCTURAL, not free text, and the reason differs
+        # per field rather than being one blanket claim.
+        #
+        # created_channel_names / created_role_names hold attacker-influenced
+        # text, since a Discord user chooses a channel name. They are still
+        # structural, because what _TEXT_MEMBERS guards is a FERRY SECRET
+        # reaching disk through an exception repr, and a name never travels that
+        # path. Classifying them as free text would be actively harmful:
+        # SecureTokenStore.sanitize does unbounded substring replacement, so a
+        # recorded name containing a registered secret as a substring would be
+        # rewritten, and ferry check would then report a rename nobody made.
+        # See test_a_recorded_name_containing_a_secret_is_not_rewritten.
+        #
+        # thread_strategy is validated against a closed set of three values at
+        # the CLI boundary by click.Choice. That does NOT hold for the GUI, which
+        # builds its config from a storage file it does not re-validate, which is
+        # why messages.py falls back to "flatten" when the value is not in
+        # _THREAD_STRATEGIES. The widest value it can hold is a short string from
+        # a local user's own storage file, and it never carries a Ferry secret.
+        "created_channel_names",
+        "created_role_names",
+        "thread_strategy",
         "channel_categories",
         "message_map",
         "emoji_map",
@@ -1076,3 +1098,38 @@ def test_repeated_checkpoints_overwrite_on_windows(
         save_state(MigrationState(stoat_server_id=f"run-{n}"), tmp_path)
 
     assert load_state(tmp_path).stoat_server_id == "run-4"
+
+
+def test_contract_fields_roundtrip(tmp_path: Path) -> None:
+    """thread_strategy and the two name maps survive save/load.
+
+    The name maps record what Ferry SENT to Stoat, never the Discord name, so a
+    fixture here uses a value that has already been through truncation.
+    """
+    state = MigrationState(
+        thread_strategy="merge",
+        created_channel_names={"d-100": "general"},
+        created_role_names={"d-role-1": "mods"},
+    )
+    save_state(state, tmp_path)
+
+    loaded = load_state(tmp_path)
+    assert loaded.thread_strategy == "merge"
+    assert loaded.created_channel_names == {"d-100": "general"}
+    assert loaded.created_role_names == {"d-role-1": "mods"}
+
+
+def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
+    """A state.json written before 2.17.0 loads with safe defaults.
+
+    The empty string is NOT the same claim as "flatten": it means no strategy was
+    recorded, which is what every migration predating the field will report. A
+    default of "flatten" would assert a strategy that was never chosen.
+    """
+    minimal = {"stoat_server_id": "s", "current_phase": "report"}
+    (tmp_path / "state.json").write_text(json.dumps(minimal), encoding="utf-8")
+
+    loaded = load_state(tmp_path)
+    assert loaded.thread_strategy == ""
+    assert loaded.created_channel_names == {}
+    assert loaded.created_role_names == {}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -851,11 +851,15 @@ _KNOWN_STATE_FIELDS = frozenset(
         # text, since a Discord user chooses a channel name. They are still
         # structural, because what _TEXT_MEMBERS guards is a FERRY SECRET
         # reaching disk through an exception repr, and a name never travels that
-        # path. Classifying them as free text would be actively harmful:
-        # SecureTokenStore.sanitize does unbounded substring replacement, so a
-        # recorded name containing a registered secret as a substring would be
-        # rewritten, and ferry check would then report a rename nobody made.
-        # See test_a_recorded_name_containing_a_secret_is_not_rewritten.
+        # path.
+        #
+        # Listing them here would in fact be INERT rather than harmful, measured
+        # by mutation rather than assumed: scrub_document descends one level into
+        # LISTS of dicts, and these are dict[str, str], so _mask_entries returns
+        # them untouched. Structural is still the correct classification, on the
+        # reason above. See
+        # test_a_recorded_name_containing_a_secret_is_not_rewritten for what does
+        # threaten them, which is a future widening of scrub_document itself.
         #
         # thread_strategy is validated against a closed set of three values at
         # the CLI boundary by click.Choice. That does NOT hold for the GUI, which
@@ -1133,3 +1137,42 @@ def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
     assert loaded.thread_strategy == ""
     assert loaded.created_channel_names == {}
     assert loaded.created_role_names == {}
+
+
+def test_a_recorded_name_containing_a_secret_is_not_rewritten() -> None:
+    """SC-5.4. A recorded name reaches disk byte-identical, so the rename
+    comparison in verify.py compares like with like.
+
+    WHAT THIS DOES NOT GUARD, corrected after running the mutation rather than
+    reasoning about it. Adding created_channel_names to _TEXT_MEMBERS does
+    NOTHING: scrub_document's _mask_entries returns early on anything that is not
+    a list, and this field is a dict[str, str]. The mutant survives. The spec and
+    design for this change both claimed otherwise, through two review rounds.
+
+    WHAT IT DOES GUARD is the widening ADR-014 actually warns against. If
+    scrub_document ever descends into dicts, SecureTokenStore.sanitize's
+    unbounded substring replacement rewrites any recorded name containing a
+    registered secret, verify.py then compares a scrubbed string against a live
+    one, and ferry check reports a rename nobody made. That is the same failure
+    shape ADR-014 measured for channel_message_offsets, where a rewritten value
+    is a silently wrong resume position.
+
+    THE POSITIVE CONTROL IS NOT OPTIONAL. The first assertion says a value is
+    unchanged, which passes just as well against a registry that never received
+    the secret. The second fails in that case, so the two together distinguish
+    "correctly left alone" from "nothing was scrubbed at all".
+    """
+    from discord_ferry.core.security import scrub_document
+    from discord_ferry.state import _state_to_dict
+
+    register_secret("proxy_password", "swordfish")
+    state = MigrationState(created_channel_names={"d-100": "team-swordfish-chat"})
+    state.warnings.append({"type": "x", "phase": "structure", "message": "proxy: swordfish"})
+
+    doc = scrub_document(_state_to_dict(state))
+
+    # The subject: a structural field is passed through untouched.
+    assert doc["created_channel_names"]["d-100"] == "team-swordfish-chat"
+    # The positive control: the same call DID scrub a classified field, so the
+    # assertion above cannot be passing because the registry was empty.
+    assert "swordfish" not in doc["warnings"][0]["message"]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3321,3 +3321,142 @@ async def test_forum_index_duplicate_skips_the_pin(tmp_path: Path) -> None:
     assert pins == [], "a pin was attempted against a message id that was never returned"
     # The channel wiring does not depend on the message id and must still have run.
     assert state.channel_map["forum-index-forum-my-forum"] == "stoat-idx1"
+
+
+# ---------------------------------------------------------------------------
+# created_channel_names: the name Ferry SENT, from the create response (#289)
+# ---------------------------------------------------------------------------
+#
+# Fixture rule for every test below: the Discord id, the Stoat id and the name
+# are three distinct literals. Seeding any two from one value is what lets a
+# rename test pass against a broken implementation.
+
+
+async def test_run_channels_records_the_created_name(tmp_path: Path) -> None:
+    """SC-2.2. The ordinary case."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [_make_export(channel_id="d-100", channel_name="general", category_id="")]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": "general"},
+        )
+        await run_channels(config, state, exports, [].append)
+
+    assert state.channel_map == {"d-100": "01JSTOATCH00000000000AAA"}
+    assert state.created_channel_names == {"d-100": "general"}
+
+
+async def test_the_recorded_name_comes_from_the_response(tmp_path: Path) -> None:
+    """SC-2.3. In every OTHER test the sent name and the returned name are equal.
+
+    Only a response whose name differs from what Ferry sent can distinguish
+    recording result["name"] from recording the local unique_name. Without this
+    test both implementations pass the whole suite.
+
+    Recording the response is what makes any server-side normalisation invisible
+    to the rename check rather than a false positive on every affected channel.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [_make_export(channel_id="d-100", channel_name="general", category_id="")]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": "general-normalised"},
+        )
+        await run_channels(config, state, exports, [].append)
+
+    assert state.created_channel_names == {"d-100": "general-normalised"}
+
+
+async def test_a_name_over_32_characters_records_the_truncated_value(tmp_path: Path) -> None:
+    """SC-2.4. The truncation trap, and the reason this field is not the Discord name.
+
+    make_unique_channel_name cuts to 32 characters. Recording ch.name would make
+    ferry check report channel_renamed for every long channel on a server nobody
+    edited, and it would only show on real data.
+    """
+    long_name = "this-channel-name-is-definitely-longer-than-thirty-two"
+    truncated = long_name[:32]
+    assert len(truncated) == 32
+    assert truncated != long_name
+
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [_make_export(channel_id="d-100", channel_name=long_name, category_id="")]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": truncated},
+        )
+        await run_channels(config, state, exports, [].append)
+
+    assert state.created_channel_names == {"d-100": truncated}
+
+
+async def test_a_collision_pair_records_distinct_suffixed_names(tmp_path: Path) -> None:
+    """SC-2.5. Two channels truncating to the same 32 characters.
+
+    make_unique_channel_name appends "-1" to the second. Recording ch.name would
+    record the same value twice and then report a rename for the suffixed one.
+    """
+    base = "a-very-long-channel-name-that-collides-here"
+    first = base[:32]
+    second = f"{base[: 32 - 2]}-1"
+
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [
+        _make_export(channel_id="d-100", channel_name=base, category_id=""),
+        _make_export(channel_id="d-101", channel_name=base, category_id=""),
+    ]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": first},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000BBB", "name": second},
+        )
+        await run_channels(config, state, exports, [].append)
+
+    assert state.created_channel_names == {"d-100": first, "d-101": second}
+    assert first != second
+
+
+async def test_a_voice_retry_records_the_retrys_response(tmp_path: Path) -> None:
+    """SC-2.6. The retry reassigns the response INSIDE an except block.
+
+    A voice channel that fails is retried as text (#194). The id-map write sits
+    OUTSIDE the try, so `result` there is whichever attempt succeeded, and the
+    name write belongs beside it.
+
+    A name write placed next to the first response read never executes on this
+    path, because the exception jumps past it, so that implementation records
+    nothing at all for every voice channel. A test driving only the success path
+    cannot see that, which is why the two responses carry different name
+    literals here.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [
+        _make_export(channel_id="d-100", channel_name="voice-room", category_id="", channel_type=2)
+    ]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/channels", status=500, body="voice unsupported")
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": "voice-room-as-text"},
+        )
+        await run_channels(config, state, exports, [].append)
+
+    assert state.channel_map == {"d-100": "01JSTOATCH00000000000AAA"}
+    assert state.created_channel_names == {"d-100": "voice-room-as-text"}

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3568,3 +3568,133 @@ async def test_the_recorded_role_name_comes_from_the_response(tmp_path: Path) ->
         await run_roles(config, state, exports, [].append)
 
     assert state.created_role_names == {"d-role-1": "moderators-normalised"}
+
+
+# ---------------------------------------------------------------------------
+# Predicate 1: completeness, after a FRESH structure run (#292)
+# ---------------------------------------------------------------------------
+
+
+def assert_names_complete(state: MigrationState) -> None:
+    """Every non-sentinel id-map entry carries a recorded name.
+
+    THE SENTINEL TEST READS THE MAP'S VALUE, not its key. A dry run writes
+    "dry-ch-{id}" and "dry-role-{id}" as the VALUE while the key stays an
+    ordinary Discord id, so a predicate filtering on the key sees a real channel
+    and fails every dry run.
+
+    Applied after a FRESH structure run ONLY. It is deliberately not applied to
+    an incremental state, and that omission is a decision rather than an
+    oversight: a runnable prototype measured it raising a false alarm on a
+    legitimate pre-2.17.0 upgrade, where channel_map is carried and no name
+    exists to carry. tests/test_engine.py::assert_nothing_dropped is the guard
+    for that path, and the two must not be merged. See SC-5.8.
+    """
+    for key, value in state.channel_map.items():
+        if not value.startswith("dry-ch-"):
+            assert key in state.created_channel_names, (
+                f"channel {key} has an id ({value}) but no recorded name. "
+                "A create site wrote channel_map without writing created_channel_names."
+            )
+    for key, value in state.role_map.items():
+        if not value.startswith("dry-role-"):
+            assert key in state.created_role_names, (
+                f"role {key} has an id ({value}) but no recorded name. "
+                "A create site wrote role_map without writing created_role_names."
+            )
+
+
+async def test_a_fresh_structure_run_records_a_name_for_every_id(tmp_path: Path) -> None:
+    """SC-2.10. Channels, a forum index and a role, all in one run.
+
+    This is the guard that catches a create site added later by someone who
+    never read the design. Removing any one of the three write sites fails it.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="d-role-1", name="Moderators")
+    exports = [
+        _make_export(
+            channel_id="d-100",
+            channel_name="first-post",
+            channel_type=15,
+            is_thread=True,
+            parent_channel_name="my-forum",
+            category_id="cat1",
+            category="General",
+            message_count=42,
+            messages=[_make_message("m1", roles=[role])],
+        ),
+        _make_export(
+            channel_id="d-101",
+            channel_name="second-post",
+            channel_type=15,
+            is_thread=True,
+            parent_channel_name="my-forum",
+            category_id="cat1",
+            category="General",
+            message_count=7,
+        ),
+    ]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "01JSTOATRL0000000000AAA", "name": "Moderators"},
+        )
+        await run_roles(config, state, exports, [].append)
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": "my-forum-first-post"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000BBB", "name": "my-forum-second-post"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATIX00000000000AAA", "name": "my-forum-index"},
+        )
+        m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages", payload={"_id": "m1"})
+        m.put(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
+        await run_channels(config, state, exports, [].append)
+
+    # Three channel ids and one role id, every one of them named.
+    assert len(state.channel_map) == 3
+    assert len(state.role_map) == 1
+    assert_names_complete(state)
+
+
+async def test_a_dry_run_records_no_names_and_still_passes_the_guard(tmp_path: Path) -> None:
+    """SC-2.9 and SC-2.12 together.
+
+    A dry run makes no request, so there is no response to record a name from,
+    and both name maps stay empty. The guard must pass anyway.
+
+    This is the test that kills a predicate filtering on the map's KEY: the keys
+    here are ordinary Discord ids with no prefix, so a key-based sentinel test
+    treats them as real channels and fails.
+    """
+    config = _make_config(tmp_path, dry_run=True)
+    state = MigrationState(stoat_server_id="dry-server-111")
+    role = DCERole(id="d-role-1", name="Moderators")
+    exports = [
+        _make_export(
+            channel_id="d-100",
+            channel_name="general",
+            category_id="",
+            messages=[_make_message("m1", roles=[role])],
+        )
+    ]
+
+    await run_roles(config, state, exports, [].append)
+    await run_channels(config, state, exports, [].append)
+
+    assert state.channel_map == {"d-100": "dry-ch-d-100"}
+    assert state.role_map == {"d-role-1": "dry-role-d-role-1"}
+    assert state.created_channel_names == {}
+    assert state.created_role_names == {}
+    assert_names_complete(state)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3460,3 +3460,63 @@ async def test_a_voice_retry_records_the_retrys_response(tmp_path: Path) -> None
 
     assert state.channel_map == {"d-100": "01JSTOATCH00000000000AAA"}
     assert state.created_channel_names == {"d-100": "voice-room-as-text"}
+
+
+async def test_the_forum_index_channel_records_its_name(tmp_path: Path) -> None:
+    """SC-2.7. channel_map keys are not all Discord snowflakes.
+
+    The forum index writer stores a synthetic `forum-index-{key}`, and its name
+    goes through make_unique_channel_name like any other, so it truncates
+    identically. Recording only at the main create site leaves every forum index
+    channel nameless, and ferry check then reports ok for a renamed one.
+
+    The name is keyed exactly as the id, so the check's lookup needs no special
+    case for the synthetic key.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [
+        _make_export(
+            channel_id="d-100",
+            channel_name="first-post",
+            channel_type=15,
+            is_thread=True,
+            parent_channel_name="my-forum",
+            category_id="cat1",
+            category="General",
+            message_count=42,
+        ),
+        _make_export(
+            channel_id="d-101",
+            channel_name="second-post",
+            channel_type=15,
+            is_thread=True,
+            parent_channel_name="my-forum",
+            category_id="cat1",
+            category="General",
+            message_count=7,
+        ),
+    ]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000AAA", "name": "my-forum-first-post"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATCH00000000000BBB", "name": "my-forum-second-post"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "01JSTOATIX00000000000AAA", "name": "my-forum-index"},
+        )
+        m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages", payload={"_id": "m1"})
+        m.put(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
+        m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
+        await run_channels(config, state, exports, [].append)
+
+    index_key = "forum-index-forum-my-forum"
+    assert state.channel_map[index_key] == "01JSTOATIX00000000000AAA"
+    assert state.created_channel_names[index_key] == "my-forum-index"
+

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3520,3 +3520,51 @@ async def test_the_forum_index_channel_records_its_name(tmp_path: Path) -> None:
     assert state.channel_map[index_key] == "01JSTOATIX00000000000AAA"
     assert state.created_channel_names[index_key] == "my-forum-index"
 
+
+async def test_run_roles_records_the_created_name(tmp_path: Path) -> None:
+    """SC-2.8. The role name Ferry sent, taken from the create response.
+
+    Roles pass through truncate_name before the request, so recording role.name
+    would report a rename for every role whose Discord name exceeds the cap,
+    against a server nobody edited. The response is read for the same reason the
+    channel site reads it: it is what the server stored.
+
+    Note the id spelling. The role create response uses "id", while the channel
+    one uses "_id". Both are read here so a fixture cannot pass by accident.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="d-role-1", name="Moderators")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "01JSTOATRL0000000000AAA", "name": "Moderators"},
+        )
+        await run_roles(config, state, exports, [].append)
+
+    assert state.role_map == {"d-role-1": "01JSTOATRL0000000000AAA"}
+    assert state.created_role_names == {"d-role-1": "Moderators"}
+
+
+async def test_the_recorded_role_name_comes_from_the_response(tmp_path: Path) -> None:
+    """SC-2.8, the discriminator half.
+
+    In every other role test the sent and returned names are equal. Only a
+    response whose name differs can tell recording result["name"] from recording
+    truncate_name(role.name).
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="d-role-1", name="Moderators")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "01JSTOATRL0000000000AAA", "name": "moderators-normalised"},
+        )
+        await run_roles(config, state, exports, [].append)
+
+    assert state.created_role_names == {"d-role-1": "moderators-normalised"}

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1827,3 +1827,55 @@ def test_the_kind_vocabulary_lists_both_rename_kinds() -> None:
     doc = CheckResult.__doc__ or ""
     assert "channel_renamed" in doc
     assert "role_renamed" in doc
+
+
+def test_every_emitted_kind_is_documented_and_a_literal() -> None:
+    """The kind vocabulary is a contract, and `kind: str` does not enforce it.
+
+    Two failures this catches, and neither is hypothetical:
+
+    Adding a kind without documenting it. The CheckResult docstring is the only
+    durable record of this vocabulary, because docs/plans is gitignored, and the
+    batch-10 repair tool dispatches on it. An undocumented kind is a contract
+    change nobody can see.
+
+    Interpolating external text into a kind. Today every one is a string literal,
+    either at the call site or returned from _classify_tail. Nothing in the type
+    prevents `kind=f"channel_{something}"`, and the --json serialiser does not
+    strip `kind` precisely because it is internal. That argument holds only while
+    this test does.
+    """
+    import pathlib
+    import re
+
+    from discord_ferry.migrator.verify import CheckResult
+
+    source = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src"
+        / "discord_ferry"
+        / "migrator"
+        / "verify.py"
+    ).read_text(encoding="utf-8")
+
+    # Literals assigned at a call site, plus literals returned by the classifier
+    # as the middle element of its (status, kind, detail) tuple.
+    at_call_site = set(re.findall(r'kind="([a-z_]+)"', source))
+    classifier = set(re.findall(r'^\s+"([a-z_]+)",$', source, re.M))
+    documented = set(re.findall(r"``([a-z_]+)``", CheckResult.__doc__ or ""))
+
+    emitted = (at_call_site | classifier) & documented
+    assert len(emitted) >= 15, f"only found {len(emitted)} kinds; the regex has drifted"
+
+    undocumented = at_call_site - documented
+    assert undocumented == set(), (
+        f"kind(s) emitted but absent from the CheckResult docstring: {sorted(undocumented)}. "
+        "That docstring is the only durable record of this vocabulary."
+    )
+
+    # No kind is ever built by interpolation, which is what lets the --json
+    # serialiser leave `kind` unstripped.
+    assert re.search(r"kind=f['\"]", source) is None, (
+        "a kind is being built by interpolation. The --json serialiser does not "
+        "strip `kind`, on the argument that it is always an internal literal."
+    )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -428,7 +428,7 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
 
 
 # ---------------------------------------------------------------------------
-# structure: categories, and the only warn in the tool (task #254)
+# structure: categories, warn's first producer and still its clearest (task #254)
 # ---------------------------------------------------------------------------
 
 
@@ -443,12 +443,13 @@ def _state_with_category(stoat_cat_id: str, expected_title: str) -> MigrationSta
 async def test_a_renamed_category_warns_rather_than_failing(
     mock_aiohttp: aioresponses,
 ) -> None:
-    """The ONLY place warn is reachable in the whole tool.
+    """warn's first producer, and the precedent the other two follow.
 
-    category_names is the one expected name MigrationState records, so a
-    category title is the one name comparison possible. It warns rather than
-    fails because the entity exists and its content is intact: someone renamed
-    a heading, nothing was lost.
+    Until 2.17.0 this was warn's ONLY producer, because category_names was the
+    one expected name MigrationState recorded. channel_renamed and role_renamed
+    joined it once the two name maps were added, and all three warn for the same
+    reason: the entity exists and its content is intact, and only the label
+    moved. Someone renamed a heading, nothing was lost.
 
     Kills an implementation reporting a cosmetic rename as fail, which would
     exit non-zero on a migration that is entirely intact.
@@ -966,11 +967,17 @@ async def test_the_tail_check_never_emits_warn(
     high_water: int | None,
     count: int,
 ) -> None:
-    """SC-3.13. warn belongs to the category title check, and nowhere else.
+    """SC-3.13. warn belongs to the NAME comparisons, and never to the tail.
 
     Driven across every tail scenario. Kills reintroducing the inverted-severity
     warn that critique round 2 removed, and documents in executable form that a
-    warn appearing in a report can only have come from a renamed category.
+    warn in a report can only have come from a name comparison: a renamed
+    category, channel or role. The tail check has no expected name to compare,
+    so it has nothing to warn about.
+
+    The assertion below is unchanged by 2.17.0 adding two more warn producers,
+    because it filters to tail: results and both new producers live in the
+    structure pass. Only this docstring needed correcting.
     """
     _register_tail(mock_aiohttp, window)
     report = await run_check(
@@ -1794,3 +1801,55 @@ async def test_a_channel_object_with_no_name_is_not_reported_renamed(
     assert len(channel_results) == 2
     assert {r.kind for r in channel_results} == {"channel_present"}
     assert report.counts()["warn"] == 0
+
+
+def test_no_prose_still_claims_warn_has_a_single_home() -> None:
+    """SC-5.13. A claim asserted only in prose is the shape this project ships wrong.
+
+    warn had exactly one producer until 2.17.0, and that fact was written into
+    five places: two in verify.py's own module comment and three here. The design
+    counted three and a fresh-context review confirmed three, so two survived
+    both. This scans instead of counting.
+
+    It reads the files as text rather than importing them, because the claims
+    live in comments, which no runtime introspection can reach.
+    """
+    import pathlib
+
+    # Built from fragments so the literals never appear in this file, which
+    # would otherwise make the scan match its own search terms. That is not
+    # hypothetical: the first version of this test failed against itself.
+    stale = [
+        "ONLY place warn" + " is reachable",
+        "only warn in" + " the tool",
+        "can only have come" + " from a renamed category",
+        "single legitimate" + " home",
+        "the only such difference" + " is a category title",
+    ]
+    root = pathlib.Path(__file__).resolve().parent.parent
+    targets = [
+        root / "src" / "discord_ferry" / "migrator" / "verify.py",
+        root / "tests" / "test_verify.py",
+    ]
+    for path in targets:
+        assert path.exists(), f"{path} moved; update this test rather than deleting it"
+        text = path.read_text(encoding="utf-8")
+        for phrase in stale:
+            assert phrase not in text, (
+                f"{path.name} still claims warn has one home: {phrase!r}. "
+                "It has three producers: category_title_mismatch, channel_renamed "
+                "and role_renamed."
+            )
+
+
+def test_the_kind_vocabulary_lists_both_rename_kinds() -> None:
+    """SC-3.12. The docstring table is the contract another batch reads.
+
+    docs/plans is gitignored, so the CheckResult docstring is the only durable
+    record of the kind vocabulary the repair tool will dispatch on.
+    """
+    from discord_ferry.migrator.verify import CheckResult
+
+    doc = CheckResult.__doc__ or ""
+    assert "channel_renamed" in doc
+    assert "role_renamed" in doc

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1661,3 +1661,136 @@ async def test_the_rename_comparison_costs_no_extra_request(
         if "/servers/" in str(key[1]) and "/messages" not in str(key[1])
     ]
     assert len(structure_calls) == 2, f"expected 2 structure requests, got {structure_calls}"
+
+
+# ---------------------------------------------------------------------------
+# role_renamed, and the guard reading a name introduces (#296, SC-3.4, SC-3.9)
+# ---------------------------------------------------------------------------
+
+
+def _roles_payload(roles: dict[str, object]) -> dict[str, object]:
+    """A ServerWithChannels body carrying only roles."""
+    return {"server": {"_id": SRV, "channels": [], "roles": roles}, "channels": []}
+
+
+async def test_a_renamed_role_reports_warn(mock_aiohttp: aioresponses) -> None:
+    """SC-3.4. The role half of the rename check.
+
+    Roles have no permission-filtered sibling list, so presence is unambiguous
+    and the comparison sits inside the present branch on the same reasoning as
+    channels: a missing role takes the other branch and cannot be renamed too.
+    """
+    stoat_id = "01JSTOATRL0000000000AAA"
+    _register(mock_aiohttp, _roles_payload({stoat_id: {"name": "moderators"}}))
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-role-1": stoat_id}
+    state.created_role_names = {"d-role-1": "mods"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    result = next(r for r in report.results if r.name == "role:d-role-1")
+    assert result.status == "warn"
+    assert result.kind == "role_renamed"
+    assert result.expected == "mods"
+    assert result.found == "moderators"
+    assert report.has_failures is False
+
+
+async def test_a_matching_role_name_emits_no_rename(mock_aiohttp: aioresponses) -> None:
+    """SC-3.4, the negative half. A match keeps role_present and nothing else."""
+    stoat_id = "01JSTOATRL0000000000AAA"
+    _register(mock_aiohttp, _roles_payload({stoat_id: {"name": "mods"}}))
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-role-1": stoat_id}
+    state.created_role_names = {"d-role-1": "mods"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    results = [r for r in report.results if r.name == "role:d-role-1"]
+    assert len(results) == 1
+    assert results[0].kind == "role_present"
+
+
+async def test_a_missing_role_is_not_also_renamed(mock_aiohttp: aioresponses) -> None:
+    """SC-3.4. One cause, one result, for roles."""
+    _register(mock_aiohttp, _roles_payload({}))
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-role-1": "01JSTOATRL0000000000AAA"}
+    state.created_role_names = {"d-role-1": "mods"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    results = [r for r in report.results if r.name == "role:d-role-1"]
+    assert len(results) == 1
+    assert results[0].kind == "role_missing"
+
+
+async def test_a_malformed_role_value_degrades_rather_than_raising(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.9. Reading a name introduces a raise that does not exist today.
+
+    Before this change the roles map was consumed with `set(...)`, which takes
+    the KEYS and never touches a value, so a None or a bare string was harmless.
+    Calling .get("name") on one raises AttributeError, and `mypy --strict` cannot
+    catch it because the payload is typed dict[str, Any]. The channel and
+    category branches both hand-write the same isinstance guard for exactly this
+    reason.
+
+    A malformed value degrades to no-name-found and keeps role_present, so a
+    broken response cannot turn into an aborted check.
+    """
+    none_id = "01JSTOATRL0000000000AAA"
+    str_id = "01JSTOATRL0000000000BBB"
+    list_id = "01JSTOATRL0000000000CCC"
+    _register(
+        mock_aiohttp,
+        _roles_payload({none_id: None, str_id: "not-an-object", list_id: ["also", "wrong"]}),
+    )
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.role_map = {"d-1": none_id, "d-2": str_id, "d-3": list_id}
+    state.created_role_names = {"d-1": "mods", "d-2": "admins", "d-3": "helpers"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    role_results = [r for r in report.results if r.name.startswith("role:")]
+    assert len(role_results) == 3
+    assert {r.kind for r in role_results} == {"role_present"}
+    assert report.has_failures is False
+
+
+async def test_a_channel_object_with_no_name_is_not_reported_renamed(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """The channel half of the same defect the role guard exposed.
+
+    A channel object carrying no "name" key, or a non-string one, means Ferry
+    could not read a name. That is NOT an empty name, and comparing a recorded
+    name against "" would report a rename on every such channel, on a response
+    Ferry simply could not parse.
+
+    Found while writing the role guard: no existing channel fixture omits the
+    name, so nothing else in the suite reaches this.
+    """
+    absent = "01JSTOATCH00000000000AAA"
+    wrong_type = "01JSTOATCH00000000000BBB"
+    _register(
+        mock_aiohttp,
+        _server_payload(
+            [absent, wrong_type],
+            [{"_id": absent}, {"_id": wrong_type, "name": 12345}],
+        ),
+    )
+    state = _state_with_channels({"d-100": absent, "d-101": wrong_type})
+    state.created_channel_names = {"d-100": "general", "d-101": "random"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    channel_results = [r for r in report.results if r.name.startswith("channel:")]
+    assert len(channel_results) == 2
+    assert {r.kind for r in channel_results} == {"channel_present"}
+    assert report.counts()["warn"] == 0

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1474,3 +1474,190 @@ async def test_an_empty_strategy_and_flatten_are_different_claims() -> None:
     assert details[""] != details["flatten"]
     assert "flatten" in details["flatten"]
     assert "flatten" not in details[""]
+
+
+# ---------------------------------------------------------------------------
+# channel_renamed (#295, SC-3.3, SC-3.5, SC-3.7, SC-3.8, SC-3.11, SC-3.13, SC-3.14)
+# ---------------------------------------------------------------------------
+#
+# Fixture rule throughout: the Discord id, the Stoat id, the recorded name and
+# the server's name are four distinct literals, so no assertion can pass by
+# comparing a value with itself.
+
+
+async def test_a_renamed_channel_reports_warn(mock_aiohttp: aioresponses) -> None:
+    """SC-3.3. The feature this release exists for.
+
+    warn rather than fail: the channel exists under its recorded id and its
+    content is intact, and only the label moved. That matches what a renamed
+    category has reported since v2.16.0, and it keeps the exit code at 0.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(
+        mock_aiohttp, _server_payload([stoat_id], [{"_id": stoat_id, "name": "renamed-here"}])
+    )
+    state = _state_with_channels({"d-100": stoat_id})
+    state.created_channel_names = {"d-100": "general"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    result = next(r for r in report.results if r.name == "channel:d-100")
+    assert result.status == "warn"
+    assert result.kind == "channel_renamed"
+    assert result.expected == "general"
+    assert result.found == "renamed-here"
+
+
+async def test_a_matching_name_emits_no_rename_result(mock_aiohttp: aioresponses) -> None:
+    """SC-3.5. A match keeps channel_present and emits nothing extra.
+
+    Not a rename result with status ok: exactly one result for the channel, and
+    it is the identity verdict.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(mock_aiohttp, _server_payload([stoat_id], [{"_id": stoat_id, "name": "general"}]))
+    state = _state_with_channels({"d-100": stoat_id})
+    state.created_channel_names = {"d-100": "general"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    results = [r for r in report.results if r.name == "channel:d-100"]
+    assert len(results) == 1
+    assert results[0].status == "ok"
+    assert results[0].kind == "channel_present"
+
+
+async def test_a_missing_channel_yields_exactly_one_result(mock_aiohttp: aioresponses) -> None:
+    """SC-3.7. One cause, one result, and it is structural rather than guarded.
+
+    A recorded name exists here, so an implementation that compared names before
+    deciding presence would emit a rename alongside the failure. The comparison
+    lives inside the arm that has already decided the channel is present, so a
+    missing channel takes a different arm and cannot reach it.
+
+    COUNT the results rather than checking the first one.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(mock_aiohttp, _server_payload([], []))
+    state = _state_with_channels({"d-100": stoat_id})
+    state.created_channel_names = {"d-100": "general"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    results = [r for r in report.results if r.name == "channel:d-100"]
+    assert len(results) == 1
+    assert results[0].kind == "channel_missing"
+    assert results[0].status == "fail"
+
+
+async def test_an_invisible_channel_yields_exactly_one_result(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.8. The same rule for the middle arm of the three-way conditional."""
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(mock_aiohttp, _server_payload([stoat_id], []))
+    state = _state_with_channels({"d-100": stoat_id})
+    state.created_channel_names = {"d-100": "general"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    results = [r for r in report.results if r.name == "channel:d-100"]
+    assert len(results) == 1
+    assert results[0].kind == "channel_not_visible"
+    assert results[0].status == "unverifiable"
+
+
+async def test_a_channel_with_no_recorded_name_reports_present(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.6, the back-compatibility half. KNOWN LIMIT, pinned deliberately.
+
+    This is NOT a missing check. A state.json written before 2.17.0 records no
+    channel name, so there is nothing to compare against and a renamed channel is
+    undetectable for that migration. Documented in
+    docs/guides/known-limitations.md, and it is what makes an old state file
+    honest rather than noisy.
+    """
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(
+        mock_aiohttp, _server_payload([stoat_id], [{"_id": stoat_id, "name": "renamed-here"}])
+    )
+    state = _state_with_channels({"d-100": stoat_id})
+    assert state.created_channel_names == {}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    result = next(r for r in report.results if r.name == "channel:d-100")
+    assert result.status == "ok"
+    assert result.kind == "channel_present"
+
+
+async def test_a_rename_keeps_the_exit_code_at_zero(mock_aiohttp: aioresponses) -> None:
+    """SC-3.10. warn is not fail, and the v2.16.0 exit contract is unchanged."""
+    stoat_id = "01JSTOATCH00000000000AAA"
+    _register(mock_aiohttp, _server_payload([stoat_id], [{"_id": stoat_id, "name": "renamed"}]))
+    state = _state_with_channels({"d-100": stoat_id})
+    state.created_channel_names = {"d-100": "general"}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    assert report.counts()["warn"] == 1
+    assert report.has_failures is False
+
+
+async def test_the_truncation_cases_report_ok_end_to_end(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.13 and SC-3.14. The check side of the trap the recording avoids.
+
+    A Discord name over 32 characters is sent truncated, and a collision pair is
+    sent with a numeric suffix. Because the RECORDED value is what Ferry sent,
+    both compare equal against the live server and report ok. Recording ch.name
+    would report a rename for both, against a server nobody edited.
+    """
+    long_truncated = "this-channel-name-is-definitely-"
+    collided = "a-very-long-channel-name-that-c-1"
+    first, second = "01JSTOATCH00000000000AAA", "01JSTOATCH00000000000BBB"
+    _register(
+        mock_aiohttp,
+        _server_payload(
+            [first, second],
+            [{"_id": first, "name": long_truncated}, {"_id": second, "name": collided}],
+        ),
+    )
+    state = _state_with_channels({"d-100": first, "d-101": second})
+    state.created_channel_names = {"d-100": long_truncated, "d-101": collided}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    channel_results = [r for r in report.results if r.name.startswith("channel:")]
+    assert len(channel_results) == 2
+    assert {r.status for r in channel_results} == {"ok"}
+
+
+async def test_the_rename_comparison_costs_no_extra_request(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-3.11. The structure family is still two requests at any entity count.
+
+    The names were already in the response the check has always made, so the
+    comparison is free. This drives several renamed channels and several renamed
+    roles at once and counts the structure requests.
+    """
+    ids = [f"01JSTOATCH0000000000{i:03d}" for i in range(6)]
+    _register(
+        mock_aiohttp,
+        _server_payload(ids, [{"_id": i, "name": f"live-{n}"} for n, i in enumerate(ids)]),
+    )
+    state = _state_with_channels({f"d-{n}": i for n, i in enumerate(ids)})
+    state.created_channel_names = {f"d-{n}": f"recorded-{n}" for n in range(6)}
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    assert report.counts()["warn"] == 6
+    structure_calls = [
+        key
+        for key in mock_aiohttp.requests
+        if "/servers/" in str(key[1]) and "/messages" not in str(key[1])
+    ]
+    assert len(structure_calls) == 2, f"expected 2 structure requests, got {structure_calls}"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1405,3 +1405,72 @@ async def test_two_shapes_of_real_loss_this_check_cannot_see(
     result = _tail_result(report)
     assert result.status == expected_status
     assert report.has_failures is False
+
+
+# ---------------------------------------------------------------------------
+# The recorded thread strategy names the cause (#293, SC-1.2, SC-1.8, SC-1.9)
+# ---------------------------------------------------------------------------
+
+
+async def test_an_unrecorded_tail_names_the_recorded_strategy(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-1.8. The whole point of recording thread_strategy.
+
+    A merge parent legitimately has no recorded tail, because _merge_threads
+    never writes message_map. Naming the strategy turns a list of possibilities
+    into the one that applies.
+    """
+    _register_tail(mock_aiohttp, [0, 1, 2])
+    state = _tail_state(high_water=2, count=3, mapped=False)
+    state.thread_strategy = "merge"
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    result = next(r for r in report.results if r.name == "tail:d-100")
+    assert result.status == "unverifiable"
+    assert result.kind == "tail_not_recorded"
+    assert "merge" in result.detail
+
+
+async def test_an_unrecorded_tail_keeps_the_old_wording_when_unrecorded(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """SC-1.9. A state.json written before 2.17.0 has no recorded strategy.
+
+    It must keep the wording that shipped in v2.16.0 rather than naming an empty
+    or unknown strategy, which would read as a defect rather than as an old file.
+    """
+    _register_tail(mock_aiohttp, [0, 1, 2])
+    state = _tail_state(high_water=2, count=3, mapped=False)
+    assert state.thread_strategy == ""
+
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+
+    result = next(r for r in report.results if r.name == "tail:d-100")
+    assert result.status == "unverifiable"
+    assert result.kind == "tail_not_recorded"
+    assert "duplicate" in result.detail
+    assert "merge" not in result.detail
+
+
+async def test_an_empty_strategy_and_flatten_are_different_claims() -> None:
+    """SC-1.2. This is the test that kills defaulting the field to "flatten".
+
+    "" means no strategy was recorded, which every pre-2.17.0 migration reports.
+    "flatten" means one was chosen. A default of "flatten" would assert a
+    strategy nobody selected, and the check would then name a cause it cannot
+    know. The two must produce different text.
+    """
+    details: dict[str, str] = {}
+    for strategy in ("", "flatten"):
+        with aioresponses() as m:
+            _register_tail(m, [0, 1, 2])
+            state = _tail_state(high_water=2, count=3, mapped=False)
+            state.thread_strategy = strategy
+            report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+        details[strategy] = next(r for r in report.results if r.name == "tail:d-100").detail
+
+    assert details[""] != details["flatten"]
+    assert "flatten" in details["flatten"]
+    assert "flatten" not in details[""]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -292,32 +292,6 @@ async def test_a_channel_the_token_cannot_see_is_unverifiable_not_a_failure(
     assert report.has_failures is False
 
 
-async def test_a_renamed_channel_is_not_reported(
-    mock_aiohttp: aioresponses,
-) -> None:
-    """KNOWN LIMIT, pinned deliberately. This is NOT coverage of an intended check.
-
-    MigrationState records no channel name. Its only name fields are
-    category_names, forum_category_names and author_names, and every write to
-    channel_map is id to id. So there is no expected name to compare a found
-    name against, and a renamed channel is undetectable.
-
-    Tracked as spec P2 S11, which would record the names for FUTURE migrations.
-    It cannot help any migration that already exists, which is the population
-    this tool serves, so it was deferred rather than built.
-    """
-    stoat_id = "01JSTOATCH00000000000AAA"
-    _register(
-        mock_aiohttp,
-        _server_payload([stoat_id], [{"_id": stoat_id, "name": "renamed-by-someone"}]),
-    )
-    report = await run_check(
-        BASE_URL, TOKEN, _state_with_channels({"d-100": stoat_id}), _noop_event
-    )
-    result = next(r for r in report.results if r.name == "channel:d-100")
-    assert result.status == "ok"
-
-
 async def test_a_forum_index_entry_is_checked_as_an_ordinary_channel(
     mock_aiohttp: aioresponses,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.16.1"
+version = "2.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Releases **2.17.0**. Closes #266, #267 and #269, three of the four follow-ups the Check tool filed when it shipped.

`ferry check` could name three things it could not do. It can now do all three.

## What changes

**A renamed channel or role is detected.** Ferry records the name it gives each channel and role as it creates them, so Check compares that against the current name and reports a rename as a `warn`. It does not fail the command, because nothing has been lost.

**An unverifiable result names its cause.** `MigrationState` records which thread strategy a migration ran under, so a merge parent is reported as expected rather than as one of three possibilities.

**`ferry check --json`** prints the report as a single JSON document for a script that wants the individual results rather than a pass or fail.

## The constraint that shaped the whole thing

Ferry does not send the Discord name. `make_unique_channel_name` truncates to 32 characters and appends `-1` on a collision; roles pass through `truncate_name`. Recording the Discord name would report a rename for every long name and every collision-suffixed duplicate, **against a server nobody edited**.

So the recorded value is what Ferry **sent**, taken from the create response. That is why these fields are `created_channel_names` rather than `channel_names`: they sit beside `category_names`, which records the Discord title, and the same suffix meaning opposite things is exactly how a future contributor reintroduces the bug.

## Foundational files are touched, and that is stated rather than glossed

`state.py`'s checkpoint format and `core/engine.py` are both on the foundational list. **The previous batch's "touches no foundational file" risk argument does not carry over.**

What holds instead:

- Every change to both is additive with a default.
- `PHASE_ORDER`, the phase list and the resume-by-name comparison are unmodified.
- `test_state_document_has_no_unclassified_fields` compares the known-field set **both ways**, so a new field fails the build until it is classified, and a listed-but-unemitted field fails too.
- `config.py` and `parser/models.py` are untouched, verified as audit target 4.

Back compatibility runs both directions and both are pinned: a `state.json` written by 2.16.1 loads with safe defaults and reports no rename, and one written by 2.17.0 loads under 2.16.1 because `load_state` reads through `data.get` and ignores unknown keys.

## Four defects the build found that no review did

These are the argument for the process rather than decoration. Each was found by doing the work, and each had already passed at least one review.

**A security claim in three documents was false.** The spec, the design and a committed code comment all said classifying a dict-shaped field in `_TEXT_MEMBERS` would corrupt a recorded name. It is **inert**: `scrub_document` descends only into lists of dicts. Two fresh-context critique rounds passed the claim; running the mutation found it. The test was rewritten to guard the widening ADR-014 actually forbids, which turns `team-swordfish-chat` into `team-****fish-chat`.

**The recorded thread strategy was the requested value, not the effective one.** `run_messages` falls back to `flatten` for anything outside the valid set, so a config carrying garbage would run as flatten while `state.json` claimed otherwise, and Check would name a strategy that never ran. Found by a chunk review, and missed by the design, the spec and both critique rounds.

**An unreadable name became `""` and reported a rename nobody made.** Adding an `isinstance` guard stopped a crash and exposed the real defect underneath: with the raise prevented, an unreadable value differs from every recorded name. The same bug existed on a second code path and **no fixture reached it**, because every channel fixture in the suite happens to carry a name.

**Seven `--json` tests all passed against the wrong implementation.** Swapping `click.echo` for `console.print` left every one green, because each payload fitted inside 80 columns. Issue #145's rule was documented in a comment and enforced by nothing. Measured: a 275-character JSON line through the module-level `Console` comes back with five newlines and fails to parse.

## Three guards that were prose and are now tests

The pattern above repeated often enough to fix structurally:

- `warn`'s producer count. Five prose statements claimed it had one home; the design and a critique round both counted three. A scan now asserts none can come back, and it is built from string fragments because the first version matched its own search terms.
- The `kind` vocabulary. The `--json` serialiser deliberately leaves `kind` unstripped, on the argument that it is always an internal literal. That was true by convention; it is now asserted.
- The `click.echo` rule, above.

## The guard that needed two shapes, measured on a prototype

The `--incremental` carry-over can drop the new name maps silently. The obvious guard is completeness: every non-sentinel id has a name. A runnable prototype measured that **wrong on 2 of 8 cases**, because a dropped carry-over and a legitimate pre-2.17.0 upgrade produce byte-identical state.

So there are two predicates, one over a single state and one over a transition, each applied at one point, and a test asserts they are not merged. The falsification is the evidence: deleting the carry lines kills three tests while the pre-2.17.0 test correctly **passes**.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src/` clean. **1892 passed**, up from 1839 at the branch point.

All nine change-manifest audit targets pass, run against comment-stripped source. Target 9 needed re-scoping first: it fired on the guard test that asserts the two predicates are separate, which is the same "audit matching prose about the code" failure the manifest header warns about.

## Chunks

| Chunk | Tasks |
|---|---|
| #279 the state fields and every path that fills them | #284, #285, #286, #287, #288 |
| #280 the three write sites and the guard over them | #289, #290, #291, #292 |
| #281 the check's use of what is recorded | #293, #294, #295, #296, #297, #298 |
| #282 the shell surface | #299, #300 |
| #283 documentation and the release | #301, #302 |

All closed, each chunk carrying its `/df-chunk-review` marker, zero unresolved critical findings.

Both review lenses were run on every chunk, and neither was reliably the productive one: chunk 1 was 0 then 3 with 1 real, chunk 2 was 2 then 0, chunk 3 was 0 then 0, chunk 4 was 0 then 0 while attacking the diff directly found three.

## Deferrals, filed rather than mentioned

**#303** a schema version in the JSON, **#304** emoji names, **#305** backfilling names into an old state file. All three carry the four ADR-005 fields. #305 is argued as possibly-never rather than not-yet: reconstructing what Ferry sent needs the original export **and** the same collision ordering, and a wrong reconstruction reports renames against an untouched server.

**#268 stays open deliberately.** Retiring `--validate-after` changes released behaviour and needs its own ADR under ADR-013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotVV9xXbWp9oR2JdF9Vkm
