### PR TITLE
fix: reject bool and NaN retry_after in 429 body parsers (fixes #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.19.2] - 2026-08-18
+
+### Fixed
+
+- **A bool or NaN `retry_after` in a 429 body defeated backoff instead of falling back to the
+  default delay.** `float(True)` gave 0.001 s and `float(False)` gave 0.0 s, because `bool` is a
+  subclass of `int`. NaN survived the `max`/`min` clamp and resolved to 0.0 s. Both paths produced
+  near-instant retries with no real backoff. The guard now rejects booleans and non-finite values
+  explicitly, matching the pattern already proven in `uploader/autumn.py`. The same fix was applied
+  to `discord/client.py`, where the audit found an identical unguarded parser. Fixes #386.
+
 ### Added
 
 - **Counters and flags on the migration documents are now asserted to start from zero.** Every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.1"
+version = "2.19.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.1"
+__version__ = "2.19.2"

--- a/src/discord_ferry/discord/client.py
+++ b/src/discord_ferry/discord/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
@@ -114,9 +115,9 @@ async def _discord_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     except (json.JSONDecodeError, ValueError):
         body = None
     raw = body.get("retry_after") if isinstance(body, dict) else None
-    try:
-        retry_after = float(raw)  # type: ignore[arg-type]  # None/non-numeric → fallback below
-    except (TypeError, ValueError):
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool) and math.isfinite(raw):
+        retry_after = float(raw)
+    else:
         retry_after = 1.0
     return min(retry_after, _MAX_RETRY_DELAY_SECONDS)
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import random
 import time
 from collections import deque
@@ -201,9 +202,9 @@ async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     except (json.JSONDecodeError, ValueError):
         body = None
     raw = body.get("retry_after") if isinstance(body, dict) else None
-    try:
-        retry_ms = float(raw)  # type: ignore[arg-type]  # None/non-numeric → fallback below
-    except (TypeError, ValueError):
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool) and math.isfinite(raw):
+        retry_ms = float(raw)
+    else:
         retry_ms = 1000.0
     return max(0.0, min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1419,6 +1419,47 @@ async def test_429_null_retry_after_falls_back(
     assert calls[0] == pytest.approx(1.0, abs=0.05)
 
 
+@pytest.mark.asyncio
+async def test_429_boolean_body_retry_after_falls_back(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A JSON `true` is not a delay of 1 ms (#386).
+
+    bool is a subclass of int, so float(True) gives 1.0 ms and float(False)
+    gives 0.0 ms.  Both must fall back to the 1 s default.
+    """
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", status=429, payload={"retry_after": True})
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == pytest.approx(1.0, abs=0.05)
+
+
+@pytest.mark.asyncio
+async def test_429_nan_body_retry_after_falls_back(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A NaN retry_after must not produce a 0 s delay (#386).
+
+    max/min propagate NaN in a way that resolves to 0.0 under the old clamp,
+    defeating backoff entirely.  The guard rejects non-finite values.
+    """
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/srv1",
+        status=429,
+        body='{"retry_after": NaN}',
+        content_type="application/json",
+    )
+    mock_aiohttp.get(f"{BASE_URL}/servers/srv1", payload={"_id": "srv1"})
+    calls, sleep = _sleep_capture()
+    with patch("discord_ferry.migrator.api.asyncio.sleep", sleep):
+        async with aiohttp.ClientSession() as session:
+            await api_fetch_server(session, BASE_URL, TOKEN, "srv1")
+    assert calls[0] == pytest.approx(1.0, abs=0.05)
+
+
 # ---------------------------------------------------------------------------
 # Rate-limit header units (batch 1)
 #

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.1"
+version = "2.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Guard 429 body `retry_after` against bool and NaN values** in both `migrator/api.py` and `discord/client.py`, falling back to the default delay instead of producing near-instant retries
- Mirrors the proven pattern already in `uploader/autumn.py` (isinstance + bool exclusion + math.isfinite)
- Two new tests: `test_429_boolean_body_retry_after_falls_back` and `test_429_nan_body_retry_after_falls_back`

## What was broken

| body value | old delay | new delay |
|---|---|---|
| `true` | 0.001 s | 1.0 s (default) |
| `false` | 0.0 s | 1.0 s (default) |
| `NaN` | 0.0 s | 1.0 s (default) |

`bool` is a subclass of `int`, so `float(True)` succeeds silently. NaN survives `max`/`min` because every comparison with NaN is False.

## Scope

Low. Reaching this path needs a 429 from a proxy or CDN that strips rate-limit headers and returns a malformed body. The worst case was three near-instant retries inside `MAX_API_RETRIES=3`.

## Audit

The codebase grep found the same unguarded pattern in `discord/client.py`, which is fixed in this PR too. `uploader/autumn.py` already had the guard.

Fixes #386
