### PR TITLE
content: correct four reference claims against source (#107 docs truth-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **Four reference claims corrected against source** (`stoat-api-notes.md`, `architecture.md`,
+  `dce-format.md`, `migrator/probe.py`). The last item on the #107 tracker, content only.
+  - **Stoat does send rate limit headers.** Two pages said it sends none.
+    `X-RateLimit-Limit`, `-Remaining`, `-Reset-After` and `-Bucket` are set unconditionally in
+    `crates/core/ratelimits/src/rocket.rs` and exposed through CORS. The false claim came from
+    revolt.js's binding documentation, which does not surface them, and the pages now say so:
+    a client binding's docs are not evidence about server behaviour.
+  - **The bucket table was wrong about keying**, which is the part that decides whether
+    concurrency helps. `channels` (15 per 10s) and `messaging` (10 per 10s) are keyed by CHANNEL
+    ID, so work spread across channels does not share a budget; only `servers` (5 per 10s) is
+    shared. The table had no row for `channels` at all.
+  - **DCE writes PascalCase enum names**, `GuildTextChat` and `GuildNews`, not the SCREAMING_SNAKE
+    constants the Discord API documentation uses. The type table listed the latter, and three of
+    its rows had no DCE spelling that matches anything. Three channel types it omitted are added.
+  - **A comment called Stoat "this fork".** Stoat is Revolt renamed, and that hedge is what let a
+    correct permission mapping get dropped once already.
+
 ## [2.18.0] - 2026-08-13
 
 ### Added

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -534,9 +534,10 @@ Stoat uses **fixed 10-second windows** (not sliding).
     Creating a channel, a role, and an emoji in quick succession all draw from the same
     5-per-10-second budget. Ferry paces structure creation phases to stay within this limit.
 
-**Response headers**: Stoat returns **no rate limit headers**. There are no
-`X-RateLimit-Remaining`, `X-RateLimit-Reset-After`, or `X-RateLimit-Bucket` headers on any
-response.
+**Response headers**: Stoat sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`,
+`X-RateLimit-Reset-After` and `X-RateLimit-Bucket` on **every** response, and exposes them through
+CORS. `X-RateLimit-Reset-After` is in **milliseconds**, unlike Discord's identically named header.
+See [Stoat API Notes](stoat-api-notes.md#rate-limits).
 
 **429 response body**: `{ "retry_after": 4200 }` — Ferry sleeps for this duration (milliseconds)
 and retries. In addition, Ferry's adaptive 429-frequency optimizer tracks 429 frequency in a

--- a/docs/reference/dce-format.md
+++ b/docs/reference/dce-format.md
@@ -59,7 +59,7 @@ with a regex on the filename.
 ```json
 {
   "guild": { "id": "...", "name": "...", "iconUrl": "..." },
-  "channel": { "id": "...", "type": "GUILD_TEXT", "name": "...", "topic": "..." },
+  "channel": { "id": "...", "type": "GuildTextChat", "name": "...", "topic": "..." },
   "dateRange": { "after": null, "before": null },
   "exportedAt": "2024-01-15T12:00:00+00:00",
   "messages": [ ... ],
@@ -75,18 +75,27 @@ during validation.
 
 ## Channel Types
 
-DCE exports the Discord channel type as a string name. Ferry maps these to Stoat channel types:
+DCE 2.47 writes the channel type as its **own PascalCase enum name**, which is not the
+SCREAMING_SNAKE constant the Discord API documentation uses. Ferry normalises both to Discord's
+canonical integer on parse, in `_coerce_channel_type`, because every downstream branch works on the
+integer.
 
-| Discord type string | Type ID | Stoat target | Notes |
-|--------------------|---------|-------------|-------|
-| `GUILD_TEXT` | 0 | TextChannel | Direct mapping |
-| `GUILD_VOICE` | 2 | VoiceChannel | May create text channel on some instances (bug #194) |
-| `GUILD_CATEGORY` | 4 | Category | Two-step creation — see [Stoat API Notes](stoat-api-notes.md) |
-| `GUILD_ANNOUNCEMENT` | 5 | TextChannel | Treated as text |
-| `PUBLIC_THREAD` | 11 | TextChannel (flatten) | Becomes a standalone text channel |
-| `PRIVATE_THREAD` | 12 | TextChannel (flatten) | Becomes a standalone text channel |
-| `GUILD_FORUM` | 15 | TextChannel(s) per thread | One text channel per thread, grouped in a category named after the forum |
-| `GUILD_MEDIA` | 16 | TextChannel(s) per thread | One text channel per thread, grouped in a category named after the media channel |
+Exports written before 2.47 carry the integer directly, and the parser still accepts that shape:
+users hold old exports.
+
+| What DCE writes | Type ID | Stoat target | Notes |
+|-----------------|---------|-------------|-------|
+| `GuildTextChat` | 0 | TextChannel | Direct mapping |
+| `GuildVoiceChat` | 2 | VoiceChannel | May create a text channel on some instances (bug #194) |
+| `GuildCategory` | 4 | Category | Two-step creation, see [Stoat API Notes](stoat-api-notes.md) |
+| `GuildNews` | 5 | TextChannel | An announcement channel, treated as text |
+| `GuildNewsThread` | 10 | TextChannel (flatten) | Becomes a standalone text channel |
+| `GuildPublicThread` | 11 | TextChannel (flatten) | Becomes a standalone text channel |
+| `GuildPrivateThread` | 12 | TextChannel (flatten) | Becomes a standalone text channel |
+| `GuildStageVoice` | 13 | Not migrated | Stoat has no stage channel |
+| `GuildDirectory` | 14 | Not migrated | No Stoat equivalent |
+| `GuildForum` | 15 | TextChannel(s) per thread | One text channel per thread, grouped in a category named after the forum |
+| `GuildMedia` | 16 | TextChannel(s) per thread | One text channel per thread, grouped in a category named after the media channel |
 
 Stoat has exactly five channel types: SavedMessages, DirectMessage, Group, TextChannel, VoiceChannel.
 There are no native threads or forums, so Discord threads are flattened into regular text channels.

--- a/docs/reference/stoat-api-notes.md
+++ b/docs/reference/stoat-api-notes.md
@@ -8,22 +8,42 @@ focusing on non-obvious behaviour, gotchas, and Ferry-specific decisions.
 
 ## Rate Limits
 
-Stoat uses **fixed 10-second windows** (not sliding). Key buckets:
+Stoat uses **fixed 10-second windows** (not sliding). Buckets are chosen by
+`resolve_bucket()` in `crates/delta/src/util/ratelimits.rs`:
 
-| Bucket | Limit | Scope |
-|--------|-------|-------|
-| `/servers` | 5 per 10s | SHARED across server create, channel create, role create, emoji create, and category edit |
-| Messages | 10 per 10s | Dedicated — `POST /channels/:id/messages` only |
-| Catch-all | 20 per 10s | Everything else, including Autumn uploads |
+| Bucket | Limit | Keyed by | Covers |
+|--------|-------|----------|--------|
+| `servers` | 5 per 10s | the server id, so **shared** | Server create and edit, channel create, role create and edit, emoji create, category PATCH |
+| `channels` | 15 per 10s | **the channel id** | Everything else on an existing channel: edit, delete, and reading messages |
+| `messaging` | 10 per 10s | **the channel id** | `POST /channels/:id/messages` |
+| Catch-all | 20 per 10s | the route | Everything else, including Autumn uploads |
 
-!!! warning "The /servers bucket is shared"
-    Creating a channel, a role, and an emoji in quick succession all draw from the same 5/10s budget.
-    Ferry paces structure creation (ROLES, CATEGORIES, CHANNELS, EMOJI phases) to stay within this limit.
+!!! warning "Two of these are per channel, and that changes what concurrency buys you"
+    `channels` and `messaging` are keyed by channel id, so work spread across different channels
+    does **not** share a budget. Parallelism genuinely helps there. The `servers` bucket is shared,
+    so creating a channel, a role and an emoji in quick succession all draw on the same 5-per-10s
+    budget however they are scheduled, and parallelism buys nothing.
 
-**Stoat returns no rate limit headers.** There are no `X-RateLimit-Remaining`,
-`X-RateLimit-Reset-After`, or `X-RateLimit-Bucket` headers on responses.
+!!! note "A read costs the same as a big read"
+    Buckets count **requests**, not items, so asking a channel for 100 messages costs exactly what
+    asking for 1 does.
 
-On a 429 response the body contains:
+**Stoat sets rate limit headers on every response.** `X-RateLimit-Limit`,
+`X-RateLimit-Remaining`, `X-RateLimit-Reset-After` and `X-RateLimit-Bucket` are attached
+unconditionally in `crates/core/ratelimits/src/rocket.rs`, and exposed through CORS in
+`crates/delta/src/main.rs`.
+
+!!! warning "`X-RateLimit-Reset-After` is MILLISECONDS"
+    Discord's identically named header is **seconds**. Ferry has confused the two in both
+    directions: v2.8.2 read Stoat's as seconds and slept the 60-second cap on every 429, and v2.8.3
+    made the opposite mistake in the Autumn client and retried nine seconds early into a bucket that
+    was still closed.
+
+    An earlier version of this page said Stoat sends no such headers. That came from revolt.js's
+    binding documentation, which does not surface them. **A client binding's docs are not evidence
+    about server behaviour.** Reading the backend source settled it.
+
+On a 429 response the body also contains:
 
 ```json
 { "retry_after": 4200 }

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -184,7 +184,7 @@ async def _report_autumn_reachable(
 async def _check_voice_bug(
     sess: aiohttp.ClientSession, stoat_url: str, token: str, server_id: str, report: ProbeReport
 ) -> None:
-    # SOURCE-VERIFIED (stoatchat/stoatchat core/models/v0/channels.rs): this fork has
+    # SOURCE-VERIFIED (stoatchat/stoatchat core/models/v0/channels.rs): Stoat has
     # NO VoiceChannel variant — every server channel serializes as
     # "channel_type":"TextChannel". A Voice request maps to TextChannel{ voice: Some(..) }.
     # So the real signal for "voice works on this instance" is the PRESENCE of a non-null


### PR DESCRIPTION
Closes the last item on #107. Content only, no version bump.

Four reference claims were wrong. Every one of them was **already known to be wrong**: the corrections sat in the memory wiki and were never applied to the docs. That is the lesson worth taking from this one, and it is why #107 kept a docs truth-up on its list for ten batches.

## What was wrong

**Stoat does send rate limit headers.** Two pages said it sends none. `X-RateLimit-Limit`, `-Remaining`, `-Reset-After` and `-Bucket` are set unconditionally in `crates/core/ratelimits/src/rocket.rs` and exposed through CORS. The false claim came from revolt.js's binding documentation, which does not surface them, and both pages now say so: **a client binding's docs are not evidence about server behaviour.**

**The bucket table was wrong about keying**, which is the part that decides whether concurrency helps at all.

| | Was | Is |
|---|---|---|
| `servers` | 5/10s, shared | unchanged, and it is the only shared one |
| `channels` | **absent from the table** | 15/10s, keyed by **channel id** |
| `messaging` | "10 per 10s, dedicated" | 10/10s, keyed by **channel id** |

Work spread across different channels does not share a budget, so parallelism genuinely helps there and buys nothing on `servers`.

**DCE writes PascalCase enum names**, `GuildTextChat` and `GuildNews`, not the SCREAMING_SNAKE constants the Discord API documentation uses. Three of the table's rows named a spelling that appears in no export. Three types it omitted entirely are added, and the pre-2.47 integer form the parser still accepts is now mentioned.

**A comment called Stoat "this fork".** It is Revolt renamed, and that hedge is what let a correct permission mapping get dropped once already.

## The one that nearly went the wrong way

The test fixtures carry integer channel types, and reading them first suggested the doc's "exports as a string name" was itself the error. It is not: the fixtures are hand-written in the **pre-2.47** shape and are not evidence about the pinned version. The parser's own coercion table is.

`.claude/rules/accuracy.md` rule 3 says exactly this, that a claim about the export format may come only from a real export or the DCE source at the pin. It earned its place again here.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src/` clean. **1988 passed.**

No stale claim survives: greps for the headers assertion, the SCREAMING_SNAKE names and "this fork" all return nothing across `docs/` and `src/`.

Code review and second opinion skipped under the docs-only rule. The diff carries exactly one non-docs line, a comment in `probe.py`, and no carve-out file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotVV9xXbWp9oR2JdF9Vkm
