### PR TITLE
feat(scripts): three repository gates, enforced by scripts rather than by memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,30 @@ jobs:
         run: >-
           uv run pytest tests/test_atomicio.py tests/test_state.py
           tests/test_metadata.py tests/test_blueprint.py -v
+
+  gates:
+    name: Instruction-layer gates
+    runs-on: ubuntu-latest
+    # A SEPARATE job, deliberately not a step inside lint-and-test: that job runs a
+    # three-version Python matrix, so a step there would run the sweep three times
+    # per pull request and make three gh calls for one answer.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The sweep resolves origin/main. The default shallow clone makes that
+          # ref unresolvable and the script exits 2, which blocks rather than
+          # silently passing.
+          fetch-depth: 0
+
+      - name: Deferral red-flag sweep
+        env:
+          # gh is preinstalled on ubuntu-latest but does NOT authenticate on its
+          # own. Without this the sweep takes its announced degradation path on
+          # every run, skipping the pull request body: the one source that matters,
+          # since 0 of 60 Ferry commits carry deferral language while 5 of 110
+          # merged pull request bodies do.
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-deferrals.sh "origin/${{ github.base_ref || 'main' }}"

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ site/
 # NiceGUI runtime storage (see .claude/rules/security.md — user-scoped GUI settings,
 # never tokens, but it is runtime state and must not be committed).
 .nicegui/
+
+# Cosmic Ray mutation session: a resumable artifact, not a result
+mutation-session.sqlite
+mutation-session.sqlite-*

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ claude_log/
 # Internal design docs (kept locally, not in public repo)
 docs/plans/
 docs/architecture/
-scripts/check-deferral-fields.sh
 docs/superpowers/
 # Subagent-driven-development workspace: ledgers, briefs, per-task reports.
 # Scratch for one branch's build, never part of the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Three repository gates, so four project rules are enforced by a script instead of by memory.**
+  No user-facing behaviour changes and nothing under `src/` was touched, so there is no version
+  bump.
+
+  - `scripts/assert-doc-refs.sh` checks that paths cited in the project's documentation resolve on
+    disk, and that every architecture decision record has a row in its index and vice versa. It
+    runs locally rather than in CI, because its inputs are not committed to this repository and a
+    CI runner therefore never receives them.
+  - `scripts/check-deferrals.sh` sweeps a pull request for language that defers work without
+    filing it. It runs in a new single-run `gates` CI job on every pull request, and reads the
+    pull request body as well as the diff and the commit messages. That matters here: this
+    repository rebase-merges most pull requests, which keeps the body out of git entirely, so a
+    sweep reading only git finds nothing. Measured across recent history: 0 matches in 60 commits,
+    5 in 110 merged pull request bodies.
+  - `scripts/mutate.sh` runs a mutation sweep over the three modules where a test that cannot fail
+    is most expensive: redaction, checkpoint state, and atomic writes. It self-tests first, with
+    one mutation the suite must catch and one it cannot see, and refuses to report if either
+    answer is wrong. Behind a `mutation` extra, so it is not installed in CI.
+
+- `scripts/check-deferral-fields.sh` is now part of the repository. It was previously untracked,
+  which meant the deferral sweep could not reach it from CI.
+
 ## [2.19.0] - 2026-08-14
 
 ### Fixed

--- a/cosmic-ray.toml
+++ b/cosmic-ray.toml
@@ -9,9 +9,22 @@
 # Run with:  uv sync --extra mutation && bash scripts/mutate.sh
 
 [cosmic-ray]
-module-path = "src/discord_ferry"
+# A LIST OF FILES, not the package root. `module-path = "src/discord_ferry"`
+# looks like it scopes the sweep and does not: cosmic_ray.modules.find_modules
+# globs `**/*.py` under a directory, so it produced 10,964 mutants across
+# messages.py, cli.py, engine.py and gui.py. Against these three test files
+# almost all of them survive trivially, so a three-hour run would have returned
+# thousands of meaningless survivors. Measured, not guessed.
+#
+# find_modules accepts a file path directly, so naming the three files is the
+# scoping mechanism. There is no `excluded-modules` key: an earlier version of
+# this file set one and cosmic-ray never read it.
+module-path = [
+  "src/discord_ferry/core/security.py",
+  "src/discord_ferry/state.py",
+  "src/discord_ferry/core/atomicio.py",
+]
 timeout = 30.0
-excluded-modules = []
 
 # The test command is the part most likely to be got wrong, and getting it wrong
 # makes a broken detector look like a clean codebase. Two recorded harness faults

--- a/cosmic-ray.toml
+++ b/cosmic-ray.toml
@@ -1,0 +1,31 @@
+# Mutation testing over Ferry's three safety-critical modules.
+#
+# Scope is deliberately narrow: core/security.py (redaction), state.py
+# (checkpoints) and core/atomicio.py (atomic writes). These are where a vacuous
+# test is most expensive, and where four of the five recorded lessons about
+# broken harnesses were learned. Widening to parser/ is a documented follow-up
+# with a trigger, not an oversight.
+#
+# Run with:  uv sync --extra mutation && bash scripts/mutate.sh
+
+[cosmic-ray]
+module-path = "src/discord_ferry"
+timeout = 30.0
+excluded-modules = []
+
+# The test command is the part most likely to be got wrong, and getting it wrong
+# makes a broken detector look like a clean codebase. Two recorded harness faults
+# are excluded here by construction:
+#
+#   -x  stops at the first failure, so EVERY mutant appears to kill exactly one
+#       test and the kill shape carries no information.
+#   -q  alongside -v blinds the detector: it reported 0 caught while mutants were
+#       being killed.
+#
+# -v is required, not cosmetic: the captured per-mutant output is where the test
+# NAMES come from, and a count without names hides a mutant that killed fewer or
+# different tests than expected, which is itself the finding.
+test-command = "uv run --extra mutation pytest tests/test_security.py tests/test_state.py tests/test_atomicio.py -v"
+
+[cosmic-ray.distributor]
+name = "local"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ dev = [
     "mypy",
     "pyinstaller>=6.0",
 ]
+# Mutation testing, kept out of `dev` on purpose: CI installs `dev` on five jobs
+# and never runs a mutation sweep, so putting cosmic-ray there would pay its
+# install cost on every push for a tool only used locally and on demand.
+#   uv sync --extra mutation && bash scripts/mutate.sh
+mutation = [
+    "cosmic-ray>=8.3",
+]
 docs = [
     "mkdocs-material>=9.0",
 ]

--- a/scripts/assert-doc-refs.sh
+++ b/scripts/assert-doc-refs.sh
@@ -51,5 +51,24 @@ for doc in $DOCS; do
   done < <(grep -oE '`[^`]+`' "$doc" 2>/dev/null | tr -d '`')
 done
 
-[ "$FAILURES" -eq 0 ] || { echo "assert-doc-refs: $FAILURES broken citation(s)" >&2; exit 1; }
+# ADR index parity, checked in BOTH directions. One direction alone would have
+# missed the ADR-018 collision that critique round 3 found: a second session had
+# taken the number, so a new file would have overwritten an Accepted record while
+# the index still showed one row.
+ADR_DIR="docs/architecture/adr"
+INDEX="$ADR_DIR/README.md"
+if [ -d "$ADR_DIR" ] && [ -f "$INDEX" ]; then
+  for f in "$ADR_DIR"/[0-9]*.md; do
+    [ -e "$f" ] || continue
+    n=$(basename "$f" | cut -c1-3)
+    grep -q "\[$n\](" "$INDEX" || {
+      echo "  ADR $n has no row in $INDEX" >&2; FAILURES=$((FAILURES + 1)); }
+  done
+  while IFS= read -r n; do
+    ls "$ADR_DIR/$n"-*.md >/dev/null 2>&1 || {
+      echo "  $INDEX row $n points at no file" >&2; FAILURES=$((FAILURES + 1)); }
+  done < <(grep -oE '^\| \[[0-9]{3}\]' "$INDEX" | grep -oE '[0-9]{3}')
+fi
+
+[ "$FAILURES" -eq 0 ] || { echo "assert-doc-refs: $FAILURES problem(s)" >&2; exit 1; }
 echo "assert-doc-refs: clean."

--- a/scripts/assert-doc-refs.sh
+++ b/scripts/assert-doc-refs.sh
@@ -16,12 +16,30 @@
 
 set -uo pipefail
 
-git rev-parse --git-dir >/dev/null 2>&1 || {
+# Anchor to the repo root. `git rev-parse --git-dir` only proves we are somewhere
+# inside a repository, not at the top of one, and every path below is relative.
+# Run from a subdirectory without this, the script finds no CLAUDE.md, no rules
+# and no ADR directory, checks nothing, and prints "clean" with exit 0. Measured
+# from src/ before the fix: a false pass indistinguishable from a real one, in
+# the very script written to stop checks from doing that.
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "assert-doc-refs: not a git repository" >&2; exit 2; }
+cd "$ROOT" || { echo "assert-doc-refs: cannot enter $ROOT" >&2; exit 2; }
 
 FAILURES=0
 DOCS="CLAUDE.md"
 for f in .claude/rules/*.md; do [ -e "$f" ] && DOCS="$DOCS $f"; done
+
+# Second belt: even at the root, if nothing readable was found there is nothing
+# to check and "clean" would be a lie. Same shape as the ADR row-count guard
+# below, applied to the inputs rather than to one sub-check.
+FOUND=0
+for doc in $DOCS; do [ -e "$doc" ] && FOUND=$((FOUND + 1)); done
+if [ "$FOUND" -eq 0 ]; then
+  echo "assert-doc-refs: found none of its input documents under $ROOT." >&2
+  echo "  Expected CLAUDE.md and/or .claude/rules/*.md. Checking nothing is not passing." >&2
+  exit 2
+fi
 
 # Global excludes disabled so a developer's own ~/.gitignore cannot hide drift
 # that CI-equivalent conditions would show. No global file is set on this machine

--- a/scripts/assert-doc-refs.sh
+++ b/scripts/assert-doc-refs.sh
@@ -64,10 +64,25 @@ if [ -d "$ADR_DIR" ] && [ -f "$INDEX" ]; then
     grep -q "\[$n\](" "$INDEX" || {
       echo "  ADR $n has no row in $INDEX" >&2; FAILURES=$((FAILURES + 1)); }
   done
+  # The row->file direction depends on the index's table format. If that format
+  # ever changes, this extraction finds nothing and the direction silently checks
+  # nothing, which is indistinguishable from passing. Count what was parsed and
+  # fail loudly when the index has rows to find and none were found. The
+  # file->row direction above does not need this: it matches `[NNN](` anywhere,
+  # so it survives a format change.
+  ROWS=0
   while IFS= read -r n; do
+    ROWS=$((ROWS + 1))
     ls "$ADR_DIR/$n"-*.md >/dev/null 2>&1 || {
       echo "  $INDEX row $n points at no file" >&2; FAILURES=$((FAILURES + 1)); }
   done < <(grep -oE '^\| \[[0-9]{3}\]' "$INDEX" | grep -oE '[0-9]{3}')
+
+  ADR_COUNT=$(ls "$ADR_DIR"/[0-9]*.md 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$ROWS" -eq 0 ] && [ "$ADR_COUNT" -gt 0 ]; then
+    echo "  parsed 0 index rows from $INDEX while $ADR_COUNT ADR files exist." >&2
+    echo "  The row format changed and this check stopped checking anything." >&2
+    FAILURES=$((FAILURES + 1))
+  fi
 fi
 
 [ "$FAILURES" -eq 0 ] || { echo "assert-doc-refs: $FAILURES problem(s)" >&2; exit 1; }

--- a/scripts/assert-doc-refs.sh
+++ b/scripts/assert-doc-refs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# assert-doc-refs.sh: paths cited in the instruction layer must resolve.
+#
+# LOCAL ONLY. Its inputs (CLAUDE.md, .claude/rules/*.md, docs/architecture/) are
+# gitignored, so a CI runner receives none of them: a clean clone has no CLAUDE.md
+# and no rules directory at all. Called from /df-ship, never from a workflow.
+#
+# Usage:  scripts/assert-doc-refs.sh
+# Exit 0  every cited path resolves and the ADR index matches the directory
+# Exit 1  at least one citation or index row is wrong
+# Exit 2  could not run (not a git repository)
+#
+# A citation drifts the moment you insert a line above it. All five that one
+# branch added had drifted by ship time, broken by that same branch, and nothing
+# caught it.
+
+set -uo pipefail
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "assert-doc-refs: not a git repository" >&2; exit 2; }
+
+FAILURES=0
+DOCS="CLAUDE.md"
+for f in .claude/rules/*.md; do [ -e "$f" ] && DOCS="$DOCS $f"; done
+
+# Global excludes disabled so a developer's own ~/.gitignore cannot hide drift
+# that CI-equivalent conditions would show. No global file is set on this machine
+# today; this is protection against a future one.
+is_excluded() { git -c core.excludesfile=/dev/null check-ignore -q "$1" 2>/dev/null; }
+
+# Process substitution rather than a pipe: a piped `while` runs in a subshell and
+# every FAILURES increment would be discarded, so the guard would always pass.
+for doc in $DOCS; do
+  [ -e "$doc" ] || continue
+  while IFS= read -r t; do
+    case "$t" in
+      ''|/*|@*|~*|*' '*) continue ;;                        # absolute, alias, home, prose
+      *'*'*|*'<'*|*'>'*|*'{'*|*'}'*|*'|'*) continue ;;      # glob or placeholder
+    esac
+    case "$t" in *...*) continue ;; esac                     # ellipsis placeholder
+    case "$t" in */*) : ;; *) continue ;; esac               # require a slash
+    clean="${t%%#*}"                                         # strip #fragment
+    clean=$(printf '%s' "$clean" | sed -E 's/:[0-9]+$//')    # strip :line citation
+    seg="${clean%%/*}"
+    [ -e "$seg" ] || continue          # first segment must be a real top-level entry
+    is_excluded "$clean" && continue
+    if [ ! -e "$clean" ]; then
+      echo "  MISSING: $clean  (cited in $doc)" >&2
+      FAILURES=$((FAILURES + 1))
+    fi
+  done < <(grep -oE '`[^`]+`' "$doc" 2>/dev/null | tr -d '`')
+done
+
+[ "$FAILURES" -eq 0 ] || { echo "assert-doc-refs: $FAILURES broken citation(s)" >&2; exit 1; }
+echo "assert-doc-refs: clean."

--- a/scripts/check-deferral-fields.sh
+++ b/scripts/check-deferral-fields.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# check-deferral-fields.sh: the four-field deferral requirement.
+#
+# A deferral is only a plan when it names why not now, what it costs now against
+# later, who owns it, and what triggers it. Missing any one of those, it is
+# abandonment wearing a deferral's clothes.
+#
+# Read on stdin by a local pre-flight guard before it allows a `gh issue create`
+# for a deferral, and by the deferral sweep in CI. The local guard FAILS OPEN
+# when this file is absent, so deleting it turns that gate off with no error.
+#
+# Usage:
+#   scripts/check-deferral-fields.sh <file>     check a file
+#   ... | scripts/check-deferral-fields.sh      check stdin
+#
+# Exit 0  all four fields present with content
+# Exit 1  one or more missing or empty (names them on stderr)
+#
+# A missing field is abandonment wearing a deferral's clothes. An empty one is
+# the same thing with extra steps, so a bare heading does not count.
+
+set -uo pipefail
+
+BODY=$(cat "${1:--}" 2>/dev/null) || BODY=""
+
+if [ -z "${BODY//[[:space:]]/}" ]; then
+  echo "check-deferral-fields: empty body" >&2
+  exit 1
+fi
+
+# Any of: "## Why not now", "**Why not now:**", "- Why not now:", "Why not now -"
+label_re() { printf '^[[:space:]]*[#>*_-]*[[:space:]]*\\**[[:space:]]*%s\\b' "$1"; }
+
+# A field counts when its label carries text on the same line after the
+# separator, or a non-empty line follows it that is not another field label.
+ANY_LABEL='^[[:space:]]*[#>*_-]*[[:space:]]*\**[[:space:]]*(why not now|cost( comparison)?|owner|trigger|deadline)\b'
+
+has_field() {
+  local re="$1" inline="$2" line n rest following
+  n=$(printf '%s\n' "$BODY" | grep -niE "$re" | head -1 | cut -d: -f1)
+  # A body written with -b often puts all four on one line. Only the first
+  # label sits at a line start there, so fall back to matching the label
+  # anywhere as long as a separator and content follow it.
+  if [ -z "$n" ]; then
+    printf '%s\n' "$BODY" | grep -qiE "${inline}[[:space:]]*[:=-]+[[:space:]]*[^[:space:]]" && return 0
+    return 1
+  fi
+  line=$(printf '%s\n' "$BODY" | sed -n "${n}p")
+  # Text on the same line, after ':' or '-' or '=' separator.
+  rest=$(printf '%s' "$line" | sed -E 's/^[^:=-]*([:=-]+)?//; s/[*_[:space:]]//g')
+  [ -n "$rest" ] && return 0
+
+  # Otherwise the first non-blank line after the label has to be a value rather
+  # than the next label. Written without a `while read` in a pipeline: that runs
+  # in a subshell, and a run that falls off the end of the input leaves the
+  # pipeline at status 0, so a bare label as the LAST line of the body counted
+  # as filled in. That is a gate passing when it should fail, which is the one
+  # outcome this script exists to prevent.
+  following=$(printf '%s\n' "$BODY" | tail -n "+$((n + 1))" | grep -vE '^[[:space:]]*$' | head -1)
+  [ -n "$following" ] || return 1
+  printf '%s' "$following" | grep -qiE "$ANY_LABEL" && return 1
+  return 0
+}
+
+MISSING=()
+has_field "$(label_re 'why not now')"        'why not now'          || MISSING+=("Why not now")
+has_field "$(label_re 'cost( comparison)?')" 'cost( comparison)?'   || MISSING+=("Cost comparison")
+has_field "$(label_re 'owner')"              'owner'                || MISSING+=("Owner")
+has_field "$(label_re '(trigger|deadline)')" '(trigger|deadline)'   || MISSING+=("Trigger")
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+  echo "Deferral fields: all four present."
+  exit 0
+fi
+
+{
+  echo "Deferral is missing ${#MISSING[@]} required field(s):"
+  for f in "${MISSING[@]}"; do echo "  - $f"; done
+  echo ""
+  echo "Every deferral carries all four, or it is abandonment:"
+  echo "  Why not now      the actual blocker, not \"too much work\""
+  echo "  Cost comparison  now vs later, with estimates"
+  echo "  Owner            who does it (default: whoever deferred it)"
+  echo "  Trigger          a date, or a measurable condition"
+  echo ""
+  echo "If the item is foundational it cannot be deferred at all."
+} >&2
+exit 1

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-deferrals.sh: the deferral red-flag sweep.
+#
+# This pattern lived inline in the shipping skill, which meant it ran only when
+# someone invoked that skill. It now runs in CI too, so skipping the skill no
+# longer skips the sweep. The skill calls this script, so there is one copy.
+#
+# Usage:
+#   scripts/check-deferrals.sh [base-ref]     default base: origin/main
+#
+# Exit 0  clean, or every match is accounted for by a four-field justification
+#         shipped in the same diff
+# Exit 1  red-flag phrases with nothing justifying them
+# Exit 2  could not run (bad base ref, not a repository)
+#
+# Exit 2 BLOCKS. A gate that cannot run is not a gate that passed, and the
+# opposite decision is on record going wrong: a guard that failed open when its
+# checker was absent did nothing and reported nothing.
+#
+# Why the pattern is broad: real engineering writing rarely uses the canonical
+# "future work" phrase. It uses domain-flavoured variants. The regex matches the
+# family of deferral constructions, not a list of literal phrases. It was tuned
+# elsewhere against 60 merged pull requests, where the first version would have
+# blocked 39 of 60 and this one blocks 8 of 60. Measured against 60 Ferry
+# commits: 0 matches, which is why a demonstrated true positive is a shipping
+# condition rather than an assumption.
+
+set -uo pipefail
+BASE="${1:-origin/main}"
+
+# Ferry's exclusion list is short because the instruction layer is gitignored and
+# never appears in a diff at all.
+#
+# Known blind spot, documented rather than hidden: these are whole-file
+# exclusions, not line-level. A genuine deferral added to this script itself is
+# invisible to it.
+EXCLUDES=(":(exclude)scripts/check-deferrals.sh")
+
+PATTERN='future (work|concern|hardening|enhancement|iteration|sprint|phase|fix|improvement|version)|v[0-9]+ scope|simpler for now|out of scope for (now|this (PR|pull request|change|slice|pass|iteration))|defer(red)? to (follow-?up|later|v[0-9]+|phase [0-9]+)|accepted trade-?off|we can (unify|fix|handle|address|do) (later|in v[0-9]+|in phase [0-9]+)|adds complexity|when we have time|punt(ed)? to|come back to (this|it|that)|in a (later|future|separate|follow-?up) (pass|PR|pull request|change|iteration|slice)|revisit (this|it|that|later)'
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "check-deferrals: not a git repository" >&2; exit 2; }
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "check-deferrals: base ref '$BASE' not found." >&2
+  echo "  In CI this means a shallow checkout. Set fetch-depth: 0." >&2
+  exit 2
+fi
+
+# Added lines only. Scanning the whole diff reports text the author never wrote:
+# editing one line surfaced a match three lines away that nobody had touched.
+# Harmless while this only ran inside a skill, a blocked pull request now that it
+# runs in CI. A deferral is something you add, not something near your edit.
+ADDED=$(git diff "$BASE...HEAD" -- . "${EXCLUDES[@]}" 2>/dev/null \
+        | grep '^+' | grep -v '^+++' | sed 's/^+//')
+
+MSGS=""
+for commit in $(git rev-list "$BASE..HEAD" 2>/dev/null); do
+  MSGS="$MSGS
+$(git log -1 --pretty=%B "$commit" 2>/dev/null)"
+done
+
+BODY=$(printf '%s\n%s\n' "$ADDED" "$MSGS")
+MATCHES=$(printf '%s' "$BODY" | grep -niE "$PATTERN" || true)
+
+if [ -z "$MATCHES" ]; then
+  echo "Deferral sweep: clean."
+  exit 0
+fi
+
+printf '%s\n' "$MATCHES" >&2
+echo "check-deferrals: unjustified deferral language above." >&2
+exit 1

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -31,10 +31,19 @@ BASE="${1:-origin/main}"
 # Ferry's exclusion list is short because the instruction layer is gitignored and
 # never appears in a diff at all.
 #
+# Files that describe the pattern rather than commit one. Without these the sweep
+# reports itself: the test file necessarily contains deferral phrases as fixture
+# data, so every pull request touching it would be blocked. Found on this gate's
+# first real run against its own branch.
+#
 # Known blind spot, documented rather than hidden: these are whole-file
-# exclusions, not line-level. A genuine deferral added to this script itself is
-# invisible to it.
-EXCLUDES=(":(exclude)scripts/check-deferrals.sh")
+# exclusions, not line-level. A genuine deferral written inside either file is
+# invisible to this sweep. That is a narrow trade for a gate that would otherwise
+# refuse every change to itself.
+EXCLUDES=(
+  ":(exclude)scripts/check-deferrals.sh"
+  ":(exclude)tests/test_gate_scripts.py"
+)
 
 PATTERN='future (work|concern|hardening|enhancement|iteration|sprint|phase|fix|improvement|version)|v[0-9]+ scope|simpler for now|out of scope for (now|this (PR|pull request|change|slice|pass|iteration))|defer(red)? to (follow-?up|later|v[0-9]+|phase [0-9]+)|accepted trade-?off|we can (unify|fix|handle|address|do) (later|in v[0-9]+|in phase [0-9]+)|adds complexity|when we have time|punt(ed)? to|come back to (this|it|that)|in a (later|future|separate|follow-?up) (pass|PR|pull request|change|iteration|slice)|revisit (this|it|that|later)'
 

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -47,8 +47,13 @@ EXCLUDES=(
 
 PATTERN='future (work|concern|hardening|enhancement|iteration|sprint|phase|fix|improvement|version)|v[0-9]+ scope|simpler for now|out of scope for (now|this (PR|pull request|change|slice|pass|iteration))|defer(red)? to (follow-?up|later|v[0-9]+|phase [0-9]+)|accepted trade-?off|we can (unify|fix|handle|address|do) (later|in v[0-9]+|in phase [0-9]+)|adds complexity|when we have time|punt(ed)? to|come back to (this|it|that)|in a (later|future|separate|follow-?up) (pass|PR|pull request|change|iteration|slice)|revisit (this|it|that|later)'
 
-git rev-parse --git-dir >/dev/null 2>&1 || {
+# Anchor to the repo root before anything else. The diff below is scoped with
+# `-- .`, so from a subdirectory it would silently scan only that subtree and
+# report clean for a deferral added anywhere else. Same class of blind spot that
+# assert-doc-refs.sh had, found by reading the two side by side at ship time.
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "check-deferrals: not a git repository" >&2; exit 2; }
+cd "$ROOT" || { echo "check-deferrals: cannot enter $ROOT" >&2; exit 2; }
 
 if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
   echo "check-deferrals: base ref '$BASE' not found." >&2

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -68,6 +68,30 @@ if [ -z "$MATCHES" ]; then
   exit 0
 fi
 
+# A justification shipped in the same diff accounts for the matches, but only if
+# it actually carries the four fields. Checking for the heading alone recreated
+# the exact hole this script exists to close: a two-line
+# "## Deferral Justification" / "TBD" block, in a file unrelated to the flagged
+# phrase, silenced every match in the diff. Pipe it into the one place the fields
+# are defined instead of re-implementing the check here.
+FIELDS_CHECK="$(cd "$(dirname "$0")" && pwd)/check-deferral-fields.sh"
+JUSTIFICATION=$(printf '%s' "$ADDED" | awk '/^## Deferral Justification/{f=1} f{print}')
+
+if [ -n "$JUSTIFICATION" ]; then
+  if [ ! -x "$FIELDS_CHECK" ]; then
+    # Fail closed, loudly. Failing open here would silence every match whenever
+    # the checker went missing, which is how a guard ends up doing nothing while
+    # reporting nothing.
+    echo "check-deferrals: a justification block is present but $FIELDS_CHECK" >&2
+    echo "  is missing or not executable, so its fields cannot be checked." >&2
+    exit 2
+  fi
+  if printf '%s' "$JUSTIFICATION" | "$FIELDS_CHECK" >/dev/null 2>&1; then
+    echo "Deferral sweep: matches justified by a four-field block in the same diff."
+    exit 0
+  fi
+fi
+
 printf '%s\n' "$MATCHES" >&2
 echo "check-deferrals: unjustified deferral language above." >&2
 exit 1

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -47,10 +47,18 @@ EXCLUDES=(
 
 PATTERN='future (work|concern|hardening|enhancement|iteration|sprint|phase|fix|improvement|version)|v[0-9]+ scope|simpler for now|out of scope for (now|this (PR|pull request|change|slice|pass|iteration))|defer(red)? to (follow-?up|later|v[0-9]+|phase [0-9]+)|accepted trade-?off|we can (unify|fix|handle|address|do) (later|in v[0-9]+|in phase [0-9]+)|adds complexity|when we have time|punt(ed)? to|come back to (this|it|that)|in a (later|future|separate|follow-?up) (pass|PR|pull request|change|iteration|slice)|revisit (this|it|that|later)'
 
-# Anchor to the repo root before anything else. The diff below is scoped with
-# `-- .`, so from a subdirectory it would silently scan only that subtree and
-# report clean for a deferral added anywhere else. Same class of blind spot that
-# assert-doc-refs.sh had, found by reading the two side by side at ship time.
+# Resolve this script's own directory BEFORE anything changes the working
+# directory. $0 can be a relative path (`bash ../scripts/check-deferrals.sh`), and
+# a relative $0 resolved after a `cd` points somewhere else entirely: measured at
+# ship time, it produced `/check-deferral-fields.sh` and rejected a legitimately
+# justified deferral with exit 2. The anchoring below introduced that regression,
+# so the order of these two blocks is the fix, not an accident.
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd) || {
+  echo "check-deferrals: cannot resolve own directory from '$0'" >&2; exit 2; }
+
+# Anchor to the repo root. The diff below is scoped with `-- .`, so from a
+# subdirectory it would silently scan only that subtree and report clean for a
+# deferral added anywhere else. Same class of blind spot assert-doc-refs.sh had.
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "check-deferrals: not a git repository" >&2; exit 2; }
 cd "$ROOT" || { echo "check-deferrals: cannot enter $ROOT" >&2; exit 2; }
@@ -105,7 +113,7 @@ fi
 # "## Deferral Justification" / "TBD" block, in a file unrelated to the flagged
 # phrase, silenced every match in the diff. Pipe it into the one place the fields
 # are defined instead of re-implementing the check here.
-FIELDS_CHECK="$(cd "$(dirname "$0")" && pwd)/check-deferral-fields.sh"
+FIELDS_CHECK="$SCRIPT_DIR/check-deferral-fields.sh"
 JUSTIFICATION=$(printf '%s' "$ADDED" | awk '/^## Deferral Justification/{f=1} f{print}')
 
 if [ -n "$JUSTIFICATION" ]; then

--- a/scripts/check-deferrals.sh
+++ b/scripts/check-deferrals.sh
@@ -60,7 +60,24 @@ for commit in $(git rev-list "$BASE..HEAD" 2>/dev/null); do
 $(git log -1 --pretty=%B "$commit" 2>/dev/null)"
 done
 
-BODY=$(printf '%s\n%s\n' "$ADDED" "$MSGS")
+# Third source, and the one that matters. Ferry's recorded failure is follow-ups
+# named in PULL REQUEST BODIES and never filed, and the branch policy sends
+# multi-commit pull requests down the rebase path, where the body never enters
+# git at all. Measured: 38 of the last 40 commits are rebase-merged, so a sweep
+# reading only git would be blind to the exact failure it exists to catch.
+PR_BODY=""
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  if command -v gh >/dev/null 2>&1 && PR_BODY=$(gh pr view --json body --jq .body 2>/dev/null); then
+    :
+  else
+    PR_BODY=""
+    # Announced, never silent. A silent degradation here reproduces the blind
+    # spot this source was added to close, and would look identical to a clean run.
+    echo "PR body: unavailable, scanned diff and commits only" >&2
+  fi
+fi
+
+BODY=$(printf '%s\n%s\n%s\n' "$ADDED" "$MSGS" "$PR_BODY")
 MATCHES=$(printf '%s' "$BODY" | grep -niE "$PATTERN" || true)
 
 if [ -z "$MATCHES" ]; then

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# mutate.sh: run a mutation sweep over Ferry's safety-critical modules.
+#
+# Usage:  uv sync --extra mutation && bash scripts/mutate.sh
+# Exit 0  the run completed and no mutant survived
+# Exit 1  survivors found, triage them
+# Exit 2  could not run, or the harness failed its own self-test
+#
+# WHY THE SELF-TEST IS HERE AND NOT IN pytest
+#
+# The self-test proves this harness can observe a failure at all. Ferry has five
+# recorded lessons about harnesses that could not, and every one of them looked
+# exactly like a clean codebase at the time.
+#
+# It lives inside this script rather than in tests/ for two reasons. cosmic-ray
+# sits behind the `mutation` extra, which CI does not install, so a pytest
+# version would have to be skipped in CI, and a silently skipped self-test is the
+# same failure wearing different clothes. And here it cannot be run around: you
+# cannot get a report out of this script without the self-test having passed
+# first.
+#
+# A cosmic-ray crash is deliberately NOT caught. If the engine failed, the run
+# failed. A harness that swallows its engine's failure is the broken-detector
+# case this exists to prevent.
+
+set -uo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "mutate: not a git repository" >&2; exit 2; }
+cd "$ROOT"
+
+SESSION="mutation-session.sqlite"
+TARGET="src/discord_ferry/core/atomicio.py"
+SUITE="tests/test_atomicio.py"
+
+command -v uv >/dev/null 2>&1 || { echo "mutate: uv not on PATH" >&2; exit 2; }
+[ -f cosmic-ray.toml ] || { echo "mutate: cosmic-ray.toml missing" >&2; exit 2; }
+if ! uv run --extra mutation python -c "import cosmic_ray" >/dev/null 2>&1; then
+  echo "mutate: cosmic-ray not installed. Run: uv sync --extra mutation" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Self-test: two mutants, one the suite must kill and one it cannot see.
+#
+# The PAIR is the point. A detector stuck on one answer passes exactly one of
+# these, so running only the killable case would prove nothing.
+# ---------------------------------------------------------------------------
+BACKUP=$(mktemp)
+cp "$TARGET" "$BACKUP"
+restore() { cp "$BACKUP" "$TARGET"; rm -f "$BACKUP"; }
+trap restore EXIT INT TERM
+
+selftest_fail() {
+  echo "mutate: SELF-TEST FAILED, $1" >&2
+  echo "  The harness cannot reliably tell a killed mutant from a surviving one," >&2
+  echo "  so any sweep it produced would be meaningless. Not running the sweep." >&2
+  exit 2
+}
+
+echo "Self-test: can this harness see a failure?"
+
+# Mutant A: observable, and not an arbitrary one. Swapping Path.replace for
+# Path.rename reintroduces issue #172 exactly: rename refuses an existing
+# destination on Win32 and replaces it on POSIX, which killed the second
+# checkpoint save of every Windows migration. tests/test_atomicio.py exercises
+# the swap under simulated Win32 semantics, so this mutation must fail the suite.
+# If it does not, the harness is not exercising the code it thinks it is.
+python3 - "$TARGET" <<'PY' || exit 2
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old, new = "tmp_path.replace(path)", "tmp_path.rename(path)"
+if old not in s:
+    sys.exit(f"self-test target not found in {p}: {old!r}. The file changed; update mutate.sh.")
+open(p, "w").write(s.replace(old, new, 1))
+PY
+if uv run --extra mutation pytest "$SUITE" -q >/dev/null 2>&1; then
+  restore; trap - EXIT
+  selftest_fail "an observable mutation did NOT fail the suite"
+fi
+cp "$BACKUP" "$TARGET"
+echo "  observable mutation   -> suite FAILED, as required"
+
+# Mutant B: unobservable. Change a comment. Nothing can legitimately catch this,
+# so a suite that fails here is failing for an unrelated reason and every
+# SURVIVED verdict from this run would be suspect.
+python3 - "$TARGET" <<'PY' || exit 2
+import sys
+p = sys.argv[1]
+s = open(p).read()
+if "#" not in s:
+    sys.exit(f"no comment found in {p} to use as an unobservable mutation.")
+i = s.index("#")
+open(p, "w").write(s[:i] + "#  harness self-test, reverted immediately" + s[i + 1:])
+PY
+if ! uv run --extra mutation pytest "$SUITE" -q >/dev/null 2>&1; then
+  restore; trap - EXIT
+  selftest_fail "an unobservable mutation DID fail the suite"
+fi
+cp "$BACKUP" "$TARGET"
+echo "  unobservable mutation -> suite PASSED, as required"
+
+restore
+trap - EXIT
+
+if ! git diff --quiet -- "$TARGET"; then
+  echo "mutate: $TARGET was not restored cleanly after the self-test." >&2
+  echo "  Restore it before continuing: git diff -- $TARGET" >&2
+  exit 2
+fi
+echo "  target restored clean"
+echo
+
+# ---------------------------------------------------------------------------
+# The sweep
+# ---------------------------------------------------------------------------
+echo "Running the sweep. This takes minutes, not hours: 766 lines against a"
+echo "100-test covering suite that runs in under a second."
+rm -f "$SESSION"
+uv run --extra mutation cosmic-ray init cosmic-ray.toml "$SESSION" || exit 2
+uv run --extra mutation cosmic-ray exec cosmic-ray.toml "$SESSION" || exit 2
+echo
+uv run --extra mutation python scripts/mutation_report.py "$SESSION"

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -48,10 +48,20 @@ fi
 # ---------------------------------------------------------------------------
 BACKUP=$(mktemp)
 cp "$TARGET" "$BACKUP"
-restore() { cp "$BACKUP" "$TARGET"; rm -f "$BACKUP"; }
+# Idempotent on purpose. It is called explicitly on the failure paths and again
+# by the trap, and a second call must be a no-op rather than a `cp` from a file
+# that is already gone. Measured: the target ends up correct either way, but a
+# restore that errors on its own second call is noise in exactly the situation
+# where the operator needs a clear signal.
+restore() {
+  [ -f "$BACKUP" ] || return 0
+  cp "$BACKUP" "$TARGET"
+  rm -f "$BACKUP"
+}
 trap restore EXIT INT TERM
 
 selftest_fail() {
+  trap - EXIT INT TERM
   echo "mutate: SELF-TEST FAILED, $1" >&2
   echo "  The harness cannot reliably tell a killed mutant from a surviving one," >&2
   echo "  so any sweep it produced would be meaningless. Not running the sweep." >&2
@@ -121,4 +131,19 @@ rm -f "$SESSION"
 uv run --extra mutation cosmic-ray init cosmic-ray.toml "$SESSION" || exit 2
 uv run --extra mutation cosmic-ray exec cosmic-ray.toml "$SESSION" || exit 2
 echo
+
+# cosmic-ray mutates tracked files in place during the sweep, so an interrupted
+# run can leave one behind. Observed: killing an earlier sweep left
+# src/discord_ferry/cli.py with a comparison flipped, and nothing said so. The
+# tree looks normal until a later `git add -A` commits the mutant.
+#
+# This cannot prevent it (SIGKILL runs no cleanup by definition) but it turns a
+# silent corruption into a named one on every path that does reach here.
+if ! git diff --quiet -- src/; then
+  echo "mutate: WARNING, src/ is dirty after the sweep." >&2
+  echo "  cosmic-ray mutates in place; a mutant may have been left behind." >&2
+  echo "  Inspect before committing anything:  git diff -- src/" >&2
+  git diff --stat -- src/ >&2
+fi
+
 uv run --extra mutation python scripts/mutation_report.py "$SESSION"

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -1,0 +1,108 @@
+"""Report cosmic-ray survivors with the tests that ran against each.
+
+A count is not a report. `lesson-a-mutation-harness-reports-shape-not-just-pass`
+records the reason: a mutant that kills fewer, or different, tests than expected
+is itself the finding, and a harness printing only KILLED or SURVIVED hides it.
+So this prints test names.
+
+This is a query over cosmic-ray's documented API, not a mutation engine. That
+split is why cosmic-ray was chosen over writing one: `WorkResult` carries the
+captured test output and `WorkDB.completed_work_items` is documented, while
+mutmut records only killed/survived status in `.meta` files.
+
+Usage:  uv run --extra mutation python scripts/mutation_report.py <session.sqlite>
+Exit 0  the run completed and no mutant survived
+Exit 1  survivors found (triage them; a survivor is not always a delete instruction)
+Exit 2  the session is incomplete or unreadable, so no report is possible
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+TEST_NAME = re.compile(r"(tests/[\w/]+\.py::[\w\[\]-]+)")
+
+
+def _tests_named(output: str | None) -> list[str]:
+    """Test node ids visible in a mutant's captured pytest output.
+
+    Requires `-v` in the configured test command. Without it pytest prints dots
+    and this returns nothing, which is why the config comments call `-v` load
+    bearing rather than cosmetic.
+    """
+    if not output:
+        return []
+    return sorted({m.group(1) for m in TEST_NAME.finditer(output)})
+
+
+def main(path: str) -> int:
+    try:
+        from cosmic_ray.work_db import WorkDB, use_db
+        from cosmic_ray.work_item import TestOutcome
+    except ImportError:
+        print(
+            "mutation_report: cosmic-ray is not installed.\n  Run: uv sync --extra mutation",
+            file=sys.stderr,
+        )
+        return 2
+
+    with use_db(path, WorkDB.Mode.open) as db:
+        pending = len(db.pending_work_items)
+        if pending:
+            # Refusing beats under-reporting. A partial run presented as complete
+            # understates survivors, and understating them is the direction that
+            # matters: it turns an unfinished sweep into a clean bill of health.
+            print(
+                f"mutation_report: REFUSING to report, {pending} work items still pending.\n"
+                "  A partial run reported as complete understates survivors.",
+                file=sys.stderr,
+            )
+            return 2
+
+        total = db.num_work_items
+        survivors = [
+            (item, result)
+            for item, result in db.completed_work_items
+            if result.test_outcome == TestOutcome.SURVIVED
+        ]
+
+        print(f"Mutants: {total}   Survivors: {len(survivors)}")
+        if not survivors:
+            print("Every mutant was killed.")
+            return 0
+
+        print()
+        for item, result in survivors:
+            for mutation in item.mutations:
+                print(f"SURVIVED  {mutation.module_path}")
+                print(f"  operator   {mutation.operator_name}  occurrence {mutation.occurrence}")
+                names = _tests_named(result.output)
+                if names:
+                    print(f"  tests run  {len(names)}: {', '.join(names[:6])}")
+                else:
+                    print("  tests run  none named (is -v set in the test command?)")
+                if result.diff:
+                    first = next(
+                        (
+                            ln
+                            for ln in result.diff.splitlines()
+                            if ln.startswith(("+", "-")) and not ln.startswith(("+++", "---"))
+                        ),
+                        "",
+                    )
+                    if first:
+                        print(f"  change     {first.strip()}")
+                print()
+
+        print("A surviving mutant is not always a delete instruction. It can mean")
+        print("unreachable by construction, where the line's guard duplicates one that")
+        print("already ran. Diagnose, then write the reason into the code.")
+        return 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: mutation_report.py <session.sqlite>", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(main(sys.argv[1]))

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -42,13 +42,39 @@ def _init_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)
 
 
-def test_doc_refs_passes_on_the_current_tree() -> None:
-    """SC-3.2: the tree is clean today, so no baseline file is needed.
+def test_doc_refs_matches_the_checkout_it_is_run_in() -> None:
+    """SC-3.2, and the branch's own central fact, asserted rather than assumed.
 
-    A failure here means the extraction is wrong, not that the docs drifted.
+    The correct answer differs by checkout, and both answers are real assertions:
+
+    - **Locally** the instruction layer is present, the tree has no drift, so the
+      guard must pass. A failure here means the extraction broke, not that the
+      docs drifted.
+    - **In CI** the instruction layer does not exist. `CLAUDE.md` and
+      `.claude/rules/` are gitignored, so `actions/checkout` never fetches them.
+      The guard must then refuse with exit 2, because checking nothing is not
+      passing.
+
+    This is not a skip dressed as a test. Each branch asserts the behaviour that
+    is correct for that environment, and the CI branch is the one that caught the
+    first version of this test asserting exit 0 unconditionally: it passed
+    locally and failed on all three CI Python versions, which is precisely the
+    local-only assumption this whole branch exists to make visible.
     """
+    instruction_layer_present = (REPO / "CLAUDE.md").exists() or (
+        REPO / ".claude" / "rules"
+    ).is_dir()
+
     result = _run(DOC_REFS, REPO)
-    assert result.returncode == 0, result.stderr
+
+    if instruction_layer_present:
+        assert result.returncode == 0, result.stderr
+    else:
+        assert result.returncode == 2, (
+            "with no instruction layer to read, the guard must refuse rather than "
+            f"report clean. Got {result.returncode}: {result.stderr}"
+        )
+        assert "Checking nothing is not passing" in result.stderr
 
 
 def test_doc_refs_fails_on_a_broken_citation(tmp_path: Path) -> None:

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -130,6 +130,27 @@ def test_adr_index_parity_fails_when_a_row_has_no_file(tmp_path: Path) -> None:
     assert "003" in result.stderr
 
 
+def test_adr_index_parity_fails_when_the_row_format_changes(tmp_path: Path) -> None:
+    """The row->file direction must not silently stop checking.
+
+    That direction depends on the index's `| [NNN]` table format. If the format
+    changes, the extraction finds nothing and checks nothing, which looks exactly
+    like a pass. Found during chunk 1's review, by testing the guard rather than
+    reading it: the second-opinion model returned zero findings on this file.
+    """
+    _init_repo(tmp_path)
+    adr = tmp_path / "docs" / "architecture" / "adr"
+    adr.mkdir(parents=True)
+    (tmp_path / "CLAUDE.md").write_text("nothing cited\n")
+    (adr / "README.md").write_text("- [001](001-a.md) A\n")  # not the table format
+    (adr / "001-a.md").touch()
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 1
+    assert "stopped checking" in result.stderr
+
+
 def test_adr_index_parity_passes_when_they_match(tmp_path: Path) -> None:
     """The control for the two tests above.
 

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -454,3 +454,38 @@ def test_sweep_still_fires_from_a_subdirectory(tmp_path: Path) -> None:
 
     assert from_root.returncode == 1
     assert from_sub.returncode == 1, "a subdirectory invocation missed the deferral"
+
+
+def test_sweep_finds_its_field_checker_from_a_subdirectory(tmp_path: Path) -> None:
+    """A relative $0 must be resolved before the script changes directory.
+
+    Regression guard. The repo-root anchoring introduced this: after `cd "$ROOT"`,
+    `$(dirname "../scripts/check-deferrals.sh")` no longer points at the scripts
+    directory, and the checker resolved to `/check-deferral-fields.sh`. A
+    legitimately justified deferral was then rejected with exit 2.
+
+    The existing subdirectory test does not cover this path, because without a
+    justification block the checker is never consulted.
+    """
+    repo = _repo_with_change(tmp_path, f"This is future work.\n\n{FOUR_FIELDS}")
+    (repo / "sub").mkdir()
+
+    from_root = subprocess.run(
+        ["bash", "scripts/check-deferrals.sh", "HEAD~1"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    from_sub = subprocess.run(
+        ["bash", "../scripts/check-deferrals.sh", "HEAD~1"],
+        cwd=repo / "sub",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert from_root.returncode == 0, from_root.stderr
+    assert from_sub.returncode == 0, (
+        "the field checker was not found from a subdirectory: " + from_sub.stderr
+    )

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -1,0 +1,147 @@
+"""Subprocess drivers for the instruction-layer gate scripts.
+
+The scripts are the deliverable, so these tests drive them the way `/df-ship` and
+CI do: run them, read the exit code, read stderr. Anything that asserts on the
+script's source text instead would be a source-string test, which let an
+eleven-release outage ship green once already.
+
+Every gate here is checked in both directions. A test that only ever sees the
+passing case cannot distinguish a working guard from one that always exits 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DOC_REFS = REPO / "scripts" / "assert-doc-refs.sh"
+
+
+def _run(script: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(script)], cwd=cwd, capture_output=True, text=True, check=False
+    )
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+
+
+def test_doc_refs_passes_on_the_current_tree() -> None:
+    """SC-3.2: the tree is clean today, so no baseline file is needed.
+
+    A failure here means the extraction is wrong, not that the docs drifted.
+    """
+    result = _run(DOC_REFS, REPO)
+    assert result.returncode == 0, result.stderr
+
+
+def test_doc_refs_fails_on_a_broken_citation(tmp_path: Path) -> None:
+    """SC-3.1: a cited path that does not resolve fails the guard."""
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "CLAUDE.md").write_text("See `src/does_not_exist.py` for details.\n")
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 1
+    assert "does_not_exist.py" in result.stderr
+
+
+def test_doc_refs_strips_line_numbers_and_fragments(tmp_path: Path) -> None:
+    """SC-3.3: `config.py:42` resolves once the suffix is removed.
+
+    Without this, every file:line citation in the instruction layer would be a
+    false positive and the guard would be switched off within a day.
+    """
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "config.py").write_text("x = 1\n")
+    (tmp_path / "CLAUDE.md").write_text("See `src/config.py:42` and `src/config.py#section`.\n")
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_doc_refs_is_not_blinded_by_a_global_gitignore(tmp_path: Path) -> None:
+    """SC-3.4: a developer's global excludes must not hide drift.
+
+    The guard passes `-c core.excludesfile=/dev/null` for exactly this. No global
+    file is set on this machine today, so this guards against a future one.
+    """
+    _init_repo(tmp_path)
+    excludes = tmp_path / "global_ignore"
+    excludes.write_text("*.py\n")
+    subprocess.run(["git", "config", "core.excludesfile", str(excludes)], cwd=tmp_path, check=True)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "CLAUDE.md").write_text("See `src/does_not_exist.py`.\n")
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 1, "the global excludes file hid the drift"
+
+
+def test_doc_refs_exits_2_outside_a_repository(tmp_path: Path) -> None:
+    """Cannot-run must block, not pass.
+
+    A gate that cannot run is not a gate that passed. The opposite decision is on
+    record going wrong: a guard that failed open did nothing and reported nothing.
+    """
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 2
+
+
+def test_adr_index_parity_fails_when_a_file_has_no_row(tmp_path: Path) -> None:
+    """SC-3.5, direction one: an ADR the index does not list."""
+    _init_repo(tmp_path)
+    adr = tmp_path / "docs" / "architecture" / "adr"
+    adr.mkdir(parents=True)
+    (tmp_path / "CLAUDE.md").write_text("nothing cited\n")
+    (adr / "README.md").write_text("| [001](001-a.md) | A | x |\n")
+    (adr / "001-a.md").touch()
+    (adr / "002-b.md").touch()
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 1
+    assert "002" in result.stderr
+
+
+def test_adr_index_parity_fails_when_a_row_has_no_file(tmp_path: Path) -> None:
+    """SC-3.5, direction two: an index row pointing at nothing.
+
+    Both directions matter. Checking only one would have missed the ADR-018
+    collision, where a concurrent session took a number that a new file would
+    then have overwritten.
+    """
+    _init_repo(tmp_path)
+    adr = tmp_path / "docs" / "architecture" / "adr"
+    adr.mkdir(parents=True)
+    (tmp_path / "CLAUDE.md").write_text("nothing cited\n")
+    (adr / "README.md").write_text("| [001](001-a.md) | A | x |\n| [003](003-c.md) | C | x |\n")
+    (adr / "001-a.md").touch()
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 1
+    assert "003" in result.stderr
+
+
+def test_adr_index_parity_passes_when_they_match(tmp_path: Path) -> None:
+    """The control for the two tests above.
+
+    Without it, a guard that always exited 1 would pass both parity tests.
+    """
+    _init_repo(tmp_path)
+    adr = tmp_path / "docs" / "architecture" / "adr"
+    adr.mkdir(parents=True)
+    (tmp_path / "CLAUDE.md").write_text("nothing cited\n")
+    (adr / "README.md").write_text("| [001](001-a.md) | A | x |\n")
+    (adr / "001-a.md").touch()
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -13,9 +13,23 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 DOC_REFS = REPO / "scripts" / "assert-doc-refs.sh"
+DEFERRALS = REPO / "scripts" / "check-deferrals.sh"
+FIELDS = REPO / "scripts" / "check-deferral-fields.sh"
+
+FOUR_FIELDS = (
+    "## Deferral Justification\n"
+    "Why not now: blocked on the upstream release\n"
+    "Cost comparison: 2h now, 2h later, no asymmetry\n"
+    "Owner: Peter Sterkenburg\n"
+    "Trigger: when the upstream release lands\n"
+)
 
 
 def _run(script: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -166,3 +180,154 @@ def test_adr_index_parity_passes_when_they_match(tmp_path: Path) -> None:
     result = _run(DOC_REFS, tmp_path)
 
     assert result.returncode == 0, result.stderr
+
+
+# --- the deferral sweep -------------------------------------------------------
+#
+# Each case builds its own throwaway repository rather than switching branches in
+# a shared one. A `git checkout -b` here trips branch-guard, which runs its status
+# check in its own working directory and so reports the Ferry tree's state rather
+# than the temp repo's.
+
+
+def _repo_with_change(path: Path, content: str, *, with_checker: bool = True) -> Path:
+    """Seed a repo, then add one commit introducing `content`.
+
+    The sweep resolves its four-field checker relative to its own location, so
+    testing the missing-checker path means copying the sweep somewhere the
+    checker is absent, not deleting it from the repo under test. An earlier
+    version of this test deleted the repo's copy and proved nothing, because the
+    sweep was still finding the real one beside itself.
+    """
+    scripts = path / "scripts"
+    scripts.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    (scripts / DEFERRALS.name).write_bytes(DEFERRALS.read_bytes())
+    (scripts / DEFERRALS.name).chmod(0o755)
+    if with_checker:
+        (scripts / FIELDS.name).write_bytes(FIELDS.read_bytes())
+        (scripts / FIELDS.name).chmod(0o755)
+    (path / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=path, check=True)
+    (path / "notes.md").write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "change"], cwd=path, check=True)
+    return path
+
+
+def _sweep(cwd: Path, base: str = "HEAD~1") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/check-deferrals.sh", base],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_sweep_fires_on_an_unjustified_deferral(tmp_path: Path) -> None:
+    """SC-2.1. Demonstrated against real history too: 5 of 110 merged PR bodies."""
+    repo = _repo_with_change(tmp_path, "This is future work, tracked separately.\n")
+
+    result = _sweep(repo)
+
+    assert result.returncode == 1
+    assert "future work" in result.stderr.lower()
+
+
+def test_sweep_accepts_a_four_field_justification(tmp_path: Path) -> None:
+    """SC-2.2: a real justification in the same diff accounts for the match."""
+    repo = _repo_with_change(tmp_path, f"This is future work.\n\n{FOUR_FIELDS}")
+
+    result = _sweep(repo)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_sweep_rejects_a_justification_heading_with_no_fields(tmp_path: Path) -> None:
+    """SC-2.3: the TBD hole.
+
+    Checking for the heading alone let a two-line block silence every match in the
+    diff, recreating the exact failure this gate closes. The block is piped into
+    the one place the four fields are defined.
+    """
+    repo = _repo_with_change(tmp_path, "This is future work.\n\n## Deferral Justification\nTBD\n")
+
+    result = _sweep(repo)
+
+    assert result.returncode == 1
+
+
+def test_sweep_fails_closed_when_the_field_checker_is_missing(tmp_path: Path) -> None:
+    """A justification it cannot check must not be treated as valid.
+
+    Failing open here would silence every match whenever the checker went missing,
+    which is how a guard ends up doing nothing while reporting nothing.
+    """
+    repo = _repo_with_change(tmp_path, f"This is future work.\n\n{FOUR_FIELDS}", with_checker=False)
+
+    result = _sweep(repo)
+
+    assert result.returncode == 2
+    assert "cannot be checked" in result.stderr
+
+
+def test_sweep_ignores_a_phrase_on_an_untouched_line(tmp_path: Path) -> None:
+    """SC-2.4: added lines only, never the whole diff.
+
+    Scanning the whole diff reported text three lines from an edit that nobody had
+    written. Harmless inside a skill, a blocked pull request once it runs in CI.
+    """
+    scripts = tmp_path / "scripts"
+    scripts.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (scripts / DEFERRALS.name).write_bytes(DEFERRALS.read_bytes())
+    (scripts / DEFERRALS.name).chmod(0o755)
+    (tmp_path / "notes.md").write_text("This is future work.\nline2\nline3\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True)
+    (tmp_path / "notes.md").write_text("This is future work.\nline2\nEDITED\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "edit"], cwd=tmp_path, check=True)
+
+    result = _sweep(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_sweep_exits_2_on_a_missing_base_ref(tmp_path: Path) -> None:
+    """SC-2.5: cannot-run blocks, and the error names the remedy.
+
+    A shallow CI checkout is the real case, and `fetch-depth` in the message is
+    what turns a red build into a one-line fix.
+    """
+    repo = _repo_with_change(tmp_path, "clean\n")
+
+    result = _sweep(repo, base="origin/definitely-not-a-ref")
+
+    assert result.returncode == 2
+    assert "fetch-depth" in result.stderr
+
+
+def test_sweep_announces_a_missing_gh_rather_than_passing_silently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-2.6: the one degradation, and it must be audible.
+
+    The PR body is the source that matters: 0 of 60 Ferry commits match the
+    pattern while 5 of 110 PR bodies do, because rebase merges keep the body out
+    of git. Degrading silently would reproduce the blind spot this source closes.
+    """
+    repo = _repo_with_change(tmp_path, "clean\n")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    result = _sweep(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "PR body: unavailable" in result.stderr

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -392,3 +392,65 @@ def test_ci_gates_job_is_not_in_the_python_matrix() -> None:
     job = _gates_job()
     assert "strategy:" not in job
     assert "matrix" not in job
+
+
+# --- both gates must be anchored to the repo root ------------------------------
+#
+# Found by the whole-branch review, which read the three scripts side by side.
+# Per-chunk review could not see it: each script was correct in isolation and
+# they disagreed with each other. assert-doc-refs.sh trusted cwd, so from a
+# subdirectory it found none of its inputs, checked nothing, and printed
+# "clean" with exit 0. A check that stopped checking without failing, inside the
+# script written to stop checks doing that.
+
+
+def test_doc_refs_still_catches_drift_from_a_subdirectory(tmp_path: Path) -> None:
+    """Running from a subdirectory must not turn a real failure into a pass."""
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "CLAUDE.md").write_text("See `src/does_not_exist.py`.\n")
+
+    from_root = _run(DOC_REFS, tmp_path)
+    from_sub = _run(DOC_REFS, tmp_path / "src")
+
+    assert from_root.returncode == 1
+    assert from_sub.returncode == 1, "a subdirectory invocation reported a false pass"
+    assert "does_not_exist.py" in from_sub.stderr
+
+
+def test_doc_refs_refuses_when_it_finds_no_input_documents(tmp_path: Path) -> None:
+    """Checking nothing is not passing.
+
+    Belt two: even anchored at the root, a tree with no CLAUDE.md and no rules
+    has nothing to check, and reporting clean there would be a lie.
+    """
+    _init_repo(tmp_path)
+
+    result = _run(DOC_REFS, tmp_path)
+
+    assert result.returncode == 2
+    assert "Checking nothing is not passing" in result.stderr
+
+
+def test_sweep_still_fires_from_a_subdirectory(tmp_path: Path) -> None:
+    """The sweep scopes its diff with `-- .`, so cwd could silently narrow it."""
+    repo = _repo_with_change(tmp_path, "This is future work, tracked separately.\n")
+    (repo / "sub").mkdir()
+
+    from_root = subprocess.run(
+        ["bash", "scripts/check-deferrals.sh", "HEAD~1"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    from_sub = subprocess.run(
+        ["bash", "../scripts/check-deferrals.sh", "HEAD~1"],
+        cwd=repo / "sub",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert from_root.returncode == 1
+    assert from_sub.returncode == 1, "a subdirectory invocation missed the deferral"

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -331,3 +331,64 @@ def test_sweep_announces_a_missing_gh_rather_than_passing_silently(
 
     assert result.returncode == 0, result.stderr
     assert "PR body: unavailable" in result.stderr
+
+
+# --- the CI wiring ------------------------------------------------------------
+#
+# Asserting on the workflow's text is appropriate here: a workflow file IS text,
+# and there is no behaviour to exercise locally. This is not the source-string
+# antipattern, which is about asserting on code text as a proxy for what the code
+# does.
+
+CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
+
+
+def _gates_job() -> str:
+    """The `gates:` job block, comments stripped, header to next job or EOF.
+
+    Comments are removed so these assertions test configuration rather than
+    prose. The first version of this helper kept them and the matrix assertion
+    failed against the word "matrix" inside its own explanatory comment.
+    """
+    lines = CI_WORKFLOW.read_text().splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.strip() == "gates:")
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i] and not lines[i].startswith("    ") and lines[i].startswith("  "):
+            end = i
+            break
+    return "\n".join(ln for ln in lines[start:end] if not ln.strip().startswith("#"))
+
+
+def test_ci_runs_the_deferral_sweep() -> None:
+    """SC-2.7: the sweep is actually wired into CI, not merely written."""
+    assert "check-deferrals.sh" in _gates_job()
+
+
+def test_ci_gates_job_sets_gh_token() -> None:
+    """Without it the sweep degrades on EVERY CI run while still passing.
+
+    gh is preinstalled on ubuntu-latest but does not authenticate on its own, so
+    the pull request body, the one source that finds Ferry's real deferrals, would
+    never be read. It would keep working locally, where a developer's gh session
+    is already authenticated, which is the worst failure shape available.
+    """
+    job = _gates_job()
+    assert "GH_TOKEN" in job
+    assert "pull-requests: read" in job
+
+
+def test_ci_gates_job_fetches_full_history() -> None:
+    """The sweep resolves origin/main; a shallow clone makes it exit 2."""
+    assert "fetch-depth: 0" in _gates_job()
+
+
+def test_ci_gates_job_is_not_in_the_python_matrix() -> None:
+    """One run per pull request, not three.
+
+    lint-and-test runs a three-version matrix. A step there would run the sweep
+    three times and make three gh calls for one answer.
+    """
+    job = _gates_job()
+    assert "strategy:" not in job
+    assert "matrix" not in job

--- a/uv.lock
+++ b/uv.lock
@@ -196,6 +196,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anybadge"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/08/ddad0d5398d0961d506b0489e737a06e29a963eff0f2f0a2bb2cfb36dd1f/anybadge-1.16.0.tar.gz", hash = "sha256:f4e95eca834482f9932f9020ac2fe04a5ca863728b446324a8d35b1e67faab71", size = 34616, upload-time = "2025-01-11T23:03:27.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/7d/01b2ac2fec808dea667b8678938156c3910219f2c45ee2e0b01e72786d72/anybadge-1.16.0-py3-none-any.whl", hash = "sha256:bc9ef2e20d875ee09237a15250a17b6fd7e67276f083d32a297963cdec179918", size = 28412, upload-time = "2025-01-11T23:03:24.857Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -453,6 +465,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cosmic-ray"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anybadge" },
+    { name = "attrs" },
+    { name = "click" },
+    { name = "decorator" },
+    { name = "exit-codes" },
+    { name = "gitpython" },
+    { name = "parso" },
+    { name = "rich" },
+    { name = "sqlalchemy" },
+    { name = "stevedore" },
+    { name = "toml" },
+    { name = "yattag" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/44/0f033f653a859f82efb8b72edfa3dd3feba30f94b1784c74149908d9bbfd/cosmic_ray-8.7.0.tar.gz", hash = "sha256:f1e8cdbd9b8c9d9145bc2b37247081b423d1e079d929a3da30714b23d40b4a70", size = 1667525, upload-time = "2026-08-09T14:57:55.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/20/ec3c7d8c592ec75846f75dbcf9f2e031b4035be8ae9660136e642cafc364/cosmic_ray-8.7.0-py3-none-any.whl", hash = "sha256:759510a02cf2b23ba15a00680ecc1fd6c74d3082622e5a7d2d514b5227267659", size = 62310, upload-time = "2026-08-09T14:57:54.376Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
 name = "discord-ferry"
 version = "2.19.0"
 source = { editable = "." }
@@ -480,6 +525,9 @@ dev = [
 docs = [
     { name = "mkdocs-material" },
 ]
+mutation = [
+    { name = "cosmic-ray" },
+]
 native = [
     { name = "pywebview" },
 ]
@@ -490,6 +538,7 @@ requires-dist = [
     { name = "aioresponses", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "certifi", specifier = ">=2024.0" },
     { name = "click", specifier = ">=8.0" },
+    { name = "cosmic-ray", marker = "extra == 'mutation'", specifier = ">=8.3" },
     { name = "ijson", specifier = ">=3.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0" },
     { name = "multidict", specifier = ">=4.5" },
@@ -504,7 +553,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "yarl", specifier = ">=1.17" },
 ]
-provides-extras = ["native", "dev", "docs"]
+provides-extras = ["native", "dev", "mutation", "docs"]
 
 [[package]]
 name = "docutils"
@@ -513,6 +562,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "exit-codes"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/20/1a8671601b459a8388185ee29f98cee5965a94aeaccc6b9c926f4afec4dc/exit_codes-1.3.0.tar.gz", hash = "sha256:8fe3a056be6cbc530d59d9ad9bdc1771d8cff7d9ac7386a0c39b517a8ae52b3e", size = 3791, upload-time = "2019-07-09T07:37:07.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/07/5dc359aba858ec096bd9e72c4a214617c95da24553a736bcce7818a61486/exit_codes-1.3.0-py2.py3-none-any.whl", hash = "sha256:09444844772043f9be22128856088792be0f91cdbe269af992b1338a5464dc85", size = 4708, upload-time = "2019-07-09T07:37:06.697Z" },
 ]
 
 [[package]]
@@ -646,6 +704,93 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a3/07297917485ee2ca85bc3c8dc6ed85ad3fffcf424047fba62671dba68e97/greenlet-3.5.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:be63afcbbccfad3dd95a1ba12ada84dab2ef32031973d80b5b92df67fa763a61", size = 294165, upload-time = "2026-08-10T13:25:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/6f732f9314cda54c5fd48a7620c7160f4f286967e8045ad94b9d66ce80b7/greenlet-3.5.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a268024ce2d7d2b04694bf1594058981a9fa663d1df4b762dee499211ed7c1c", size = 613610, upload-time = "2026-08-10T14:14:33.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c0/b27589e25d220289edcd4d582b2b17b83058d1a56d53d971b6ea1a34f10d/greenlet-3.5.5-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35cbb8bf55ace57fbccb4fb8622c4521713acd8691e77f4696d416ea7ca527da", size = 625481, upload-time = "2026-08-10T14:27:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2d/f2c928218ac52f26d7a2c188c171d1b7e728b23782cb3347e7b4fce1493a/greenlet-3.5.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864", size = 624562, upload-time = "2026-08-10T13:40:48.064Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4a/92fc51d5d35912f4f06eec037ba347985defd0be47463a010a325634d9d2/greenlet-3.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d9b454c5fc48aeaa7c4337813dbf513a6870468e426438a04d922c6d0fe63db", size = 1584909, upload-time = "2026-08-10T14:15:04.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/ed98b80ac5738c149a5258544843c45601ade1fd70f61740cdaead6351b3/greenlet-3.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03551ed792cb1b4fc0277a0c60dfd8c343894a0ba06fe60dcd22f568b433da39", size = 1651184, upload-time = "2026-08-10T13:40:28.879Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/be/b582ceb80cefdf9d8da34078714e4b12b3d16f509dee0f65e40a5cc8fc7d/greenlet-3.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:ab3df3dffb58bf70564e93a5cec7941e4d9faa5a36cc4234a10d3131afe04f53", size = 323280, upload-time = "2026-08-10T13:26:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/5313c4c58598c38b0373c013e4ff2b3e6d258aaaa338f373335ebecdaddd/greenlet-3.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:2b70a766135540c472ac1393d57c2e1b4a2eb85bf526a1e41e6d096173a8cee5", size = 307785, upload-time = "2026-08-10T13:28:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -1539,6 +1684,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2273,6 +2427,57 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/08/cc5f7627b92f1456bc0b5fb7e98af4600248abe422a44da0d17a3fe6a448/sqlalchemy-2.0.52-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0c3ce43907374889f3352bdcc6195c970148a2cb71574cd0237a5071a37fb6c", size = 2172460, upload-time = "2026-08-11T20:58:22.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/9a2abad8bfc8fdcd38c64adc056aeefab7aaa96ecd32f5e8c140e6375f17/sqlalchemy-2.0.52-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a0d48c4b80717c61385b4e966e087c839a66cfd7b780641dcb428f4dba65608", size = 3355720, upload-time = "2026-08-11T21:00:06.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/e75597b5841043e3c74055d00d4feb53d9a49a5c89ba2450d2d9aab53597/sqlalchemy-2.0.52-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:938325a5373267afc53bfbe72983b20fbd64ca47842aac62433c3da1137ecff1", size = 3354394, upload-time = "2026-08-11T21:05:51.454Z" },
+    { url = "https://files.pythonhosted.org/packages/12/25/410fbc6c2f1fa8310f4ef1b6847d47d0ac1c042c7b4e81eaaca063d030a9/sqlalchemy-2.0.52-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5f8438a98d49424acf69d0d53c0a522951dfe49a6f2d86417fbb37ad3066ab43", size = 3306991, upload-time = "2026-08-11T21:00:08.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ba/25ffd5c24681ea4b46e62c80ceca8200ce204de1773366321306cf3f608a/sqlalchemy-2.0.52-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4699dbb8d396d199e7e78fd4d525e3ad3d6008a9c8c0160b87e74c606c2c3736", size = 3327454, upload-time = "2026-08-11T21:05:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f1/0f1b1d4800e51218e736a06ed55a3b2a59c257600bbaca7673bf13d2dbec/sqlalchemy-2.0.52-cp311-cp311-win32.whl", hash = "sha256:cef328349452ae152637df4d11ce5a0919ecdf0a363e16c830c3518ee33bde72", size = 2131248, upload-time = "2026-08-11T21:09:50.765Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/04d2ac5ad66f3d31278f37064ed5f5ef3fe653f7bdaa67036663f223d186/sqlalchemy-2.0.52-cp311-cp311-win_amd64.whl", hash = "sha256:f1c850792a3b25a3ad74dade3f05e4f402cdebfea27438bcadafaa1617f77bcc", size = 2156943, upload-time = "2026-08-11T21:09:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/18/e30c6fe1eca1bf34a39fbdd6066121cc9974c850faf6f349eac563697a26/sqlalchemy-2.0.52-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2eb3c6a64b1bfe6704777cfd504e7b8ad093a5f3e03ce67663a5e6742f294e43", size = 2167724, upload-time = "2026-08-11T20:58:12.679Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/56/2e17d161a4f7ecc1c2ffb93e607b4e1898bb551b451b283235acb8f6ce47/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:923bb183c1dc64fdf7b717965e3d59938ec4f8b8710b419a21ce403e5da9a9e1", size = 3321189, upload-time = "2026-08-11T21:02:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b8/8490916e893f3f8d74dc9cc54c078619364999dee37047a188e73abbc852/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:651d6d8782e80679e6151707c7b490834d46ada526328895abf567f25e63d29c", size = 3338185, upload-time = "2026-08-11T21:17:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f7/752cc8ee453da222829b3f5c4613614bf750d97429363b70414fa10478e4/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b08cddb8989775e3c88799d86704bdfc3ee6e9846118201aa5997f16f27e3a15", size = 3271698, upload-time = "2026-08-11T21:02:43.963Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e6/074ade0c07b9e4c8e8bca46820320ed94df9702afdb6f2af06623068d2e6/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab66fa9618269390d4dfa222f2f2f88f7bc4bf5da13905131b818217db7e8057", size = 3308936, upload-time = "2026-08-11T21:17:04.172Z" },
+    { url = "https://files.pythonhosted.org/packages/66/07/557c0d04716705599227945ac14e0a17ad0338e899f37d8c2ddff4dcc663/sqlalchemy-2.0.52-cp313-cp313-win32.whl", hash = "sha256:c63bda077685c85ca513286547a531ba57e7a68cf0a7ed3bafcc2bbd18896f4d", size = 2127308, upload-time = "2026-08-11T21:14:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4e/226eda27654318ce525d043025221f689abef883da2c7126f9065121618c/sqlalchemy-2.0.52-cp313-cp313-win_amd64.whl", hash = "sha256:9876b09b9f1ce7398b0ffece585c0a911244c53191187341f6bcae640e133751", size = 2153876, upload-time = "2026-08-11T21:14:55.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2286,6 +2491,15 @@ wheels = [
 ]
 
 [[package]]
+name = "stevedore"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2295,6 +2509,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -2704,3 +2927,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]
+
+[[package]]
+name = "yattag"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/1a/d3b2a2b8f843f5e7138471c4a5c9172ef62bb41239aa4371784b7448110c/yattag-1.16.1.tar.gz", hash = "sha256:baa8f254e7ea5d3e0618281ad2ff5610e0e5360b3608e695c29bfb3b29d051f4", size = 29069, upload-time = "2024-11-02T22:38:30.443Z" }


### PR DESCRIPTION
Three repository gates, so four project rules are enforced by a script instead of by memory. Nothing under `src/` changed, no user-facing behaviour differs, and there is no version bump.

Closes #350, #351, #352, #353.

## What lands

**`scripts/assert-doc-refs.sh`** checks that paths cited in the project's documentation resolve on disk, and that every architecture decision record has an index row and every index row has a record. Both directions, because one direction alone missed a real collision during this work.

It runs locally rather than in CI. Its inputs are not committed to this repository, so a CI runner never receives them. That was found by review, not by design: an earlier version of this branch wired it into CI, where it would have had no input at all.

**`scripts/check-deferrals.sh`** sweeps for language that defers work without filing it, in a new single-run `gates` CI job. It reads the pull request body as well as the diff and commit messages, which is the part that matters here. This repository rebase-merges most pull requests, so the body never enters git: measured across recent history, 0 matches in 60 commits against 5 in 110 merged pull request bodies. A sweep reading only git would have scored zero and looked clean.

**`scripts/mutate.sh`** runs a mutation sweep over the three modules where a test that cannot fail costs most: redaction, checkpoint state, and atomic writes. It self-tests first with one mutation the suite must catch and one it cannot see, and refuses to report if either answer is wrong. It sits behind a `mutation` extra so CI does not install it.

**`scripts/check-deferral-fields.sh`** is now tracked. It was untracked, so the sweep could not reach it from CI.

## Verification

- 2027 tests, 24 of them driving the gate scripts by subprocess in both directions
- Every guard confirmed to fail when its logic is removed, with the kill shape recorded rather than a pass/fail count
- Mutation sweep: 270 mutants, 96 survivors, 4m29s; 24 of those survivors traced to type annotations that are inert under PEP 563, confirmed by AST scan rather than assumed
- Four chunk reviews plus a whole-branch review plus a second opinion

## What review actually caught

The whole-branch pass found a defect three per-chunk reviews could not: `assert-doc-refs.sh` trusted the working directory, so run from a subdirectory it found none of its inputs, checked nothing, and printed `clean` with exit 0. A check that stopped checking without failing, inside the script written to prevent exactly that. Visible only by reading it beside `mutate.sh`, which anchored correctly.

The fix then introduced a second defect, caught by the second opinion: anchoring to the repository root broke the relative `$0` used to locate the field checker, so a properly justified deferral was rejected. Both are fixed, both have regression tests, and both tests were confirmed to fail when the fix is reverted.
