### PR TITLE
fix(probe): escape server-controlled strings before Rich renders them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [2.19.2] - 2026-08-18
+## [2.19.3] - 2026-08-18
+
+### Fixed
+
+- **`ferry probe` rendered server-controlled strings through Rich unescaped, so a stray closing
+  tag in a Stoat response killed all output.** A `[/bold]` or `[/red]` anywhere in the instance's
+  feature limits, version string, rate-limit headers or an exception message raised `MarkupError`
+  and gave exit 1 with no table at all. Now wraps `c.name` and `c.detail` in `escape()`, matching
+  `_render_check_report` which already did this. `--json` was never affected. Fixes #384.
 
 ## [2.19.2] - 2026-08-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.2"
+version = "2.19.3"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.2"
+__version__ = "2.19.3"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1366,7 +1366,7 @@ def probe_cmd(
     table.add_column("Detail")
     for c in report.checks:
         colour = {"ok": "green", "warn": "yellow", "fail": "red"}.get(c.status, "white")
-        table.add_row(c.name, f"[{colour}]{c.status}[/]", c.detail)
+        table.add_row(escape(c.name), f"[{colour}]{c.status}[/]", escape(c.detail))
     console.print(table)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -903,6 +903,45 @@ def test_probe_json_stdout_survives_a_realistic_payload(runner: CliRunner) -> No
     assert payload["autumn_limits"]["detail"].startswith("attachments 20000000")
 
 
+def test_probe_table_escapes_server_controlled_markup(runner: CliRunner) -> None:
+    """Issue #384. A closing Rich tag in a server-supplied detail string raises
+    MarkupError and kills all probe output. Killing: a code path that passes
+    c.name or c.detail to Rich without escape()."""
+    from discord_ferry.migrator.probe import ProbeCheck, ProbeReport
+
+    report = ProbeReport(
+        checks=[
+            ProbeCheck(
+                name="rate_limits[/bold]",
+                status="ok",
+                detail="bucket [/red] reset_after 10000ms",
+            ),
+        ]
+    )
+
+    with patch(
+        "discord_ferry.migrator.probe.run_probe",
+        AsyncMock(return_value=report),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "probe",
+                "--stoat-url",
+                "https://api.test",
+                "--token",
+                "t",
+                "--test-server-id",
+                "srv1",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert "rate_limits[/bold]" in result.output
+    assert "[/red]" in result.output
+
+
 def test_no_create_invite_flag_threads_to_config(runner: CliRunner) -> None:
     mock_engine = _make_mock_engine()
     with patch("discord_ferry.cli.run_migration", mock_engine):

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.2"
+version = "2.19.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Escape server-controlled strings in the probe table renderer.** `c.name` and `c.detail` are
  now wrapped in `escape()` before passing to Rich's `table.add_row()`, matching the pattern
  `_render_check_report` already uses. A closing Rich tag (e.g. `[/bold]`) in any Stoat response
  field raised `MarkupError` and killed all probe output. `--json` was never affected.
- **Regression test** feeds Rich markup metacharacters through the probe renderer and asserts no
  error and literal text in output.

## Test plan

- [x] New test `test_probe_table_escapes_server_controlled_markup` passes
- [x] Same test fails without the fix (verified by reverting in place)
- [x] Full suite: 2052 passed
- [x] Lint, format, mypy clean

Fixes #384

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
