### PR TITLE
test(state): counters start at zero, flags start False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Counters and flags on the migration documents are now asserted to start from zero.** Every
+  `int` field on `MigrationState`, `RollbackProgress`, `FailedMessage` and `ChannelResult` must be
+  `0` on a fresh instance, and every `bool` must be `False`. Test-only, nothing under `src/`
+  changed, so there is no version bump.
+
+  This came from the first mutation sweep. Changing a counter's default from `0` to `1` left the
+  entire state test suite passing: a counter that starts at one is not a crash, it is a silently
+  wrong number in every total the migration reports, and no single test was ever going to be
+  written for each of the twenty-eight fields individually. One assertion covers them all and
+  extends to fields added later. Measured: it kills thirty-eight mutants the suite previously
+  missed.
+
 - **Three repository gates, so four project rules are enforced by a script instead of by memory.**
   No user-facing behaviour changes and nothing under `src/` was touched, so there is no version
   bump.

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1224,6 +1224,12 @@ def test_every_integer_counter_starts_at_zero() -> None:
         # passes. The first version of this test did exactly that, and the
         # mutation run that was meant to prove it caught only the one class where
         # the emptiness guard below happened to fire.
+        # `("int", int)` is not belt and braces, it is required, and narrowing it
+        # to `f.type is int` would silently drop coverage rather than fail. The
+        # modules disagree on PEP 563: state.py has no `from __future__ import
+        # annotations`, so its field types are real type objects, while
+        # messages.py has it, so ChannelResult's are the strings "int" and "bool".
+        # Measured: `f.type is int` matches 0 of ChannelResult's 8 int fields.
         int_fields = [f.name for f in dataclasses.fields(cls) if f.type in ("int", int)]
         assert int_fields, (
             f"{cls.__name__} declares no int fields. If that is deliberate, drop it "

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1176,3 +1176,53 @@ def test_a_recorded_name_containing_a_secret_is_not_rewritten() -> None:
     # The positive control: the same call DID scrub a classified field, so the
     # assertion above cannot be passing because the registry was empty.
     assert "swordfish" not in doc["warnings"][0]["message"]
+
+
+def test_every_integer_counter_starts_at_zero() -> None:
+    """Every `int` field declared with a zero default must actually be zero.
+
+    Found by the first mutation sweep: changing `retry_count: int = 0` to `= 1`
+    left all 64 tests in this file passing. Around thirty of that run's
+    ninety-six survivors were this one shape, across three dataclasses.
+
+    A counter that starts at one is not a crash. It is a silently wrong number in
+    every total the migration reports, and the kind of defect nobody writes a
+    single test for. One introspective assertion kills the whole class and covers
+    fields added later without anyone remembering to.
+
+    Derived from the dataclass fields rather than a hardcoded list on purpose: a
+    literal list drifts the moment a field is added, and the emptiness guard below
+    means a refactor that removes the fields fails here instead of turning this
+    into a test that checks nothing.
+    """
+    import dataclasses
+
+    cases = [
+        MigrationState(),
+        RollbackProgress(),
+        FailedMessage(discord_msg_id="1", stoat_channel_id="2", error="boom"),
+    ]
+
+    for instance in cases:
+        cls = type(instance)
+        # Select by TYPE, assert on VALUE. Selecting by `default == 0` and then
+        # asserting the value is 0 is circular: change a default to 1 and the
+        # field drops out of the selection, so nothing is checked and the test
+        # passes. The first version of this test did exactly that, and the
+        # mutation run that was meant to prove it caught only the one class where
+        # the emptiness guard below happened to fire.
+        int_fields = [f.name for f in dataclasses.fields(cls) if f.type in ("int", int)]
+        assert int_fields, (
+            f"{cls.__name__} declares no int fields. If that is deliberate, drop it "
+            "from this test; otherwise this check has stopped checking anything."
+        )
+
+        for name in int_fields:
+            actual = getattr(instance, name)
+            assert actual == 0, (
+                f"{cls.__name__}.{name} is an int field whose fresh-instance value "
+                f"is {actual!r}, not 0. Every int on these documents is a counter, "
+                "and one that does not start at zero misreports every total derived "
+                "from it. If a non-zero default is genuinely wanted, this test is "
+                "the place to say so explicitly."
+            )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1197,10 +1197,23 @@ def test_every_integer_counter_starts_at_zero() -> None:
     """
     import dataclasses
 
+    from discord_ferry.migrator.messages import ChannelResult
+
+    # ChannelResult is here because the ship audit went looking for the same shape
+    # elsewhere and found it: eight counters, all defaulting to zero, feeding the
+    # same totals. Twenty other dataclasses also carry int or bool fields and are
+    # deliberately absent. FerryConfig is the clearest reason why: `max_channels =
+    # 200` and `create_invite = True` are correct non-zero defaults, so the
+    # invariant is "counters start at zero", not "every int is zero".
+    #
+    # ReviewSummary looked like a candidate and is not one: all nine of its fields
+    # are required, so it has no defaults to assert. A check over zero fields
+    # passes for the wrong reason.
     cases = [
         MigrationState(),
         RollbackProgress(),
         FailedMessage(discord_msg_id="1", stoat_channel_id="2", error="boom"),
+        ChannelResult(),
     ]
 
     for instance in cases:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1216,6 +1216,8 @@ def test_every_integer_counter_starts_at_zero() -> None:
         ChannelResult(),
     ]
 
+    bools_checked = 0
+
     for instance in cases:
         cls = type(instance)
         # Select by TYPE, assert on VALUE. Selecting by `default == 0` and then
@@ -1252,9 +1254,21 @@ def test_every_integer_counter_starts_at_zero() -> None:
         for field_ in dataclasses.fields(cls):
             if field_.type not in ("bool", bool):
                 continue
+            bools_checked += 1
             actual = getattr(instance, field_.name)
             assert actual is False, (
                 f"{cls.__name__}.{field_.name} is a bool field whose fresh-instance "
                 f"value is {actual!r}, not False. These flags record what has already "
                 "happened, so one that starts True skips the work it guards."
             )
+
+    # The bool loop gets an aggregate guard rather than a per-class one, because
+    # FailedMessage and ChannelResult legitimately have no bool fields and a
+    # per-class assertion would fail on them today. Without this the bool half
+    # could quietly drop to zero iterations everywhere and still pass, which is
+    # the exact failure the int half's guard exists to prevent. Three bool fields
+    # are checked at the time of writing.
+    assert bools_checked, (
+        "no bool field was checked on any of the cases above. The bool half of "
+        "this test has stopped checking anything."
+    )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1226,3 +1226,16 @@ def test_every_integer_counter_starts_at_zero() -> None:
                 "from it. If a non-zero default is genuinely wanted, this test is "
                 "the place to say so explicitly."
             )
+
+        # Same invariant, same reasoning, one type over. A flag that starts True
+        # makes the migration believe it already did something it has not done:
+        # `categories_cleaned` and `is_dry_run` both gate real work.
+        for field_ in dataclasses.fields(cls):
+            if field_.type not in ("bool", bool):
+                continue
+            actual = getattr(instance, field_.name)
+            assert actual is False, (
+                f"{cls.__name__}.{field_.name} is a bool field whose fresh-instance "
+                f"value is {actual!r}, not False. These flags record what has already "
+                "happened, so one that starts True skips the work it guards."
+            )


### PR DESCRIPTION
Every `int` counter on the migration documents must start at zero, and every `bool` flag at `False`. Test-only: nothing under `src/` changed and there is no version bump.

This is the survivor triage from the mutation harness that shipped in #377.

## Why it exists

Changing `retry_count: int = 0` to `= 1` left the entire state test suite passing. A counter that starts at one is not a crash, it is a silently wrong number in every total the migration reports, and nobody was ever going to write a test for each of the twenty-eight fields individually.

Measured against the sweep: **96 survivors before, 58 after.** Thirty-eight mutants killed by one assertion, and it covers fields added later without anyone remembering to.

## The part worth reading

**The first version of this test could not fail.** It selected fields whose `default == 0` and then asserted their value was 0, which is circular: mutate a default to `1` and the field drops out of the selection, so nothing is checked and the test passes.

It looked like it worked, because one mutant died. Not from the assertion though — `FailedMessage` has exactly one int field, so mutating it emptied the list and tripped a separate emptiness guard. The assertion the test was written for was doing nothing.

| | Mutants killed |
|---|---|
| Circular version | 1 of 4 |
| Select by type, assert on value | 8 of 8 |

Caught by checking the kill *shape* rather than trusting that the suite passed. Three of four surviving was the finding; a pass/fail count would have read as partial coverage.

## Two further defects, both found by a gate rather than by reading

- **The ship audit** found the same shape in `ChannelResult`: eight counters, same invariant, not covered. Added.
- **The second opinion returned zero findings**, so the specific question it declined to answer got tested instead: the bool loop had no emptiness guard while the int loop did. Two of the four classes legitimately have no bool fields, so a per-class guard cannot exist and the bool half could have dropped to zero iterations everywhere while still passing. It now carries an aggregate guard, verified to fail when the loop is neutered.

## Scope, and what is deliberately excluded

`FerryConfig` is out: `max_channels = 200` and `create_invite = True` are correct non-zero defaults, so the invariant is "counters start at zero", not "every int is zero". `ReviewSummary` looked like a candidate and is not one — all nine of its fields are required, so it has no defaults to assert and a check over zero fields would pass for the wrong reason.

`f.type in ("int", int)` is required rather than defensive: `state.py` has no `from __future__ import annotations` so its field types are type objects, while `messages.py` has it so `ChannelResult`'s are strings. Narrowing it to `f.type is int` matches 0 of `ChannelResult`'s 8 fields, which would lose coverage silently rather than fail. That reasoning is recorded in the code.

## Still open from the sweep

Fifty-eight survivors remain, all classified: forty-six are annotation sites that are inert under PEP 563, about ten are `data.get(key, 0)` fallbacks on the load path (a real but separate class), and four `ExceptionReplacer` mutants still need a per-site reading. Runtime is now 5:00 against a 5-minute budget, so the next few tests will breach it.
