### PR TITLE
fix: use POST for pin API, not PUT (fixes #348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `scripts/check-deferral-fields.sh` is now part of the repository. It was previously untracked,
   which meant the deferral sweep could not reach it from CI.
 
+## [2.19.1] - 2026-08-17
+
+### Fixed
+
+- **Pinned messages were never restored because the pin API call used the wrong HTTP method.**
+  `api_pin_message` sent PUT, but the Stoat backend registers the route as POST. Rocket returned a
+  raw HTML 404 for every pin attempt. Changed to POST. Fixes #348.
+
 ## [2.19.0] - 2026-08-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.0"
+version = "2.19.1"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.0"
+__version__ = "2.19.1"

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -889,7 +889,7 @@ async def api_pin_message(
         Empty dict (API returns 204).
     """
     url = f"{stoat_url.rstrip('/')}/channels/{channel_id}/messages/{message_id}/pin"
-    return await _api_request(session, "PUT", url, token, None)
+    return await _api_request(session, "POST", url, token, None)
 
 
 async def api_set_role_permissions(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -582,8 +582,8 @@ async def test_api_add_reaction_custom_emoji(mock_aiohttp: aioresponses) -> None
 
 
 async def test_api_pin_message(mock_aiohttp: aioresponses) -> None:
-    """PUT /channels/ch1/messages/msg1/pin returns empty dict on 204."""
-    mock_aiohttp.put(
+    """POST /channels/ch1/messages/msg1/pin returns empty dict on 204."""
+    mock_aiohttp.post(
         f"{BASE_URL}/channels/ch1/messages/msg1/pin",
         status=204,
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1622,7 +1622,7 @@ async def test_forum_index_rebuild_uses_actual_message_counts(tmp_path: Path) ->
             "https://api.test/channels/stoat-idx-news/messages",
             payload={"_id": "new-idx-msg"},
         )
-        mock.put(
+        mock.post(
             "https://api.test/channels/stoat-idx-news/messages/new-idx-msg/pin",
             payload={},
         )
@@ -2222,7 +2222,7 @@ async def test_index_rebuild_duplicate_writes_no_state_entry(tmp_path: Path) -> 
             payload={"type": "DuplicateNonce", "location": "crates/x/src/lib.rs:1:1"},
         )
         # Registered so a stray pin is recorded rather than erroring out.
-        mock.put(
+        mock.post(
             "https://api.test/channels/stoat-idx-news/messages/new-idx-msg/pin",
             payload={},
             callback=lambda url, **kwargs: pins.append(str(url)),  # type: ignore[misc]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -2298,7 +2298,7 @@ async def test_forum_index_channel_created(tmp_path: Path) -> None:
             ),
         )
         # Pin the index message.
-        m.put(
+        m.post(
             f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg1/pin",
             payload={},
         )
@@ -2389,7 +2389,7 @@ async def test_forum_index_empty_forum(tmp_path: Path) -> None:
             ),
         )
         # Pin.
-        m.put(
+        m.post(
             f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg1/pin",
             payload={},
         )
@@ -3309,7 +3309,7 @@ async def test_forum_index_duplicate_skips_the_pin(tmp_path: Path) -> None:
             payload={"type": "DuplicateNonce", "location": "crates/x/src/lib.rs:1:1"},
         )
         # Registered so a stray pin is recorded rather than erroring out.
-        m.put(
+        m.post(
             f"{STOAT_URL}/channels/stoat-idx1/messages/idx-msg1/pin",
             payload={},
             callback=lambda url, **kwargs: pins.append(str(url)),  # type: ignore[misc]
@@ -3512,7 +3512,7 @@ async def test_the_forum_index_channel_records_its_name(tmp_path: Path) -> None:
             payload={"_id": "01JSTOATIX00000000000AAA", "name": "my-forum-index"},
         )
         m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages", payload={"_id": "m1"})
-        m.put(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
+        m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
         m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
         await run_channels(config, state, exports, [].append)
 
@@ -3658,7 +3658,7 @@ async def test_a_fresh_structure_run_records_a_name_for_every_id(tmp_path: Path)
             payload={"_id": "01JSTOATIX00000000000AAA", "name": "my-forum-index"},
         )
         m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages", payload={"_id": "m1"})
-        m.put(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
+        m.post(f"{STOAT_URL}/channels/01JSTOATIX00000000000AAA/messages/m1/pin", payload={})
         m.patch(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
         await run_channels(config, state, exports, [].append)
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.0"
+version = "2.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Pin API calls used PUT, but the Stoat backend registers the route as POST (`message_pin.rs`). Rocket returned a raw HTML 404 for every pin attempt, so no pins were ever restored.
- Changed `api_pin_message` from PUT to POST. Updated the test mock to match.

Fixes #348

## Verification

- Verified against upstream source at `revoltchat/backend/crates/delta/src/routes/channels/message_pin.rs`: `#[post("/<target>/messages/<msg>/pin")]`
- `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest` all pass
- Grepped for remaining PUT+pin references: none
