### PR TITLE
fix: apply role hierarchy through the ranks route, which has never worked (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `scripts/check-deferral-fields.sh` is now part of the repository. It was previously untracked,
   which meant the deferral sweep could not reach it from CI.
 
+### Fixed
+
+- **Role hierarchy is applied for the first time (#380).** Every migration since v1.x sent each
+  role's Discord position as `rank` on `PATCH /servers/{id}/roles/{role_id}`, and the Stoat backend
+  discarded it: the upstream `roles_edit` handler destructures `DataEditRole` with a rest pattern
+  that does not bind `rank`. The request returned 200, `hoist` and `icon` in the same call still
+  landed, and no warning fired, so every run reported ordering as applied while the server kept its
+  default ranks. Two shipped documents claimed the behaviour worked.
+
+  Ordering now goes through `PATCH /servers/{id}/roles/ranks`, which takes the complete ordered role
+  list and assigns each role a rank equal to its index, making index 0 the top of the hierarchy.
+  Discord's `position` runs the other way, so the sort is descending, negating the position rather
+  than reversing so the id tie-break stays ascending.
+
+  The list is built from a read-back of the server rather than from `role_map`. That map can lag the
+  server, because the create loop persists state every ten roles (#389), and the route rejects any
+  list that omits a role. Only roles Ferry created are moved: every other role keeps its exact
+  index, so migrating into an existing server with `--server-id` leaves that server's own hierarchy
+  alone. A refusal for lack of permission becomes a `role_ordering_not_permitted` warning naming the
+  cause, and any other failure a `role_ordering_failed` warning. Neither fails the phase.
+
+  Three tests that had asserted `rank` appeared in a mocked request body were replaced. They passed
+  for years against a field the server threw away, because an assertion about what Ferry sent can
+  never observe what the server kept.
+
+  **Not covered by this change:** `ferry build` replays blueprint and template role ranks through
+  the same discarded field (#387), and correcting ordering on a server migrated by an earlier
+  release needs its own path (#388).
+
+
 ## [2.19.1] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [2.19.2] - 2026-08-18
 
 ### Added
 
@@ -49,7 +49,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   discarded it: the upstream `roles_edit` handler destructures `DataEditRole` with a rest pattern
   that does not bind `rank`. The request returned 200, `hoist` and `icon` in the same call still
   landed, and no warning fired, so every run reported ordering as applied while the server kept its
-  default ranks. Two shipped documents claimed the behaviour worked.
+  default ranks. **Three** shipped documents claimed the behaviour worked, and the third,
+  `docs/reference/architecture.md`, was found only by the whole-branch review after the first two
+  had been corrected. All three are fixed here.
 
   Ordering now goes through `PATCH /servers/{id}/roles/ranks`, which takes the complete ordered role
   list and assigns each role a rank equal to its index, making index 0 the top of the hierarchy.

--- a/docs/getting-started/first-migration.md
+++ b/docs/getting-started/first-migration.md
@@ -282,7 +282,7 @@ After a successful migration:
 - NSFW channels are correctly flagged
 - Channel permission overrides (@everyone and per-role) are applied
 - Forum posts are grouped into dedicated categories named after the parent forum
-- Roles are recreated with colours, rank ordering, and permissions preserved
+- Roles are recreated with colours, hierarchy order, and permissions preserved
 - Messages appear under the original author's name and avatar, so conversations look natural
 - Original timestamps appear at the start of each message: `*[2024-01-15 14:30 UTC]*`
 - Embeds are preserved with uploaded thumbnails and images

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -361,8 +361,17 @@ Uploads the guild icon to Autumn and applies it. Sets server default permissions
 
 **ROLES** (Phase 4): Iterates all exports to collect unique role IDs (skipping @everyone where
 `role_id == guild_id`). Creates each role with name and British-spelled `colour`. If Discord
-metadata is available, applies translated permission bits via `api_set_role_permissions()`.
-Attempts rank ordering in a second pass using DCE position data. Populates `state.role_map`.
+metadata is available, applies hoist and icon in an attributes pass, and translated permission bits
+via `api_set_role_permissions()`. Populates `state.role_map`.
+
+Hierarchy is applied last, once for the whole server, by reading the server back and sending the
+complete ordered role list to `PATCH /servers/:id/roles/ranks`. Index 0 of that list is the top of
+the hierarchy, so Ferry sorts by Discord `position` descending. Only roles Ferry created are moved:
+every other role keeps its position, so migrating into an existing server with `--server-id` leaves
+that server's own hierarchy alone. The step is skipped when it cannot change anything, and a failure
+degrades to a `role_ordering_failed` warning, or `role_ordering_not_permitted` when Ferry lacks the
+rank or permission to reorder that server. The per-role `PATCH` does **not** carry a rank: the Stoat
+backend accepts that field and discards it.
 
 **CATEGORIES** (Phase 5): Collects unique category names from exports. Creates each category
 via the two-step process: create a channel-like object, then PATCH the server's `categories`
@@ -494,7 +503,8 @@ writing a new callback — no engine changes needed.
 | `api_fetch_server` | `GET /servers/:id` | Verify server exists |
 | `api_edit_server` | `PATCH /servers/:id` | Update server settings |
 | `api_create_role` | `POST /servers/:id/roles` | Create role |
-| `api_edit_role` | `PATCH /servers/:id/roles/:id` | Update role (colour, rank) |
+| `api_edit_role` | `PATCH /servers/:id/roles/:id` | Update role (colour, hoist, icon) |
+| `api_edit_role_ranks` | `PATCH /servers/:id/roles/ranks` | Set the whole role hierarchy, index 0 highest |
 | `api_set_role_permissions` | `PUT /servers/:id/permissions/:id` | Set role permission bits |
 | `api_set_server_default_permissions` | `PUT /servers/:id/permissions/default` | Set @everyone server permissions |
 | `api_create_channel` | `POST /servers/:id/channels` | Create channel |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.1"
+version = "2.19.2"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.1"
+__version__ = "2.19.2"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2083,9 +2083,14 @@ async def run_repair(
                     role_created = await _recreate_role(sess, config, state, result, on_event)
                     if role_created:
                         # DECLINED, and said so rather than left silent. The
-                        # migration sets a role's colour, rank, hoist and icon in
-                        # two further api_edit_role passes, and the icon one
-                        # uploads a file to Autumn. Restoring those is a second
+                        # migration sets a role's colour, hoist and icon through
+                        # api_edit_role, and the icon path uploads a file to
+                        # Autumn. Rank is NOT among them since #380: the per-role
+                        # PATCH discards that field, and ordering now goes through
+                        # _apply_role_ordering, which recomputes the whole server
+                        # from a read-back. So an --incremental re-run does now
+                        # restore this role's position, which is why that advice
+                        # stays in the message below. Restoring the rest is a second
                         # content path in a batch already carrying two commands,
                         # and the reasoning that keeps emoji out of repair (#307)
                         # applies to the icon. Recorded whether or not metadata

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -635,6 +635,38 @@ async def api_edit_role(
     return await _api_request(session, "PATCH", url, token, kwargs)
 
 
+async def api_edit_role_ranks(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    server_id: str,
+    ranks: list[str],
+) -> dict[str, Any]:
+    """Set the server's role hierarchy in one call.
+
+    ``PATCH /servers/{id}/roles/{role_id}`` accepts a ``rank`` field and throws it
+    away: the upstream ``roles_edit`` handler destructures ``DataEditRole`` with a
+    rest pattern that does not bind ``rank``. This route is the only one that sets
+    ordering.
+
+    ``edit_role_ranks`` assigns each role a rank equal to its INDEX in *ranks*, so
+    **index 0 is the top of the hierarchy**. It rejects any list that does not name
+    every role on the server, answering ``InvalidOperation``.
+
+    Args:
+        session: An active aiohttp ClientSession.
+        stoat_url: Stoat API base URL.
+        token: Stoat session token.
+        server_id: Target server ID.
+        ranks: Every role id on the server, highest authority first.
+
+    Returns:
+        Updated server object dict.
+    """
+    url = f"{stoat_url.rstrip('/')}/servers/{server_id}/roles/ranks"
+    return await _api_request(session, "PATCH", url, token, {"ranks": ranks})
+
+
 async def api_edit_channel(
     session: aiohttp.ClientSession,
     stoat_url: str,

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -532,7 +532,18 @@ async def _apply_role_ordering(
     if not state.role_map:
         return
 
-    server = await api_fetch_server(session, config.stoat_url, config.token, state.stoat_server_id)
+    def _degrade(message: str, warning_type: str = "role_ordering_failed") -> None:
+        """Record an ordering failure without failing the phase."""
+        state.warnings.append({"phase": "roles", "type": warning_type, "message": message})
+        on_event(MigrationEvent(phase="roles", status="warning", message=message))
+
+    try:
+        server = await api_fetch_server(
+            session, config.stoat_url, config.token, state.stoat_server_id
+        )
+    except MigrationError as exc:
+        _degrade(f"Failed to apply role ordering: {exc}")
+        return
     # Upstream omits `roles` entirely when the map is empty, so this cannot be a
     # plain subscript.
     server_roles: dict[str, Any] = server.get("roles") or {}
@@ -567,9 +578,27 @@ async def _apply_role_ordering(
     for slot, stoat_id in zip(slots, ordered_known, strict=True):
         new_order[slot] = stoat_id
 
-    await api_edit_role_ranks(
-        session, config.stoat_url, config.token, state.stoat_server_id, new_order
-    )
+    try:
+        await api_edit_role_ranks(
+            session, config.stoat_url, config.token, state.stoat_server_id, new_order
+        )
+    except MigrationError as exc:
+        # Classify on the message, matching the TooManyRoles branch in the create
+        # loop. _api_request folds the status and the raw body into the message,
+        # and neither 403 nor 400 is retryable, so this has already failed fast.
+        text = str(exc)
+        if "NotElevated" in text or "MissingPermission" in text:
+            _degrade(
+                "Role ordering was refused: Ferry lacks the ManageRole permission, "
+                "or holds no role ranked above the roles it tried to reorder. The "
+                "roles were created, but their hierarchy was left at the server "
+                f"default ({exc}).",
+                "role_ordering_not_permitted",
+            )
+        else:
+            _degrade(f"Failed to apply role ordering: {exc}")
+        return
+
     on_event(
         MigrationEvent(
             phase="roles",
@@ -873,6 +902,15 @@ async def run_roles(
                             "message": f"Failed to set server default permissions: {exc}",
                         }
                     )
+
+    # Ordering is the last thing the phase does: the ranks route rejects any list
+    # that does not name every role on the server, so it cannot run until every
+    # create has landed. It opens its own session on purpose. The permissions pass
+    # above is nested inside `if discord_metadata and not config.dry_run`, so
+    # reusing that block would skip ordering on every run without a discord_token.
+    # Dry run never reaches here: run_roles returns right after the create loop.
+    async with get_session(config) as session:
+        await _apply_role_ordering(session, config, state, roles_to_create, on_event)
 
     # S3: mark every mapped role finalized (regardless of whether the metadata-gated perms pass
     # ran) so --incremental skips re-editing; a crash before here leaves them un-finalized and

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -685,8 +685,8 @@ async def run_roles(
             # unfinished roles; --incremental skips prior-completed (finalized) roles.
             if role.id in state.roles_finalized:
                 continue
-            rank_role_id = state.role_map.get(role.id)
-            if not rank_role_id:
+            attribute_role_id = state.role_map.get(role.id)
+            if not attribute_role_id:
                 continue
             edit_kwargs: dict[str, Any] = {}
             rm = role_meta.get(role.id)
@@ -716,7 +716,7 @@ async def run_roles(
                     config.stoat_url,
                     config.token,
                     state.stoat_server_id,
-                    rank_role_id,
+                    attribute_role_id,
                     **edit_kwargs,
                 )
             except Exception as exc:  # noqa: BLE001

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -670,13 +670,17 @@ async def run_roles(
                 )
             )
 
-    # Second pass: set role attributes (rank from DCE position; hoist from Discord
-    # metadata). Both fold into a single api_edit_role call per role when present.
+    # Second pass: set role attributes (hoist and icon from Discord metadata), folded
+    # into a single api_edit_role call per role. Rank is NOT set here: the upstream
+    # roles_edit handler drops DataEditRole.rank through a rest pattern, so it was
+    # accepted with a 200 and never persisted. Ordering lives in _apply_role_ordering.
     discord_metadata = load_discord_metadata(config.output_dir)
     role_meta = discord_metadata.role_metadata if discord_metadata else {}
-    ranked_roles = sorted(roles_to_create, key=lambda r: (r.position, r.id))
+    # The sort no longer decides anything the server sees, but deterministic iteration
+    # keeps this pass's request order stable across runs.
+    attribute_roles = sorted(roles_to_create, key=lambda r: (r.position, r.id))
     async with get_session(config) as session:
-        for role in ranked_roles:
+        for role in attribute_roles:
             # S3: gate on roles_finalized (not pre_existing) so resume finalizes created-but-
             # unfinished roles; --incremental skips prior-completed (finalized) roles.
             if role.id in state.roles_finalized:
@@ -685,8 +689,6 @@ async def run_roles(
             if not rank_role_id:
                 continue
             edit_kwargs: dict[str, Any] = {}
-            if role.position != 0:
-                edit_kwargs["rank"] = role.position
             rm = role_meta.get(role.id)
             if rm is not None:
                 edit_kwargs["hoist"] = rm.hoist

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -26,6 +26,7 @@ from discord_ferry.migrator.api import (
     api_create_server,
     api_edit_channel,
     api_edit_role,
+    api_edit_role_ranks,
     api_edit_server,
     api_fetch_root,
     api_fetch_server,
@@ -494,6 +495,88 @@ async def apply_role_permissions(
                 "message": f"Failed to set permissions for role '{label}': {exc}",
             }
         )
+
+
+async def _apply_role_ordering(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    roles: list[DCERole],
+    on_event: EventCallback,
+) -> None:
+    """Apply Discord role hierarchy to the Stoat server in one call.
+
+    Stoat's per-role PATCH accepts ``rank`` and discards it: the upstream
+    ``roles_edit`` handler destructures ``DataEditRole`` with a rest pattern that
+    does not bind the field. ``edit_role_ranks`` is the only route that sets
+    ordering, and it assigns each role a rank equal to its INDEX in the submitted
+    list, so index 0 is the top. Discord's ``position`` runs the other way, which
+    is why the sort is descending.
+
+    The route rejects any list that does not name every role on the server, so the
+    list comes from a read-back rather than from ``role_map``. That map can lag the
+    server: the create loop persists state every ten roles, so a hard kill strands
+    created roles outside it (#389).
+
+    Only roles Ferry knows about move. Every other role keeps its exact index,
+    which leaves a ``--server-id`` target's own hierarchy alone and keeps the
+    upstream elevation check quiet for roles the caller may not outrank.
+
+    Args:
+        session: An active aiohttp ClientSession.
+        config: Ferry configuration.
+        state: Migration state; ``role_map`` supplies the roles Ferry created.
+        roles: The DCE roles this phase handled, carrying Discord ``position``.
+        on_event: Event callback for progress reporting.
+    """
+    if not state.role_map:
+        return
+
+    server = await api_fetch_server(session, config.stoat_url, config.token, state.stoat_server_id)
+    # Upstream omits `roles` entirely when the map is empty, so this cannot be a
+    # plain subscript.
+    server_roles: dict[str, Any] = server.get("roles") or {}
+    if len(server_roles) < 2:
+        return
+
+    # The server's present arrangement. The id breaks a rank tie so the base order
+    # is deterministic even if the server holds duplicate ranks.
+    current_order = sorted(server_roles, key=lambda rid: (server_roles[rid].get("rank", 0), rid))
+    on_server = set(current_order)
+
+    # Ferry-known roles that are actually present, highest Discord position first.
+    # Negate the position rather than reversing: `reverse=True` would flip the id
+    # tie-break to descending too, which is what structure.py's truncation sort does
+    # and what the attributes pass does not.
+    known = [
+        (r.position, r.id, state.role_map[r.id])
+        for r in roles
+        if r.id in state.role_map and state.role_map[r.id] in on_server
+    ]
+    known.sort(key=lambda item: (-item[0], item[1]))
+    ordered_known = [stoat_id for _, _, stoat_id in known]
+    if not ordered_known:
+        return
+
+    known_ids = set(ordered_known)
+    slots = [i for i, rid in enumerate(current_order) if rid in known_ids]
+    new_order = list(current_order)
+    # strict=True on purpose: both lists derive from `known_ids`, so a length
+    # mismatch is a logic error here. Raising beats sending a truncated list that
+    # the server rejects with an InvalidOperation naming nothing useful.
+    for slot, stoat_id in zip(slots, ordered_known, strict=True):
+        new_order[slot] = stoat_id
+
+    await api_edit_role_ranks(
+        session, config.stoat_url, config.token, state.stoat_server_id, new_order
+    )
+    on_event(
+        MigrationEvent(
+            phase="roles",
+            status="progress",
+            message=f"Applied role ordering to {len(new_order)} roles",
+        )
+    )
 
 
 async def run_roles(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -529,7 +529,11 @@ async def _apply_role_ordering(
         roles: The DCE roles this phase handled, carrying Discord ``position``.
         on_event: Event callback for progress reporting.
     """
-    if not state.role_map:
+    # Fewer than two known roles cannot produce a permutation: the single role
+    # would be written back into the slot it already occupies. Guarding here
+    # rather than after the read-back saves BOTH requests, and both land in the
+    # `servers` bucket, which is the tightest in the run at 5 per 10 seconds.
+    if len(state.role_map) < 2:
         return
 
     def _degrade(message: str, warning_type: str = "role_ordering_failed") -> None:
@@ -577,6 +581,13 @@ async def _apply_role_ordering(
     # the server rejects with an InvalidOperation naming nothing useful.
     for slot, stoat_id in zip(slots, ordered_known, strict=True):
         new_order[slot] = stoat_id
+
+    if new_order == current_order:
+        # The server already holds this order. Measured, not assumed: a single
+        # known role always permutes to itself, and an --incremental re-run over
+        # an unchanged export reproduces the order it applied last time. Sending
+        # it again spends a request in the tightest bucket to change nothing.
+        return
 
     try:
         await api_edit_role_ranks(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,6 +32,7 @@ from discord_ferry.migrator.api import (
     api_delete_role,
     api_delete_webhook,
     api_edit_role,
+    api_edit_role_ranks,
     api_edit_server,
     api_execute_webhook,
     api_fetch_channel,
@@ -337,6 +338,79 @@ async def test_api_edit_role(mock_aiohttp: aioresponses) -> None:
             session, BASE_URL, TOKEN, "srv1", "role1", colour="#FF0000", hoist=True
         )
     assert result["colour"] == "#FF0000"
+
+
+# ---------------------------------------------------------------------------
+# api_edit_role_ranks
+# ---------------------------------------------------------------------------
+
+
+async def test_api_edit_role_ranks_sends_ordered_list(mock_aiohttp: aioresponses) -> None:
+    """PATCH /servers/srv1/roles/ranks sends the ordered id list and returns the Server."""
+    bodies: list[dict[str, object]] = []
+    mock_aiohttp.patch(
+        f"{BASE_URL}/servers/srv1/roles/ranks",
+        payload={"_id": "srv1", "roles": {}},
+        callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+    )
+    async with aiohttp.ClientSession() as session:
+        result = await api_edit_role_ranks(session, BASE_URL, TOKEN, "srv1", ["r3", "r1", "r2"])
+    assert bodies == [{"ranks": ["r3", "r1", "r2"]}]
+    assert result["_id"] == "srv1"
+
+
+async def test_api_edit_role_ranks_incomplete_list_raises(mock_aiohttp: aioresponses) -> None:
+    """A 400 InvalidOperation surfaces as MigrationError carrying status and type.
+
+    The attempt count is asserted, not assumed: 400 is absent from
+    ``_RETRYABLE_STATUSES``, and a silent retry here would burn the budget on a
+    request that can never succeed.
+    """
+    attempts: list[str] = []
+    mock_aiohttp.patch(
+        f"{BASE_URL}/servers/srv1/roles/ranks",
+        status=400,
+        payload={"type": "InvalidOperation"},
+        repeat=True,
+        callback=lambda url, **kwargs: attempts.append("hit"),  # type: ignore[misc]
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc_info:
+            await api_edit_role_ranks(session, BASE_URL, TOKEN, "srv1", ["r1"])
+    assert "400" in str(exc_info.value)
+    assert "InvalidOperation" in str(exc_info.value)
+    assert attempts == ["hit"]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"type": "NotElevated"},
+        {"type": "MissingPermission", "permission": "ManageRole"},
+    ],
+)
+async def test_api_edit_role_ranks_forbidden_is_identifiable(
+    mock_aiohttp: aioresponses, body: dict[str, str]
+) -> None:
+    """A 403 keeps its type in the message so the call site can classify it.
+
+    On the ``--server-id`` path this is the ordinary outcome rather than an exotic
+    one, so it must fail fast and stay identifiable.
+    """
+    attempts: list[str] = []
+    mock_aiohttp.patch(
+        f"{BASE_URL}/servers/srv1/roles/ranks",
+        status=403,
+        payload=body,
+        repeat=True,
+        callback=lambda url, **kwargs: attempts.append("hit"),  # type: ignore[misc]
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc_info:
+            await api_edit_role_ranks(session, BASE_URL, TOKEN, "srv1", ["r1", "r2"])
+    assert "403" in str(exc_info.value)
+    assert body["type"] in str(exc_info.value)
+    assert attempts == ["hit"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_incremental_structure.py
+++ b/tests/test_incremental_structure.py
@@ -283,13 +283,19 @@ async def test_run_roles_fresh_run_creates_and_attributes_all_roles(
     tmp_path: Path,
 ) -> None:
     """SC-5: empty state → pre_existing_role_ids is empty → every role created AND
-    api_edit_role (attributes) fires for roles with position != 0 or hoist set.
+    api_edit_role (attributes) fires for every role carrying an attribute.
 
     Guards against the trap where a guard on the live role_map would wrongly
     skip attributes for roles created earlier in the same pass.
+
+    Both roles carry hoist metadata. Before #380 role_a carried none and leaned on
+    ``position != 0`` to trigger the pass through the ``rank`` field, which the Stoat
+    backend discarded. With that field gone role_a would have had no attribute at all,
+    and the ">= 2 edits" assertion would have passed vacuously at 1 while no longer
+    guarding the skip it was written for.
     """
-    # role_a: position=2 → attributes pass fires (rank)
-    # role_b: position=1, hoist=True via metadata → attributes pass fires (hoist)
+    # role_a: hoist=True via metadata → attributes pass fires
+    # role_b: hoist=True via metadata → attributes pass fires
     role_a = DCERole(id="r1", name="Admin", position=2)
     role_b = DCERole(id="r2", name="Mod", position=1)
 
@@ -300,6 +306,7 @@ async def test_run_roles_fresh_run_creates_and_attributes_all_roles(
         role_permissions={},
         channel_metadata={},
         role_metadata={
+            "r1": RoleMeta(hoist=True, position=2),
             "r2": RoleMeta(hoist=True, position=1),
         },
     )
@@ -341,10 +348,12 @@ async def test_run_roles_fresh_run_creates_and_attributes_all_roles(
         await run_roles(config, state, exports, lambda e: None)
 
     assert len(create_calls) == 2, f"Expected 2 creates on fresh run, got {len(create_calls)}"
-    # Both roles should have had attributes applied (r1: rank, r2: hoist).
-    assert len(edit_calls) >= 2, (
-        f"Expected >= 2 attribute edits on fresh run, got {len(edit_calls)}"
-    )
+    # Both roles carry hoist, so both must be edited. Asserting on the set of URLs
+    # rather than a count means a pass that edited one role twice cannot satisfy it.
+    assert {str(u) for u in edit_calls} == {
+        f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+        f"{STOAT_URL}/servers/srv1/roles/stoat-r2",
+    }, f"Expected an attribute edit for each role on a fresh run, got {edit_calls}"
 
 
 # ===========================================================================

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1272,3 +1272,48 @@ def test_every_integer_counter_starts_at_zero() -> None:
         "no bool field was checked on any of the cases above. The bool half of "
         "this test has stopped checking anything."
     )
+
+
+def test_role_ordering_warnings_are_classified_for_redaction() -> None:
+    """The two role-ordering warning types keep their structure and lose their secret.
+
+    #380 adds `role_ordering_failed` and `role_ordering_not_permitted`. Both use
+    the existing phase/type/message keys, so `_TEXT_MEMBERS["warnings"]` needs no
+    new member. This asserts that rather than reasoning about it: a new member key
+    on a warnings entry is invisible to the writer until it is classified, which is
+    the failure ADR-014 exists to prevent.
+
+    THE POSITIVE CONTROL MATTERS. The type/phase assertions pass just as well
+    against a registry that never received the secret, so the message assertion is
+    what distinguishes "structure preserved" from "nothing was scrubbed at all".
+    """
+    from discord_ferry.core.security import scrub_document
+    from discord_ferry.state import _state_to_dict
+
+    register_secret("proxy_password", "hunter2horse")
+    state = MigrationState()
+    state.warnings.append(
+        {
+            "phase": "roles",
+            "type": "role_ordering_not_permitted",
+            "message": "Role ordering was refused, proxy hunter2horse in the text",
+        }
+    )
+    state.warnings.append(
+        {
+            "phase": "roles",
+            "type": "role_ordering_failed",
+            "message": "Failed to apply role ordering: proxy hunter2horse",
+        }
+    )
+
+    doc = scrub_document(_state_to_dict(state))
+
+    # Structure survives: the machine-readable discriminators are untouched.
+    assert [w["type"] for w in doc["warnings"]] == [
+        "role_ordering_not_permitted",
+        "role_ordering_failed",
+    ]
+    assert all(w["phase"] == "roles" for w in doc["warnings"])
+    # The positive control: free text was actually scrubbed.
+    assert all("hunter2horse" not in w["message"] for w in doc["warnings"])

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -21,6 +21,7 @@ from discord_ferry.discord.metadata import (
 from discord_ferry.errors import AutumnUploadError, MigrationError
 from discord_ferry.migrator.structure import (
     FERRY_MIN_PERMISSIONS,
+    _apply_role_ordering,
     make_unique_channel_name,
     run_categories,
     run_channels,
@@ -3664,3 +3665,178 @@ async def test_a_dry_run_records_no_names_and_still_passes_the_guard(tmp_path: P
     assert state.created_channel_names == {}
     assert state.created_role_names == {}
     assert_names_complete(state)
+
+
+# ---------------------------------------------------------------------------
+# _apply_role_ordering (#380)
+# ---------------------------------------------------------------------------
+
+
+def _server_payload(ranks: dict[str, int]) -> dict[str, object]:
+    """Build a GET /servers/{id} payload whose roles carry the given ranks."""
+    return {
+        "_id": "srv1",
+        "roles": {rid: {"name": rid, "rank": rank} for rid, rank in ranks.items()},
+    }
+
+
+async def test_apply_role_ordering_sorts_position_descending(tmp_path: Path) -> None:
+    """Index 0 is the top of the hierarchy, so the highest Discord position leads.
+
+    Upstream ``set_role_ordering`` assigns rank by enumeration index and
+    ``ordered_roles()`` sorts ascending by rank, while Discord's ``position`` is
+    higher-is-higher. An ascending sort here would produce the exact reverse and
+    would still look like deliberate ordering on the server.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"low": "stoat-low", "mid": "stoat-mid", "high": "stoat-high"}
+    roles = [
+        DCERole(id="low", name="Low", position=1),
+        DCERole(id="mid", name="Mid", position=5),
+        DCERole(id="high", name="High", position=9),
+    ]
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-low": 0, "stoat-mid": 1, "stoat-high": 2}),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    assert bodies == [{"ranks": ["stoat-high", "stoat-mid", "stoat-low"]}]
+
+
+async def test_apply_role_ordering_tie_breaks_on_ascending_id(tmp_path: Path) -> None:
+    """Equal positions order by ascending Discord id.
+
+    This is the only case that distinguishes ``key=(-position, id)`` from
+    ``key=(position, id)`` with ``reverse=True``, which would flip the id tie-break
+    and yield "30" before "20". Replaces the coverage of the retired
+    test_run_roles_rank_tie_break_is_deterministic, which asserted on PATCH-call
+    order rather than on what the server was told.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"30": "stoat-30", "20": "stoat-20"}
+    roles = [
+        DCERole(id="30", name="Thirty", position=5),
+        DCERole(id="20", name="Twenty", position=5),
+    ]
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-30": 0, "stoat-20": 1}),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    assert bodies == [{"ranks": ["stoat-20", "stoat-30"]}]
+
+
+async def test_apply_role_ordering_keeps_unknown_roles_at_their_index(tmp_path: Path) -> None:
+    """A role Ferry did not create stays exactly where it was.
+
+    This is the whole point of the in-place permutation. It keeps a --server-id
+    target's own hierarchy intact, and it is what keeps the upstream elevation
+    check quiet for roles the caller may not outrank.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a", "b": "stoat-b"}
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload(
+                {"stoat-a": 0, "stoat-manual": 1, "stoat-b": 2, "stoat-other": 3}
+            ),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    # stoat-manual stays at index 1, stoat-other at index 3. The two Ferry roles
+    # swap into the slots they already held, indices 0 and 2. The list also names
+    # every role on the server, which the route requires.
+    assert bodies == [{"ranks": ["stoat-b", "stoat-manual", "stoat-a", "stoat-other"]}]
+
+
+async def test_apply_role_ordering_empty_role_map_makes_no_request(tmp_path: Path) -> None:
+    """The role_map guard runs before the read-back, so no route is touched.
+
+    No routes are registered at all. aioresponses raises on an unregistered
+    request, so this fails loudly if the guard is placed after the GET rather
+    than before it.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, [], lambda e: None)
+
+
+async def test_apply_role_ordering_missing_roles_key_is_empty(tmp_path: Path) -> None:
+    """Upstream omits `roles` when the map is empty; that must not raise.
+
+    The v0 Server model declares roles with
+    skip_serializing_if = "HashMap::<String, Role>::is_empty".
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a"}
+    roles = [DCERole(id="a", name="A", position=1)]
+
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1"})
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+
+async def test_apply_role_ordering_single_role_sends_read_back_only(tmp_path: Path) -> None:
+    """One role means nothing to order, so only the GET fires.
+
+    The role count is not knowable locally, so this guard can only be judged
+    after the read-back. No PATCH route is registered, so an ordering call would
+    raise rather than pass silently.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a"}
+    roles = [DCERole(id="a", name="A", position=1)]
+
+    gets: list[str] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0}),
+            callback=lambda url, **kwargs: gets.append("hit"),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    assert gets == ["hit"]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3818,23 +3818,77 @@ async def test_apply_role_ordering_missing_roles_key_is_empty(tmp_path: Path) ->
             await _apply_role_ordering(session, config, state, roles, lambda e: None)
 
 
-async def test_apply_role_ordering_single_role_sends_read_back_only(tmp_path: Path) -> None:
-    """One role means nothing to order, so only the GET fires.
+async def test_apply_role_ordering_one_known_role_makes_no_request(tmp_path: Path) -> None:
+    """A single known role cannot permute, so neither request is worth making.
 
-    The role count is not knowable locally, so this guard can only be judged
-    after the read-back. No PATCH route is registered, so an ordering call would
-    raise rather than pass silently.
+    Measured during the chunk-2 review: with one Ferry role on a four-role server
+    the submitted list came back byte-identical to the current order. Both the
+    read-back and the ordering call land in the `servers` bucket, the tightest in
+    the run, so the guard sits before the read-back. No routes are registered, and
+    aioresponses raises on an unregistered request, so a guard placed after the
+    GET fails this loudly.
     """
     config = _make_config(tmp_path)
     state = MigrationState(stoat_server_id="srv1")
     state.role_map = {"a": "stoat-a"}
     roles = [DCERole(id="a", name="A", position=1)]
 
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+
+async def test_apply_role_ordering_server_with_one_role_sends_read_back_only(
+    tmp_path: Path,
+) -> None:
+    """A server holding fewer than two roles is judged only after the read-back.
+
+    Ferry knows two roles here, so the local guard passes. The server's own count
+    is not knowable without asking, which is why this guard cannot move earlier.
+    No PATCH route is registered, so an ordering call would raise.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a", "b": "stoat-b"}
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+
     gets: list[str] = []
     with aioresponses() as m:
         m.get(
             f"{STOAT_URL}/servers/srv1",
             payload=_server_payload({"stoat-a": 0}),
+            callback=lambda url, **kwargs: gets.append("hit"),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    assert gets == ["hit"]
+
+
+async def test_apply_role_ordering_skips_a_no_op_submission(tmp_path: Path) -> None:
+    """When the server already holds the target order, no ordering call is sent.
+
+    This is the --incremental re-run case: the export has not changed, so the
+    permutation reproduces what the previous run applied. No PATCH route is
+    registered, so a redundant submission raises rather than passing quietly.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a", "b": "stoat-b"}
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+
+    gets: list[str] = []
+    with aioresponses() as m:
+        # b outranks a and already sits first, which is exactly what the sort wants.
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-b": 0, "stoat-a": 1}),
             callback=lambda url, **kwargs: gets.append("hit"),  # type: ignore[misc]
         )
         async with aiohttp.ClientSession() as session:
@@ -4004,9 +4058,14 @@ async def test_run_roles_ordering_is_the_last_request(tmp_path: Path) -> None:
             repeat=True,
             callback=lambda url, **kwargs: seen.append("perms"),  # type: ignore[misc]
         )
+        # Ranks deliberately opposite to the target order, so ordering has real
+        # work to do. Note the union-path id flip described above: role "b" holds
+        # "stoat-a". Seeding this the other way makes the permutation an identity
+        # and the no-op guard correctly skips the call, which would leave this
+        # test asserting nothing about ordering being last.
         m.get(
             f"{STOAT_URL}/servers/srv1",
-            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            payload=_server_payload({"stoat-b": 0, "stoat-a": 1}),
             repeat=True,
             callback=lambda url, **kwargs: seen.append("read"),  # type: ignore[misc]
         )
@@ -4103,4 +4162,46 @@ async def test_run_roles_ordering_converges_on_a_second_run(tmp_path: Path) -> N
 
     assert creates == [], "the second run must not recreate roles already in role_map"
     assert first == [{"ranks": ["stoat-b", "stoat-a"]}]
-    assert second == first
+    # Sharper than "the same list again": the second run reads the server back,
+    # sees the order it wants is already there, and sends nothing. Convergence
+    # with one fewer request in the tightest bucket.
+    assert second == []
+
+
+async def test_apply_role_ordering_tolerates_a_stale_role_map(tmp_path: Path) -> None:
+    """A role_map entry naming a role the server no longer has must not crash.
+
+    role_map can lag the server in both directions. #389 records the create loop
+    persisting only every ten roles, and a role can also be deleted on the server
+    between runs. The `state.role_map[r.id] in on_server` filter is what keeps
+    such an entry out of the submitted list, which in turn keeps `slots` and
+    `ordered_known` the same length so `zip(..., strict=True)` cannot raise.
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    # "ghost" maps to a Stoat role that is absent from the read-back.
+    state.role_map = {"a": "stoat-a", "b": "stoat-b", "ghost": "stoat-ghost"}
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+        DCERole(id="ghost", name="Ghost", position=5),
+    ]
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        async with aiohttp.ClientSession() as session:
+            await _apply_role_ordering(session, config, state, roles, lambda e: None)
+
+    # No exception, and the ghost never reaches the payload. Submitting it would
+    # be rejected wholesale: the route requires the list to match the server's
+    # role set exactly.
+    assert bodies == [{"ranks": ["stoat-b", "stoat-a"]}]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4205,3 +4205,58 @@ async def test_apply_role_ordering_tolerates_a_stale_role_map(tmp_path: Path) ->
     # be rejected wholesale: the route requires the list to match the server's
     # role set exactly.
     assert bodies == [{"ranks": ["stoat-b", "stoat-a"]}]
+
+
+async def test_run_roles_retries_ordering_when_every_role_is_finalized(tmp_path: Path) -> None:
+    """An --incremental run still fixes ordering, even with every role finalized.
+
+    The ordering step is deliberately NOT gated by `roles_finalized`, unlike the
+    attributes and permissions passes beside it. Ordering is a property of the
+    whole server rather than of any one role, and gating it per-role would make a
+    degraded ordering permanent: a run whose ordering was refused with a 403 marks
+    its roles finalized anyway, so a gated step would never retry.
+
+    This drives exactly that recovery. Every role is finalized, the server is in
+    the wrong order, and the run must still correct it.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, incremental=True)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "stoat-a", "b": "stoat-b"}
+    state.roles_finalized = {"a", "b"}
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    bodies: list[dict[str, object]] = []
+    creates: list[str] = []
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "unexpected", "name": "X"},
+            repeat=True,
+            callback=lambda url, **kwargs: creates.append("hit"),  # type: ignore[misc]
+        )
+        # The server is in the WRONG order: a outranks b, but b has the higher
+        # Discord position.
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    assert creates == [], "finalized roles must not be recreated"
+    assert bodies == [{"ranks": ["stoat-b", "stoat-a"]}], (
+        "ordering must still run for finalized roles, otherwise a degraded "
+        "ordering could never be repaired by a later run"
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
+import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
@@ -3840,3 +3841,266 @@ async def test_apply_role_ordering_single_role_sends_read_back_only(tmp_path: Pa
             await _apply_role_ordering(session, config, state, roles, lambda e: None)
 
     assert gets == ["hit"]
+
+
+async def test_run_roles_ordering_failure_is_non_fatal(tmp_path: Path) -> None:
+    """A generic ordering failure warns, and the phase still completes.
+
+    Replaces the coverage of the retired test_run_roles_rank_failure_is_non_fatal,
+    which drove a failure of the discarded per-role rank PATCH.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/ranks", status=500, payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    failures = [w for w in state.warnings if w["type"] == "role_ordering_failed"]
+    assert len(failures) == 1
+    # The rest of the phase's work survives the degradation.
+    assert state.role_map == {"a": "stoat-a", "b": "stoat-b"}
+    assert "a" in state.roles_finalized and "b" in state.roles_finalized
+    assert any(e.status == "warning" for e in events)
+
+
+@pytest.mark.parametrize("err_type", ["NotElevated", "MissingPermission"])
+async def test_run_roles_ordering_forbidden_warns_about_permissions(
+    tmp_path: Path, err_type: str
+) -> None:
+    """A 403 gets its own warning type, naming permissions rather than a bug.
+
+    On the --server-id path this is the ordinary outcome when the account holds no
+    role on the target, because the upstream elevation check protects every role
+    when the caller's top rank is None.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            status=403,
+            payload={"type": err_type},
+            repeat=True,
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    warned = [w for w in state.warnings if w["type"] == "role_ordering_not_permitted"]
+    assert len(warned) == 1
+    assert "permission" in warned[0]["message"].lower()
+    # It must NOT be classified as a generic failure, or the user is told to file a bug.
+    assert not [w for w in state.warnings if w["type"] == "role_ordering_failed"]
+
+
+async def test_run_roles_read_back_failure_is_non_fatal(tmp_path: Path) -> None:
+    """A failed read-back degrades the same way the ordering call does."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
+        m.get(f"{STOAT_URL}/servers/srv1", status=500, payload={}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    assert [w["type"] for w in state.warnings if "ordering" in w["type"]] == [
+        "role_ordering_failed"
+    ]
+    assert state.role_map == {"a": "stoat-a", "b": "stoat-b"}
+
+
+async def test_run_roles_ordering_is_the_last_request(tmp_path: Path) -> None:
+    """Ordering runs after every create and after the permissions pass, exactly once.
+
+    The route rejects any list that does not name every role, so it cannot run
+    until the creates have landed.
+
+    FIXTURE NOTE, measured rather than assumed. Supplying Discord metadata takes
+    run_roles down the live-role union path, which sorts roles_to_create
+    position-descending (structure.py:676). So role "b" (position 9) is created
+    FIRST and receives "stoat-a", the reverse of the export-only path. The union
+    path also calls api_fetch_root, which returns {} on any client error instead
+    of raising (api.py:443-458), so an unregistered root route degrades quietly
+    and the limit falls back to 200. Both permission routes are registered here
+    because of that id flip; registering only one made this test fail while the
+    code was correct.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={"a": PermissionPair(allow=4_194_304, deny=0)},
+        channel_metadata={},
+    )
+    save_discord_metadata(meta, tmp_path)
+
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(guild_id="111", messages=[_make_message("m1", roles=roles)])]
+
+    seen: list[str] = []
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-a", "name": "A"},
+            callback=lambda url, **kwargs: seen.append("create"),  # type: ignore[misc]
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "stoat-b", "name": "B"},
+            callback=lambda url, **kwargs: seen.append("create"),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/servers/srv1/permissions/stoat-a",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: seen.append("perms"),  # type: ignore[misc]
+        )
+        m.put(
+            f"{STOAT_URL}/servers/srv1/permissions/stoat-b",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: seen.append("perms"),  # type: ignore[misc]
+        )
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+            callback=lambda url, **kwargs: seen.append("read"),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: seen.append("ranks"),  # type: ignore[misc]
+        )
+
+        await run_roles(config, state, exports, events.append)
+
+    assert "perms" in seen, (
+        f"the permissions pass must have run, or the ordering is not last. "
+        f"seen={seen} warnings={[w['type'] for w in state.warnings]}"
+    )
+    assert seen[-2:] == ["read", "ranks"]
+    assert seen.count("ranks") == 1
+
+
+async def test_run_roles_dry_run_sends_no_ordering(tmp_path: Path) -> None:
+    """Dry run needs no guard of its own: run_roles returns before the session block."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path, dry_run=True)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    # No routes registered at all: aioresponses raises on any request.
+    with aioresponses():
+        await run_roles(config, state, exports, events.append)
+
+    assert state.role_map == {"a": "dry-role-a", "b": "dry-role-b"}
+
+
+async def test_run_roles_ordering_converges_on_a_second_run(tmp_path: Path) -> None:
+    """A second pass reaches the same order and creates no duplicate roles.
+
+    Idempotence comes from recomputing off a fresh read-back rather than from a
+    guard flag, so the second run is driven against a server that already reflects
+    the first run's ordering.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    first: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: first.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_roles(config, state, exports, events.append)
+
+    creates: list[str] = []
+    second: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "unexpected", "name": "X"},
+            repeat=True,
+            callback=lambda url, **kwargs: creates.append("hit"),  # type: ignore[misc]
+        )
+        # The server now reflects the ordering the first run applied.
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-b": 0, "stoat-a": 1}),
+            repeat=True,
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            repeat=True,
+            callback=lambda url, **kwargs: second.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        await run_roles(config, state, exports, events.append)
+
+    assert creates == [], "the second run must not recreate roles already in role_map"
+    assert first == [{"ranks": ["stoat-b", "stoat-a"]}]
+    assert second == first

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1712,8 +1712,47 @@ def test_make_unique_channel_name_truncated_collision() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_run_roles_sets_rank_from_position(tmp_path: Path) -> None:
-    """ROLES phase sets rank on created roles from DCE position data."""
+async def test_run_roles_never_sends_rank(tmp_path: Path) -> None:
+    """No per-role PATCH body carries ``rank``; the Stoat backend discards it.
+
+    Replaces test_run_roles_sets_rank_from_position, which asserted that ``rank``
+    appeared in a mocked request body. That assertion was true and useless: the
+    upstream roles_edit handler destructures DataEditRole with a rest pattern that
+    does not bind ``rank``, so the field was accepted with a 200 and never stored.
+    Ordering now lives in _apply_role_ordering. See #380.
+    """
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    role = DCERole(id="r1", name="Admin", position=3, color="#FF0000")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+
+    bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kwargs: bodies.append(kwargs.get("json", {})),  # type: ignore[misc]
+        )
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1", "roles": {}}, repeat=True)
+
+        await run_roles(config, state, exports, events.append)
+
+    # The colour PATCH proves the pass still runs, so "no rank" is not vacuous.
+    assert bodies, "expected the colour PATCH, otherwise this test checks nothing"
+    assert all("rank" not in b for b in bodies)
+
+
+async def test_run_roles_position_only_role_sends_no_patch(tmp_path: Path) -> None:
+    """A role whose only attribute was rank now triggers no PATCH at all.
+
+    With ``rank`` gone and no Discord metadata, edit_kwargs is empty and the
+    ``if not edit_kwargs: continue`` guard skips the call entirely.
+    """
     events: list[MigrationEvent] = []
     config = _make_config(tmp_path)
     state = MigrationState(stoat_server_id="srv1")
@@ -1721,95 +1760,22 @@ async def test_run_roles_sets_rank_from_position(tmp_path: Path) -> None:
     role = DCERole(id="r1", name="Admin", position=3)
     exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
 
-    rank_bodies: list[dict[str, object]] = []
+    patched: list[str] = []
 
     with aioresponses() as m:
         m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
-        # Capture the rank PATCH call.
         m.patch(
             f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
             payload={},
-            callback=lambda url, **kwargs: rank_bodies.append(  # type: ignore[misc]
-                kwargs.get("json", {})
-            ),
-        )
-
-        await run_roles(config, state, exports, events.append)
-
-    assert any(b.get("rank") == 3 for b in rank_bodies)
-
-
-async def test_run_roles_rank_tie_break_is_deterministic(tmp_path: Path) -> None:
-    """On equal position, the rank pass processes roles in a deterministic id order.
-
-    Two roles share position 5 but have ids "30" and "20". The deterministic sort
-    key (position, id) must process role "20" before role "30" regardless of input
-    order. The functional goal is determinism — same-position roles emit a stable
-    processing order independent of export/union insertion order.
-    """
-    events: list[MigrationEvent] = []
-    config = _make_config(tmp_path)
-    state = MigrationState(stoat_server_id="srv1")
-
-    # Export order lists "30" first, then "20" — so a position-only (stable) sort
-    # would preserve that input order and process "30" before "20".
-    role_30 = DCERole(id="30", name="Thirty", position=5)
-    role_20 = DCERole(id="20", name="Twenty", position=5)
-    exports = [
-        _make_export(
-            messages=[
-                _make_message("m1", roles=[role_30]),
-                _make_message("m2", roles=[role_20]),
-            ]
-        )
-    ]
-
-    # FIFO POST registration mirrors first-pass insertion (export) order:
-    # "30" -> stoat-30, "20" -> stoat-20.
-    patched_role_ids: list[str] = []
-
-    with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-30", "name": "Thirty"})
-        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-20", "name": "Twenty"})
-        m.patch(
-            f"{STOAT_URL}/servers/srv1/roles/stoat-30",
-            payload={},
             repeat=True,
-            callback=lambda url, **kwargs: patched_role_ids.append("30"),  # type: ignore[misc]
+            callback=lambda url, **kwargs: patched.append("hit"),  # type: ignore[misc]
         )
-        m.patch(
-            f"{STOAT_URL}/servers/srv1/roles/stoat-20",
-            payload={},
-            repeat=True,
-            callback=lambda url, **kwargs: patched_role_ids.append("20"),  # type: ignore[misc]
-        )
+        m.get(f"{STOAT_URL}/servers/srv1", payload={"_id": "srv1", "roles": {}}, repeat=True)
 
         await run_roles(config, state, exports, events.append)
 
-    # Real processing order: the rank PATCH for the lexically-smaller id fires first.
-    assert patched_role_ids == ["20", "30"]
-
-
-async def test_run_roles_rank_failure_is_non_fatal(tmp_path: Path) -> None:
-    """ROLES phase logs a warning and continues if rank setting fails."""
-    events: list[MigrationEvent] = []
-    config = _make_config(tmp_path)
-    state = MigrationState(stoat_server_id="srv1")
-
-    role = DCERole(id="r1", name="Admin", position=2)
-    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
-
-    with aioresponses() as m:
-        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
-        # Rank PATCH fails.
-        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-r1", status=500)
-
-        # Should NOT raise.
-        await run_roles(config, state, exports, events.append)
-
-    assert state.role_map["r1"] == "stoat-r1"
-    attr_warnings = [w for w in state.warnings if w.get("type") == "role_attributes_failed"]
-    assert len(attr_warnings) > 0
+    assert state.role_map["r1"] == "stoat-r1", "the role must still be created"
+    assert patched == []
 
 
 async def test_run_roles_applies_permissions(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.1"
+version = "2.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Role hierarchy has never been applied on any migration since v1.x. `run_roles` sent each role's Discord position as `rank` on `PATCH /servers/{id}/roles/{role_id}`, and the Stoat backend discards that field: the upstream `roles_edit` handler destructures `DataEditRole { name, colour, hoist, icon, remove, .. }`, so `rank` falls into the rest pattern and is never persisted. The request returned 200, `hoist` and `icon` in the same call still landed, and no warning fired, so every run reported ordering as applied while the server kept its defaults.

Found by a whole-codebase bug hunt. Verified against `revoltchat/backend` at `main` rather than inferred.

## What changed

`api_edit_role_ranks` reaches `PATCH /servers/{id}/roles/ranks`, the only route that sets ordering. A new `_apply_role_ordering` step runs once at the end of `run_roles`: it reads the server back, sorts Ferry-known roles by Discord `position` descending, and writes them into the index slots they already occupy.

Index 0 is the top of the hierarchy, because `set_role_ordering` assigns rank by enumeration index and `ordered_roles()` sorts ascending. Discord `position` runs the other way. The sort negates position rather than passing `reverse=True`, which would flip the id tie-break as well; the two existing sort sites in this file disagree on exactly that point, so neither was safe to copy.

The list is built from a read-back, never from `role_map`. That map can lag the server, because the create loop persists only every ten roles (#389), and the route rejects any list that omits a role. Only roles Ferry created move, so migrating into an existing server with `--server-id` leaves that server's own hierarchy alone.

Failures degrade rather than fail the phase. A 403 becomes `role_ordering_not_permitted` naming permissions, anything else `role_ordering_failed`. On the `--server-id` path the 403 is the ordinary outcome, not an exotic one, because the upstream elevation check protects every role when the caller holds no role on the target.

## What the gates actually caught

The three prose critique rounds, two chunk reviews, one second opinion and one whole-branch review returned 12 findings between them. Four were real.

- **Round 2 of the design critique** found that the tie-break reasoning had no test. Confirmed by mutation afterwards: `reverse=True` kills only that one test, so without it the whole argument was unverified.
- **The chunk 2 review** found the ordering step submitting a no-op. Measured: one Ferry role on a four-role server produced a list byte-identical to the current order. Two guards added. Adding them immediately broke a test whose fixture was already in the target order, so its claim about ordering running last had been passing against a fixture where ordering did nothing.
- **The whole-branch review** found a third stale document, `docs/reference/architecture.md`, in a file this branch never opened. Every other gate was scoped to the diff and could not see it. The CHANGELOG's own claim of "two shipped documents" was wrong and is corrected.
- **The build** found that the plan named the wrong call site: the permissions pass's session block is nested inside `if discord_metadata and not config.dry_run`, so ordering would have been skipped on every run without a `discord_token`.

The eight refuted findings included two whose suggested fixes would have broken working code: an anchored `'"type": "NotElevated"'` that does not match the actual compact body, and a `roles_finalized` gate that would have made a degraded ordering permanent.

## Tests

Three tests that asserted `rank` appeared in a mocked request body are gone. They passed for years against a field the server threw away, because an assertion about what Ferry sent can never observe what the server kept. A fourth, in a file the plan never named, surfaced only in a full-suite run.

Full suite: 2049 passing.

## Not covered here

- `ferry build` replays blueprint and template ranks through the same discarded field: #387
- Correcting ordering on a server migrated by an earlier release: #388
- The rank half of repair stays blocked: #344
- A hard kill mid create-loop recreates roles as duplicates on resume: #389

Plan chunks: #390, #391. Both carry review markers.

Fixes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Nkezv4g9LNy1v77KAUC7a
