### PR TITLE
feat: ferry repair and ferry retry (2.18.0, #107 batch 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-08-13
+
+### Added
+
+- **`ferry repair`, which acts on what `ferry check` found** (`core/engine.py`, `cli.py`). Check
+  could name three kinds of damage and do nothing about them. Repair runs the check itself, then
+  recreates a missing channel, role or category under the name Ferry originally gave it, applies its
+  recorded permission overrides, re-sends the messages a recreated channel held in their original
+  order, restores a channel's lost last message, and drains the dead-letter queue. `--dry-run`
+  reports the plan and changes nothing.
+- **`ferry retry`, exposing a coroutine that had no user surface** (`cli.py`). `run_retry_failed`
+  has been complete and tested since v1.x with no command able to reach it, so a user with failed
+  messages in `state.json` had no way to re-send them. Cheaper and narrower than `repair`: it
+  contacts the server only to send, where repair spends a request per channel checking first.
+
+### Fixed
+
+- **`run_retry_failed` never populated the token store** (`core/engine.py`). `_ensure_token_store`
+  was called by `run_migration` and `run_rollback` and by nothing else, so `config.token_store`
+  stayed `None` for the whole retry path. `safe_sanitize` is an identity function with a `None`
+  store, so a Stoat token appearing in an exception reached `state.failed_messages`, and through it
+  `report.json`, unredacted. Latent only because no command could reach the coroutine, which
+  `ferry retry` changes.
+- **A repair's sends could be swallowed by Stoat's idempotency cache** (`migrator/messages.py`).
+  Every send key is built from a Discord identifier, which a recreated channel does not change, and
+  Stoat's key store is a 1000-entry in-memory cache with no expiry. A repair running while those
+  keys were still held would be answered "duplicate" and treat a message the server had lost as
+  already delivered, restoring nothing while reporting success. `_process_message` takes an
+  `idempotency_salt`, empty for a migration so its keys are unchanged, and repair passes the new
+  channel identifier.
+
+### Changed
+
+- **Permission application is callable from two places** (`migrator/structure.py`). The channel and
+  per-role override blocks are now `apply_channel_permissions` and `apply_role_permissions`, so a
+  repair applies exactly what a migration applies rather than recomputing a mask. The server-default
+  call that follows the role loop is deliberately not part of it: it writes onto the server's default
+  role, which every member holds. Both take the phase label as a parameter, so a repair-time failure
+  is recorded as one.
+
+### Documentation
+
+- `cli-reference.md` gains both commands, their options and their exit codes.
+- `known-limitations.md` gains what repair cannot reach: it inherits every limit of the check, and
+  a mid-channel gap, a message accepted as a duplicate, merged thread content, a forum index and a
+  custom emoji are each declined for a stated reason.
+
 ## [2.17.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`ferry repair`, which acts on what `ferry check` found** (`core/engine.py`, `cli.py`). Check
   could name three kinds of damage and do nothing about them. Repair runs the check itself, then
   recreates a missing channel, role or category under the name Ferry originally gave it, applies its
-  recorded permission overrides, re-sends the messages a recreated channel held in their original
-  order, restores a channel's lost last message, and drains the dead-letter queue. `--dry-run`
-  reports the plan and changes nothing.
+  recorded permission overrides, puts it back in the category it belonged to, restores its slowmode
+  and voice user limit, re-sends the messages it held in their original order, restores a channel's
+  lost last message, and drains the dead-letter queue. A recreated role comes back with its name and
+  permissions; its colour, rank, hoist setting and icon are not restored and repair says so (#344).
+  `--dry-run` reports the plan and changes nothing.
 - **`ferry retry`, exposing a coroutine that had no user surface** (`cli.py`). `run_retry_failed`
   has been complete and tested since v1.x with no command able to reach it, so a user with failed
   messages in `state.json` had no way to re-send them. Cheaper and narrower than `repair`: it

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -496,6 +496,8 @@ or to find a lost message, and it says so rather than guessing.
 
 - A **missing channel, role or category**, recreated under the name Ferry originally gave it, with
   its recorded permission overrides.
+- A recreated channel's **category placement**, its permission overrides, its slowmode and its
+  voice user limit.
 - The **messages a recreated channel held**, re-sent in their original order, with the origin
   header if it was a thread.
 - A **channel's lost last message**, re-sent into the channel that is still there.
@@ -512,6 +514,8 @@ or to find a lost message, and it says so rather than guessing.
   rebuilding a server you chose to remove.
 - **A missing forum index channel.** Its index message is derived content with nothing in the export
   to restore it from.
+- **A recreated role's colour, rank, hoist setting or icon.** The name and the permissions come
+  back; the rest does not, and repair says so.
 - **A missing custom emoji.** An emoji's identifier *is* its uploaded file, so recreating one mints
   a different emoji rather than restoring the old one.
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -472,6 +472,104 @@ if ! ferry check ./ferry-output; then
 fi
 ```
 
+## `ferry repair`
+
+Restore what `ferry check` found missing. Repair runs the check itself, then acts only on what it
+reported as a failure.
+
+```bash
+ferry repair <output-dir> --export-dir <export-dir> [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--export-dir PATH` | **Required.** The DCE export the original migration used |
+| `--stoat-url URL` | Stoat API base URL. Or set `STOAT_URL` |
+| `--token TOKEN` | Stoat user token. Prefer the `STOAT_TOKEN` environment variable |
+| `--dry-run` | Report what would be repaired, and change nothing |
+
+The export is required because the content lives there and not in the state file. Point repair at
+the same export the migration used: a narrower one leaves repair unable to type a recreated channel
+or to find a lost message, and it says so rather than guessing.
+
+### What it repairs
+
+- A **missing channel, role or category**, recreated under the name Ferry originally gave it, with
+  its recorded permission overrides.
+- The **messages a recreated channel held**, re-sent in their original order, with the origin
+  header if it was a thread.
+- A **channel's lost last message**, re-sent into the channel that is still there.
+- Anything left in the **dead-letter queue**, the same work `ferry retry` does.
+
+### What it will not touch
+
+- **A renamed channel, role or category.** A rename almost always means you renamed it. Repair fixes
+  failures, not the edits you made on purpose.
+- **Anything the check could not verify.** If Check could not look, repair has nothing to act on and
+  guessing at a live server is worse than stopping.
+- **A rolled-back migration.** Rollback keeps the identifier maps as an audit trail, so a check
+  against a rolled-back state reports every channel missing. Repair refuses outright rather than
+  rebuilding a server you chose to remove.
+- **A missing forum index channel.** Its index message is derived content with nothing in the export
+  to restore it from.
+- **A missing custom emoji.** An emoji's identifier *is* its uploaded file, so recreating one mints
+  a different emoji rather than restoring the old one.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Nothing is left failing |
+| 1 | Something remains: a message would not send, or repair declined a defect it cannot fix |
+| 2 | The state file or the export directory could not be read |
+| 130 | Interrupted. State is saved after each repair, so re-running continues |
+
+`--dry-run` always exits 0. It reports on a plan rather than an outcome, so a script that treats a
+non-zero code as "act now" is not misled by a preview.
+
+### Examples
+
+```bash
+# See what is wrong, then fix it
+ferry check ./ferry-output --stoat-url https://api.stoat.chat --token "$STOAT_TOKEN"
+ferry repair ./ferry-output --export-dir ./export --stoat-url https://api.stoat.chat
+
+# Preview first
+ferry repair ./ferry-output --export-dir ./export --dry-run
+
+# In a script: repair, then confirm against the server rather than trusting the tool
+ferry repair ./ferry-output --export-dir ./export
+ferry check ./ferry-output --json > result.json
+```
+
+## `ferry retry`
+
+Re-send the messages that failed during a migration. These are the ones Ferry recorded in its
+dead-letter queue: sends that were refused or timed out, and were never retried.
+
+```bash
+ferry retry <output-dir> --export-dir <export-dir> [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--export-dir PATH` | **Required.** The DCE export the original migration used |
+| `--stoat-url URL` | Stoat API base URL. Or set `STOAT_URL` |
+| `--token TOKEN` | Stoat user token. Prefer the `STOAT_TOKEN` environment variable |
+
+Cheaper than `ferry repair`, and narrower. It contacts the server only to send, where repair spends
+a request per channel checking first. Use `retry` when you already know messages failed, and
+`repair` when you want to find out what is wrong.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | The queue is empty |
+| 1 | Something is still failing |
+| 2 | The state file or the export directory could not be read |
+| 130 | Interrupted |
+
 ## `ferry probe`
 
 Check what a live Stoat instance actually supports before you migrate to it. Probe measures upload size limits, checks whether voice channels can be created (Stoat Bug #194), checks webhook availability, and inspects rate-limit behaviour. It is most useful for self-hosted instances, where limits differ from the official service.

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -139,6 +139,44 @@ These limitations relate to platform-level features that either work differently
 
 **Check refuses to run against a dry run.** A dry run records placeholders for channels and messages that were never created, so there is nothing on a server to compare them with.
 
+## Repairing a Migration
+
+`ferry repair` acts on what `ferry check` reports, so **it inherits every limit above**. It cannot
+restore what the check cannot see, and the cases below are deliberate rather than unfinished.
+
+**A gap in the middle of a channel cannot be repaired, because it cannot be found.** Check confirms
+the recorded last message is present; it has no way to notice messages missing earlier in the
+channel, so repair has nothing to act on.
+
+**A message accepted as a duplicate cannot be restored.** Ferry holds no identifier for it, so
+neither the check nor the repair can tell whether it is there.
+
+**Merged thread content is not restored.** Under `--thread-strategy=merge` a thread's messages were
+appended to its parent channel, and Ferry finds them by the parent's *name* rather than its
+identifier. A repair working from a channel's own export cannot reach them. If repair recreates a
+parent that absorbed thread content, it restores the parent's own messages and records a warning
+naming each thread it left behind. `flatten`, the default, gives every thread its own channel and is
+restored completely.
+
+**A missing forum index channel is declined.** Its index message is generated from the forum's
+posts rather than copied from the export, so there is nothing to re-send. Re-run the migration with
+`--incremental` to rebuild it.
+
+**A missing custom emoji is declined.** An emoji's identifier on Stoat *is* its uploaded file, so
+recreating one produces a different emoji that merely looks the same.
+
+**A migration run before 2.18.0 may not be repairable.** Repair recreates an entity under the name
+Ferry originally gave it, and that name is recorded only from 2.17.0 onward. Where it is missing,
+repair declines and says so rather than inventing one: an entity restored under a different name
+looks repaired and is not.
+
+**Repair never renames anything.** A renamed channel, role or category is reported by the check as a
+warning and left alone, because a rename almost always means you made it.
+
+**Repair refuses a rolled-back migration.** Rollback deliberately keeps the identifier maps as an
+audit trail, so a check against that state reports every channel missing. Repair stops rather than
+rebuilding a server you chose to remove.
+
 ## See Also
 
 - [Troubleshooting](troubleshooting.md) — solutions for common migration errors

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -170,6 +170,11 @@ Ferry originally gave it, and that name is recorded only from 2.17.0 onward. Whe
 repair declines and says so rather than inventing one: an entity restored under a different name
 looks repaired and is not.
 
+**A recreated role comes back without its colour, rank, hoist setting or icon.** Repair restores a
+role's name and its permissions. The rest is set by separate calls during a migration, and the icon
+is an uploaded file whose identifier cannot be reused, so repair records a warning naming the role
+rather than restoring them. Set them by hand, or re-run the migration with `--incremental`.
+
 **Repair never renames anything.** A renamed channel, role or category is reported by the check as a
 warning and left alone, because a rename almost always means you made it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.17.0"
+version = "2.18.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.17.0"
+__version__ = "2.18.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1656,7 +1656,12 @@ def retry_cmd(output_dir: str, export_dir: str, stoat_url: str | None, token: st
     try:
         exports = parse_export_directory(export_path)
     except Exception as exc:  # noqa: BLE001 — any parse failure is the same outcome here
-        click.echo(f"Error: could not read the export at {export_path}: {_safe(exc)}", err=True)
+        # Plain str(exc), NOT _safe(exc). _safe is Rich-markup escaping, and
+        # click.echo does not interpret markup, so escaping here would print a
+        # literal backslash in front of every bracket the error contains. It is
+        # not a redaction step and never was: the export holds no Stoat token,
+        # and documents are redacted at their writer.
+        click.echo(f"Error: could not read the export at {export_path}: {exc}", err=True)
         sys.exit(2)
 
     config = FerryConfig(

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1791,7 +1791,22 @@ def repair_cmd(
     # a script that treats non-zero as "act now".
     if dry_run:
         sys.exit(0)
-    sys.exit(1 if state.failed_messages else 0)
+
+    # "Non-zero when any defect remains", and a defect repair DECLINED remains
+    # just as surely as a message that would not send. A channel with no
+    # recorded name, one missing from the export, and a forum index are all
+    # cases repair cannot fix, and exiting 0 on them would tell a script the
+    # server is whole when it is not.
+    #
+    # merge_thread_content_not_restored is deliberately NOT here: that names a
+    # partial restore of something repair DID fix, and failing every merge
+    # repair on it would make the code useless. no_discord_metadata is likewise
+    # a degradation rather than an unrepaired defect.
+    unrepaired = {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
+    declined = [w for w in state.warnings if w.get("type") in unrepaired]
+    if state.failed_messages or declined:
+        sys.exit(1)
+    sys.exit(0)
 
 
 @main.command("tls-check")

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -24,7 +24,12 @@ from rich.table import Table
 
 from discord_ferry import __version__
 from discord_ferry.config import FerryConfig
-from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
+from discord_ferry.core.engine import (
+    PHASE_ORDER,
+    run_migration,
+    run_retry_failed,
+    run_rollback,
+)
 from discord_ferry.core.http import format_proxy_notices, new_session
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
@@ -1582,6 +1587,102 @@ def _render_check_report(report: CheckReport, thread_strategy: str = "") -> None
             f"[cyan]{counts['unverifiable']} checks could not be verified.[/] Ferry did "
             f"not record what it would need to confirm them, {cause}."
         )
+
+
+@main.command(name="retry")
+@click.argument("output_dir", type=click.Path(exists=True))
+@click.option(
+    "--export-dir",
+    type=click.Path(file_okay=False),
+    required=True,
+    help="The DCE export directory the original migration used",
+)
+@click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
+@click.option(
+    "--token",
+    envvar="STOAT_TOKEN",
+    default=None,
+    help="Stoat user token. Prefer the STOAT_TOKEN environment variable",
+)
+def retry_cmd(output_dir: str, export_dir: str, stoat_url: str | None, token: str | None) -> None:
+    """Re-send the messages that failed during a migration.
+
+    Reads state.json from OUTPUT_DIR and re-attempts every message in its
+    dead-letter queue. Needs the original export, because the message content
+    lives there and not in the state file.
+
+    Exits 0 when nothing is left failed, 1 when something still is, and 2 when
+    the state or the export cannot be read.
+    """
+    load_dotenv()
+    if not stoat_url:
+        console.print("[bold red]Error:[/] --stoat-url is required (or set STOAT_URL)")
+        sys.exit(1)
+    if not token:
+        console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
+        sys.exit(1)
+
+    _print_proxy_notices()
+
+    # This command builds its own FerryConfig, so run_migration's token hook
+    # never fires for it. run_retry_failed calls _ensure_token_store itself, but
+    # that covers the engine's own store, not the process-wide registry the log
+    # redaction filter reads. Both are needed and neither is a superset.
+    register_secret("stoat", token)
+    init_request_semaphore(FerryConfig.max_concurrent_requests)
+
+    out_path = Path(output_dir)
+    try:
+        state = load_state(out_path)
+    except StateError as exc:
+        console.print(f"[bold red]Error:[/] state.json not found or unreadable: {_safe(exc)}")
+        sys.exit(2)
+
+    # The export is NOT optional and NOT a placeholder, which is the whole point
+    # of this option. run_retry_failed resolves each FailedMessage back to a
+    # DCEMessage by scanning `exports`, so an empty list makes every retry a
+    # silent no-op that still reports a plausible result. `rollback_cmd` passes
+    # exports=[] because rollback genuinely never needs them; copying that here
+    # would produce a command that does nothing.
+    export_path = Path(export_dir)
+    # click.echo, not console.print, for anything carrying a path. The
+    # module-level Console has soft_wrap=False and falls back to 80 columns off
+    # a terminal, so it inserts a real newline wherever the wrap lands, which
+    # for a long temp path lands INSIDE the path and hands the user something
+    # they cannot copy. Same mechanism as issue #145, which was about JSON.
+    if not export_path.exists():
+        click.echo(f"Error: export directory not found: {export_path}", err=True)
+        sys.exit(2)
+    try:
+        exports = parse_export_directory(export_path)
+    except Exception as exc:  # noqa: BLE001 — any parse failure is the same outcome here
+        click.echo(f"Error: could not read the export at {export_path}: {_safe(exc)}", err=True)
+        sys.exit(2)
+
+    config = FerryConfig(
+        export_dir=export_path,
+        stoat_url=stoat_url,
+        token=token,
+        output_dir=out_path,
+        server_id=state.stoat_server_id or None,
+        skip_export=True,
+    )
+
+    def _on_event(event: MigrationEvent) -> None:
+        colour = {"error": "bold red", "warning": "yellow"}.get(event.status, "cyan")
+        console.print(f"[{colour}]{_safe(event.message)}[/]")
+
+    console.print("[bold]Discord Ferry[/] — retrying failed messages\n")
+    try:
+        asyncio.run(run_retry_failed(config, state, exports, _on_event))
+    except MigrationError as exc:
+        console.print(f"\n[bold red]Retry failed:[/] {_safe(exc)}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted.[/] State saved — re-run to continue.")
+        sys.exit(130)
+
+    sys.exit(1 if state.failed_messages else 0)
 
 
 @main.command("tls-check")

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -27,6 +27,7 @@ from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import (
     PHASE_ORDER,
     run_migration,
+    run_repair,
     run_retry_failed,
     run_rollback,
 )
@@ -1687,6 +1688,109 @@ def retry_cmd(output_dir: str, export_dir: str, stoat_url: str | None, token: st
         console.print("\n[yellow]Interrupted.[/] State saved — re-run to continue.")
         sys.exit(130)
 
+    sys.exit(1 if state.failed_messages else 0)
+
+
+@main.command(name="repair")
+@click.argument("output_dir", type=click.Path(exists=True))
+@click.option(
+    "--export-dir",
+    type=click.Path(file_okay=False),
+    required=True,
+    help="The DCE export directory the original migration used",
+)
+@click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
+@click.option(
+    "--token",
+    envvar="STOAT_TOKEN",
+    default=None,
+    help="Stoat user token. Prefer the STOAT_TOKEN environment variable",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report what would be repaired, and change nothing",
+)
+def repair_cmd(
+    output_dir: str,
+    export_dir: str,
+    stoat_url: str | None,
+    token: str | None,
+    dry_run: bool,
+) -> None:
+    """Restore what `ferry check` found missing.
+
+    Runs the check itself, then recreates missing channels, roles and
+    categories, re-sends the messages a recreated channel held, restores a
+    channel's lost last message, and drains the dead-letter queue.
+
+    It never renames anything and never acts on a result the check could not
+    verify. Exits 0 when nothing is left failing, 1 when something is, and 2
+    when the state or the export cannot be read.
+    """
+    load_dotenv()
+    if not stoat_url:
+        console.print("[bold red]Error:[/] --stoat-url is required (or set STOAT_URL)")
+        sys.exit(1)
+    if not token:
+        console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
+        sys.exit(1)
+
+    _print_proxy_notices()
+    register_secret("stoat", token)
+    init_request_semaphore(FerryConfig.max_concurrent_requests)
+
+    out_path = Path(output_dir)
+    try:
+        state = load_state(out_path)
+    except StateError as exc:
+        console.print(f"[bold red]Error:[/] state.json not found or unreadable: {_safe(exc)}")
+        sys.exit(2)
+
+    export_path = Path(export_dir)
+    # click.echo for anything carrying a path: the module Console wraps at 80
+    # columns off a terminal and would break the path across lines (#145).
+    if not export_path.exists():
+        click.echo(f"Error: export directory not found: {export_path}", err=True)
+        sys.exit(2)
+    try:
+        exports = parse_export_directory(export_path)
+    except Exception as exc:  # noqa: BLE001 — any parse failure is the same outcome
+        click.echo(f"Error: could not read the export at {export_path}: {exc}", err=True)
+        sys.exit(2)
+
+    config = FerryConfig(
+        export_dir=export_path,
+        stoat_url=stoat_url,
+        token=token,
+        output_dir=out_path,
+        server_id=state.stoat_server_id or None,
+        skip_export=True,
+        dry_run=dry_run,
+    )
+
+    def _on_event(event: MigrationEvent) -> None:
+        colour = {"error": "bold red", "warning": "yellow"}.get(event.status, "cyan")
+        console.print(f"[{colour}]{_safe(event.message)}[/]")
+
+    console.print("[bold]Discord Ferry[/] — repairing\n")
+    try:
+        asyncio.run(run_repair(config, state, exports, _on_event))
+    except (CheckError, MigrationError) as exc:
+        console.print(f"\n[bold red]Repair failed:[/] {_safe(exc)}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        console.print(
+            "\n[yellow]Interrupted.[/] State saved after each repair — re-run to continue."
+        )
+        sys.exit(130)
+
+    # A dry run changed nothing, so it reports on the plan rather than on an
+    # outcome and always exits 0. Anything else would make --dry-run unusable in
+    # a script that treats non-zero as "act now".
+    if dry_run:
+        sys.exit(0)
     sys.exit(1 if state.failed_messages else 0)
 
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -32,6 +32,7 @@ from discord_ferry.exporter import (
 )
 from discord_ferry.migrator.api import (
     api_create_invite,
+    api_create_role,
     api_delete_channel,
     api_delete_emoji,
     api_delete_role,
@@ -1238,6 +1239,72 @@ async def _live_channel_names(
     return names
 
 
+def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
+    """Record why an entity could not be recreated, and return the message.
+
+    The name to recreate under is the one Ferry SENT, which lives in
+    ``created_channel_names`` or ``created_role_names``. A migration run before
+    2.17.0 recorded neither, and nothing in the state can reconstruct them: the
+    Discord name is not there, and even with the export in hand the collision
+    suffixes depended on the order that run happened to process channels in.
+
+    So repair declines rather than inventing a name. A recreated entity under a
+    different name is worse than an absent one: the operator sees something that
+    looks restored and is not, and ``ferry check`` would then report it renamed
+    forever after.
+    """
+    message = (
+        f"Cannot recreate {kind} {discord_id}: Ferry has no record of the name it gave it. "
+        "Migrations run before 2.17.0 did not record created names, and the name cannot be "
+        "reconstructed from this state. Recreate it by hand, or re-run the migration with "
+        "--incremental."
+    )
+    state.warnings.append({"phase": "repair", "type": "no_recorded_name", "message": message})
+    return message
+
+
+async def _recreate_role(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    result: CheckResult,
+    on_event: EventCallback,
+) -> bool:
+    """Recreate one missing role. Returns True when it was created."""
+    discord_id = result.discord_id or ""
+    recorded = state.created_role_names.get(discord_id)
+    if not recorded:
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="warning",
+                message=_no_recorded_name(state, "role", discord_id),
+            )
+        )
+        return False
+
+    # api_create_role answers with `id`; api_create_channel answers with `_id`.
+    # The five create routes disagree by design and a pass that "makes these
+    # consistent" breaks two of the three.
+    created = await api_create_role(
+        session, config.stoat_url, config.token, state.stoat_server_id, recorded
+    )
+    new_id: str = created["id"]
+    state.role_map[discord_id] = new_id
+    # From the RESPONSE, which is what the server actually stored, not from the
+    # local variable. 2.17.0's rule, and the reason it exists is that the two
+    # differ exactly when it matters.
+    state.created_role_names[discord_id] = created.get("name") or recorded
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=f"Recreated role '{state.created_role_names[discord_id]}' as {new_id}.",
+        )
+    )
+    return True
+
+
 async def run_repair(
     config: FerryConfig,
     state: MigrationState,
@@ -1371,16 +1438,19 @@ async def run_repair(
         sess = session or new_session()
         try:
             existing_names = await _live_channel_names(sess, config, state)
+            on_event(
+                MigrationEvent(
+                    phase="repair",
+                    status="progress",
+                    message=f"{len(existing_names)} channel names already on the server.",
+                )
+            )
+            for result in structure_work:
+                if result.kind == "role_missing":
+                    await _recreate_role(sess, config, state, result, on_event)
         finally:
             if own_session:
                 await sess.close()
-        on_event(
-            MigrationEvent(
-                phase="repair",
-                status="progress",
-                message=f"{len(existing_names)} channel names already on the server.",
-            )
-        )
 
     # One save, at the end. Never under --dry-run, and not merely a save that
     # happens to change nothing: run_check REFUSES a dry-run state outright,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1443,10 +1443,20 @@ async def _resend_channel(
     #
     # isdigit(): real Discord ids are numeric snowflakes, but a system message
     # can carry something else, and int() on it would abort the whole repair.
-    numeric_ids = [mid for mid in _channel_message_ids(export) if mid.isdigit()]
-
     sent = 0
+    highest = 0
     for msg in _ordered_messages(export):
+        # Tracked HERE rather than in a second pass over the export. The send
+        # loop already visits every message, and for a streamed channel a
+        # separate pass would double the file reads. Materialising the messages
+        # to avoid that is not an option: streaming is what keeps a large export
+        # from exhausting memory, which is the OutOfMemoryException DCE 2.47.2
+        # fixed upstream.
+        #
+        # Advanced BEFORE the send and not rolled back on failure, so it covers a
+        # message that did not land. That is the whole point of the formula.
+        if msg.id.isdigit():
+            highest = max(highest, int(msg.id))
         try:
             await _process_message(
                 msg=msg,
@@ -1469,8 +1479,8 @@ async def _resend_channel(
     # _process_message does NOT write this; only the phase loops do. Without it
     # a recreated channel reports tail_not_recorded, which is `unverifiable`
     # rather than `ok`, and the repair looks unfinished when it is not.
-    if numeric_ids:
-        state.channel_high_water[export.channel.id] = max(numeric_ids, key=int)
+    if highest:
+        state.channel_high_water[export.channel.id] = str(highest)
     return sent
 
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -37,6 +37,7 @@ from discord_ferry.migrator.api import (
     api_delete_channel,
     api_delete_emoji,
     api_delete_role,
+    api_edit_channel,
     api_edit_message,
     api_edit_server,
     api_fetch_server,
@@ -84,6 +85,8 @@ from discord_ferry.state import (
 )
 
 if TYPE_CHECKING:
+    from discord_ferry.discord.metadata import ChannelMeta
+
     # Type-only: run_check itself is imported inside run_repair, matching how
     # check_cmd reaches it, so the verify module stays off the engine's import
     # path at runtime.
@@ -1739,6 +1742,104 @@ async def _recreate_channel(
     return True
 
 
+async def _apply_channel_attributes(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    stoat_channel_id: str,
+    ch_meta: ChannelMeta | None,
+    label: str,
+) -> None:
+    """Restore a recreated channel's slowmode and voice user limit.
+
+    ``run_channels`` sets these with an ``api_edit_channel`` call after the
+    permission pass. A recreation that skipped it would come back with slowmode
+    off and a voice channel uncapped, which is a silent change to how the
+    channel behaves rather than to how it looks.
+    """
+    if ch_meta is None or config.dry_run:
+        return
+    edits: dict[str, Any] = {}
+    if ch_meta.slowmode > 0:
+        edits["slowmode"] = min(ch_meta.slowmode, 21600)
+    if ch_meta.user_limit > 0:
+        edits["user_limit"] = ch_meta.user_limit
+    if not edits:
+        return
+    try:
+        await api_edit_channel(session, config.stoat_url, config.token, stoat_channel_id, **edits)
+    except Exception as exc:  # noqa: BLE001
+        state.warnings.append(
+            {
+                "phase": "repair",
+                "type": "channel_attributes_failed",
+                "message": f"Could not restore slowmode or user limit for '{label}': {exc}",
+            }
+        )
+
+
+async def _reattach_to_category(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    discord_id: str,
+    new_channel_id: str,
+    live_categories: list[dict[str, Any]],
+    on_event: EventCallback,
+) -> None:
+    """Put a recreated channel back into the category it belonged to.
+
+    Category membership on Stoat lives ONLY in the server's categories array, so
+    a channel created with ``api_create_channel`` sits outside every category
+    until that array names it. ``run_channels`` handles this with an end-of-phase
+    upsert; a recreation has no such phase behind it.
+
+    Without this a repaired channel comes back bare, outside the category it was
+    in, permanently and with nothing said about it. That is a visible structural
+    change the operator did not ask for, and it is the primary path this release
+    exists to serve.
+
+    Mutates ``live_categories`` in place so a second recreation in the same run
+    sees the first one's placement rather than overwriting it.
+    """
+    discord_category_id = state.channel_categories.get(discord_id)
+    if not discord_category_id:
+        # Redundant with the next guard on its own, and kept deliberately:
+        # `category_map.get(None)` would also return None, so a mutant removing
+        # this line SURVIVES. It stays because it names a distinct case, a
+        # channel that belonged to no category, which the next line does not.
+        return
+    stoat_category_id = state.category_map.get(discord_category_id)
+    if not stoat_category_id:
+        return
+
+    target = next((c for c in live_categories if c.get("id") == stoat_category_id), None)
+    if target is None:
+        # The category is gone too. _recreate_category rebuilds its channel list
+        # from channel_categories and channel_map, and channel_map now holds the
+        # new id, so it will pick this channel up. Nothing to do here.
+        return
+    channels = target.get("channels")
+    if not isinstance(channels, list):
+        return
+    if new_channel_id in channels:
+        return
+    channels.append(new_channel_id)
+
+    await api_upsert_categories(
+        session, config.stoat_url, config.token, state.stoat_server_id, live_categories
+    )
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=(
+                f"Re-attached the channel to category '{target.get('title', stoat_category_id)}'."
+            ),
+        )
+    )
+
+
 async def _recreate_category(
     session: aiohttp.ClientSession,
     config: FerryConfig,
@@ -1969,7 +2070,31 @@ async def run_repair(
                 #
                 # Unreachable under --dry-run: that path returns above.
                 if result.kind == "role_missing":
-                    if await _recreate_role(sess, config, state, result, on_event) and metadata:
+                    role_created = await _recreate_role(sess, config, state, result, on_event)
+                    if role_created:
+                        # DECLINED, and said so rather than left silent. The
+                        # migration sets a role's colour, rank, hoist and icon in
+                        # two further api_edit_role passes, and the icon one
+                        # uploads a file to Autumn. Restoring those is a second
+                        # content path in a batch already carrying two commands,
+                        # and the reasoning that keeps emoji out of repair (#307)
+                        # applies to the icon. Recorded whether or not metadata
+                        # exists, because the attributes are lost either way.
+                        # Deferred as #344.
+                        role_label = state.created_role_names.get(discord_id, discord_id)
+                        state.warnings.append(
+                            {
+                                "phase": "repair",
+                                "type": "role_attributes_not_restored",
+                                "message": (
+                                    f"Role '{role_label}' was recreated with its name and "
+                                    "permissions. Its colour, rank, hoist setting and icon are "
+                                    "not restored: set them by hand, or re-run the migration "
+                                    "with --incremental (see issue #344)."
+                                ),
+                            }
+                        )
+                    if role_created and metadata:
                         # ONE role. The server-default call that follows the loop
                         # this helper was extracted from is deliberately not here:
                         # it writes a mask onto the server's DEFAULT ROLE, which
@@ -2004,6 +2129,16 @@ async def run_repair(
                                     message=f"Re-sent {count} message(s) into {label}.",
                                 )
                             )
+                    if created:
+                        await _reattach_to_category(
+                            sess,
+                            config,
+                            state,
+                            discord_id,
+                            state.channel_map[discord_id],
+                            live_categories,
+                            on_event,
+                        )
                     if created and metadata:
                         await apply_channel_permissions(
                             sess,
@@ -2013,6 +2148,14 @@ async def run_repair(
                             metadata.channel_metadata.get(discord_id),
                             state.created_channel_names.get(discord_id, discord_id),
                             phase="repair",
+                        )
+                        await _apply_channel_attributes(
+                            sess,
+                            config,
+                            state,
+                            state.channel_map[discord_id],
+                            metadata.channel_metadata.get(discord_id),
+                            state.created_channel_names.get(discord_id, discord_id),
                         )
                 save_state(state, config.output_dir)
         finally:

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1289,6 +1289,7 @@ def _clear_channel_state(
     discord_id: str,
     message_ids: list[str],
     old_stoat_id: str | None = None,
+    new_stoat_id: str | None = None,
 ) -> None:
     """Drop everything that described the channel that is now gone.
 
@@ -1320,6 +1321,18 @@ def _clear_channel_state(
     state.completed_channel_ids.discard(discord_id)
     for message_id in message_ids:
         state.message_map.pop(message_id, None)
+
+    # A queued FAILURE, on the other hand, is still worth sending: it just has to
+    # go to the channel that now exists. FailedMessage.stoat_channel_id was
+    # recorded at migration time against the id that has since been deleted, and
+    # run_retry_failed sends to exactly that field, so without this remap the
+    # drain posts every backlogged message of a recreated channel to a dead id
+    # and collects a 404. The repair would recreate the channel, restore its
+    # export, and still never clear its backlog.
+    if old_stoat_id and new_stoat_id:
+        for failed in state.failed_messages:
+            if failed.stoat_channel_id == old_stoat_id:
+                failed.stoat_channel_id = new_stoat_id
 
     # Queued pins and reactions naming the deleted channel can never succeed.
     # Both lists survive a finished migration when their phase left failures
@@ -1702,7 +1715,7 @@ async def _recreate_channel(
     state.created_channel_names[discord_id] = created.get("name") or unique_name
     # result.stoat_id is the id the check found missing, so it is the OLD one:
     # channel_map was overwritten a line above and no longer holds it.
-    _clear_channel_state(state, discord_id, _channel_message_ids(export), result.stoat_id)
+    _clear_channel_state(state, discord_id, _channel_message_ids(export), result.stoat_id, new_id)
     on_event(
         MigrationEvent(
             phase="repair",

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1458,6 +1458,7 @@ async def _resend_channel(
     # can carry something else, and int() on it would abort the whole repair.
     sent = 0
     highest = 0
+    succeeded: set[str] = set()
     for msg in _ordered_messages(export):
         # Tracked HERE rather than in a second pass over the export. The send
         # loop already visits every message, and for a streamed channel a
@@ -1482,6 +1483,7 @@ async def _resend_channel(
                 idempotency_salt=new_channel_id,
             )
             sent += 1
+            succeeded.add(msg.id)
         except Exception:  # noqa: BLE001
             # _process_message appends a FailedMessage and re-raises when
             # channel_result is None, so the failure is already durable. Carrying
@@ -1494,6 +1496,17 @@ async def _resend_channel(
     # rather than `ok`, and the repair looks unfinished when it is not.
     if highest:
         state.channel_high_water[export.channel.id] = str(highest)
+
+    # Anything this resend delivered is no longer a failure, and leaving it
+    # queued would make the drain send it a SECOND time. The two paths do not
+    # protect each other: this one salts its idempotency key with the new
+    # channel id and run_retry_failed does not, so Stoat sees two distinct
+    # nonces and accepts both. _merge_threads reconciles the same way and for
+    # the same reason, dropping from the queue whatever succeeded this run.
+    if succeeded:
+        state.failed_messages = [
+            fm for fm in state.failed_messages if fm.discord_msg_id not in succeeded
+        ]
     return sent
 
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -31,6 +31,7 @@ from discord_ferry.exporter import (
     validate_discord_token,
 )
 from discord_ferry.migrator.api import (
+    api_create_channel,
     api_create_invite,
     api_create_role,
     api_delete_channel,
@@ -52,7 +53,14 @@ from discord_ferry.migrator.emoji import run_emoji
 from discord_ferry.migrator.messages import _THREAD_STRATEGIES, _process_message, run_messages
 from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
-from discord_ferry.migrator.structure import run_categories, run_channels, run_roles, run_server
+from discord_ferry.migrator.structure import (
+    _stoat_channel_type,
+    make_unique_channel_name,
+    run_categories,
+    run_channels,
+    run_roles,
+    run_server,
+)
 from discord_ferry.parser.dce_parser import parse_export_directory, stream_messages, validate_export
 from discord_ferry.parser.models import DCEExport, DCEMessage
 from discord_ferry.reporter import generate_markdown_report, generate_report
@@ -1305,6 +1313,73 @@ async def _recreate_role(
     return True
 
 
+async def _recreate_channel(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    result: CheckResult,
+    exports: list[DCEExport],
+    existing_names: set[str],
+    on_event: EventCallback,
+) -> bool:
+    """Recreate one missing channel. Returns True when it was created."""
+    discord_id = result.discord_id or ""
+    recorded = state.created_channel_names.get(discord_id)
+    if not recorded:
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="warning",
+                message=_no_recorded_name(state, "channel", discord_id),
+            )
+        )
+        return False
+
+    # The channel TYPE lives only in the export. Nothing in MigrationState
+    # records it, and a voice channel restored as text is a different channel:
+    # nobody can join it. So a channel the given export does not describe is
+    # declined rather than guessed at as Text.
+    export = next((e for e in exports if e.channel.id == discord_id), None)
+    if export is None:
+        message = (
+            f"Cannot recreate channel {discord_id}: it is not in the export directory given. "
+            "The channel type is recorded only in the export, and restoring a voice channel "
+            "as text would produce a channel nobody can join. Re-run with the export the "
+            "migration used."
+        )
+        state.warnings.append({"phase": "repair", "type": "not_in_export", "message": message})
+        on_event(MigrationEvent(phase="repair", status="warning", message=message))
+        return False
+
+    # The recorded name is what Ferry SENT, so it is already truncated to 32 and
+    # already carries whatever suffix the migration needed. Passing it through
+    # make_unique_channel_name against the LIVE set is what lets a suffix be
+    # dropped when its collision partner is gone, and forces a new one when the
+    # server has taken the name since.
+    unique_name = make_unique_channel_name(recorded, existing_names)
+    created = await api_create_channel(
+        session,
+        config.stoat_url,
+        config.token,
+        state.stoat_server_id,
+        name=unique_name,
+        channel_type=_stoat_channel_type(export.channel.type),
+        description=export.channel.topic or None,
+    )
+    # `_id` here, `id` for roles. Upstream's spelling, not ours.
+    new_id: str = created["_id"]
+    state.channel_map[discord_id] = new_id
+    state.created_channel_names[discord_id] = created.get("name") or unique_name
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=f"Recreated channel '{state.created_channel_names[discord_id]}' as {new_id}.",
+        )
+    )
+    return True
+
+
 async def run_repair(
     config: FerryConfig,
     state: MigrationState,
@@ -1448,6 +1523,10 @@ async def run_repair(
             for result in structure_work:
                 if result.kind == "role_missing":
                     await _recreate_role(sess, config, state, result, on_event)
+                elif result.kind == "channel_missing":
+                    await _recreate_channel(
+                        sess, config, state, result, exports, existing_names, on_event
+                    )
         finally:
             if own_session:
                 await sess.close()

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1060,6 +1060,13 @@ async def run_retry_failed(
     Uses a single-scan strategy: collects all failed message IDs, then
     scans exports once to find matching DCEMessage objects.
     """
+    # Same reason run_rollback calls it: this coroutine is invoked directly by a
+    # shell, which never sets the store, so without this every safe_sanitize on
+    # the retry path is an identity no-op and a Stoat token in an exception
+    # reaches state.failed_messages, and through it report.json, unredacted.
+    # Before the early return, so the store exists on every path out.
+    _ensure_token_store(config)
+
     if not state.failed_messages:
         on_event(
             MigrationEvent(

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1266,6 +1266,57 @@ async def _live_server_view(
     return names, categories
 
 
+def _channel_message_ids(export: DCEExport) -> list[str]:
+    """Every Discord message id this export holds, in export order.
+
+    NEW work, not a reuse of the scan in ``run_retry_failed``. That one filters
+    on ``msg.id in failed_ids``, a MESSAGE predicate seeded from failures Ferry
+    already knows about. Repair needs a CHANNEL predicate, and nothing in
+    ``MigrationState`` can answer "which ``message_map`` entries belonged to
+    channel X": the map is keyed by message id with no channel anywhere in it.
+    The export is the only source.
+
+    Streams when a path is known, for the same reason ``run_retry_failed``
+    streams: a channel export can be large and there is no need to hold it.
+    """
+    if export.json_path is not None:
+        return [msg.id for msg in stream_messages(export.json_path)]
+    return [msg.id for msg in export.messages]
+
+
+def _clear_channel_state(state: MigrationState, discord_id: str, message_ids: list[str]) -> None:
+    """Drop everything that described the channel that is now gone.
+
+    Every per-channel field is keyed by DISCORD id, so only one map VALUE moved
+    (``channel_map``, written by the caller) and no key changes here.
+
+    ``channel_message_counts`` is the one that is easy to think unnecessary and
+    is not. ``_classify_tail``'s "nothing expected" shortcut requires the count
+    to be zero AND no expected id. Leaving a stale non-zero count while the
+    high-water mark is gone falls past that shortcut into ``channel_empty``,
+    which is a ``fail``: a repair that did everything it could would report as a
+    failure. It is observable ONLY when the resend puts nothing back, because a
+    successful resend repopulates it, which is why the test for it drives an
+    export holding nothing for this channel.
+
+    ``channel_message_offsets`` is cleared for a different reason and no check
+    can see it: nothing in ``_classify_tail`` or ``_expected_tail`` reads that
+    map. It is transient within-run resume state for a channel that no longer
+    exists, so it serves a later ``--resume`` rather than the next check. Not
+    dead, just unreachable by that predicate.
+
+    The ``message_map`` entries name messages deleted along with the channel.
+    They come from a channel-scoped scan of the export because no reverse index
+    from a channel to its messages exists anywhere in the state.
+    """
+    state.channel_high_water.pop(discord_id, None)
+    state.channel_message_counts.pop(discord_id, None)
+    state.channel_message_offsets.pop(discord_id, None)
+    state.completed_channel_ids.discard(discord_id)
+    for message_id in message_ids:
+        state.message_map.pop(message_id, None)
+
+
 def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
     """Record why an entity could not be recreated, and return the message.
 
@@ -1389,6 +1440,7 @@ async def _recreate_channel(
     new_id: str = created["_id"]
     state.channel_map[discord_id] = new_id
     state.created_channel_names[discord_id] = created.get("name") or unique_name
+    _clear_channel_state(state, discord_id, _channel_message_ids(export))
     on_event(
         MigrationEvent(
             phase="repair",

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1263,24 +1263,41 @@ async def run_repair(
     structure_work: list[CheckResult] = []
     tail_work: list[CheckResult] = []
     for result in report.results:
-        if result.kind in _REPAIRABLE_STRUCTURE:
-            if (result.discord_id or "").startswith(_UNREPAIRABLE_CHANNEL_PREFIX):
+        is_structure = result.kind in _REPAIRABLE_STRUCTURE
+        if not is_structure and result.kind not in _REPAIRABLE_TAIL:
+            continue
+
+        # The exclusion is tested ONCE, against both families, and that placement
+        # is the fix for a real gap rather than tidiness. Guarding only the
+        # structure branch let a forum index channel with `tail_absent` through
+        # into the tail work, and the tail of a forum index channel IS the index
+        # message: it lives in forum_index_message_ids and has no message in any
+        # export to re-send. Measured during the chunk 3 review.
+        if (result.discord_id or "").startswith(_UNREPAIRABLE_CHANNEL_PREFIX):
+            notice = (
+                f"Forum index channel {result.discord_id} needs repair ({result.kind}) and "
+                "repair cannot do it. The index message is derived content with no message "
+                "in the export to restore from, and rebuilding it needs the forum's posts. "
+                "Re-run the migration with --incremental to rebuild it (see issue #311)."
+            )
+            on_event(MigrationEvent(phase="repair", status="warning", message=notice))
+            # Not under --dry-run. A dry run reports and changes nothing, and
+            # state.warnings is state: mutating it during a preview would leave
+            # an in-memory record the run never persists and the operator never
+            # asked for. The event above carries the same information either way.
+            if not config.dry_run:
                 state.warnings.append(
                     {
                         "phase": "repair",
                         "type": "forum_index_not_repairable",
-                        "message": (
-                            f"The forum index channel {result.discord_id} is missing from the "
-                            "server. Repair cannot restore it: the index message is derived "
-                            "content with no messages in the export, and rebuilding it needs "
-                            "the forum's posts. Recreate the forum index by re-running the "
-                            "migration with --incremental (see issue #311)."
-                        ),
+                        "message": notice,
                     }
                 )
-                continue
+            continue
+
+        if is_structure:
             structure_work.append(result)
-        elif result.kind in _REPAIRABLE_TAIL:
+        else:
             tail_work.append(result)
 
     prefix = "[DRY RUN] " if config.dry_run else ""

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1784,6 +1784,7 @@ async def _reattach_to_category(
     state: MigrationState,
     discord_id: str,
     new_channel_id: str,
+    old_channel_id: str | None,
     live_categories: list[dict[str, Any]],
     on_event: EventCallback,
 ) -> None:
@@ -1822,9 +1823,18 @@ async def _reattach_to_category(
     channels = target.get("channels")
     if not isinstance(channels, list):
         return
-    if new_channel_id in channels:
+    # Drop the dead id while adding the live one. Both can be present: if the
+    # CATEGORY was recreated earlier in this same run, _recreate_category built
+    # its channel list from channel_map, which still held the old id for a
+    # channel not yet recreated. Appending without removing would leave the
+    # category naming a channel that does not exist.
+    stale = old_channel_id is not None and old_channel_id in channels
+    if new_channel_id in channels and not stale:
         return
-    channels.append(new_channel_id)
+    if stale and old_channel_id is not None:
+        channels.remove(old_channel_id)
+    if new_channel_id not in channels:
+        channels.append(new_channel_id)
 
     await api_upsert_categories(
         session, config.stoat_url, config.token, state.stoat_server_id, live_categories
@@ -2136,6 +2146,7 @@ async def run_repair(
                             state,
                             discord_id,
                             state.channel_map[discord_id],
+                            result.stoat_id,
                             live_categories,
                             on_event,
                         )

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -55,6 +55,8 @@ from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
 from discord_ferry.migrator.structure import (
     _stoat_channel_type,
+    apply_channel_permissions,
+    apply_role_permissions,
     make_unique_channel_name,
     run_categories,
     run_channels,
@@ -1520,13 +1522,54 @@ async def run_repair(
                     message=f"{len(existing_names)} channel names already on the server.",
                 )
             )
+            # Loaded once, not per entity. None means the file is absent, which
+            # is a real case: it is written during the migration and an operator
+            # repairing from a copied output directory may not have brought it.
+            metadata = load_discord_metadata(config.output_dir)
+            if metadata is None and structure_work:
+                message = (
+                    "discord_metadata.json is not in the output directory, so a recreated "
+                    "channel or role gets no permission overrides. It looks migrated and "
+                    "grants nobody the right to use it. Copy that file across from the "
+                    "original migration, or set the permissions by hand afterwards."
+                )
+                state.warnings.append(
+                    {"phase": "repair", "type": "no_discord_metadata", "message": message}
+                )
+                on_event(MigrationEvent(phase="repair", status="warning", message=message))
+
             for result in structure_work:
+                discord_id = result.discord_id or ""
                 if result.kind == "role_missing":
-                    await _recreate_role(sess, config, state, result, on_event)
+                    if await _recreate_role(sess, config, state, result, on_event) and metadata:
+                        # ONE role. The server-default call that follows the loop
+                        # this helper was extracted from is deliberately not here:
+                        # it writes a mask onto the server's DEFAULT ROLE, which
+                        # every member holds, and re-firing it during a one-role
+                        # repair is the defect batch 5 of #107 existed to fix.
+                        await apply_role_permissions(
+                            sess,
+                            config,
+                            state,
+                            state.role_map[discord_id],
+                            metadata.role_permissions.get(discord_id),
+                            state.created_role_names.get(discord_id, discord_id),
+                            phase="repair",
+                        )
                 elif result.kind == "channel_missing":
-                    await _recreate_channel(
+                    created = await _recreate_channel(
                         sess, config, state, result, exports, existing_names, on_event
                     )
+                    if created and metadata:
+                        await apply_channel_permissions(
+                            sess,
+                            config,
+                            state,
+                            state.channel_map[discord_id],
+                            metadata.channel_metadata.get(discord_id),
+                            state.created_channel_names.get(discord_id, discord_id),
+                            phase="repair",
+                        )
         finally:
             if own_session:
                 await sess.close()

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1283,16 +1283,34 @@ async def run_repair(
         elif result.kind in _REPAIRABLE_TAIL:
             tail_work.append(result)
 
+    prefix = "[DRY RUN] " if config.dry_run else ""
     on_event(
         MigrationEvent(
             phase="repair",
             status="progress",
             message=(
-                f"{len(structure_work)} entities to recreate, "
+                f"{prefix}{len(structure_work)} entities to recreate, "
                 f"{len(tail_work)} channels with a lost tail."
             ),
         )
     )
+
+    if config.dry_run:
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="completed",
+                message="[DRY RUN] Nothing was created, sent or written.",
+            )
+        )
+        return
+
+    # One save, at the end. Never under --dry-run, and not merely a save that
+    # happens to change nothing: run_check REFUSES a dry-run state outright,
+    # because a dry run fills the id maps with `dry-` sentinels naming entities
+    # nobody created. Writing those into a real state file would leave the user
+    # with a migration that can never be checked again.
+    save_state(state, config.output_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -54,6 +54,7 @@ from discord_ferry.migrator.messages import _THREAD_STRATEGIES, _process_message
 from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
 from discord_ferry.migrator.structure import (
+    _generate_category_id,
     _stoat_channel_type,
     apply_channel_permissions,
     apply_role_permissions,
@@ -1209,12 +1210,26 @@ _REPAIRABLE_TAIL = frozenset({"tail_absent", "tail_and_after_absent"})
 _UNREPAIRABLE_CHANNEL_PREFIX = "forum-index-"
 
 
-async def _live_channel_names(
+async def _live_server_view(
     session: aiohttp.ClientSession,
     config: FerryConfig,
     state: MigrationState,
-) -> set[str]:
-    """Every channel name currently on the server, for the collision set.
+) -> tuple[set[str], list[dict[str, Any]]]:
+    """One fetch, two things repair needs: the collision set and the categories.
+
+    Returns ``(channel_names, categories)``. Both come from the same response
+    because both are needed only when something is being recreated, and the
+    /servers bucket allows 5 requests per 10 seconds.
+
+    The categories half exists because ``api_upsert_categories`` is a FULL-ARRAY
+    PATCH: it sets the server's entire categories list. Recreating one missing
+    category by sending only that category would delete every other one. So the
+    current array has to come back first, and a test drives two survivors.
+
+    ``server.categories`` is Optional upstream and the key can be absent
+    entirely, which is why it is read through ``or []`` rather than indexed.
+
+    The channel-names half, for the collision set:
 
     Repair names a recreated channel with ``make_unique_channel_name``, and what
     differs from a migration is not the rule but its INPUT. ``run_channels``
@@ -1246,7 +1261,9 @@ async def _live_channel_names(
             name = channel.get("name")
             if isinstance(name, str):
                 names.add(name)
-    return names
+    server = payload.get("server") or {}
+    categories = [c for c in (server.get("categories") or []) if isinstance(c, dict)]
+    return names, categories
 
 
 def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
@@ -1377,6 +1394,69 @@ async def _recreate_channel(
             phase="repair",
             status="progress",
             message=f"Recreated channel '{state.created_channel_names[discord_id]}' as {new_id}.",
+        )
+    )
+    return True
+
+
+async def _recreate_category(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    result: CheckResult,
+    live_categories: list[dict[str, Any]],
+    on_event: EventCallback,
+) -> bool:
+    """Recreate one missing category by PATCHing the whole array back.
+
+    Two things make this different from the channel and role cases.
+
+    First, ``api_upsert_categories`` sets the server's ENTIRE categories list.
+    Sending only the recreated category would delete every other one, so the
+    live array is read first and the new entry appended to it. A test drives two
+    existing categories and asserts both survive.
+
+    Second, a Stoat category carries its channels. Recreating one with an empty
+    channel list produces an empty category: a recreation that reports success
+    and restores nothing, the same shape as the forum index case this module
+    already declines. The channel list is rebuilt from ``channel_categories``,
+    which records ``discord_channel_id -> discord_category_id`` for exactly
+    this, mapped through ``channel_map`` to the ids the server knows.
+    """
+    discord_id = result.discord_id or ""
+    title = state.category_names.get(discord_id)
+    if not title:
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="warning",
+                message=_no_recorded_name(state, "category", discord_id),
+            )
+        )
+        return False
+
+    stoat_channel_ids = [
+        stoat_id
+        for discord_channel_id, category_id in state.channel_categories.items()
+        if category_id == discord_id
+        and (stoat_id := state.channel_map.get(discord_channel_id)) is not None
+    ]
+    new_id = state.category_map.get(discord_id) or _generate_category_id()
+    rebuilt = [c for c in live_categories if c.get("id") != new_id]
+    rebuilt.append({"id": new_id, "title": title, "channels": stoat_channel_ids})
+
+    await api_upsert_categories(
+        session, config.stoat_url, config.token, state.stoat_server_id, rebuilt
+    )
+    state.category_map[discord_id] = new_id
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=(
+                f"Recreated category '{title}' with {len(stoat_channel_ids)} channel(s), "
+                f"preserving {len(rebuilt) - 1} existing."
+            ),
         )
     )
     return True
@@ -1514,7 +1594,7 @@ async def run_repair(
         own_session = session is None
         sess = session or new_session()
         try:
-            existing_names = await _live_channel_names(sess, config, state)
+            existing_names, live_categories = await _live_server_view(sess, config, state)
             on_event(
                 MigrationEvent(
                     phase="repair",
@@ -1556,6 +1636,8 @@ async def run_repair(
                             state.created_role_names.get(discord_id, discord_id),
                             phase="repair",
                         )
+                elif result.kind == "category_missing":
+                    await _recreate_category(sess, config, state, result, live_categories, on_event)
                 elif result.kind == "channel_missing":
                     created = await _recreate_channel(
                         sess, config, state, result, exports, existing_names, on_event

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1284,7 +1284,12 @@ def _channel_message_ids(export: DCEExport) -> list[str]:
     return [msg.id for msg in export.messages]
 
 
-def _clear_channel_state(state: MigrationState, discord_id: str, message_ids: list[str]) -> None:
+def _clear_channel_state(
+    state: MigrationState,
+    discord_id: str,
+    message_ids: list[str],
+    old_stoat_id: str | None = None,
+) -> None:
     """Drop everything that described the channel that is now gone.
 
     Every per-channel field is keyed by DISCORD id, so only one map VALUE moved
@@ -1315,6 +1320,22 @@ def _clear_channel_state(state: MigrationState, discord_id: str, message_ids: li
     state.completed_channel_ids.discard(discord_id)
     for message_id in message_ids:
         state.message_map.pop(message_id, None)
+
+    # Queued pins and reactions naming the deleted channel can never succeed.
+    # Both lists survive a finished migration when their phase left failures
+    # behind: run_pins ends with `state.pending_pins = remaining`, which keeps
+    # exactly the ones that did not land, and run_reactions does the same. A
+    # later --incremental would retry them against a channel that is gone and
+    # collect another failure.
+    #
+    # Repair does not make that worse, the deletion did, so this is a tidy-up
+    # rather than a fix. It is here because this function's job is dropping
+    # everything that described the channel that is gone, and these do.
+    if old_stoat_id:
+        state.pending_pins = [p for p in state.pending_pins if p[0] != old_stoat_id]
+        state.pending_reactions = [
+            r for r in state.pending_reactions if r.get("channel_id") != old_stoat_id
+        ]
 
 
 def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
@@ -1440,7 +1461,9 @@ async def _recreate_channel(
     new_id: str = created["_id"]
     state.channel_map[discord_id] = new_id
     state.created_channel_names[discord_id] = created.get("name") or unique_name
-    _clear_channel_state(state, discord_id, _channel_message_ids(export))
+    # result.stoat_id is the id the check found missing, so it is the OLD one:
+    # channel_map was overwritten a line above and no longer holds it.
+    _clear_channel_state(state, discord_id, _channel_message_ids(export), result.stoat_id)
     on_event(
         MigrationEvent(
             phase="repair",

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1484,6 +1484,99 @@ async def _resend_channel(
     return sent
 
 
+async def _repair_tail(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    result: CheckResult,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> bool:
+    """Re-send the one message a present channel lost. True when it was sent.
+
+    Both repairable tail kinds resolve to the same work. ``tail_absent`` means
+    the recorded last message is gone while messages around it survive;
+    ``tail_and_after_absent`` means everything from it onward is gone, and since
+    the mark IS the newest thing Ferry recorded, there is nothing after it in
+    Ferry's record either. One message, in both cases.
+
+    This deliberately goes around the high-water gate. Content at or below the
+    mark is unreachable by ``--resume``, ``--incremental`` and ``ferry retry``
+    alike, which ``docs/guides/earlier-migrations.md`` documents, and reaching it
+    is the point of this command rather than an oversight.
+    """
+    discord_id = result.discord_id or ""
+    tail_message_id = state.channel_high_water.get(discord_id)
+    if not tail_message_id:
+        # The check cannot report an absent tail without one, so this is
+        # unreachable today. Guarded anyway: a future kind arriving here with no
+        # mark would otherwise send nothing and report success.
+        return False
+
+    export = next((e for e in exports if e.channel.id == discord_id), None)
+    if export is None:
+        message = (
+            f"Cannot restore the last message of channel {discord_id}: it is not in the "
+            "export directory given. Re-run with the export the migration used."
+        )
+        state.warnings.append({"phase": "repair", "type": "not_in_export", "message": message})
+        on_event(MigrationEvent(phase="repair", status="warning", message=message))
+        return False
+
+    target = next((m for m in _ordered_messages(export) if m.id == tail_message_id), None)
+    if target is None:
+        message = (
+            f"Cannot restore message {tail_message_id} in channel {discord_id}: the export "
+            "given does not contain it. It may be narrower than the one the migration used."
+        )
+        state.warnings.append({"phase": "repair", "type": "not_in_export", "message": message})
+        on_event(MigrationEvent(phase="repair", status="warning", message=message))
+        return False
+
+    stoat_channel_id = state.channel_map[discord_id]
+    try:
+        await _process_message(
+            msg=target,
+            stoat_channel_id=stoat_channel_id,
+            config=config,
+            state=state,
+            session=session,
+            on_event=on_event,
+            export_channel_id=discord_id,
+            # Salted for the same reason a recreation's sends are, and the need
+            # is sharper here: this channel was NOT recreated, so its Stoat id is
+            # unchanged and the original send's key is exactly `ferry-{msg.id}`.
+            # Unsalted, Stoat's LRU would answer 409 and _process_message would
+            # treat a message the server has lost as already delivered.
+            idempotency_salt=stoat_channel_id,
+        )
+    except Exception:  # noqa: BLE001
+        # Already durable in state.failed_messages, and re-raised by
+        # _process_message when channel_result is None. `ferry retry` drains it.
+        return False
+
+    # The mark needs NO update, and the reason is worth stating because the plan
+    # asked for a formula here. A tail repair re-sends the message the mark
+    # already names, because `tail_message_id` is read out of
+    # `channel_high_water` at the top of this function and nothing between here
+    # and there writes it: `_process_message` never touches that map, only the
+    # phase loops do. So any "greater of the two" comparison compares a value
+    # with itself and can never fire.
+    #
+    # An earlier draft had exactly that comparison. A mutant replacing it with an
+    # unconditional write SURVIVED, which is what showed it was inert rather than
+    # protective. The recreation path in `_resend_channel` is where a real
+    # formula is needed, because there the mark was cleared first.
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=f"Restored the last message of channel {discord_id}.",
+        )
+    )
+    return True
+
+
 def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
     """Record why an entity could not be recreated, and return the message.
 
@@ -1899,6 +1992,34 @@ async def run_repair(
         finally:
             if own_session:
                 await sess.close()
+
+    if tail_work:
+        own_tail_session = session is None
+        tail_sess = session or new_session()
+        try:
+            restored = 0
+            for result in tail_work:
+                if await _repair_tail(tail_sess, config, state, result, exports, on_event):
+                    restored += 1
+                    save_state(state, config.output_dir)
+            on_event(
+                MigrationEvent(
+                    phase="repair",
+                    status="progress",
+                    message=f"Restored {restored} of {len(tail_work)} lost last message(s).",
+                )
+            )
+        finally:
+            if own_tail_session:
+                await tail_sess.close()
+
+    # Whatever is still in the dead-letter queue, including anything the two
+    # passes above just failed on. run_retry_failed is reused rather than
+    # reimplemented: it already resolves each FailedMessage back to a DCEMessage,
+    # rebuilds the queue from what still fails, and saves. It returns early on an
+    # empty queue, so this costs nothing when there is nothing to drain.
+    if state.failed_messages:
+        await run_retry_failed(config, state, exports, on_event)
 
     # One save, at the end. Never under --dry-run, and not merely a save that
     # happens to change nothing: run_check REFUSES a dry-run state outright,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -38,6 +38,7 @@ from discord_ferry.migrator.api import (
     api_edit_message,
     api_edit_server,
     api_fetch_server,
+    api_fetch_server_with_channels,
     api_pin_message,
     api_send_message,
     api_upsert_categories,
@@ -1197,6 +1198,46 @@ _REPAIRABLE_TAIL = frozenset({"tail_absent", "tail_and_after_absent"})
 _UNREPAIRABLE_CHANNEL_PREFIX = "forum-index-"
 
 
+async def _live_channel_names(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+) -> set[str]:
+    """Every channel name currently on the server, for the collision set.
+
+    Repair names a recreated channel with ``make_unique_channel_name``, and what
+    differs from a migration is not the rule but its INPUT. ``run_channels``
+    builds its set across the whole export, because on a migration that is every
+    name about to exist. On a repair the correct set is what is on the server
+    NOW: a channel originally created as ``general-1``, whose collision partner
+    has since been deleted, should come back as ``general``.
+
+    Costs ONE request, on the ``/servers`` bucket at 5 per 10 seconds. It cannot
+    be taken from the ``CheckReport``, which is why repair pays for it
+    separately: ``visible_names`` is local to ``_check_structure`` and reaches a
+    ``CheckResult`` only through ``expected``/``found`` on a rename comparison,
+    so the far more common unchanged-name case carries no name at all.
+
+    Known limit, shared with ``ferry check`` itself and not introduced here: the
+    sibling ``channels`` array holds only what this token may ViewChannel, so a
+    channel it cannot see is absent from this set and a recreation could collide
+    with one. That is the same blindness ``channel_not_visible`` documents.
+    """
+    payload = await api_fetch_server_with_channels(
+        session, config.stoat_url, config.token, state.stoat_server_id
+    )
+    names: set[str] = set()
+    for channel in payload.get("channels") or []:
+        # isinstance rather than a bare .get: the payload is dict[str, Any], so
+        # mypy cannot help, and an entry Ferry cannot read must be skipped rather
+        # than contribute None to a set[str]. verify.py guards the same way.
+        if isinstance(channel, dict):
+            name = channel.get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
 async def run_repair(
     config: FerryConfig,
     state: MigrationState,
@@ -1321,6 +1362,25 @@ async def run_repair(
             )
         )
         return
+
+    if structure_work:
+        # Only when something is actually being recreated. A repair with nothing
+        # to create should not spend a request on the /servers bucket, and a
+        # test asserts that.
+        own_session = session is None
+        sess = session or new_session()
+        try:
+            existing_names = await _live_channel_names(sess, config, state)
+        finally:
+            if own_session:
+                await sess.close()
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="progress",
+                message=f"{len(existing_names)} channel names already on the server.",
+            )
+        )
 
     # One save, at the end. Never under --dry-run, and not merely a save that
     # happens to change nothing: run_check REFUSES a dry-run state outright,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1406,6 +1406,7 @@ async def _resend_channel(
     original migration sent and the restored thread would lose the line saying
     where it came from.
     """
+    new_channel_id = state.channel_map[export.channel.id]
     if export.is_thread and export.parent_channel_name:
         header = (
             f"[Forum post migrated from #{export.parent_channel_name}]"
@@ -1417,10 +1418,14 @@ async def _resend_channel(
                 session,
                 config.stoat_url,
                 config.token,
-                state.channel_map[export.channel.id],
+                new_channel_id,
                 content=header,
                 masquerade={"name": "Discord Ferry"},
-                idempotency_key=f"ferry-header-{export.channel.id}",
+                # Salted with the NEW channel id for the same reason the message
+                # keys are: the old key may still be in Stoat's LRU, and a 409
+                # there would silently drop the header from a channel that is
+                # genuinely new.
+                idempotency_key=f"ferry-header-{export.channel.id}-{new_channel_id}",
             )
 
     # The mark is the max over EVERY id this export holds, not over the ones
@@ -1445,12 +1450,13 @@ async def _resend_channel(
         try:
             await _process_message(
                 msg=msg,
-                stoat_channel_id=state.channel_map[export.channel.id],
+                stoat_channel_id=new_channel_id,
                 config=config,
                 state=state,
                 session=session,
                 on_event=on_event,
                 export_channel_id=export.channel.id,
+                idempotency_salt=new_channel_id,
             )
             sent += 1
         except Exception:  # noqa: BLE001

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -9,7 +9,7 @@ import re
 import socket
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
 
@@ -69,6 +69,12 @@ from discord_ferry.state import (
     load_state,
     save_state,
 )
+
+if TYPE_CHECKING:
+    # Type-only: run_check itself is imported inside run_repair, matching how
+    # check_cmd reaches it, so the verify module stays off the engine's import
+    # path at runtime.
+    from discord_ferry.migrator.verify import CheckResult
 
 PhaseFunction = Callable[
     [FerryConfig, MigrationState, list[DCEExport], EventCallback],
@@ -1164,6 +1170,32 @@ async def run_retry_failed(
 # Repair engine (#107 batch 10)
 # ---------------------------------------------------------------------------
 
+#: The only structure kinds repair acts on.
+#:
+#: Membership against a literal set, NEVER a test on ``status``. A ``fail`` kind
+#: added after this batch would be swept into a status test silently, and repair
+#: has no way to handle a defect it has not seen.
+_REPAIRABLE_STRUCTURE = frozenset({"channel_missing", "role_missing", "category_missing"})
+
+#: The only tail kinds repair acts on. ``tail_not_recorded`` and
+#: ``tail_window_exhausted`` are unverifiable: the check could not look, so
+#: there is nothing to act on and acting anyway is guessing at a live server.
+_REPAIRABLE_TAIL = frozenset({"tail_absent", "tail_and_after_absent"})
+
+#: A synthetic channel key repair declines even when the kind matches.
+#:
+#: The forum index writer stores ``channel_map["forum-index-{key}"]`` whose
+#: value is a real Stoat channel id, so a deleted index reports
+#: ``channel_missing`` exactly like any other channel. Generic recreation cannot
+#: restore it: there is no ``ChannelMeta`` for a synthetic id, a channel-scoped
+#: export scan finds zero messages because the key names no Discord channel, and
+#: nothing rebuilds the index message or ``forum_index_message_ids``.
+#: ``_select_invite_channel`` already excludes the same prefix. Deferred as #311.
+#:
+#: This is the second level of the rule above: a test on ``status`` sweeps in a
+#: future KIND, and a test on ``kind`` alone sweeps in a channel TYPE.
+_UNREPAIRABLE_CHANNEL_PREFIX = "forum-index-"
+
 
 async def run_repair(
     config: FerryConfig,
@@ -1224,6 +1256,40 @@ async def run_repair(
             message=(
                 f"Check complete: {counts['fail']} failing, {counts['warn']} warned, "
                 f"{counts['unverifiable']} unverifiable."
+            ),
+        )
+    )
+
+    structure_work: list[CheckResult] = []
+    tail_work: list[CheckResult] = []
+    for result in report.results:
+        if result.kind in _REPAIRABLE_STRUCTURE:
+            if (result.discord_id or "").startswith(_UNREPAIRABLE_CHANNEL_PREFIX):
+                state.warnings.append(
+                    {
+                        "phase": "repair",
+                        "type": "forum_index_not_repairable",
+                        "message": (
+                            f"The forum index channel {result.discord_id} is missing from the "
+                            "server. Repair cannot restore it: the index message is derived "
+                            "content with no messages in the export, and rebuilding it needs "
+                            "the forum's posts. Recreate the forum index by re-running the "
+                            "migration with --incremental (see issue #311)."
+                        ),
+                    }
+                )
+                continue
+            structure_work.append(result)
+        elif result.kind in _REPAIRABLE_TAIL:
+            tail_work.append(result)
+
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=(
+                f"{len(structure_work)} entities to recreate, "
+                f"{len(tail_work)} channels with a lost tail."
             ),
         )
     )

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1620,6 +1620,14 @@ async def run_repair(
 
             for result in structure_work:
                 discord_id = result.discord_id or ""
+                # Persist after EACH recreation, not once at the end. run_roles
+                # already does this mid-loop and says why: a hard kill between a
+                # create and the save leaves the id map naming the entity that is
+                # gone, so the next run's check reports it missing again and
+                # repair creates a SECOND one. One extra atomic write per
+                # recreated entity is cheap against a duplicate nobody asked for.
+                #
+                # Unreachable under --dry-run: that path returns above.
                 if result.kind == "role_missing":
                     if await _recreate_role(sess, config, state, result, on_event) and metadata:
                         # ONE role. The server-default call that follows the loop
@@ -1652,6 +1660,7 @@ async def run_repair(
                             state.created_channel_names.get(discord_id, discord_id),
                             phase="repair",
                         )
+                save_state(state, config.output_dir)
         finally:
             if own_session:
                 await sess.close()

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -7,7 +7,7 @@ import contextlib
 import dataclasses
 import re
 import socket
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterator
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -1338,6 +1338,136 @@ def _clear_channel_state(
         ]
 
 
+def _ordered_messages(export: DCEExport) -> Iterator[DCEMessage]:
+    """This export's messages in the order the migration sent them.
+
+    Mirrors ``_process_single_channel`` exactly: stream from disk when a path is
+    known, otherwise sort the in-memory list by timestamp. The sort is not
+    cosmetic. Stoat orders by its own ULIDs, assigned on arrival, so sending out
+    of order puts the channel out of order permanently, and the tail Ferry then
+    records would not be the newest message.
+    """
+    if export.json_path is not None:
+        return stream_messages(export.json_path)
+    return iter(sorted(export.messages, key=lambda m: m.timestamp))
+
+
+def _warn_unrestored_merge_threads(
+    state: MigrationState,
+    export: DCEExport,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> None:
+    """Name the merged thread content a recreated parent does not get back.
+
+    Under ``--thread-strategy=merge`` a thread's messages were appended to the
+    PARENT's Stoat channel, and ``_merge_threads`` resolves that target by parent
+    channel NAME. A channel-scoped scan keyed on the parent's Discord id
+    therefore cannot reach them, and the merge path never wrote ``message_map``
+    either, so nothing in the state points at them.
+
+    The gap is stated rather than silent, which is the whole difference between
+    this and the defect a critique round found. Deferred as #310.
+    """
+    orphans = [
+        e.channel.name
+        for e in exports
+        if e.is_thread and e.parent_channel_name == export.channel.name
+    ]
+    if not orphans:
+        return
+    names = ", ".join(sorted(orphans))
+    message = (
+        f"Channel '{export.channel.name}' was migrated with --thread-strategy=merge, so "
+        f"{len(orphans)} thread(s) had their messages appended to it: {names}. "
+        "Repair restored the channel's own messages only. The merged thread content is "
+        "reachable by parent channel name rather than by id, so a channel-scoped resend "
+        "cannot find it (see issue #310)."
+    )
+    state.warnings.append(
+        {"phase": "repair", "type": "merge_thread_content_not_restored", "message": message}
+    )
+    on_event(MigrationEvent(phase="repair", status="warning", message=message))
+
+
+async def _resend_channel(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    export: DCEExport,
+    on_event: EventCallback,
+) -> int:
+    """Re-send every message this export holds. Returns the count that landed.
+
+    The origin header is sent here rather than left to ``_process_message``,
+    because it does not live there: ``_process_single_channel`` sends it, gated
+    on the channel being absent from ``channel_high_water``. Repair clears that
+    mark, so a loop over ``_process_message`` alone would drop a header the
+    original migration sent and the restored thread would lose the line saying
+    where it came from.
+    """
+    if export.is_thread and export.parent_channel_name:
+        header = (
+            f"[Forum post migrated from #{export.parent_channel_name}]"
+            if export.channel.type in (15, 16)
+            else f"[Thread migrated from #{export.parent_channel_name}]"
+        )
+        with contextlib.suppress(DuplicateSendError):
+            await api_send_message(
+                session,
+                config.stoat_url,
+                config.token,
+                state.channel_map[export.channel.id],
+                content=header,
+                masquerade={"name": "Discord Ferry"},
+                idempotency_key=f"ferry-header-{export.channel.id}",
+            )
+
+    # The mark is the max over EVERY id this export holds, not over the ones
+    # that landed, and taking the easier reading gives a NICER answer that is
+    # wrong. If the newest message fails to send, "max of successful" names the
+    # second-newest, which did land, so the next check finds it and reports
+    # ("ok", "tail_present") over a message that is genuinely missing. Taking
+    # the max over everything reports ("unverifiable", "tail_not_recorded"),
+    # which is honest: Ferry cannot confirm a tail it never sent.
+    #
+    # It matches the phase, where _channel_max_id advances before each send and
+    # is not rolled back on failure. That is safe rather than a permanent hole
+    # only because a failed send lands in state.failed_messages and the #76
+    # self-heal re-attempts any id found there even below the mark.
+    #
+    # isdigit(): real Discord ids are numeric snowflakes, but a system message
+    # can carry something else, and int() on it would abort the whole repair.
+    numeric_ids = [mid for mid in _channel_message_ids(export) if mid.isdigit()]
+
+    sent = 0
+    for msg in _ordered_messages(export):
+        try:
+            await _process_message(
+                msg=msg,
+                stoat_channel_id=state.channel_map[export.channel.id],
+                config=config,
+                state=state,
+                session=session,
+                on_event=on_event,
+                export_channel_id=export.channel.id,
+            )
+            sent += 1
+        except Exception:  # noqa: BLE001
+            # _process_message appends a FailedMessage and re-raises when
+            # channel_result is None, so the failure is already durable. Carrying
+            # on is deliberate: one bad message must not cost the rest of the
+            # channel, and `ferry retry` is what drains what is left.
+            continue
+
+    # _process_message does NOT write this; only the phase loops do. Without it
+    # a recreated channel reports tail_not_recorded, which is `unverifiable`
+    # rather than `ok`, and the repair looks unfinished when it is not.
+    if numeric_ids:
+        state.channel_high_water[export.channel.id] = max(numeric_ids, key=int)
+    return sent
+
+
 def _no_recorded_name(state: MigrationState, kind: str, discord_id: str) -> str:
     """Record why an entity could not be recreated, and return the message.
 
@@ -1725,6 +1855,20 @@ async def run_repair(
                     created = await _recreate_channel(
                         sess, config, state, result, exports, existing_names, on_event
                     )
+                    if created:
+                        matching = next((e for e in exports if e.channel.id == discord_id), None)
+                        label = state.created_channel_names.get(discord_id, discord_id)
+                        if matching is not None:
+                            if state.thread_strategy == "merge":
+                                _warn_unrestored_merge_threads(state, matching, exports, on_event)
+                            count = await _resend_channel(sess, config, state, matching, on_event)
+                            on_event(
+                                MigrationEvent(
+                                    phase="repair",
+                                    status="progress",
+                                    message=f"Re-sent {count} message(s) into {label}.",
+                                )
+                            )
                     if created and metadata:
                         await apply_channel_permissions(
                             sess,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1161,6 +1161,75 @@ async def run_retry_failed(
 
 
 # ---------------------------------------------------------------------------
+# Repair engine (#107 batch 10)
+# ---------------------------------------------------------------------------
+
+
+async def run_repair(
+    config: FerryConfig,
+    state: MigrationState,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> None:
+    """Act on a CheckReport: restore missing structure and lost messages.
+
+    A sibling of :func:`run_retry_failed` and :func:`run_rollback`, not a phase.
+    ``PHASE_ORDER``, the phase list and the resume-by-name comparison are
+    untouched, and repair is not resumable by design: it re-derives its work
+    from a fresh check on every run, so there is nothing to checkpoint.
+
+    Raises:
+        CheckError: the state is from a dry run, or records no server. Both come
+            from ``run_check`` and are deliberately not caught here, because the
+            shell turns them into an exit code and a sentence.
+    """
+    # Rollback preserves the id maps as an audit trail and NEVER clears them
+    # (RollbackProgress' own docstring in state.py says so), which means a check
+    # on a rolled-back state reports channel_missing for every channel it
+    # mapped. A repair acting on that report would rebuild a server the user
+    # deliberately destroyed, so this refusal comes before any request.
+    #
+    # rollback_progress is set once, at the start of run_rollback, checkpointed
+    # on both success and failure, and never cleared, so a non-None value also
+    # covers a rollback that failed at its first delete. What it cannot see: a
+    # hand-edited state.json, or a fresh migration into the same output_dir.
+    if state.rollback_progress is not None:
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="error",
+                message=(
+                    "This state records a rollback, so every channel it maps was deleted "
+                    "on purpose. Rollback keeps the id maps as an audit trail, so a check "
+                    "reports them all missing and a repair would rebuild a server you "
+                    "chose to remove. Refusing."
+                ),
+            )
+        )
+        return
+
+    _ensure_token_store(config)
+    init_request_semaphore(config.max_concurrent_requests)
+
+    from discord_ferry.migrator.verify import run_check
+
+    report = await run_check(config.stoat_url, config.token, state, on_event, session=session)
+    counts = report.counts()
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=(
+                f"Check complete: {counts['fail']} failing, {counts['warn']} warned, "
+                f"{counts['unverifiable']} unverifiable."
+            ),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
 # Rollback engine (issue #10)
 # ---------------------------------------------------------------------------
 

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -1163,6 +1163,7 @@ async def _process_message(
     on_event: EventCallback,
     channel_result: ChannelResult | None = None,
     export_channel_id: str = "",
+    idempotency_salt: str = "",
 ) -> None:
     """Process and send a single message.
 
@@ -1471,7 +1472,21 @@ async def _process_message(
     try:
         for part_idx, part_content in enumerate(parts):
             is_first = part_idx == 0
-            idem_key = f"ferry-{msg.id}" if len(parts) == 1 else f"ferry-{msg.id}_p{part_idx + 1}"
+            # The salt exists for ferry repair. Stoat's Idempotency-Key store is a
+            # 1000-entry in-memory LRU with no TTL, and this key is built from the
+            # DISCORD message id, which a recreated channel does not change. So a
+            # repair running while those keys are still cached would be answered
+            # 409 DuplicateNonce and treat the message as already delivered, when
+            # the channel holding it was deleted and it is not there at all.
+            # Repair passes the new Stoat channel id, which makes the key unique
+            # to that recreation. Empty for the migration, so its keys are
+            # unchanged.
+            _salt = f"-{idempotency_salt}" if idempotency_salt else ""
+            idem_key = (
+                f"ferry-{msg.id}{_salt}"
+                if len(parts) == 1
+                else f"ferry-{msg.id}{_salt}_p{part_idx + 1}"
+            )
             try:
                 result = await api_send_message(
                     session,

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -13,7 +13,12 @@ import aiohttp
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
-from discord_ferry.discord.metadata import ChannelMeta, RoleMeta, load_discord_metadata
+from discord_ferry.discord.metadata import (
+    ChannelMeta,
+    PermissionPair,
+    RoleMeta,
+    load_discord_metadata,
+)
 from discord_ferry.errors import AutumnUploadError, DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     api_create_channel,
@@ -442,6 +447,55 @@ def _role_from_metadata(role_id: str, rm: RoleMeta) -> DCERole:
     return DCERole(id=role_id, name=rm.name, color=rm.color or None, position=rm.position)
 
 
+async def apply_role_permissions(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    stoat_role_id: str,
+    role_perms: PermissionPair | None,
+    label: str,
+    *,
+    phase: str,
+) -> None:
+    """Apply ONE role's translated Discord permissions to its Stoat role.
+
+    Deliberately scoped to one role. The ``api_set_server_default_permissions``
+    call that follows the loop this was extracted from is NOT included, and that
+    boundary is the point of the extraction rather than an accident of it: that
+    call merges ``server_default_permissions | FERRY_MIN_PERMISSIONS`` onto the
+    server's DEFAULT ROLE, so it is server-wide and tied to no single recreated
+    entity. A repair that re-fired it would re-impose a mask on a server whose
+    defaults may have changed since the migration, which is the class of defect
+    batch 5 of #107 existed to fix.
+
+    The ``roles_finalized`` and ``role_map`` guards stay at the call site. They
+    decide WHETHER to apply, which is caller policy, not application.
+
+    ``str(exc)`` needs no scrub at this append site for the same reason as
+    ``apply_channel_permissions``: ADR-014 redacts at the writer.
+    """
+    if not role_perms:
+        return
+    try:
+        await api_set_role_permissions(
+            session,
+            config.stoat_url,
+            config.token,
+            state.stoat_server_id,
+            stoat_role_id,
+            allow=role_perms.allow,
+            deny=role_perms.deny,
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.warnings.append(
+            {
+                "phase": phase,
+                "type": "role_permissions_failed",
+                "message": f"Failed to set permissions for role '{label}': {exc}",
+            }
+        )
+
+
 async def run_roles(
     config: FerryConfig,
     state: MigrationState,
@@ -705,28 +759,15 @@ async def run_roles(
                 if not stoat_role_id_or_none:
                     continue
                 stoat_role_id = stoat_role_id_or_none
-                role_perms = discord_metadata.role_permissions.get(role.id)
-                if role_perms:
-                    try:
-                        await api_set_role_permissions(
-                            session,
-                            config.stoat_url,
-                            config.token,
-                            state.stoat_server_id,
-                            stoat_role_id,
-                            allow=role_perms.allow,
-                            deny=role_perms.deny,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        state.warnings.append(
-                            {
-                                "phase": "roles",
-                                "type": "role_permissions_failed",
-                                "message": (
-                                    f"Failed to set permissions for role '{role.name}': {exc}"
-                                ),
-                            }
-                        )
+                await apply_role_permissions(
+                    session,
+                    config,
+                    state,
+                    stoat_role_id,
+                    discord_metadata.role_permissions.get(role.id),
+                    role.name,
+                    phase="roles",
+                )
 
             # Apply @everyone server default permissions (merged with ferry minimum).
             if discord_metadata.server_default_permissions:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -13,7 +13,7 @@ import aiohttp
 from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
-from discord_ferry.discord.metadata import RoleMeta, load_discord_metadata
+from discord_ferry.discord.metadata import ChannelMeta, RoleMeta, load_discord_metadata
 from discord_ferry.errors import AutumnUploadError, DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     api_create_channel,
@@ -857,6 +857,80 @@ async def run_categories(
     )
 
 
+async def apply_channel_permissions(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    stoat_channel_id: str,
+    ch_meta: ChannelMeta | None,
+    label: str,
+    *,
+    phase: str,
+) -> None:
+    """Apply a channel's Discord permission overrides to its Stoat channel.
+
+    Extracted from ``run_channels`` so ``run_repair`` can apply the same
+    overrides to a channel it recreates. A recreated channel without them is
+    silently wrong in exactly the way batch 5 of #107 existed to fix.
+
+    ``phase`` is a parameter rather than the hardcoded ``"channels"`` it was
+    inline, so a repair-time failure is not recorded in ``state.warnings`` as a
+    migration-time one. ADR-014 relies on that document being an honest record.
+
+    The raw ``str(exc)`` below needs no ``safe_sanitize`` at this append site.
+    Redaction happens at the WRITER: ``scrub_document`` masks
+    ``warnings[].message`` on the way into ``state.json`` and ``report.json``
+    (``_TEXT_MEMBERS`` in ``core/security.py``). That is ADR-014's whole point,
+    a call site cannot forget a scrub it never has to make.
+
+    The early return replaces an ``if ch_meta and not config.dry_run:`` block
+    that wrapped the whole body. Same behaviour, one level less nesting.
+    """
+    if not ch_meta or config.dry_run:
+        return
+    if ch_meta.default_override:
+        try:
+            await api_set_channel_default_permissions(
+                session,
+                config.stoat_url,
+                config.token,
+                stoat_channel_id,
+                allow=ch_meta.default_override.allow,
+                deny=ch_meta.default_override.deny,
+            )
+            await asyncio.sleep(config.upload_delay)
+        except Exception as exc:  # noqa: BLE001
+            state.warnings.append(
+                {
+                    "phase": phase,
+                    "type": "channel_default_perm_failed",
+                    "message": f"Default override for '{label}': {exc}",
+                }
+            )
+    for ow in ch_meta.role_overrides:
+        stoat_role_id = state.role_map.get(ow.discord_role_id)
+        if stoat_role_id:
+            try:
+                await api_set_channel_role_permissions(
+                    session,
+                    config.stoat_url,
+                    config.token,
+                    stoat_channel_id,
+                    stoat_role_id,
+                    allow=ow.allow,
+                    deny=ow.deny,
+                )
+                await asyncio.sleep(config.upload_delay)
+            except Exception as exc:  # noqa: BLE001
+                state.warnings.append(
+                    {
+                        "phase": phase,
+                        "type": "channel_role_perm_failed",
+                        "message": f"Role override for '{label}': {exc}",
+                    }
+                )
+
+
 async def run_channels(
     config: FerryConfig,
     state: MigrationState,
@@ -1113,48 +1187,15 @@ async def run_channels(
                 state.created_channel_names[ch.id] = result.get("name") or unique_name
 
                 # Apply channel permission overrides from Discord metadata.
-                if ch_meta and not config.dry_run:
-                    if ch_meta.default_override:
-                        try:
-                            await api_set_channel_default_permissions(
-                                session,
-                                config.stoat_url,
-                                config.token,
-                                stoat_channel_id,
-                                allow=ch_meta.default_override.allow,
-                                deny=ch_meta.default_override.deny,
-                            )
-                            await asyncio.sleep(config.upload_delay)
-                        except Exception as exc:  # noqa: BLE001
-                            state.warnings.append(
-                                {
-                                    "phase": "channels",
-                                    "type": "channel_default_perm_failed",
-                                    "message": f"Default override for '{unique_name}': {exc}",
-                                }
-                            )
-                    for ow in ch_meta.role_overrides:
-                        stoat_role_id = state.role_map.get(ow.discord_role_id)
-                        if stoat_role_id:
-                            try:
-                                await api_set_channel_role_permissions(
-                                    session,
-                                    config.stoat_url,
-                                    config.token,
-                                    stoat_channel_id,
-                                    stoat_role_id,
-                                    allow=ow.allow,
-                                    deny=ow.deny,
-                                )
-                                await asyncio.sleep(config.upload_delay)
-                            except Exception as exc:  # noqa: BLE001
-                                state.warnings.append(
-                                    {
-                                        "phase": "channels",
-                                        "type": "channel_role_perm_failed",
-                                        "message": f"Role override for '{unique_name}': {exc}",
-                                    }
-                                )
+                await apply_channel_permissions(
+                    session,
+                    config,
+                    state,
+                    stoat_channel_id,
+                    ch_meta,
+                    unique_name,
+                    phase="channels",
+                )
 
                 # S1/S2 (native-fidelity batch 2): apply slowmode + voice user_limit.
                 if ch_meta is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2709,3 +2709,178 @@ def test_retry_with_an_unreadable_state_exits_two(runner: CliRunner, tmp_path: P
     assert result.exit_code == 2, result.output
     assert "No such command" not in result.output, "the command does not exist yet"
     assert "state.json" in result.output
+
+
+# ---------------------------------------------------------------------------
+# ferry repair (#107 batch 10, task #340)
+# ---------------------------------------------------------------------------
+
+
+def _repair_argv(out_dir: Path, export_dir: Path, *extra: str) -> list[str]:
+    return [
+        "repair",
+        str(out_dir),
+        "--export-dir",
+        str(export_dir),
+        "--stoat-url",
+        "https://api.test",
+        "--token",
+        "t",
+        *extra,
+    ]
+
+
+def test_repair_exits_zero_when_nothing_is_left_failing(runner: CliRunner, tmp_path: Path) -> None:
+    """The contract a script reads, alongside re-running ferry check --json."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+
+    async def _noop(*_a: Any, **_k: Any) -> None:
+        return None
+
+    with patch("discord_ferry.cli.run_repair", new=_noop):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir))
+    assert result.exit_code == 0, result.output
+
+
+def test_repair_exits_non_zero_when_a_message_is_still_failed(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A repair that could not finish must not look like one that did."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+
+    async def _leaves_it(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        return None
+
+    with patch("discord_ferry.cli.run_repair", new=_leaves_it):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir))
+    assert result.exit_code == 1, result.output
+
+
+def test_a_repair_dry_run_always_exits_zero(runner: CliRunner, tmp_path: Path) -> None:
+    """A preview reports on a plan, not an outcome.
+
+    Exiting non-zero here would make --dry-run unusable in a script that treats
+    a non-zero code as "there is work to do, act now": the preview would look
+    exactly like a failed repair.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+    seen: dict[str, Any] = {}
+
+    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        seen["dry_run"] = config.dry_run
+
+    with patch("discord_ferry.cli.run_repair", new=_capture):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir, "--dry-run"))
+
+    assert seen["dry_run"] is True, "the --dry-run flag never reached the config"
+    assert result.exit_code == 0, (
+        f"a dry run exited {result.exit_code}, which a script cannot tell from real work"
+    )
+
+
+def test_repair_passes_a_real_export_to_the_coroutine(runner: CliRunner, tmp_path: Path) -> None:
+    """The same hole ferry retry had: an empty exports list is a silent no-op.
+
+    A recreated channel's resend and a tail repair both resolve their messages
+    out of `exports`. Given an empty list they restore nothing and report
+    success.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+    seen: dict[str, Any] = {}
+
+    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        seen["exports"] = exports
+
+    with patch("discord_ferry.cli.run_repair", new=_capture):
+        runner.invoke(main, _repair_argv(out_dir, export_dir))
+
+    assert len(seen["exports"]) > 0, "an empty exports list restores nothing"
+
+
+def test_repair_registers_the_token_and_the_semaphore_before_any_request(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Asserted as CALLS, never as the absence of a token from output."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+    order: list[str] = []
+
+    async def _noop(*_a: Any, **_k: Any) -> None:
+        order.append("request")
+
+    with (
+        patch(
+            "discord_ferry.cli.register_secret",
+            side_effect=lambda *_a: order.append("register_secret"),
+        ),
+        patch(
+            "discord_ferry.cli.init_request_semaphore",
+            side_effect=lambda *_a: order.append("semaphore"),
+        ),
+        patch("discord_ferry.cli.run_repair", new=_noop),
+    ):
+        runner.invoke(main, _repair_argv(out_dir, export_dir))
+
+    assert "register_secret" in order and "semaphore" in order
+    assert order.index("register_secret") < order.index("request")
+    assert order.index("semaphore") < order.index("request")
+
+
+def test_repair_reports_a_refusal_and_exits_one(runner: CliRunner, tmp_path: Path) -> None:
+    """CheckError reaches the operator as a sentence and a code, not a traceback.
+
+    run_repair raises it for a dry-run state and for a state recording no
+    server, and deliberately does not catch it.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+
+    async def _raises(*_a: Any, **_k: Any) -> None:
+        from discord_ferry.errors import CheckError
+
+        raise CheckError("cannot check a dry-run state")
+
+    with patch("discord_ferry.cli.run_repair", new=_raises):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir))
+
+    assert result.exit_code == 1, result.output
+    assert "dry-run state" in result.output
+
+
+def test_repair_with_a_missing_export_directory_exits_two(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Exit 2, the path intact, and the coroutine never reached."""
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+    missing = tmp_path / "not-here"
+    calls: list[str] = []
+
+    async def _record(*_a: Any, **_k: Any) -> None:
+        calls.append("ran")
+
+    with patch("discord_ferry.cli.run_repair", new=_record):
+        result = runner.invoke(main, _repair_argv(out_dir, missing))
+
+    assert result.exit_code == 2, result.output
+    assert str(missing) in result.output, "the path was wrapped or lost"
+    assert calls == [], "repair ran despite a missing export directory"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2884,3 +2884,67 @@ def test_repair_with_a_missing_export_directory_exits_two(
     assert result.exit_code == 2, result.output
     assert str(missing) in result.output, "the path was wrapped or lost"
     assert calls == [], "repair ran despite a missing export directory"
+
+
+def test_repair_exits_non_zero_when_it_declined_a_repair(runner: CliRunner, tmp_path: Path) -> None:
+    """A defect repair could not fix REMAINS, so the code must say so.
+
+    A channel with no recorded name, one missing from the export, and a forum
+    index are all cases repair declines. None of them leaves a FailedMessage, so
+    an exit code reading only that queue would report 0 and tell a script the
+    server is whole when it is not.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+
+    async def _declines(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        state.warnings.append(
+            {
+                "phase": "repair",
+                "type": "no_recorded_name",
+                "message": "Cannot recreate channel 800000000000000001",
+            }
+        )
+
+    with patch("discord_ferry.cli.run_repair", new=_declines):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir))
+    assert result.exit_code == 1, (
+        f"a declined repair exited {result.exit_code}, which reads as success"
+    )
+
+
+def test_repair_still_exits_zero_on_a_documented_partial_restore(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """The other half, so the assertion above cannot be met by failing everything.
+
+    merge_thread_content_not_restored names a partial restore of something
+    repair DID fix, and no_discord_metadata is a degradation rather than an
+    unrepaired defect. Exiting 1 on either would make the code useless for the
+    strategy where it always fires.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+
+    async def _partial(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        state.warnings.append(
+            {
+                "phase": "repair",
+                "type": "merge_thread_content_not_restored",
+                "message": "thread content not restored",
+            }
+        )
+
+    with patch("discord_ferry.cli.run_repair", new=_partial):
+        result = runner.invoke(main, _repair_argv(out_dir, export_dir))
+    assert result.exit_code == 0, (
+        f"a documented partial restore exited {result.exit_code}, which fails every merge repair"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2475,3 +2475,237 @@ def test_the_summary_does_not_claim_an_exclusive_cause(runner: CliRunner, tmp_pa
         assert "Each result above says which cause applies" in result.output, (
             f"the {strategy} summary does not point at the per-result detail"
         )
+
+
+# ---------------------------------------------------------------------------
+# ferry retry (#107 batch 10, task #323)
+# ---------------------------------------------------------------------------
+
+D_MSG = "100000000000000001"
+S_CHANNEL = "01JSTOATCHN000000000OLD"
+
+
+def _write_minimal_export(export_dir: Path, channel_id: str = "800000000000000001") -> Path:
+    """A DCE export directory holding exactly one message.
+
+    Written by hand rather than reusing a fixture, so the message id is the
+    literal the retry state names. Discord and Stoat ids stay visibly different
+    throughout: a fixture that seeds both sides from one variable lets a test
+    pass by comparing a value with itself.
+    """
+    export_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "guild": {"id": "900000000000000001", "name": "Test Guild", "iconUrl": ""},
+        "channel": {
+            "id": channel_id,
+            "type": 0,
+            "name": "general",
+            "categoryId": "",
+            "category": "",
+            "topic": "",
+        },
+        "dateRange": {"after": None, "before": None},
+        "exportedAt": "2026-01-01T00:00:00+00:00",
+        "messageCount": 1,
+        "messages": [
+            {
+                "id": D_MSG,
+                "type": "Default",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "timestampEdited": None,
+                "content": "hello",
+                "author": {
+                    "id": "700000000000000001",
+                    "name": "author",
+                    "nickname": "author",
+                    "isBot": False,
+                    "avatarUrl": "",
+                },
+                "attachments": [],
+                "embeds": [],
+                "stickers": [],
+                "reactions": [],
+                "mentions": [],
+            }
+        ],
+    }
+    (export_dir / "general.json").write_text(json.dumps(payload), encoding="utf-8")
+    return export_dir
+
+
+def _write_state_with_one_failure(out_dir: Path) -> Path:
+    """An output directory whose state.json carries one failed message."""
+    from discord_ferry.state import FailedMessage, save_state
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    state = MigrationState(
+        stoat_server_id="01JSTOATSRV000000000AAA",
+        channel_map={"800000000000000001": S_CHANNEL},
+        failed_messages=[
+            FailedMessage(discord_msg_id=D_MSG, stoat_channel_id=S_CHANNEL, error="timeout")
+        ],
+    )
+    save_state(state, out_dir)
+    return out_dir
+
+
+def _retry_argv(out_dir: Path, export_dir: Path) -> list[str]:
+    return [
+        "retry",
+        str(out_dir),
+        "--export-dir",
+        str(export_dir),
+        "--stoat-url",
+        "https://api.test",
+        "--token",
+        "t",
+    ]
+
+
+def test_retry_passes_a_real_export_to_the_coroutine(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.7. Asserts the parse happened AND that exports is non-empty.
+
+    This is the highest-value assertion in the command. run_retry_failed needs
+    both a real config.export_dir and a NON-EMPTY exports list, which it scans
+    to resolve each FailedMessage back to a DCEMessage. Given an empty list
+    every message takes the "not found in exports, skipping" branch, stays
+    failed, and the command still reports a plausible result.
+
+    A test asserting only the exit code passes against exactly that. Neither
+    obvious template wires it: rollback_cmd sets export_dir to a value it never
+    reads and passes exports=[], and check_cmd builds no FerryConfig at all.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+    seen: dict[str, Any] = {}
+
+    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        seen["exports"] = exports
+        seen["export_dir"] = config.export_dir
+        # Stand in for a retry that succeeded, so the exit code reflects the
+        # command's contract rather than this stub doing nothing.
+        state.failed_messages.clear()
+
+    with patch("discord_ferry.cli.run_retry_failed", new=_capture):
+        result = runner.invoke(main, _retry_argv(out_dir, export_dir))
+
+    assert result.exit_code == 0, result.output
+    assert seen["export_dir"] == export_dir
+    assert len(seen["exports"]) > 0, (
+        "an empty exports list makes every retry a silent no-op that still reports success"
+    )
+    assert seen["exports"][0].channel.id == "800000000000000001"
+
+
+def test_retry_registers_the_token_and_the_semaphore_before_any_request(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-1.2 and SC-1.3. Asserts the CALLS and their ORDER.
+
+    Never the absence of a token from output: an absence assertion passes
+    against a token that simply did not appear in that string.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+    order: list[str] = []
+
+    async def _noop_coro(*_a: Any, **_k: Any) -> None:
+        order.append("request")
+
+    with (
+        patch(
+            "discord_ferry.cli.register_secret",
+            side_effect=lambda *_a: order.append("register_secret"),
+        ),
+        patch(
+            "discord_ferry.cli.init_request_semaphore",
+            side_effect=lambda *_a: order.append("semaphore"),
+        ),
+        patch("discord_ferry.cli.run_retry_failed", new=_noop_coro),
+    ):
+        runner.invoke(main, _retry_argv(out_dir, export_dir))
+
+    assert "register_secret" in order, "the Stoat token was never registered for masking"
+    assert "semaphore" in order, "the concurrency semaphore was never initialised"
+    assert order.index("register_secret") < order.index("request")
+    assert order.index("semaphore") < order.index("request")
+
+
+def test_retry_with_nothing_failed_exits_zero_in_the_coroutines_own_words(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-1.5. The wording comes from the engine event, not from the shell.
+
+    A separate CLI sentence would drift from the engine's the first time either
+    changed, and the engine is the one that knows.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+
+    result = runner.invoke(main, _retry_argv(out_dir, export_dir))
+    assert result.exit_code == 0, result.output
+    assert "No failed messages to retry." in result.output
+
+
+def test_retry_exits_non_zero_when_a_message_is_still_failed(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-1.6. A retry that fixed nothing must not look like success."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+
+    async def _leaves_it_failed(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        state.failed_messages[0].retry_count += 1
+
+    with patch("discord_ferry.cli.run_retry_failed", new=_leaves_it_failed):
+        result = runner.invoke(main, _retry_argv(out_dir, export_dir))
+    assert result.exit_code == 1, result.output
+
+
+def test_retry_with_a_missing_export_directory_exits_two_and_makes_no_request(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-1.8. Asserts the request COUNT, not the message.
+
+    A command that reached the network and then failed would pass an assertion
+    that only reads stdout.
+    """
+    out_dir = _write_state_with_one_failure(tmp_path / "out")
+    missing = tmp_path / "not-here"
+    calls: list[str] = []
+
+    async def _record(*_a: Any, **_k: Any) -> None:
+        calls.append("request")
+
+    with patch("discord_ferry.cli.run_retry_failed", new=_record):
+        result = runner.invoke(main, _retry_argv(out_dir, missing))
+
+    assert result.exit_code == 2, result.output
+    assert str(missing) in result.output
+    assert calls == [], "the command reached the coroutine despite a missing export directory"
+
+
+def test_retry_with_an_unreadable_state_exits_two(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.1's error half: a corrupt state file is exit 2, matching rollback.
+
+    The exit code alone is NOT enough here, and the first draft of this test
+    proved it: Click returns 2 for "No such command 'retry'" too, so a bare
+    `exit_code == 2` assertion passed before the command existed at all. It
+    could not distinguish the case under test from the command being absent.
+
+    So it asserts the message names the state file, and that Click did not
+    reject the invocation itself.
+    """
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "state.json").write_text("{not json", encoding="utf-8")
+
+    result = runner.invoke(main, _retry_argv(out_dir, export_dir))
+    assert result.exit_code == 2, result.output
+    assert "No such command" not in result.output, "the command does not exist yet"
+    assert "state.json" in result.output

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4116,3 +4116,123 @@ async def test_a_resend_sends_in_timestamp_order_not_list_order(tmp_path: Path) 
         "msg:100000000000000002",
         "msg:100000000000000003",
     ], f"the resend followed list order rather than timestamp order: {sent}"
+
+
+def test_the_migration_idempotency_key_is_unchanged_without_a_salt() -> None:
+    """The salt is additive: an unsalted call produces exactly the old key.
+
+    Every migration send goes through this path, and a changed key would make
+    Stoat treat a resumed migration's messages as new and duplicate them all.
+    """
+    import inspect
+
+    source = inspect.getsource(messages_module._process_message)
+    assert 'f"ferry-{msg.id}{_salt}"' in source
+    assert '_salt = f"-{idempotency_salt}" if idempotency_salt else ""' in source
+    signature = inspect.signature(messages_module._process_message)
+    assert signature.parameters["idempotency_salt"].default == "", (
+        "the salt must default to empty, or every migration key changes"
+    )
+
+
+async def test_a_resend_salts_its_idempotency_keys_with_the_new_channel(
+    tmp_path: Path,
+) -> None:
+    """Otherwise Stoat's LRU silently swallows the whole resend.
+
+    The per-message key is built from the DISCORD message id, which a recreated
+    channel does not change, and Stoat's Idempotency-Key store is a 1000-entry
+    in-memory LRU with NO TTL. A repair running while those keys are still
+    cached is answered 409 DuplicateNonce, and _process_message treats that as
+    "already on the server" and moves on. The channel holding those messages was
+    deleted, so it is not there at all: the repair would report success and
+    restore nothing.
+
+    Salting with the new Stoat channel id makes the key unique to the
+    recreation. Asserts the salt reached the call, not that a send succeeded.
+    """
+    export = _export_for(R_D_CHANNEL)
+    export.messages.append(_dce_msg("100000000000000001"))
+    seen: list[str] = []
+
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    async def _capture(*, msg: Any, idempotency_salt: str = "", **_kw: Any) -> None:
+        seen.append(idempotency_salt)
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "_process_message", _capture),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        await run_repair(config, state, [export], lambda _e: None)
+
+    assert seen == ["01JSTOATCHN000000000NEW"], (
+        f"the resend did not salt its keys with the new channel id: {seen}"
+    )
+
+
+async def test_the_origin_header_key_is_salted_too(tmp_path: Path) -> None:
+    """The header has the same exposure and the same fix."""
+    export = _thread_export(R_D_CHANNEL, parent="general")
+    export.messages.append(_dce_msg("100000000000000001"))
+    keys: list[str] = []
+
+    async def _fake_send(*_a: Any, **kwargs: Any) -> dict[str, str]:
+        keys.append(str(kwargs.get("idempotency_key", "")))
+        return {"_id": "01JSTOATMSG0000000000AA"}
+
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "api_send_message", _fake_send),
+        patch.object(engine_module, "_process_message", _noop_process),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        await run_repair(config, state, [export], lambda _e: None)
+
+    assert keys == ["ferry-header-800000000000000001-01JSTOATCHN000000000NEW"], (
+        f"the header key was not salted with the new channel: {keys}"
+    )
+
+
+async def _noop_process(**_kw: Any) -> None:
+    """A _process_message stand-in that sends nothing."""
+    return None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 """Tests for the migration engine orchestrator."""
 
 import asyncio
+import contextlib
 import json
 import re
 import shutil
@@ -2827,13 +2828,84 @@ async def test_repair_dry_run_never_calls_save_state_at_all(tmp_path: Path) -> N
     assert requests == [], "a dry run made a write request"
 
 
-async def test_repair_saves_state_once_when_not_a_dry_run(tmp_path: Path) -> None:
+async def test_repair_saves_state_when_not_a_dry_run(tmp_path: Path) -> None:
     """The other half, so the dry-run assertion above can actually fail.
 
     Without this, `save_state` removed entirely would pass the dry-run test.
+
+    Deliberately not an exact count. Repair saves after EACH recreation as well
+    as at the end, for the reason run_roles already saves mid-loop: a hard kill
+    between a create and the save leaves the id map naming the entity that is
+    gone, so the next run's check reports it missing again and repair creates a
+    SECOND one. Asserting a number here would make that durability property look
+    like a regression the next time it changes.
     """
     saves, _, _ = await _repair_recording_saves(tmp_path, _report_with("channel_missing", "fail"))
-    assert len(saves) == 1, f"expected exactly one save_state call, saw {len(saves)}"
+    assert saves, "a real run wrote no state at all"
+
+
+async def test_an_interrupted_repair_keeps_what_it_already_recreated(tmp_path: Path) -> None:
+    """The finding the chunk 4 review produced, and the reason for the per-entity save.
+
+    Two channels need recreating and the second create fails. Without a save
+    between them, the first channel's new id is lost: state still names the
+    deleted one, the next run's check reports it missing again, and repair
+    creates a duplicate. run_roles saves mid-loop for exactly this reason and
+    says so in its own comment.
+    """
+    second = "800000000000000002"
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL, second: "01JSTOATCHN0000000002ND"},
+        created_channel_names={R_D_CHANNEL: "general", second: "random"},
+    )
+    saved_ids: list[str] = []
+
+    report = CheckReport()
+    for did, sid in ((R_D_CHANNEL, R_S_CHANNEL), (second, "01JSTOATCHN0000000002ND")):
+        report.add(
+            name=f"channel:{did}",
+            status="fail",
+            kind="channel_missing",
+            detail="fixture",
+            discord_id=did,
+            stoat_id=sid,
+        )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    def _record_save(st: MigrationState, _out: Path) -> None:
+        saved_ids.append(st.channel_map[R_D_CHANNEL])
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", _record_save),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        m.post(f"{BASE_URL}/servers/{R_SERVER}/channels", status=500)
+        with contextlib.suppress(Exception):
+            await run_repair(
+                config,
+                state,
+                [_export_for(R_D_CHANNEL), _export_for(second, name="random")],
+                lambda _e: None,
+            )
+
+    assert "01JSTOATCHN000000000NEW" in saved_ids, (
+        "the first recreation was never persisted, so an interruption after it would "
+        "leave state naming the deleted channel and the next run would duplicate it"
+    )
 
 
 async def test_repair_dry_run_says_what_it_would_have_done(tmp_path: Path) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -2641,3 +2642,136 @@ async def test_repair_populates_the_token_store_and_the_semaphore(tmp_path: Path
     assert order.index("token_store") < order.index("check")
     assert order.index("semaphore") < order.index("check")
     assert config.token_store is not None
+
+
+def _report_with(kind: str, status: str, *, discord_id: str = R_D_CHANNEL) -> CheckReport:
+    """A one-result CheckReport, for driving the partition."""
+    report = CheckReport()
+    report.add(
+        name=f"channel:{discord_id}",
+        status=status,  # type: ignore[arg-type]
+        kind=kind,
+        detail="fixture",
+        discord_id=discord_id,
+        stoat_id=R_S_CHANNEL,
+    )
+    return report
+
+
+def _partition_counts(events: list[MigrationEvent]) -> tuple[int, int]:
+    """Read the (structure, tail) work counts out of run_repair's own event.
+
+    Without this the request-count assertions below are INERT until a later
+    chunk gives repair something to send: a mis-partition changes which lists
+    fill, and with nothing consuming those lists yet no request happens either
+    way. Measured, not assumed: swapping the `kind` test for a `status` one, and
+    widening the tail set, both survived until these counts were asserted.
+    """
+    for event in reversed(events):
+        match = re.search(r"(\d+) entities to recreate, (\d+) channels", event.message)
+        if match:
+            return int(match.group(1)), int(match.group(2))
+    raise AssertionError(f"run_repair emitted no partition summary: {[e.message for e in events]}")
+
+
+async def _repair_with_report(
+    tmp_path: Path, report: CheckReport
+) -> tuple[Any, list[Any], list[MigrationEvent]]:
+    """Drive run_repair against a fixed report and hand back the request log."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        aioresponses() as m,
+    ):
+        await run_repair(config, state, [], events.append)
+        requests = list(m.requests)
+    return state, requests, events
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "check_error",
+        "tail_not_recorded",
+        "tail_window_exhausted",
+        "channel_not_visible",
+        "category_title_unknown",
+    ],
+)
+async def test_repair_never_acts_on_an_unverifiable_result(tmp_path: Path, kind: str) -> None:
+    """The check could not look, so there is nothing to act on.
+
+    Acting anyway is guessing at a live server. Asserts the REQUEST COUNT: an
+    assertion that the report is unchanged would pass against a repair that
+    sent something and then failed.
+    """
+    _, requests, events = await _repair_with_report(tmp_path, _report_with(kind, "unverifiable"))
+    assert requests == [], f"repair acted on an unverifiable {kind}"
+    assert _partition_counts(events) == (0, 0), f"an unverifiable {kind} entered the work lists"
+
+
+@pytest.mark.parametrize("kind", ["channel_renamed", "role_renamed", "category_title_mismatch"])
+async def test_repair_never_acts_on_a_warn_result(tmp_path: Path, kind: str) -> None:
+    """A rename almost always means the operator renamed it on purpose.
+
+    A user who asked to fix failures did not ask to have their own edits
+    overruled, which is why warn is excluded and fail is not.
+    """
+    _, requests, events = await _repair_with_report(tmp_path, _report_with(kind, "warn"))
+    assert requests == [], f"repair acted on a warn: {kind}"
+    assert _partition_counts(events) == (0, 0), f"a warn {kind} entered the work lists"
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "tail_present",
+        "channel_empty",
+        "nothing_expected",
+        "tail_not_recorded",
+        "tail_window_exhausted",
+    ],
+)
+async def test_repair_never_acts_on_a_non_actionable_tail_kind(tmp_path: Path, kind: str) -> None:
+    """Only tail_absent and tail_and_after_absent are repairable tails."""
+    status = "fail" if kind == "channel_empty" else "ok"
+    _, requests, events = await _repair_with_report(tmp_path, _report_with(kind, status))
+    assert requests == [], f"repair acted on a non-actionable tail kind: {kind}"
+    assert _partition_counts(events) == (0, 0), f"{kind} entered the work lists"
+
+
+async def test_repair_declines_a_missing_forum_index_channel(tmp_path: Path) -> None:
+    """SC-3.17. A DELIBERATE EXCLUSION, not an unimplemented case.
+
+    The forum index writer stores its channel under a SYNTHETIC key,
+    `channel_map["forum-index-{forum_key}"]`, whose value is a real Stoat
+    channel id. So the check reports a deleted index as channel_missing exactly
+    like any other channel, and a membership test on `kind` alone would sweep it
+    into generic recreation.
+
+    Generic recreation cannot restore it. There is no ChannelMeta for a
+    synthetic id, the channel-scoped export scan finds zero messages because the
+    key names no Discord channel, and nothing rebuilds the index message or
+    forum_index_message_ids. _select_invite_channel already excludes the same
+    prefix for the same reason. Deferred as #311.
+
+    This is the second level of the lesson the partition comment records: a test
+    on `status` would sweep in a future kind, and a test on `kind` alone sweeps
+    in a channel TYPE nobody considered.
+    """
+    forum_key = "forum-index-800000000000000009"
+    report = _report_with("channel_missing", "fail", discord_id=forum_key)
+    state, requests, events = await _repair_with_report(tmp_path, report)
+
+    assert requests == [], "repair tried to recreate a forum index channel"
+    assert _partition_counts(events) == (0, 0), "the forum index entered the work lists"
+    assert any(
+        w.get("type") == "forum_index_not_repairable" and w.get("phase") == "repair"
+        for w in state.warnings
+    ), f"no warning names the declined forum index: {state.warnings}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2957,7 +2957,7 @@ async def test_the_collision_set_comes_from_the_live_server(tmp_path: Path) -> N
             payload=_server_with_channels("general", "announcements"),
         )
         async with aiohttp.ClientSession() as session:
-            names = await engine_module._live_channel_names(session, config, state)
+            names, _ = await engine_module._live_server_view(session, config, state)
     assert names == {"general", "announcements"}
 
 
@@ -2982,7 +2982,7 @@ async def test_the_collision_set_skips_an_entry_it_cannot_read(tmp_path: Path) -
     with aioresponses() as m:
         m.get(f"{BASE_URL}/servers/{R_SERVER}?include_channels=true", payload=payload)
         async with aiohttp.ClientSession() as session:
-            names = await engine_module._live_channel_names(session, config, state)
+            names, _ = await engine_module._live_server_view(session, config, state)
     assert names == {"general"}
 
 
@@ -3471,3 +3471,105 @@ async def test_repair_warns_by_name_when_the_metadata_file_is_absent(tmp_path: P
         w.get("type") == "no_discord_metadata" and "discord_metadata.json" in w["message"]
         for w in state.warnings
     ), f"nothing named the missing file: {state.warnings}"
+
+
+D_CAT = "700000000000000001"
+S_CAT_OLD = "01JSTOATCAT000000000OLD"
+
+
+async def _repair_recreating_category(
+    tmp_path: Path,
+    *,
+    live_categories: list[dict[str, Any]] | None = None,
+    title: str | None = "Announcements",
+) -> tuple[MigrationState, dict[str, Any] | None, list[MigrationEvent]]:
+    """Drive run_repair against one category_missing result."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL, "800000000000000002": "01JSTOATCHN0000000002ND"},
+        channel_categories={R_D_CHANNEL: D_CAT, "800000000000000002": "other-category"},
+        category_map={D_CAT: S_CAT_OLD},
+    )
+    if title is not None:
+        state.category_names[D_CAT] = title
+    events: list[MigrationEvent] = []
+
+    report = CheckReport()
+    report.add(
+        name=f"category:{D_CAT}",
+        status="fail",
+        kind="category_missing",
+        detail="fixture",
+        discord_id=D_CAT,
+        stoat_id=S_CAT_OLD,
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    payload = _server_with_channels("general")
+    if live_categories is not None:
+        payload["server"]["categories"] = live_categories  # type: ignore[index]
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(re.compile(r".*/servers/.*include_channels.*"), payload=payload, repeat=True)
+        m.patch(f"{BASE_URL}/servers/{R_SERVER}", payload={})
+        await run_repair(config, state, [], events.append)
+        sent: dict[str, Any] | None = None
+        for (method, url), calls in m.requests.items():
+            if method == "PATCH" and str(url).endswith(f"/servers/{R_SERVER}"):
+                body = calls[0].kwargs.get("json")
+                sent = body if isinstance(body, dict) else None
+    return state, sent, events
+
+
+async def test_a_recreated_category_carries_its_channels(tmp_path: Path) -> None:
+    """An empty category is a recreation that restores nothing.
+
+    A Stoat category carries its channel list, so the PATCH has to rebuild it
+    from channel_categories, which records discord_channel_id to
+    discord_category_id for exactly this. Only the channels that belonged to
+    THIS category, mapped through channel_map to ids the server knows.
+    """
+    _, sent, _ = await _repair_recreating_category(tmp_path)
+    assert sent is not None, "no categories PATCH was sent"
+    mine = [c for c in sent["categories"] if c["title"] == "Announcements"]
+    assert mine, f"the recreated category is not in the PATCH: {sent}"
+    assert mine[0]["channels"] == [R_S_CHANNEL], (
+        f"the category was recreated with the wrong channels: {mine[0]}"
+    )
+
+
+async def test_recreating_one_category_does_not_delete_the_others(tmp_path: Path) -> None:
+    """The destructive failure mode this whole helper is shaped around.
+
+    api_upsert_categories sets the server's ENTIRE categories array. Sending
+    only the recreated entry would delete every other category on the server,
+    silently, as a side effect of restoring one. Two survivors are driven here
+    and both must come back in the PATCH.
+    """
+    live = [
+        {
+            "id": "01JSTOATCAT000000000AAA",
+            "title": "General",
+            "channels": ["01JSTOATCHN000000000AAA"],
+        },
+        {"id": "01JSTOATCAT000000000BBB", "title": "Voice", "channels": []},
+    ]
+    _, sent, _ = await _repair_recreating_category(tmp_path, live_categories=live)
+    assert sent is not None, "no categories PATCH was sent"
+    titles = {c["title"] for c in sent["categories"]}
+    assert {"General", "Voice"} <= titles, f"recreating one category deleted the others: {titles}"
+    assert "Announcements" in titles
+
+
+async def test_repair_declines_a_category_it_has_no_recorded_title_for(tmp_path: Path) -> None:
+    """The same known limit as the channel and role cases."""
+    state, sent, _ = await _repair_recreating_category(tmp_path, title=None)
+    assert sent is None, "repair PATCHed a category it could not title"
+    assert any(w.get("type") == "no_recorded_name" for w in state.warnings), state.warnings

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -25,7 +25,13 @@ from discord_ferry.core.engine import (
 from discord_ferry.core.events import EventCallback, MigrationEvent
 from discord_ferry.errors import CheckError, DuplicateSendError
 from discord_ferry.migrator.verify import CheckReport
-from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
+from discord_ferry.parser.models import (
+    DCEAuthor,
+    DCEChannel,
+    DCEExport,
+    DCEGuild,
+    DCEMessage,
+)
 from discord_ferry.state import FailedMessage, MigrationState
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -3645,3 +3651,199 @@ async def test_repair_declines_a_category_it_has_no_recorded_title_for(tmp_path:
     state, sent, _ = await _repair_recreating_category(tmp_path, title=None)
     assert sent is None, "repair PATCHed a category it could not title"
     assert any(w.get("type") == "no_recorded_name" for w in state.warnings), state.warnings
+
+
+def _dce_msg(msg_id: str) -> DCEMessage:
+    """A minimal in-memory DCEMessage, for the non-streaming branch."""
+    return DCEMessage(
+        id=msg_id,
+        type="Default",
+        timestamp="2026-01-01T00:00:00+00:00",
+        content="hello",
+        author=DCEAuthor(id="700000000000000001", name="author", nickname="author"),
+    )
+
+
+def test_the_channel_scan_streams_from_disk_when_a_path_is_known(tmp_path: Path) -> None:
+    """A large channel export is not held in memory to list its ids.
+
+    run_retry_failed streams for the same reason. This asserts the path is
+    actually used, by leaving export.messages EMPTY while the file on disk holds
+    two messages: an implementation reading the in-memory list would return
+    nothing and the assertion would fail.
+    """
+    export_dir = tmp_path / "exports"
+    export_dir.mkdir()
+    path = _write_dce_json(
+        export_dir,
+        "800000000000000001",
+        [_dce_msg_dict("100000000000000001"), _dce_msg_dict("100000000000000002")],
+    )
+    export = DCEExport(
+        guild=DCEGuild(id="900000000000000009", name="G", icon_url=""),
+        channel=DCEChannel(id="800000000000000001", type=0, name="general"),
+        messages=[],
+        json_path=path,
+    )
+    assert engine_module._channel_message_ids(export) == [
+        "100000000000000001",
+        "100000000000000002",
+    ]
+
+
+def test_the_channel_scan_falls_back_to_messages_held_in_memory() -> None:
+    """An export parsed with metadata_only=False carries its messages directly.
+
+    Paired with the test above so neither branch can be deleted unnoticed.
+    """
+    export = DCEExport(
+        guild=DCEGuild(id="900000000000000009", name="G", icon_url=""),
+        channel=DCEChannel(id="800000000000000001", type=0, name="general"),
+        messages=[_dce_msg("100000000000000003"), _dce_msg("100000000000000004")],
+    )
+    assert engine_module._channel_message_ids(export) == [
+        "100000000000000003",
+        "100000000000000004",
+    ]
+
+
+def test_the_channel_scan_is_empty_for_a_channel_with_no_messages() -> None:
+    """The case SC-3.2 later depends on: an export that fills nothing back."""
+    export = DCEExport(
+        guild=DCEGuild(id="900000000000000009", name="G", icon_url=""),
+        channel=DCEChannel(id="800000000000000001", type=0, name="general"),
+        messages=[],
+    )
+    assert engine_module._channel_message_ids(export) == []
+
+
+async def _repair_with_state(
+    tmp_path: Path, state: MigrationState, exports: list[Any]
+) -> tuple[MigrationState, list[MigrationEvent]]:
+    """Recreate one channel against a caller-supplied state."""
+    config = _make_repair_config(tmp_path)
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        await run_repair(config, state, exports, events.append)
+    return state, events
+
+
+def _state_for_rewrite(**overrides: Any) -> MigrationState:
+    """A state describing a channel that WAS migrated and is now deleted."""
+    defaults: dict[str, Any] = {
+        "stoat_server_id": R_SERVER,
+        "channel_map": {R_D_CHANNEL: R_S_CHANNEL},
+        "created_channel_names": {R_D_CHANNEL: "general"},
+        "channel_high_water": {R_D_CHANNEL: "100000000000000002"},
+        "channel_message_counts": {R_D_CHANNEL: 2},
+        "channel_message_offsets": {R_D_CHANNEL: "100000000000000001"},
+        "completed_channel_ids": {R_D_CHANNEL},
+        "message_map": {
+            "100000000000000001": "01JSTOATOLD0000000000BA",
+            "100000000000000002": "01JSTOATOLD0000000000BB",
+            "999000000000000009": "01JSTOATOTHER00000000CC",
+        },
+    }
+    defaults.update(overrides)
+    return MigrationState(**defaults)
+
+
+async def test_a_recreated_channels_new_id_lands_under_the_unchanged_key(
+    tmp_path: Path,
+) -> None:
+    """Only one map VALUE moves. No key changes anywhere."""
+    state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [_export_for(R_D_CHANNEL)])
+    assert state.channel_map == {R_D_CHANNEL: "01JSTOATCHN000000000NEW"}
+
+
+async def test_the_recreated_channels_stale_per_channel_state_is_cleared(
+    tmp_path: Path,
+) -> None:
+    """The four Discord-keyed entries that described the channel that is gone."""
+    export = _export_for(R_D_CHANNEL)
+    export.messages.extend([_dce_msg("100000000000000001"), _dce_msg("100000000000000002")])
+    state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [export])
+
+    assert R_D_CHANNEL not in state.channel_high_water
+    assert R_D_CHANNEL not in state.channel_message_counts
+    assert R_D_CHANNEL not in state.channel_message_offsets
+    assert R_D_CHANNEL not in state.completed_channel_ids
+
+
+async def test_only_this_channels_message_map_entries_are_dropped(tmp_path: Path) -> None:
+    """The scan is channel-scoped, so another channel's entries survive.
+
+    A message_map wiped wholesale would strand every reply reference in the
+    migration, and nothing would report it: the map is consulted, never checked.
+    """
+    export = _export_for(R_D_CHANNEL)
+    export.messages.extend([_dce_msg("100000000000000001"), _dce_msg("100000000000000002")])
+    state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [export])
+
+    assert "100000000000000001" not in state.message_map
+    assert "100000000000000002" not in state.message_map
+    assert state.message_map.get("999000000000000009") == "01JSTOATOTHER00000000CC", (
+        "another channel's message_map entry was dropped"
+    )
+
+
+async def test_a_stale_message_count_does_not_survive_a_repair_that_resends_nothing(
+    tmp_path: Path,
+) -> None:
+    """SC-3.2. The ONLY test that can see the channel_message_counts clear.
+
+    Clearing the count is observable ONLY when the resend puts nothing back. A
+    successful resend repopulates it, and only a ZERO count changes any verdict:
+    _classify_tail's "nothing expected" shortcut requires recorded_count == 0
+    AND expected is None. With a stale count of 2 and the high-water mark gone,
+    control falls past that shortcut to `if not window_ids`, which returns
+    ("fail", "channel_empty"). A repair that did everything it could would then
+    report as a failure.
+
+    The runnable prototype measured this. Its first case set was all successful
+    resends, and the mutant that skips the clear SURVIVED. This is the shape
+    that kills it: an export holding NOTHING for this channel, which is what an
+    operator gets by pointing repair at a narrower re-export.
+
+    DO NOT weaken this to a successful resend. The clear then becomes
+    unobservable and can be deleted without any test noticing.
+    """
+    state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [_export_for(R_D_CHANNEL)])
+    assert state.channel_message_counts.get(R_D_CHANNEL, 0) == 0, (
+        "a stale non-zero count survived, so the next check reports channel_empty "
+        "for a channel repair restored as far as it could"
+    )
+
+
+async def test_the_offsets_clear_is_invisible_to_the_check_by_construction(
+    tmp_path: Path,
+) -> None:
+    """SC-3.9. Pins a KNOWN LIMIT, not a missing check.
+
+    The mutant that skips clearing channel_message_offsets SURVIVES the
+    prototype, correctly: nothing in _classify_tail or _expected_tail reads that
+    map, so no check verdict can observe the clear. It is not dead code, it
+    serves a later --resume.
+
+    So this asserts the STATE directly. Do not add an assertion that the check
+    notices it, because none can.
+    """
+    state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [_export_for(R_D_CHANNEL)])
+    assert R_D_CHANNEL not in state.channel_message_offsets

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3020,3 +3020,101 @@ async def test_repair_fetches_the_collision_set_when_there_is_work(tmp_path: Pat
     assert any("names already on the server" in e.message for e in events), (
         f"repair never fetched the collision set: {[e.message for e in events]}"
     )
+
+
+D_ROLE = "900000000000000001"
+S_ROLE_OLD = "01JSTOATROL000000000OLD"
+S_ROLE_NEW = "01JSTOATROL000000000NEW"
+
+
+async def _repair_recreating_role(
+    tmp_path: Path,
+    *,
+    recorded_name: str | None = "moderator",
+    create_payload: dict[str, Any] | None = None,
+) -> tuple[MigrationState, list[Any], list[MigrationEvent]]:
+    """Drive run_repair against one role_missing result."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, role_map={D_ROLE: S_ROLE_OLD})
+    if recorded_name is not None:
+        state.created_role_names[D_ROLE] = recorded_name
+    events: list[MigrationEvent] = []
+
+    report = CheckReport()
+    report.add(
+        name=f"role:{D_ROLE}",
+        status="fail",
+        kind="role_missing",
+        detail="fixture",
+        discord_id=D_ROLE,
+        stoat_id=S_ROLE_OLD,
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels("general"),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/roles",
+            payload=create_payload if create_payload is not None else {"id": S_ROLE_NEW},
+        )
+        await run_repair(config, state, [], events.append)
+        requests = list(m.requests)
+    return state, requests, events
+
+
+async def test_repair_recreates_a_missing_role_and_records_its_new_id(tmp_path: Path) -> None:
+    """role_map moves to the new Stoat id under the UNCHANGED Discord key."""
+    state, _, _ = await _repair_recreating_role(tmp_path)
+    assert state.role_map[D_ROLE] == S_ROLE_NEW, (
+        f"role_map still names the deleted role: {state.role_map}"
+    )
+    assert D_ROLE in state.role_map, "the Discord key changed, which it must never do"
+
+
+async def test_a_recreated_role_records_the_name_from_the_response(tmp_path: Path) -> None:
+    """The RESPONSE, not the local variable, per the rule 2.17.0 established.
+
+    api_create_role answers with `id`, while api_create_channel answers with
+    `_id`. The five create routes disagree by design and a pass that makes them
+    consistent breaks two of the three. This drives a response whose name
+    DIFFERS from what was sent, because in every other case the two are equal
+    and nothing distinguishes recording one from the other.
+    """
+    state, _, _ = await _repair_recreating_role(
+        tmp_path, create_payload={"id": S_ROLE_NEW, "name": "moderator-renamed-by-server"}
+    )
+    assert state.created_role_names[D_ROLE] == "moderator-renamed-by-server", (
+        "the recorded name came from the local variable, not the create response"
+    )
+
+
+async def test_repair_declines_a_role_it_has_no_recorded_name_for(tmp_path: Path) -> None:
+    """A KNOWN LIMIT for a state written before 2.17.0, not a missing feature.
+
+    The name to recreate a role under is the one Ferry SENT, which lives in
+    created_role_names. A migration run before 2.17.0 recorded none, and there
+    is nothing to reconstruct it from: the Discord name is not in state, and
+    inventing one would produce a role that silently differs from what the
+    server lost. So repair declines and says so.
+
+    Asserts ZERO create requests, not merely that role_map is unchanged: a
+    repair that created a role and then failed to record it would pass the
+    weaker assertion while leaving an orphan on the server.
+    """
+    state, requests, _ = await _repair_recreating_role(tmp_path, recorded_name=None)
+    creates = [k for k in requests if str(k[1]).endswith("/roles")]
+    assert creates == [], "repair created a role it could not name correctly"
+    assert state.role_map[D_ROLE] == S_ROLE_OLD, "role_map moved without a creation"
+    assert any(
+        w.get("type") == "no_recorded_name" and w.get("phase") == "repair" for w in state.warnings
+    ), f"no warning explains why the role was skipped: {state.warnings}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4236,3 +4236,202 @@ async def test_the_origin_header_key_is_salted_too(tmp_path: Path) -> None:
 async def _noop_process(**_kw: Any) -> None:
     """A _process_message stand-in that sends nothing."""
     return None
+
+
+async def _repair_tail_run(
+    tmp_path: Path,
+    *,
+    kind: str = "tail_absent",
+    high_water: str | None = "100000000000000002",
+    export_ids: tuple[str, ...] = ("100000000000000001", "100000000000000002"),
+    fail: bool = False,
+) -> tuple[MigrationState, list[dict[str, Any]], list[MigrationEvent]]:
+    """Drive one tail repair against a channel that is PRESENT."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+    )
+    if high_water is not None:
+        state.channel_high_water[R_D_CHANNEL] = high_water
+    events: list[MigrationEvent] = []
+    calls: list[dict[str, Any]] = []
+
+    export = _export_for(R_D_CHANNEL)
+    export.messages.extend(_dce_msg(i) for i in export_ids)
+
+    report = CheckReport()
+    report.add(
+        name=f"tail:{R_D_CHANNEL}",
+        status="fail",
+        kind=kind,
+        detail="fixture",
+        discord_id=R_D_CHANNEL,
+        stoat_id=R_S_CHANNEL,
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    async def _capture(*, msg: Any, **kw: Any) -> None:
+        calls.append(
+            {
+                "id": msg.id,
+                "channel": kw.get("stoat_channel_id"),
+                "salt": kw.get("idempotency_salt", ""),
+            }
+        )
+        if fail:
+            raise MigrationError("send refused")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "_process_message", _capture),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        await run_repair(config, state, [export], events.append)
+    return state, calls, events
+
+
+@pytest.mark.parametrize("kind", ["tail_absent", "tail_and_after_absent"])
+async def test_a_lost_tail_is_re_sent(tmp_path: Path, kind: str) -> None:
+    """Both repairable tail kinds resolve to the same one message.
+
+    tail_absent means the recorded last message is gone while its neighbours
+    survive. tail_and_after_absent means everything from it onward is gone, and
+    since the mark IS the newest thing Ferry recorded there is nothing after it
+    in Ferry's record either.
+    """
+    _, calls, _ = await _repair_tail_run(tmp_path, kind=kind)
+    assert [c["id"] for c in calls] == ["100000000000000002"], (
+        f"the wrong message, or none, was re-sent: {calls}"
+    )
+    assert calls[0]["channel"] == R_S_CHANNEL, "it went to the wrong channel"
+
+
+async def test_a_tail_repair_salts_its_key_with_the_channel(tmp_path: Path) -> None:
+    """The need is SHARPER here than for a recreation.
+
+    This channel was not recreated, so its Stoat id is unchanged and the
+    original send's key is exactly ferry-{msg.id}. Unsalted, Stoat's 1000-entry
+    idempotency LRU would answer 409 and _process_message would treat a message
+    the server has LOST as already delivered: the repair would report success
+    and restore nothing.
+    """
+    _, calls, _ = await _repair_tail_run(tmp_path)
+    assert calls[0]["salt"] == R_S_CHANNEL, (
+        f"the tail repair did not salt its idempotency key: {calls}"
+    )
+
+
+async def test_a_tail_repair_declines_a_message_the_export_lacks(tmp_path: Path) -> None:
+    """A narrower re-export than the migration used cannot restore it.
+
+    Asserts ZERO sends, not merely a warning: a repair that sent the wrong
+    message and then warned would pass a message-only assertion.
+    """
+    state, calls, _ = await _repair_tail_run(tmp_path, export_ids=("100000000000000001",))
+    assert calls == [], f"repair sent something it could not identify: {calls}"
+    assert any(w.get("type") == "not_in_export" for w in state.warnings), state.warnings
+
+
+async def test_a_tail_repair_leaves_the_mark_exactly_where_it_was(tmp_path: Path) -> None:
+    """A tail repair needs NO high-water formula, and that is worth pinning.
+
+    The plan asked for one: "the greater of the existing mark and the highest id
+    this repair touched". Writing it revealed there is nothing to compare. The
+    message a tail repair sends is READ OUT of channel_high_water, and nothing
+    between the read and the write touches that map, so any comparison compares
+    a value with itself.
+
+    A mutant replacing the comparison with an unconditional write SURVIVED,
+    which is how the inertness surfaced. The guard is gone and this asserts the
+    property that actually holds: the mark is untouched.
+
+    _resend_channel is where a real formula is needed, because a recreation
+    clears the mark first and has to rebuild it.
+    """
+    state, _, _ = await _repair_tail_run(
+        tmp_path,
+        high_water="100000000000000009",
+        export_ids=("100000000000000009",),
+    )
+    assert state.channel_high_water[R_D_CHANNEL] == "100000000000000009"
+
+
+async def test_a_failed_tail_repair_is_counted_as_unrestored(tmp_path: Path) -> None:
+    """A repair that could not send must not report that it did."""
+    _, _, events = await _repair_tail_run(tmp_path, fail=True)
+    assert any("Restored 0 of 1" in e.message for e in events), (
+        f"a failed tail repair was reported as restored: {[e.message for e in events]}"
+    )
+
+
+async def test_repair_drains_the_dead_letter_queue(tmp_path: Path) -> None:
+    """Whatever the two passes left failed, plus anything already queued.
+
+    run_retry_failed is reused rather than reimplemented, so this asserts the
+    CALL and the arguments it received, not that a message happened to send.
+    """
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        failed_messages=[
+            FailedMessage(
+                discord_msg_id="100000000000000001",
+                stoat_channel_id=R_S_CHANNEL,
+                error="timeout",
+            )
+        ],
+    )
+    seen: dict[str, Any] = {}
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return CheckReport()
+
+    async def _fake_retry(cfg: Any, st: Any, exps: Any, _on: Any) -> None:
+        seen["exports"] = exps
+        seen["queued"] = len(st.failed_messages)
+
+    export = _export_for(R_D_CHANNEL)
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "run_retry_failed", _fake_retry),
+        aioresponses(),
+    ):
+        await run_repair(config, state, [export], lambda _e: None)
+
+    assert seen.get("queued") == 1, "repair never drained the dead-letter queue"
+    assert seen["exports"] == [export], "the drain was given the wrong exports"
+
+
+async def test_repair_skips_the_drain_when_nothing_is_queued(tmp_path: Path) -> None:
+    """The other half, so the assertion above can fail."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    called: list[str] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return CheckReport()
+
+    async def _fake_retry(*_a: Any, **_k: Any) -> None:
+        called.append("retry")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "run_retry_failed", _fake_retry),
+        aioresponses(),
+    ):
+        await run_repair(config, state, [], lambda _e: None)
+
+    assert called == [], "repair ran the drain with an empty queue"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3847,3 +3847,41 @@ async def test_the_offsets_clear_is_invisible_to_the_check_by_construction(
     """
     state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [_export_for(R_D_CHANNEL)])
     assert R_D_CHANNEL not in state.channel_message_offsets
+
+
+async def test_queued_pins_and_reactions_for_the_deleted_channel_are_dropped(
+    tmp_path: Path,
+) -> None:
+    """Entries naming the channel that is gone can never succeed.
+
+    Both lists survive a finished migration when their phase left failures
+    behind: run_pins ends with `state.pending_pins = remaining`, which keeps
+    exactly the ones that did not land, and run_reactions does the same. A later
+    --incremental would retry them against a channel that no longer exists and
+    collect another failure.
+
+    Repair did not create that situation, the deletion did, so this is a tidy-up
+    rather than a fix. It belongs here because this function's job is dropping
+    everything that described the channel that is gone.
+
+    Another channel's queued work must survive, which is what stops this being a
+    wholesale clear.
+    """
+    state = _state_for_rewrite()
+    state.pending_pins = [
+        (R_S_CHANNEL, "01JSTOATOLD0000000000BA"),
+        ("01JSTOATCHN0000000OTHER", "01JSTOATOTHER00000000CC"),
+    ]
+    state.pending_reactions = [
+        {"channel_id": R_S_CHANNEL, "message_id": "01JSTOATOLD0000000000BB", "emoji": "wave"},
+        {"channel_id": "01JSTOATCHN0000000OTHER", "message_id": "x", "emoji": "wave"},
+    ]
+
+    state, _ = await _repair_with_state(tmp_path, state, [_export_for(R_D_CHANNEL)])
+
+    assert state.pending_pins == [("01JSTOATCHN0000000OTHER", "01JSTOATOTHER00000000CC")], (
+        f"the deleted channel's queued pins were not dropped: {state.pending_pins}"
+    )
+    assert [r["channel_id"] for r in state.pending_reactions] == ["01JSTOATCHN0000000OTHER"], (
+        f"the deleted channel's queued reactions were not dropped: {state.pending_reactions}"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4435,3 +4435,42 @@ async def test_repair_skips_the_drain_when_nothing_is_queued(tmp_path: Path) -> 
         await run_repair(config, state, [], lambda _e: None)
 
     assert called == [], "repair ran the drain with an empty queue"
+
+
+async def test_a_recreated_channels_backlog_is_pointed_at_the_new_channel(
+    tmp_path: Path,
+) -> None:
+    """Otherwise a recreated channel can never clear its dead-letter queue.
+
+    FailedMessage.stoat_channel_id is recorded at migration time, against the id
+    that has since been deleted, and run_retry_failed sends to exactly that
+    field. Without the remap the drain posts every backlogged message of a
+    recreated channel to a dead id and collects a 404: the repair would recreate
+    the channel, restore its export, and still leave the backlog stuck forever.
+
+    Another channel's queued failure must keep its own target, which is what
+    stops this being a wholesale rewrite.
+    """
+    state = _state_for_rewrite()
+    state.failed_messages = [
+        FailedMessage(
+            discord_msg_id="100000000000000001",
+            stoat_channel_id=R_S_CHANNEL,
+            error="timeout",
+        ),
+        FailedMessage(
+            discord_msg_id="999000000000000009",
+            stoat_channel_id="01JSTOATCHN0000000OTHER",
+            error="timeout",
+        ),
+    ]
+
+    state, _ = await _repair_with_state(tmp_path, state, [_export_for(R_D_CHANNEL)])
+
+    targets = {fm.discord_msg_id: fm.stoat_channel_id for fm in state.failed_messages}
+    assert targets["100000000000000001"] == "01JSTOATCHN000000000NEW", (
+        "the backlog still points at the deleted channel, so the drain would 404"
+    )
+    assert targets["999000000000000009"] == "01JSTOATCHN0000000OTHER", (
+        "another channel's queued failure was retargeted"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4698,3 +4698,36 @@ async def test_a_recreated_role_says_its_attributes_are_not_restored(tmp_path: P
         w.get("type") == "role_attributes_not_restored" and "#344" in w["message"]
         for w in state.warnings
     ), f"the role attribute decline was not recorded: {state.warnings}"
+
+
+async def test_re_attaching_removes_the_dead_channel_id(tmp_path: Path) -> None:
+    """Both ids can be present, and leaving the dead one is a category that lies.
+
+    Found by reading the diff at ship time rather than by a review. If the
+    CATEGORY is recreated earlier in the same run, _recreate_category builds its
+    channel list from channel_map, which still holds the OLD id for a channel
+    not yet recreated. The later re-attach appends the new id, so without a
+    removal the category names both: one live channel and one that does not
+    exist.
+    """
+    live = [
+        {
+            "id": "01JSTOATCAT000000000AAA",
+            "title": "General",
+            # The dead id, as _recreate_category would have left it.
+            "channels": [R_S_CHANNEL, "01JSTOATCHN0000000OTHER"],
+        }
+    ]
+    _, patches, _ = await _repair_with_live_categories(
+        tmp_path,
+        live_categories=live,
+        channel_categories={R_D_CHANNEL: "700000000000000001"},
+        category_map={"700000000000000001": "01JSTOATCAT000000000AAA"},
+    )
+    assert patches, "no categories PATCH was sent"
+    mine = next(c for c in patches[-1]["categories"] if c["id"] == "01JSTOATCAT000000000AAA")
+    assert R_S_CHANNEL not in mine["channels"], (
+        f"the category still names the deleted channel: {mine['channels']}"
+    )
+    assert "01JSTOATCHN000000000NEW" in mine["channels"]
+    assert "01JSTOATCHN0000000OTHER" in mine["channels"], "an unrelated channel was evicted"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2794,6 +2794,15 @@ async def _repair_recording_saves(
         patch.object(engine_module, "save_state", lambda *a, **k: saves.append(a)),
         aioresponses() as m,
     ):
+        # The collision fetch fires whenever the partition found structure work.
+        # Registered with repeat so a report with none simply never uses it, which
+        # is what test_repair_fetches_the_collision_set_only_when_recreating then
+        # asserts by counting.
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels("general"),
+            repeat=True,
+        )
         await run_repair(config, state, [], events.append)
         requests = list(m.requests)
     return saves, requests, events
@@ -2917,4 +2926,97 @@ async def test_repair_dry_run_does_not_mutate_state_warnings(tmp_path: Path) -> 
     assert state.warnings == [], f"a dry run mutated state.warnings: {state.warnings}"
     assert any("forum index" in e.message.lower() for e in events), (
         "the dry run hid the exclusion instead of reporting it"
+    )
+
+
+def _server_with_channels(*names: str) -> dict[str, Any]:
+    """A ServerWithChannels body carrying the given visible channel names.
+
+    Stoat ids stay visibly different from the names, so a test cannot pass by
+    comparing a value with itself.
+    """
+    ids = [f"01JSTOATCHN00000000{i:04d}" for i in range(len(names))]
+    return {
+        "server": {"_id": R_SERVER, "channels": ids},
+        "channels": [{"_id": cid, "name": n} for cid, n in zip(ids, names, strict=True)],
+    }
+
+
+async def test_the_collision_set_comes_from_the_live_server(tmp_path: Path) -> None:
+    """The names currently on the server, not the names the export would produce.
+
+    A channel originally created as `general-1`, whose collision partner has
+    since been deleted, should come back as `general`. Building the set from the
+    export would carry the migration's input into a context where it is wrong.
+    """
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER)
+    with aioresponses() as m:
+        m.get(
+            f"{BASE_URL}/servers/{R_SERVER}?include_channels=true",
+            payload=_server_with_channels("general", "announcements"),
+        )
+        async with aiohttp.ClientSession() as session:
+            names = await engine_module._live_channel_names(session, config, state)
+    assert names == {"general", "announcements"}
+
+
+async def test_the_collision_set_skips_an_entry_it_cannot_read(tmp_path: Path) -> None:
+    """A malformed entry contributes nothing rather than None.
+
+    The payload is dict[str, Any], so mypy cannot catch a missing or non-string
+    name. An unreadable entry must be skipped, not coerced: a None in a set[str]
+    would blow up make_unique_channel_name later, far from the cause.
+    """
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER)
+    payload = {
+        "server": {"_id": R_SERVER, "channels": ["a", "b", "c", "d"]},
+        "channels": [
+            {"_id": "01JSTOATCHN000000000AAA", "name": "general"},
+            {"_id": "01JSTOATCHN000000000BBB"},  # no name key at all
+            {"_id": "01JSTOATCHN000000000CCC", "name": None},  # explicit null
+            "not-a-dict",  # not an object
+        ],
+    }
+    with aioresponses() as m:
+        m.get(f"{BASE_URL}/servers/{R_SERVER}?include_channels=true", payload=payload)
+        async with aiohttp.ClientSession() as session:
+            names = await engine_module._live_channel_names(session, config, state)
+    assert names == {"general"}
+
+
+async def test_repair_fetches_the_collision_set_only_when_recreating(tmp_path: Path) -> None:
+    """No structure work, no request on the /servers bucket.
+
+    Paired with the test below, which is what stops this one passing against a
+    repair that never fetches at all.
+    """
+    _, requests, _ = await _repair_recording_saves(tmp_path, _report_with("tail_absent", "fail"))
+    fetches = [k for k in requests if "include_channels" in str(k[1])]
+    assert fetches == [], "repair fetched the collision set with nothing to recreate"
+
+
+async def test_repair_fetches_the_collision_set_when_there_is_work(tmp_path: Path) -> None:
+    """The other half, so the assertion above can fail."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER)
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            f"{BASE_URL}/servers/{R_SERVER}?include_channels=true",
+            payload=_server_with_channels("general"),
+        )
+        await run_repair(config, state, [], events.append)
+
+    assert any("names already on the server" in e.message for e in events), (
+        f"repair never fetched the collision set: {[e.message for e in events]}"
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,7 +22,7 @@ from discord_ferry.core.engine import (
     run_retry_failed,
 )
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.errors import DuplicateSendError
+from discord_ferry.errors import CheckError, DuplicateSendError
 from discord_ferry.migrator.verify import CheckReport
 from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
 from discord_ferry.state import FailedMessage, MigrationState
@@ -2775,3 +2775,84 @@ async def test_repair_declines_a_missing_forum_index_channel(tmp_path: Path) -> 
         w.get("type") == "forum_index_not_repairable" and w.get("phase") == "repair"
         for w in state.warnings
     ), f"no warning names the declined forum index: {state.warnings}"
+
+
+async def _repair_recording_saves(
+    tmp_path: Path, report: CheckReport, **config_overrides: Any
+) -> tuple[list[Any], list[Any], list[MigrationEvent]]:
+    """Drive run_repair and record every save_state call and HTTP request."""
+    config = _make_repair_config(tmp_path, **config_overrides)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    events: list[MigrationEvent] = []
+    saves: list[Any] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: saves.append(a)),
+        aioresponses() as m,
+    ):
+        await run_repair(config, state, [], events.append)
+        requests = list(m.requests)
+    return saves, requests, events
+
+
+async def test_repair_dry_run_never_calls_save_state_at_all(tmp_path: Path) -> None:
+    """Not "called with no changes". NEVER CALLED.
+
+    run_check raises outright on a dry-run STATE, because a dry run fills the id
+    maps with `dry-` sentinels naming entities nobody created. So a repair that
+    wrote sentinels into a real state file would make that state permanently
+    uncheckable, which is the exact opposite of what this tool is for.
+
+    Paired with the non-dry-run test below, which is what stops this one being
+    inert: an implementation that never saved at all would satisfy this
+    assertion and look correct.
+    """
+    saves, requests, _ = await _repair_recording_saves(
+        tmp_path, _report_with("channel_missing", "fail"), dry_run=True
+    )
+    assert saves == [], "a dry run wrote state"
+    assert requests == [], "a dry run made a write request"
+
+
+async def test_repair_saves_state_once_when_not_a_dry_run(tmp_path: Path) -> None:
+    """The other half, so the dry-run assertion above can actually fail.
+
+    Without this, `save_state` removed entirely would pass the dry-run test.
+    """
+    saves, _, _ = await _repair_recording_saves(tmp_path, _report_with("channel_missing", "fail"))
+    assert len(saves) == 1, f"expected exactly one save_state call, saw {len(saves)}"
+
+
+async def test_repair_dry_run_says_what_it_would_have_done(tmp_path: Path) -> None:
+    """A dry run that reports nothing is indistinguishable from a broken one."""
+    _, _, events = await _repair_recording_saves(
+        tmp_path, _report_with("channel_missing", "fail"), dry_run=True
+    )
+    assert any("dry run" in e.message.lower() for e in events), (
+        f"the dry run never said it was one: {[e.message for e in events]}"
+    )
+    assert _partition_counts(events) == (1, 0), "the dry run did not report the work it found"
+
+
+async def test_repair_does_not_swallow_a_check_error(tmp_path: Path) -> None:
+    """CheckError propagates to the shell, which turns it into an exit code.
+
+    run_check raises it on a dry-run state and on a state recording no server.
+    Catching it here would leave the operator with a repair that reported
+    success against a state it never managed to read.
+    """
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER)
+
+    async def _raises(*_a: Any, **_k: Any) -> CheckReport:
+        raise CheckError("cannot check this migration")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_raises),
+        pytest.raises(CheckError),
+    ):
+        await run_repair(config, state, [], lambda _e: None)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,6 +12,7 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
+from discord_ferry.core import engine as engine_module
 from discord_ferry.core.engine import PHASE_ORDER, PhaseFunction, run_migration, run_retry_failed
 from discord_ferry.core.events import EventCallback, MigrationEvent
 from discord_ferry.errors import DuplicateSendError
@@ -842,6 +843,67 @@ async def test_retry_failed_missing_export_dir(tmp_path: Path) -> None:
     await run_retry_failed(config, state, [], events.append)
     assert any("export directory not found" in e.message for e in events)
     assert len(state.failed_messages) == 1  # Unchanged
+
+
+async def test_retry_failed_populates_the_token_store(tmp_path: Path) -> None:
+    """run_retry_failed must build the token store, as both its siblings do.
+
+    ``_ensure_token_store`` is called by ``run_migration`` and ``run_rollback``
+    and by nothing else. Without it ``config.token_store`` stays None for the
+    whole run, and ``_process_message``'s handler calls
+    ``safe_sanitize(config.token_store, str(exc))``, which is an identity no-op
+    with a None store. A Stoat token in an exception therefore reaches
+    ``state.failed_messages`` and, through it, report.json unredacted.
+
+    The defect was latent only because no command could reach this coroutine.
+    ``ferry retry`` makes it reachable, so this is that command's precondition.
+
+    ASSERTS THE CALL AND ITS EFFECT, never that a token is absent from a
+    message. An absence assertion passes against a token that simply never
+    appeared in that string, and this project shipped unredacted Stoat tokens
+    for two releases behind exactly that shape.
+    """
+    config = _make_retry_config(tmp_path)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    config.token_store = None
+
+    _write_dce_json(config.export_dir, "ch1", [_dce_msg_dict("100000000000000001")])
+    exports = _make_exports_from_dir(config.export_dir)
+
+    state = MigrationState(
+        channel_map={"800000000000000001": "01JSTOATCHN000000000OLD"},
+        autumn_url=AUTUMN_URL,
+        failed_messages=[
+            FailedMessage(
+                discord_msg_id="100000000000000001",
+                stoat_channel_id="01JSTOATCHN000000000OLD",
+                error="timeout",
+            )
+        ],
+    )
+
+    calls: list[str] = []
+    real = engine_module._ensure_token_store
+
+    def _spy(cfg: FerryConfig) -> None:
+        calls.append("ensure_token_store")
+        real(cfg)
+
+    with (
+        patch.object(engine_module, "_ensure_token_store", _spy),
+        aioresponses() as m,
+    ):
+        m.post(
+            f"{BASE_URL}/channels/01JSTOATCHN000000000OLD/messages",
+            payload={"_id": "01JSTOATMSG0000000000AA"},
+        )
+        await run_retry_failed(config, state, exports, lambda _e: None)
+
+    assert calls == ["ensure_token_store"], (
+        "run_retry_failed did not call _ensure_token_store, so every safe_sanitize "
+        "on this path is an identity no-op"
+    )
+    assert config.token_store is not None, "the call left token_store unset"
 
 
 async def test_retry_failed_success_removes_from_list(tmp_path: Path) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3118,3 +3118,168 @@ async def test_repair_declines_a_role_it_has_no_recorded_name_for(tmp_path: Path
     assert any(
         w.get("type") == "no_recorded_name" and w.get("phase") == "repair" for w in state.warnings
     ), f"no warning explains why the role was skipped: {state.warnings}"
+
+
+def _export_for(
+    channel_id: str, *, name: str = "general", ch_type: int = 0, topic: str = ""
+) -> Any:
+    """One DCEExport carrying a channel's identity, with no messages."""
+    return DCEExport(
+        guild=DCEGuild(id="900000000000000009", name="Guild", icon_url=""),
+        channel=DCEChannel(id=channel_id, type=ch_type, name=name, topic=topic),
+        messages=[],
+    )
+
+
+async def _repair_recreating_channel(
+    tmp_path: Path,
+    *,
+    recorded_name: str | None = "general-1",
+    exports: list[Any] | None = None,
+    live_names: tuple[str, ...] = (),
+    create_payload: dict[str, Any] | None = None,
+) -> tuple[MigrationState, list[Any], list[MigrationEvent]]:
+    """Drive run_repair against one channel_missing result."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    if recorded_name is not None:
+        state.created_channel_names[R_D_CHANNEL] = recorded_name
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(*live_names),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload=create_payload
+            if create_payload is not None
+            else {"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        await run_repair(
+            config,
+            state,
+            exports if exports is not None else [_export_for(R_D_CHANNEL)],
+            events.append,
+        )
+        sent = _created_channel_body(m)
+    return state, sent, events
+
+
+def _created_channel_body(mock: aioresponses) -> dict[str, Any] | None:
+    """The JSON body of the channel-create POST, or None if none was made.
+
+    aioresponses keys its request log by (method, URL), so the body has to be
+    read out of the call record rather than by indexing the key list.
+    """
+    for (method, url), calls in mock.requests.items():
+        if method == "POST" and str(url).endswith("/channels"):
+            body = calls[0].kwargs.get("json")
+            return body if isinstance(body, dict) else None
+    return None
+
+
+async def test_repair_recreates_a_missing_channel_and_records_its_new_id(
+    tmp_path: Path,
+) -> None:
+    """channel_map moves to the new Stoat id under the UNCHANGED Discord key."""
+    state, _, _ = await _repair_recreating_channel(tmp_path)
+    assert state.channel_map[R_D_CHANNEL] == "01JSTOATCHN000000000NEW"
+    assert state.created_channel_names[R_D_CHANNEL] == "general"
+
+
+async def test_a_recreated_channel_drops_a_suffix_its_partner_no_longer_needs(
+    tmp_path: Path,
+) -> None:
+    """The whole reason the collision set comes from the live server.
+
+    The channel was originally created as `general-1`, because a `general`
+    already existed at migration time. That partner has since been deleted, so
+    the live set does not contain `general` and the recreation should take the
+    unsuffixed name. Building the set from the export would carry the
+    migration's input into a context where it is wrong and keep the -1 forever.
+    """
+    _, sent, _ = await _repair_recreating_channel(
+        tmp_path, recorded_name="general-1", live_names=("announcements",)
+    )
+    assert sent is not None, "no channel was created"
+    assert sent["name"] == "general-1", (
+        "repair renamed a channel it was asked to restore; the recorded name is what "
+        "Ferry sent and must be reused verbatim when the live server has no conflict"
+    )
+
+
+async def test_a_recreated_channel_avoids_a_name_the_server_now_holds(tmp_path: Path) -> None:
+    """A name taken since the migration must not be reused.
+
+    Stoat would accept the duplicate, and the operator would end up with two
+    channels of the same name and no way to tell them apart in the client.
+    """
+    _, sent, _ = await _repair_recreating_channel(
+        tmp_path, recorded_name="general", live_names=("general",)
+    )
+    assert sent is not None, "no channel was created"
+    assert sent["name"] != "general", "repair reused a name the server already holds"
+    assert sent["name"].startswith("general-"), f"unexpected disambiguation: {sent['name']}"
+
+
+async def test_a_recreated_voice_channel_is_recreated_as_voice(tmp_path: Path) -> None:
+    """The type comes from the export, because state records none.
+
+    A voice channel restored as text is a different channel: nobody can join it.
+    Discord type 2 is the only one that maps to a Stoat Voice channel.
+    """
+    _, sent, _ = await _repair_recreating_channel(
+        tmp_path, exports=[_export_for(R_D_CHANNEL, name="Lounge", ch_type=2)]
+    )
+    assert sent is not None, "no channel was created"
+    assert sent.get("type") == "Voice", f"a voice channel was recreated as {sent.get('type')}"
+
+
+async def test_repair_declines_a_channel_missing_from_the_export(tmp_path: Path) -> None:
+    """A KNOWN LIMIT, not a missing feature.
+
+    The channel type lives only in the export, and a channel restored as the
+    wrong type is a different channel. If the operator points repair at a
+    narrower export than the migration used, repair declines that channel and
+    says so rather than guessing Text.
+    """
+    state, sent, _ = await _repair_recreating_channel(tmp_path, exports=[])
+    assert sent is None, "repair created a channel it could not type correctly"
+    assert state.channel_map[R_D_CHANNEL] == R_S_CHANNEL
+    assert any(w.get("type") == "not_in_export" for w in state.warnings), state.warnings
+
+
+async def test_the_collision_set_is_not_built_from_the_export(tmp_path: Path) -> None:
+    """The case that separates the live set from an export-derived one.
+
+    Added because a mutant building the set from the exports SURVIVED the other
+    channel tests. In each of those, both implementations happened to return the
+    same name, so nothing distinguished them: the fixture could not tell the
+    design decision from its opposite.
+
+    This one can. The channel being recreated is itself named in the exports, so
+    its own name is always in an exports-derived set, which would force a suffix
+    onto EVERY recreated channel. The live server holds no such name, so the
+    correct set is empty and the name is reused verbatim.
+    """
+    _, sent, _ = await _repair_recreating_channel(
+        tmp_path,
+        recorded_name="general",
+        live_names=(),  # the server holds nothing
+        exports=[_export_for(R_D_CHANNEL, name="general")],  # the exports hold itself
+    )
+    assert sent is not None, "no channel was created"
+    assert sent["name"] == "general", (
+        "the collision set came from the exports, so the channel collided with its own "
+        "entry there and took a suffix it does not need"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4529,3 +4529,172 @@ async def test_a_resent_message_is_dropped_from_the_dead_letter_queue(
     assert "999000000000000009" in drained, (
         "another channel's queued failure was dropped without being sent"
     )
+
+
+async def _repair_with_live_categories(
+    tmp_path: Path,
+    *,
+    live_categories: list[dict[str, Any]],
+    channel_categories: dict[str, str],
+    category_map: dict[str, str],
+    ch_meta_slowmode: int = 0,
+    ch_meta_user_limit: int = 0,
+) -> tuple[MigrationState, list[dict[str, Any]], list[Any]]:
+    """Recreate one channel and hand back every categories PATCH and edit sent."""
+    config = _make_repair_config(tmp_path)
+    _write_discord_metadata(config.output_dir)
+    if ch_meta_slowmode or ch_meta_user_limit:
+        from discord_ferry.discord.metadata import (
+            ChannelMeta,
+            DiscordMetadata,
+            PermissionPair,
+            _meta_to_dict,
+        )
+
+        meta = DiscordMetadata(
+            guild_id="900000000000000009",
+            fetched_at="2026-08-13T00:00:00+00:00",
+            server_default_permissions=0,
+            role_permissions={},
+            channel_metadata={
+                R_D_CHANNEL: ChannelMeta(
+                    nsfw=False,
+                    default_override=PermissionPair(allow=1, deny=0),
+                    slowmode=ch_meta_slowmode,
+                    user_limit=ch_meta_user_limit,
+                )
+            },
+        )
+        (config.output_dir / "discord_metadata.json").write_text(
+            json.dumps(_meta_to_dict(meta)), encoding="utf-8"
+        )
+
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+        channel_categories=channel_categories,
+        category_map=category_map,
+    )
+    patches: list[dict[str, Any]] = []
+    edits: list[Any] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    payload = _server_with_channels("other")
+    payload["server"]["categories"] = live_categories  # type: ignore[index]
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "_process_message", _noop_process),
+        aioresponses() as m,
+    ):
+        m.get(re.compile(r".*/servers/.*include_channels.*"), payload=payload, repeat=True)
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        m.patch(f"{BASE_URL}/servers/{R_SERVER}", payload={}, repeat=True)
+        m.patch(re.compile(r".*/channels/.*"), payload={}, repeat=True)
+        m.put(re.compile(r".*/permissions/.*"), payload={}, repeat=True)
+        await run_repair(config, state, [_export_for(R_D_CHANNEL)], lambda _e: None)
+        for (method, url), calls in m.requests.items():
+            if method == "PATCH" and str(url).endswith(f"/servers/{R_SERVER}"):
+                body = calls[0].kwargs.get("json")
+                if isinstance(body, dict):
+                    patches.append(body)
+            elif method == "PATCH" and "/channels/" in str(url):
+                edits.append(calls[0].kwargs.get("json"))
+    return state, patches, edits
+
+
+async def test_a_recreated_channel_goes_back_into_its_category(tmp_path: Path) -> None:
+    """Found by the whole-branch review, and invisible to every chunk review.
+
+    Category membership on Stoat lives ONLY in the server's categories array, so
+    a channel made with api_create_channel sits outside every category until
+    that array names it. run_channels does this with an end-of-phase upsert; a
+    recreation has no phase behind it.
+
+    Without this a repaired channel comes back bare, outside the category it was
+    in, permanently, with nothing said about it. That is a visible structural
+    change the operator did not ask for, on the primary path this release
+    exists to serve.
+    """
+    live = [
+        {
+            "id": "01JSTOATCAT000000000AAA",
+            "title": "General",
+            "channels": ["01JSTOATCHN0000000OTHER"],
+        }
+    ]
+    _, patches, _ = await _repair_with_live_categories(
+        tmp_path,
+        live_categories=live,
+        channel_categories={R_D_CHANNEL: "700000000000000001"},
+        category_map={"700000000000000001": "01JSTOATCAT000000000AAA"},
+    )
+    assert patches, "no categories PATCH was sent, so the channel is outside every category"
+    cats = patches[-1]["categories"]
+    mine = next(c for c in cats if c["id"] == "01JSTOATCAT000000000AAA")
+    assert "01JSTOATCHN000000000NEW" in mine["channels"], (
+        f"the recreated channel was not put back in its category: {mine}"
+    )
+    assert "01JSTOATCHN0000000OTHER" in mine["channels"], (
+        "re-attaching evicted the category's other channel"
+    )
+
+
+async def test_a_channel_with_no_category_sends_no_patch(tmp_path: Path) -> None:
+    """The other half, so the assertion above cannot be met by patching always."""
+    _, patches, _ = await _repair_with_live_categories(
+        tmp_path,
+        live_categories=[{"id": "01JSTOATCAT000000000AAA", "title": "General", "channels": []}],
+        channel_categories={},
+        category_map={},
+    )
+    assert patches == [], f"a category PATCH was sent for a channel in no category: {patches}"
+
+
+async def test_a_recreated_channel_gets_its_slowmode_back(tmp_path: Path) -> None:
+    """run_channels sets slowmode with api_edit_channel after the permission pass.
+
+    A recreation that skipped it comes back with slowmode off, which is a silent
+    change to how the channel BEHAVES rather than how it looks.
+    """
+    _, _, edits = await _repair_with_live_categories(
+        tmp_path,
+        live_categories=[],
+        channel_categories={},
+        category_map={},
+        ch_meta_slowmode=30,
+    )
+    assert any(e and e.get("slowmode") == 30 for e in edits), f"slowmode was not restored: {edits}"
+
+
+async def test_a_recreated_channel_with_no_attributes_sends_no_edit(tmp_path: Path) -> None:
+    """The other half again: no attributes means no request."""
+    _, _, edits = await _repair_with_live_categories(
+        tmp_path, live_categories=[], channel_categories={}, category_map={}
+    )
+    assert edits == [], f"an edit was sent for a channel with nothing to set: {edits}"
+
+
+async def test_a_recreated_role_says_its_attributes_are_not_restored(tmp_path: Path) -> None:
+    """A DECLINE, recorded rather than silent.
+
+    The migration sets a role's colour, rank, hoist and icon in two further
+    api_edit_role passes, and the icon one uploads a file to Autumn. Restoring
+    those is a second content path in a batch already carrying two commands, and
+    the reasoning that keeps emoji out of repair applies to the icon too.
+
+    Declining is defensible. Declining silently is not: the operator would see a
+    role that looks restored and is uncoloured and unranked.
+    """
+    state, _, _ = await _repair_recreating_role(tmp_path)
+    assert any(
+        w.get("type") == "role_attributes_not_restored" and "#344" in w["message"]
+        for w in state.warnings
+    ), f"the role attribute decline was not recorded: {state.warnings}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4474,3 +4474,58 @@ async def test_a_recreated_channels_backlog_is_pointed_at_the_new_channel(
     assert targets["999000000000000009"] == "01JSTOATCHN0000000OTHER", (
         "another channel's queued failure was retargeted"
     )
+
+
+async def test_a_resent_message_is_dropped_from_the_dead_letter_queue(
+    tmp_path: Path,
+) -> None:
+    """Otherwise repair sends it twice and Stoat keeps both.
+
+    A message can be in the export of a recreated channel AND in
+    failed_messages, because it failed during the original migration. The resend
+    sends every message the export holds, including that one, and nothing
+    removed it from the queue, so the drain sent it again.
+
+    The idempotency keys do not save it: the resend salts with the new channel
+    id while the drain does not, so Stoat sees two distinct nonces and accepts
+    both. The user gets a duplicate.
+
+    _merge_threads reconciles the same way and for the same reason, dropping
+    from the queue anything that succeeded this run.
+    """
+    state = _state_for_rewrite()
+    state.failed_messages = [
+        FailedMessage(
+            discord_msg_id="100000000000000001",
+            stoat_channel_id=R_S_CHANNEL,
+            error="timeout",
+        ),
+        FailedMessage(
+            discord_msg_id="999000000000000009",
+            stoat_channel_id="01JSTOATCHN0000000OTHER",
+            error="timeout",
+        ),
+    ]
+    export = _export_for(R_D_CHANNEL)
+    export.messages.append(_dce_msg("100000000000000001"))
+
+    drained: list[str] = []
+
+    async def _fake_retry(_cfg: Any, st: Any, _exports: Any, _on: Any) -> None:
+        drained.extend(fm.discord_msg_id for fm in st.failed_messages)
+
+    async def _sends_fine(**_kw: Any) -> None:
+        return None
+
+    with (
+        patch.object(engine_module, "run_retry_failed", _fake_retry),
+        patch.object(engine_module, "_process_message", _sends_fine),
+    ):
+        state, _ = await _repair_with_state(tmp_path, state, [export])
+
+    assert "100000000000000001" not in drained, (
+        "the drain re-sent a message the resend had already delivered, so it lands twice"
+    )
+    assert "999000000000000009" in drained, (
+        "another channel's queued failure was dropped without being sent"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2856,3 +2856,65 @@ async def test_repair_does_not_swallow_a_check_error(tmp_path: Path) -> None:
         pytest.raises(CheckError),
     ):
         await run_repair(config, state, [], lambda _e: None)
+
+
+async def test_repair_declines_a_forum_index_whose_tail_is_missing(tmp_path: Path) -> None:
+    """The gap the chunk 3 review found, and the reason the exclusion moved.
+
+    Guarding only the structure branch let a forum index channel reporting
+    tail_absent through into the tail work. That path cannot restore it: the
+    tail of a forum index channel IS the index message, which lives in
+    forum_index_message_ids and has no message in any export to re-send.
+
+    The review that surfaced this described the mechanism wrongly, claiming the
+    `continue` dropped a tail result. A CheckResult has exactly one kind, so a
+    result taking the structure branch could never have taken the tail branch.
+    Running it found the real defect underneath.
+    """
+    report = CheckReport()
+    report.add(
+        name="tail:forum-index-800000000000000009",
+        status="fail",
+        kind="tail_absent",
+        detail="fixture",
+        discord_id="forum-index-800000000000000009",
+        stoat_id="01JSTOATCHN000000000IDX",
+    )
+    state, requests, events = await _repair_with_report(tmp_path, report)
+
+    assert _partition_counts(events) == (0, 0), "a forum index entered the tail work"
+    assert requests == [], "repair acted on a forum index tail"
+    assert any(w.get("type") == "forum_index_not_repairable" for w in state.warnings)
+
+
+async def test_repair_dry_run_does_not_mutate_state_warnings(tmp_path: Path) -> None:
+    """A preview that changes state is not a preview.
+
+    The forum index notice reaches the operator as an EVENT either way, so a dry
+    run loses no information by leaving state.warnings alone. Without this, a
+    dry run appended a warning it then never saved, which is a record nobody
+    asked for and nobody would ever see.
+    """
+    report = CheckReport()
+    report.add(
+        name="channel:forum-index-800000000000000009",
+        status="fail",
+        kind="channel_missing",
+        detail="fixture",
+        discord_id="forum-index-800000000000000009",
+        stoat_id="01JSTOATCHN000000000IDX",
+    )
+    config = _make_repair_config(tmp_path, dry_run=True)
+    state = MigrationState(stoat_server_id=R_SERVER)
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    with patch("discord_ferry.migrator.verify.run_check", new=_fake_check):
+        await run_repair(config, state, [], events.append)
+
+    assert state.warnings == [], f"a dry run mutated state.warnings: {state.warnings}"
+    assert any("forum index" in e.message.lower() for e in events), (
+        "the dry run hid the exclusion instead of reporting it"
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,9 +13,16 @@ from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
 from discord_ferry.core import engine as engine_module
-from discord_ferry.core.engine import PHASE_ORDER, PhaseFunction, run_migration, run_retry_failed
+from discord_ferry.core.engine import (
+    PHASE_ORDER,
+    PhaseFunction,
+    run_migration,
+    run_repair,
+    run_retry_failed,
+)
 from discord_ferry.core.events import EventCallback, MigrationEvent
 from discord_ferry.errors import DuplicateSendError
+from discord_ferry.migrator.verify import CheckReport
 from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
 from discord_ferry.state import FailedMessage, MigrationState
 
@@ -2500,3 +2507,137 @@ async def test_an_invalid_thread_strategy_is_recorded_as_the_effective_one(
     config = _make_config(tmp_path, thread_strategy="not-a-strategy")
     state = await run_migration(config, lambda _e: None, phase_overrides=_NOOP_OVERRIDES)
     assert state.thread_strategy == "flatten"
+
+
+# ---------------------------------------------------------------------------
+# run_repair (#107 batch 10, chunk #314)
+# ---------------------------------------------------------------------------
+
+R_SERVER = "01JSTOATSRV000000000AAA"
+R_D_CHANNEL = "800000000000000001"
+R_S_CHANNEL = "01JSTOATCHN000000000OLD"
+
+
+def _make_repair_config(tmp_path: Path, **overrides: Any) -> FerryConfig:
+    """Config for repair tests, mirroring _make_retry_config above.
+
+    Kept as its own helper rather than reusing the retry one, because repair
+    reads output_dir for state and export_dir for content, and a test that
+    conflated them would pass for the wrong reason.
+    """
+    export_dir = tmp_path / "exports"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    defaults: dict[str, Any] = {
+        "export_dir": export_dir,
+        "stoat_url": BASE_URL,
+        "token": TOKEN,
+        "output_dir": output_dir,
+        "message_rate_limit": 0.0,
+        "upload_delay": 0.0,
+    }
+    defaults.update(overrides)
+    return FerryConfig(**defaults)
+
+
+async def test_repair_refuses_a_rolled_back_state_without_a_single_request(
+    tmp_path: Path,
+) -> None:
+    """The most damaging thing this batch could get wrong.
+
+    Rollback NEVER mutates the id maps, deliberately, to preserve the
+    migration's audit trail (see RollbackProgress' docstring in state.py). So
+    `ferry check` run on a rolled-back state reports channel_missing for EVERY
+    channel it mapped, and a repair acting on that report would rebuild a server
+    the user deliberately destroyed.
+
+    rollback_progress is set once, at the start of run_rollback, is checkpointed
+    on both success and failure, and is never cleared. Refusing whenever it is
+    not None therefore also covers a rollback that failed at its very first
+    delete, which is the conservative and correct reading.
+
+    ASSERTS ZERO HTTP REQUESTS, not that an error was printed. A repair that
+    fetched the server and then refused would pass a message-only assertion
+    while having already spent the request that tells an operator it ran.
+    """
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        rollback_progress=RollbackProgress(started_at="2026-08-13T00:00:00+00:00"),
+    )
+    events: list[MigrationEvent] = []
+
+    with aioresponses() as m:
+        await run_repair(config, state, [], events.append)
+        assert not m.requests, (
+            f"repair made {len(m.requests)} request(s) against a rolled-back state"
+        )
+
+    assert any(e.status == "error" for e in events), "the refusal was not reported"
+    assert any("rollback" in e.message.lower() for e in events)
+
+
+async def test_repair_runs_the_check_when_the_state_was_never_rolled_back(
+    tmp_path: Path,
+) -> None:
+    """The other half of the guard, so the refusal cannot be unconditional.
+
+    Without this, a run_repair that refused everything would pass the test
+    above and look correct. The guard has to let an ordinary state through.
+    """
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    events: list[MigrationEvent] = []
+    seen: dict[str, Any] = {}
+
+    async def _fake_check(stoat_url: str, token: str, st: Any, on_event: Any, **_kw: Any) -> Any:
+        seen["called"] = True
+        return CheckReport()
+
+    with patch("discord_ferry.migrator.verify.run_check", new=_fake_check):
+        await run_repair(config, state, [], events.append)
+
+    assert seen.get("called"), "repair refused a state that was never rolled back"
+
+
+async def test_repair_populates_the_token_store_and_the_semaphore(tmp_path: Path) -> None:
+    """Both asserted as CALLS, for the reason recorded on the retry path.
+
+    A test asserting a token is absent from some string passes against a token
+    that simply never appeared in it.
+    """
+    config = _make_repair_config(tmp_path)
+    config.token_store = None
+    state = MigrationState(stoat_server_id=R_SERVER)
+    order: list[str] = []
+
+    real_store = engine_module._ensure_token_store
+
+    def _spy_store(cfg: FerryConfig) -> None:
+        order.append("token_store")
+        real_store(cfg)
+
+    async def _fake_check(*_a: Any, **_k: Any) -> Any:
+        order.append("check")
+        return CheckReport()
+
+    with (
+        patch.object(engine_module, "_ensure_token_store", _spy_store),
+        patch.object(
+            engine_module,
+            "init_request_semaphore",
+            lambda *_a: order.append("semaphore"),
+        ),
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+    ):
+        await run_repair(config, state, [], lambda _e: None)
+
+    assert "token_store" in order, "repair never built the token store"
+    assert "semaphore" in order, "repair never initialised the request semaphore"
+    assert order.index("token_store") < order.index("check")
+    assert order.index("semaphore") < order.index("check")
+    assert config.token_store is not None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3283,3 +3283,191 @@ async def test_the_collision_set_is_not_built_from_the_export(tmp_path: Path) ->
         "the collision set came from the exports, so the channel collided with its own "
         "entry there and took a suffix it does not need"
     )
+
+
+def _write_discord_metadata(
+    output_dir: Path,
+    *,
+    channel_id: str = R_D_CHANNEL,
+    role_id: str = D_ROLE,
+    with_channel_override: bool = True,
+    server_default: int = 4_194_304,
+) -> None:
+    """Write a real discord_metadata.json, round-tripped through the codec.
+
+    Built from the dataclasses and serialised with the module's own writer, so a
+    field renamed upstream breaks this fixture loudly rather than leaving it
+    silently describing a shape the loader no longer reads.
+    """
+    from discord_ferry.discord.metadata import (
+        ChannelMeta,
+        DiscordMetadata,
+        PermissionPair,
+        RoleOverride,
+        _meta_to_dict,
+    )
+
+    channel_meta = ChannelMeta(
+        nsfw=False,
+        default_override=PermissionPair(allow=1_048_576, deny=0) if with_channel_override else None,
+        role_overrides=[RoleOverride(discord_role_id=role_id, allow=2_097_152, deny=8)]
+        if with_channel_override
+        else [],
+    )
+    meta = DiscordMetadata(
+        guild_id="900000000000000009",
+        fetched_at="2026-08-13T00:00:00+00:00",
+        server_default_permissions=server_default,
+        role_permissions={role_id: PermissionPair(allow=4_194_304, deny=16)},
+        channel_metadata={channel_id: channel_meta},
+    )
+    (output_dir / "discord_metadata.json").write_text(
+        json.dumps(_meta_to_dict(meta)), encoding="utf-8"
+    )
+
+
+def _permission_calls(mock: aioresponses) -> list[str]:
+    """Every permission URL the run touched, in order."""
+    return [
+        str(url) for (_method, url), _calls in mock.requests.items() if "/permissions/" in str(url)
+    ]
+
+
+async def _repair_with_metadata(
+    tmp_path: Path, report: CheckReport, *, write_metadata: bool = True
+) -> tuple[MigrationState, list[str], list[MigrationEvent]]:
+    config = _make_repair_config(tmp_path)
+    if write_metadata:
+        _write_discord_metadata(config.output_dir)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        role_map={D_ROLE: S_ROLE_OLD},
+        created_channel_names={R_D_CHANNEL: "general"},
+        created_role_names={D_ROLE: "moderator"},
+    )
+    events: list[MigrationEvent] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        m.post(f"{BASE_URL}/servers/{R_SERVER}/roles", payload={"id": S_ROLE_NEW})
+        m.put(re.compile(r".*/permissions/.*"), payload={}, repeat=True)
+        await run_repair(config, state, [_export_for(R_D_CHANNEL)], events.append)
+        urls = _permission_calls(m)
+    return state, urls, events
+
+
+async def test_a_recreated_channel_gets_its_recorded_overrides(tmp_path: Path) -> None:
+    """SC-4.3. Both override kinds, through the chunk 1 helper."""
+    _, urls, _ = await _repair_with_metadata(tmp_path, _report_with("channel_missing", "fail"))
+    assert any(u.endswith("/channels/01JSTOATCHN000000000NEW/permissions/default") for u in urls), (
+        f"the default override was not applied: {urls}"
+    )
+    assert any(
+        u.endswith(f"/channels/01JSTOATCHN000000000NEW/permissions/{S_ROLE_OLD}") for u in urls
+    ), f"the role override was not applied: {urls}"
+
+
+async def test_repair_never_reapplies_the_server_default_mask(tmp_path: Path) -> None:
+    """SC-4.6, and the highest-consequence assertion in this chunk.
+
+    api_set_server_default_permissions merges the recorded server defaults with
+    FERRY_MIN_PERMISSIONS onto the SERVER'S DEFAULT ROLE, which every member
+    holds. It is server-wide and tied to no single recreated entity, and it sits
+    AFTER the per-role loop in run_roles, which is why chunk 1 extracted only
+    the loop body. Re-firing it during a one-role repair would re-impose a mask
+    on a server whose defaults may have changed since the migration: the class
+    of defect batch 5 of #107 existed to fix.
+
+    Asserted by URL and as a count of ZERO, not by inspecting output.
+    """
+    report = CheckReport()
+    report.add(
+        name=f"role:{D_ROLE}",
+        status="fail",
+        kind="role_missing",
+        detail="fixture",
+        discord_id=D_ROLE,
+        stoat_id=S_ROLE_OLD,
+    )
+    _, urls, _ = await _repair_with_metadata(tmp_path, report)
+    server_default = [u for u in urls if u.endswith(f"/servers/{R_SERVER}/permissions/default")]
+    assert server_default == [], (
+        f"repair re-applied the server default mask, which every member holds: {server_default}"
+    )
+    assert any(u.endswith(f"/servers/{R_SERVER}/permissions/{S_ROLE_NEW}") for u in urls), (
+        f"the recreated role's own permissions were not applied: {urls}"
+    )
+
+
+async def test_a_repair_permission_failure_is_recorded_as_a_repair(tmp_path: Path) -> None:
+    """SC-4.5. phase="repair", not "channels".
+
+    ADR-014 relies on state.warnings and report.json being an honest record of
+    where a failure came from. The inline blocks hardcoded their phase, which is
+    why chunk 1 made it a parameter.
+    """
+    config = _make_repair_config(tmp_path)
+    _write_discord_metadata(config.output_dir)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        aioresponses() as m,
+    ):
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        m.put(re.compile(r".*/permissions/.*"), status=403, repeat=True)
+        await run_repair(config, state, [_export_for(R_D_CHANNEL)], lambda _e: None)
+
+    perm_warnings = [w for w in state.warnings if "perm" in w.get("type", "")]
+    assert perm_warnings, f"a 403 on every permission call recorded nothing: {state.warnings}"
+    assert all(w["phase"] == "repair" for w in perm_warnings), (
+        f"a repair-time failure was filed as a migration-time one: {perm_warnings}"
+    )
+
+
+async def test_repair_warns_by_name_when_the_metadata_file_is_absent(tmp_path: Path) -> None:
+    """SC-4.4. Naming the file, and making no permission call.
+
+    A silent pass here reproduces batch 5's defect exactly: a channel that looks
+    migrated and grants nobody the right to use it.
+    """
+    state, urls, _ = await _repair_with_metadata(
+        tmp_path, _report_with("channel_missing", "fail"), write_metadata=False
+    )
+    assert urls == [], f"permissions were applied with no metadata to apply: {urls}"
+    assert any(
+        w.get("type") == "no_discord_metadata" and "discord_metadata.json" in w["message"]
+        for w in state.warnings
+    ), f"nothing named the missing file: {state.warnings}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -23,7 +23,8 @@ from discord_ferry.core.engine import (
     run_retry_failed,
 )
 from discord_ferry.core.events import EventCallback, MigrationEvent
-from discord_ferry.errors import CheckError, DuplicateSendError
+from discord_ferry.errors import CheckError, DuplicateSendError, MigrationError
+from discord_ferry.migrator import messages as messages_module
 from discord_ferry.migrator.verify import CheckReport
 from discord_ferry.parser.models import (
     DCEAuthor,
@@ -3653,12 +3654,12 @@ async def test_repair_declines_a_category_it_has_no_recorded_title_for(tmp_path:
     assert any(w.get("type") == "no_recorded_name" for w in state.warnings), state.warnings
 
 
-def _dce_msg(msg_id: str) -> DCEMessage:
+def _dce_msg(msg_id: str, timestamp: str = "2026-01-01T00:00:00+00:00") -> DCEMessage:
     """A minimal in-memory DCEMessage, for the non-streaming branch."""
     return DCEMessage(
         id=msg_id,
         type="Default",
-        timestamp="2026-01-01T00:00:00+00:00",
+        timestamp=timestamp,
         content="hello",
         author=DCEAuthor(id="700000000000000001", name="author", nickname="author"),
     )
@@ -3751,7 +3752,7 @@ def _state_for_rewrite(**overrides: Any) -> MigrationState:
         "stoat_server_id": R_SERVER,
         "channel_map": {R_D_CHANNEL: R_S_CHANNEL},
         "created_channel_names": {R_D_CHANNEL: "general"},
-        "channel_high_water": {R_D_CHANNEL: "100000000000000002"},
+        "channel_high_water": {R_D_CHANNEL: "100000000000000009"},
         "channel_message_counts": {R_D_CHANNEL: 2},
         "channel_message_offsets": {R_D_CHANNEL: "100000000000000001"},
         "completed_channel_ids": {R_D_CHANNEL},
@@ -3781,7 +3782,15 @@ async def test_the_recreated_channels_stale_per_channel_state_is_cleared(
     export.messages.extend([_dce_msg("100000000000000001"), _dce_msg("100000000000000002")])
     state, _ = await _repair_with_state(tmp_path, _state_for_rewrite(), [export])
 
-    assert R_D_CHANNEL not in state.channel_high_water
+    # The mark is CLEARED and then rewritten by the resend, so the observable
+    # end state is the export's newest id rather than the stale one. Asserting
+    # only that the key is absent would fail against correct behaviour, and
+    # asserting nothing about it would pass against never clearing it: the
+    # fixture's stale value is deliberately higher than anything in the export
+    # so the two are distinguishable.
+    assert state.channel_high_water[R_D_CHANNEL] == "100000000000000002", (
+        "the stale high-water mark survived the recreation"
+    )
     assert R_D_CHANNEL not in state.channel_message_counts
     assert R_D_CHANNEL not in state.channel_message_offsets
     assert R_D_CHANNEL not in state.completed_channel_ids
@@ -3885,3 +3894,225 @@ async def test_queued_pins_and_reactions_for_the_deleted_channel_are_dropped(
     assert [r["channel_id"] for r in state.pending_reactions] == ["01JSTOATCHN0000000OTHER"], (
         f"the deleted channel's queued reactions were not dropped: {state.pending_reactions}"
     )
+
+
+async def _repair_resending(
+    tmp_path: Path,
+    *,
+    exports: list[Any],
+    msg_ids: list[str],
+    fail_ids: tuple[str, ...] = (),
+    thread_strategy: str = "flatten",
+) -> tuple[MigrationState, list[str], list[MigrationEvent]]:
+    """Recreate one channel and resend it, returning the message bodies sent."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        created_channel_names={R_D_CHANNEL: "general"},
+        channel_high_water={R_D_CHANNEL: "100000000000000009"},
+        channel_message_counts={R_D_CHANNEL: len(msg_ids)},
+        thread_strategy=thread_strategy,
+    )
+    events: list[MigrationEvent] = []
+    bodies: list[str] = []
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return _report_with("channel_missing", "fail")
+
+    async def _fake_send(*_a: Any, **kwargs: Any) -> dict[str, str]:
+        content = str(kwargs.get("content", ""))
+        bodies.append(content)
+        return {"_id": "01JSTOATMSG0000000000AA"}
+
+    real_process = messages_module._process_message
+
+    async def _process(*, msg: Any, **kw: Any) -> None:
+        if msg.id in fail_ids:
+            raise MigrationError(f"send failed for {msg.id}")
+        bodies.append(f"msg:{msg.id}")
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch.object(engine_module, "api_send_message", _fake_send),
+        patch.object(engine_module, "_process_message", _process),
+        aioresponses() as m,
+    ):
+        assert real_process is not None
+        m.get(
+            re.compile(r".*/servers/.*include_channels.*"),
+            payload=_server_with_channels(),
+            repeat=True,
+        )
+        m.post(
+            f"{BASE_URL}/servers/{R_SERVER}/channels",
+            payload={"_id": "01JSTOATCHN000000000NEW", "name": "general"},
+        )
+        await run_repair(config, state, exports, events.append)
+    return state, bodies, events
+
+
+def _thread_export(channel_id: str, *, parent: str, ch_type: int = 0) -> Any:
+    export = _export_for(channel_id, name="a-thread", ch_type=ch_type)
+    export.is_thread = True
+    export.parent_channel_name = parent
+    return export
+
+
+async def test_a_recreated_thread_channel_gets_its_origin_header_back(
+    tmp_path: Path,
+) -> None:
+    """The header lives in _process_single_channel, NOT in _process_message.
+
+    The migration sends it gated on the channel being absent from
+    channel_high_water. Repair clears that mark, so a loop over _process_message
+    alone would drop a line the original migration sent and the restored thread
+    would lose the note saying where it came from.
+    """
+    export = _thread_export(R_D_CHANNEL, parent="general")
+    export.messages.append(_dce_msg("100000000000000001"))
+    _, bodies, _ = await _repair_resending(
+        tmp_path, exports=[export], msg_ids=["100000000000000001"]
+    )
+    assert "[Thread migrated from #general]" in bodies, (
+        f"the origin header was not re-sent: {bodies}"
+    )
+
+
+async def test_a_recreated_forum_post_gets_the_forum_wording(tmp_path: Path) -> None:
+    """Discord channel types 15 and 16 are forums, and say so."""
+    export = _thread_export(R_D_CHANNEL, parent="ideas", ch_type=15)
+    export.messages.append(_dce_msg("100000000000000001"))
+    _, bodies, _ = await _repair_resending(
+        tmp_path, exports=[export], msg_ids=["100000000000000001"]
+    )
+    assert "[Forum post migrated from #ideas]" in bodies, bodies
+
+
+async def test_an_ordinary_channel_gets_no_origin_header(tmp_path: Path) -> None:
+    """The other half, so the header assertion above can fail."""
+    export = _export_for(R_D_CHANNEL)
+    export.messages.append(_dce_msg("100000000000000001"))
+    _, bodies, _ = await _repair_resending(
+        tmp_path, exports=[export], msg_ids=["100000000000000001"]
+    )
+    assert not any("migrated from" in b for b in bodies), (
+        f"a header was sent for a channel that is not a thread: {bodies}"
+    )
+
+
+async def test_the_high_water_mark_covers_a_message_that_failed_to_send(
+    tmp_path: Path,
+) -> None:
+    """The formula where the WRONG answer looks nicer, measured by the prototype.
+
+    Three messages, the newest fails. Taking the max over successful sends only
+    would name the second-newest, which did land, so the next check would find
+    it and report ("ok", "tail_present") over a message that is genuinely
+    missing: a false pass. Taking the max over every scanned id names the failed
+    one, which resolves through no message_map entry, so the check reports
+    ("unverifiable", "tail_not_recorded"). That is honest.
+
+    Safe rather than a permanent hole only because the failure is durable in
+    state.failed_messages and the #76 self-heal re-attempts any id found there
+    even below the mark.
+    """
+    export = _export_for(R_D_CHANNEL)
+    ids = ["100000000000000001", "100000000000000002", "100000000000000003"]
+    export.messages.extend(_dce_msg(i) for i in ids)
+    state, _, _ = await _repair_resending(
+        tmp_path, exports=[export], msg_ids=ids, fail_ids=("100000000000000003",)
+    )
+    assert state.channel_high_water[R_D_CHANNEL] == "100000000000000003", (
+        "the mark was taken over successful sends only, which reports a false pass "
+        "over the message that did not land"
+    )
+
+
+async def test_a_non_numeric_message_id_does_not_break_the_mark(tmp_path: Path) -> None:
+    """A system message can carry a non-snowflake id, and int() on it would abort."""
+    export = _export_for(R_D_CHANNEL)
+    ids = ["100000000000000001", "not-a-snowflake"]
+    export.messages.extend(_dce_msg(i) for i in ids)
+    state, _, _ = await _repair_resending(tmp_path, exports=[export], msg_ids=ids)
+    assert state.channel_high_water[R_D_CHANNEL] == "100000000000000001"
+
+
+async def test_a_recreated_merge_parent_names_the_threads_it_cannot_restore(
+    tmp_path: Path,
+) -> None:
+    """PINS A KNOWN LIMIT (#310), not intended coverage.
+
+    Under --thread-strategy=merge a thread's messages were appended to the
+    PARENT's Stoat channel, and _merge_threads resolves that target by parent
+    channel NAME. A channel-scoped scan keyed on the parent's Discord id cannot
+    reach them, and the merge path never wrote message_map either.
+
+    ASSERTS THE WARNING EXISTS. Never that content is absent: an absence
+    assertion passes against a repair that restored nothing at all.
+    """
+    parent = _export_for(R_D_CHANNEL, name="general")
+    parent.messages.append(_dce_msg("100000000000000001"))
+    thread = _thread_export("800000000000000077", parent="general")
+    state, _, events = await _repair_resending(
+        tmp_path,
+        exports=[parent, thread],
+        msg_ids=["100000000000000001"],
+        thread_strategy="merge",
+    )
+    warning = [w for w in state.warnings if w.get("type") == "merge_thread_content_not_restored"]
+    assert warning, f"the merge gap was not recorded: {state.warnings}"
+    assert "a-thread" in warning[0]["message"], (
+        f"the warning does not name the thread it left behind: {warning[0]['message']}"
+    )
+    assert any("merge" in e.message for e in events)
+
+
+async def test_a_flatten_parent_gets_no_merge_warning(tmp_path: Path) -> None:
+    """The other half. Under flatten each thread has its own channel and is fine."""
+    parent = _export_for(R_D_CHANNEL, name="general")
+    parent.messages.append(_dce_msg("100000000000000001"))
+    thread = _thread_export("800000000000000077", parent="general")
+    state, _, _ = await _repair_resending(
+        tmp_path,
+        exports=[parent, thread],
+        msg_ids=["100000000000000001"],
+        thread_strategy="flatten",
+    )
+    assert not [
+        w for w in state.warnings if w.get("type") == "merge_thread_content_not_restored"
+    ], "a flatten migration was warned about merged thread content"
+
+
+async def test_a_resend_sends_in_timestamp_order_not_list_order(tmp_path: Path) -> None:
+    """The case that separates sorted from as-listed, added after a survivor.
+
+    A mutant dropping the sort SURVIVED every other resend test, because each
+    fixture happened to append its messages already in order: both
+    implementations produced the same sequence and nothing distinguished them.
+
+    Order is not cosmetic here. Stoat assigns its own ULIDs on arrival, so send
+    order becomes channel order permanently, and a channel restored backwards
+    reads backwards forever. _process_single_channel sorts for the same reason,
+    and this mirrors it.
+    """
+    export = _export_for(R_D_CHANNEL)
+    export.messages.extend(
+        [
+            _dce_msg("100000000000000003", "2026-01-03T00:00:00+00:00"),
+            _dce_msg("100000000000000001", "2026-01-01T00:00:00+00:00"),
+            _dce_msg("100000000000000002", "2026-01-02T00:00:00+00:00"),
+        ]
+    )
+    _, bodies, _ = await _repair_resending(
+        tmp_path,
+        exports=[export],
+        msg_ids=["100000000000000001", "100000000000000002", "100000000000000003"],
+    )
+    sent = [b for b in bodies if b.startswith("msg:")]
+    assert sent == [
+        "msg:100000000000000001",
+        "msg:100000000000000002",
+        "msg:100000000000000003",
+    ], f"the resend followed list order rather than timestamp order: {sent}"

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.17.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Releases **2.18.0**. Closes the last batch in #107.

`ferry check` could name what was wrong and do nothing about it. Now something acts on it.

## What changes

**`ferry repair`** runs the check in process and acts only on what it reports as a failure. It recreates a missing channel, role or category under the name Ferry originally gave it, puts a recreated channel back in its category, restores its permission overrides, slowmode and voice user limit, re-sends the messages it held in their original order, restores a channel's lost last message, and drains the dead-letter queue. `--dry-run` reports the plan and changes nothing.

**`ferry retry`** exposes `run_retry_failed`, an engine coroutine complete and tested since v1.x that no command could reach. A user with failed messages in `state.json` had no way to re-send them.

## The line that decides what repair touches

`fail` means content is gone. `warn` means content is intact and merely different. **The status is the consent boundary**, and that is why a rename is never repaired: someone who read a failure and typed `repair` did not ask to have their own edits overruled.

The same reasoning excludes everything `unverifiable`. If the check could not look, repair has nothing to act on, and guessing at a live server is worse than stopping.

## Three defects that would have shipped silently

Each was found by a structural self-check before a review saw the code, and each is invisible from any single chunk.

**`run_retry_failed` never populated the token store.** `_ensure_token_store` was called by `run_migration` and `run_rollback` and by nothing else, so `safe_sanitize` was an identity function for that whole path and a Stoat token appearing in an exception reached `state.failed_messages`, and through it `report.json`, unredacted. Latent only because no command could reach the coroutine, which `ferry retry` changes.

**Repair's sends reused the migration's idempotency keys.** Send keys are built from Discord identifiers, which a recreation does not change, and Stoat's key store is a 1000-entry cache with no expiry. A repair running while those keys were still held would be answered "duplicate" and treat a message the server had **lost** as already delivered: it would restore nothing and report success. `_process_message` now takes a salt, empty for a migration so its keys are byte-for-byte unchanged.

**A recreated channel's backlog pointed at the deleted channel.** `FailedMessage.stoat_channel_id` is recorded at migration time and the drain sends to exactly that field, so a repaired channel could never clear its queue.

## What the whole-branch review found that eight chunk reviews could not

**A recreated channel was never re-attached to its category.** Category membership on Stoat lives only in the server's categories array, and `run_channels` writes it with an end-of-phase upsert that a recreation has no equivalent of. The channel came back outside every category, permanently, with nothing said about it, on the primary path this release exists to serve.

That is the case for the gate: per-chunk reviews each saw a correct chunk.

## Four mutants survived, and each one was a fixture that could not tell two implementations apart

- The collision set built **from the exports** rather than the live server passed all five channel tests, because in every fixture both answers happened to match. The separating case is a channel appearing in its own export, which would suffix every recreated channel forever.
- Dropping the **timestamp sort** passed every resend test, because each fixture appended its messages already in order. Stoat assigns ULIDs on arrival, so a channel restored backwards reads backwards permanently.
- The **partition counts** were unobservable until `run_repair` reported them, so seventeen exclusion tests were inert.
- One survivor was **genuinely dead code**: the tail path's high-water comparison compared a value with itself, because the message it sends is read out of the map it would update. Removed, with the reason recorded.

## Deferred, filed rather than mentioned

**#308** a machine-readable repair outcome, **#309** a mid-channel gap, **#310** merged thread content under `merge`, **#311** a forum index channel, **#344** a recreated role's colour, rank, hoist and icon. Each carries the four ADR-005 fields. **#307** (emoji) and **#343** (uncapped channel topics, pre-existing on both the migration and repair paths) are in triage.

Every one of these is also a `state.warnings` entry the operator sees at the time, and a line in `known-limitations.md`. Declining is defensible; declining silently is not.

## Foundational impact, stated rather than inherited

`core/engine.py` and the identifier maps in `MigrationState` are both on the foundational list, so batch 9's "touches no foundational file" argument does not carry over.

- `PHASE_ORDER`, the phase list and the resume-by-name comparison are unmodified.
- The checkpoint **format** is unmodified: `state.py` has a zero-byte diff.
- `config.py`, `parser/models.py` and `discord/permissions.py` are untouched, and **no permission mask is computed anywhere**. `api_set_server_default_permissions`, which writes onto the role every member holds, is called from exactly one site, outside any loop, and is unreachable from repair.
- No identifier-map key is ever removed or re-keyed. Only values move.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src/` clean. **1988 passed**, up from 1892 at the branch point.

All nine change-manifest audit targets pass, run against comment-stripped source. Target 8, no stale `file:line` in shipped comments, is clean; the previous batch shipped five.

Eight chunk reviews, each posting its marker, both lenses on every chunk that changed code. The whole-branch review returned FIX FIRST and its Critical is fixed. The second opinion returned zero findings.

## Chunks

| Chunk | Tasks |
|---|---|
| #312 the extraction, changing no behaviour | #320, #321 |
| #313 `ferry retry` | #322, #323 |
| #314 the skeleton and its refusals | #324, #325, #326 |
| #315 structure recreation | #327 to #331 |
| #316 the state rewrite | #332, #333, #334 |
| #317 the resend | #335, #336, #337 |
| #318 tail repair and the shell | #338, #339, #340 |
| #319 documentation and the release | #341, #342 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotVV9xXbWp9oR2JdF9Vkm
