### PR TITLE
fix(roles): move colour to attributes pass so resume retries it (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.6] - 2026-08-18
+
+### Fixed
+
+- **A failed role colour is now retried on resume.** Colour was applied inside the create loop,
+  gated on `pre_existing_role_ids`, so a role already in `role_map` was skipped on resume. Moved
+  to the attributes pass alongside hoist and icon, gated on `roles_finalized`, so colour retries
+  the same way those do. Fixes #408.
+
 ## [2.19.5] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.5"
+version = "2.19.6"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.5"
+__version__ = "2.19.6"

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -771,10 +771,11 @@ async def run_roles(
                 )
             )
 
-    # Second pass: set role attributes (hoist and icon from Discord metadata), folded
-    # into a single api_edit_role call per role. Rank is NOT set here: the upstream
-    # roles_edit handler drops DataEditRole.rank through a rest pattern, so it was
-    # accepted with a 200 and never persisted. Ordering lives in _apply_role_ordering.
+    # Second pass: set role attributes (colour, hoist, icon). Colour is a separate
+    # api_edit_role call so a parse failure does not block hoist/icon. Rank is NOT
+    # set here: the upstream roles_edit handler drops DataEditRole.rank through a
+    # rest pattern, so it was accepted with a 200 and never persisted. Ordering
+    # lives in _apply_role_ordering.
     discord_metadata = load_discord_metadata(config.output_dir)
     role_meta = discord_metadata.role_metadata if discord_metadata else {}
     # The sort no longer decides anything the server sees, but deterministic iteration

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -761,28 +761,6 @@ async def run_roles(
                     state.native_fidelity_counts.get("structural_roles", 0) + 1
                 )
 
-            # Apply colour if present (British spelling required by Stoat API).
-            if role.color:
-                color_str = role.color.lstrip("#")
-                try:
-                    colour_int = int(color_str, 16)
-                    await api_edit_role(
-                        session,
-                        config.stoat_url,
-                        config.token,
-                        state.stoat_server_id,
-                        stoat_role_id,
-                        colour=colour_int,
-                    )
-                except (ValueError, MigrationError) as exc:
-                    state.warnings.append(
-                        {
-                            "phase": "roles",
-                            "type": "role_colour_failed",
-                            "message": f"Failed to set colour for role '{role.name}': {exc}",
-                        }
-                    )
-
             on_event(
                 MigrationEvent(
                     phase="roles",
@@ -811,6 +789,26 @@ async def run_roles(
             attribute_role_id = state.role_map.get(role.id)
             if not attribute_role_id:
                 continue
+            if role.color:
+                color_str = role.color.lstrip("#")
+                try:
+                    colour_int = int(color_str, 16)
+                    await api_edit_role(
+                        session,
+                        config.stoat_url,
+                        config.token,
+                        state.stoat_server_id,
+                        attribute_role_id,
+                        colour=colour_int,
+                    )
+                except (ValueError, MigrationError) as exc:
+                    state.warnings.append(
+                        {
+                            "phase": "roles",
+                            "type": "role_colour_failed",
+                            "message": f"Failed to set colour for role '{role.name}': {exc}",
+                        }
+                    )
             edit_kwargs: dict[str, Any] = {}
             rm = role_meta.get(role.id)
             if rm is not None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4391,12 +4391,9 @@ async def test_run_roles_incremental_adds_a_role_and_places_it_at_the_top(
 async def test_run_roles_ordering_survives_an_interrupt_and_resume(tmp_path: Path) -> None:
     """SC-I2. An interrupted run, resumed, submits the same order as an uninterrupted one.
 
-    The first attempt fails in the colour step of the CREATE loop, after both roles
-    are created, so role_map is populated and roles_finalized is not. Note the
-    phase name: colour is applied inside the create loop (structure.py:764), while
-    the pass the source calls the "attributes pass" (:796) handles hoist and icon.
-    An earlier version of this docstring said the failure was in the attributes
-    pass, which is the wrong loop.
+    The first attempt fails in the colour step of the ATTRIBUTES pass, after both
+    roles are created, so role_map is populated and roles_finalized is not. Colour,
+    hoist and icon all live in the attributes pass, gated on roles_finalized.
 
     The resume then completes the phase, and its submitted ordering list must match
     what a single clean run produces from the same export.
@@ -4433,7 +4430,7 @@ async def test_run_roles_ordering_survives_an_interrupt_and_resume(tmp_path: Pat
         )
         await run_roles(_make_config(clean_dir), clean_state, exports, events.append)
 
-    # --- the interrupted attempt: roles created, then the colour PATCH kills it ---
+    # --- the interrupted attempt: roles created, then the attributes-pass colour PATCH kills it ---
     crash_dir = tmp_path / "crash"
     crash_dir.mkdir()
     crash_state = MigrationState(stoat_server_id="srv1")
@@ -4445,12 +4442,12 @@ async def test_run_roles_ordering_survives_an_interrupt_and_resume(tmp_path: Pat
     with aioresponses() as m:
         m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
         m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
-        # The create loop runs create-then-colour per role, so the kill has to land
-        # on the SECOND role's colour PATCH for both roles to exist first, which is
-        # the state SC-I2 describes. Killing on the first leaves role "b" uncreated
-        # and tests a different scenario. RuntimeError is used deliberately: the
-        # colour handler catches ValueError and MigrationError, so neither would
-        # interrupt anything.
+        # The attributes pass runs colour per role after the create loop finishes,
+        # so both roles exist before any colour PATCH fires. The kill lands on
+        # the SECOND role's colour PATCH so both are mapped but neither is
+        # finalized, which is the state SC-I2 describes. RuntimeError is used
+        # deliberately: the colour handler catches ValueError and MigrationError,
+        # so neither would interrupt anything.
         m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-a", payload={}, repeat=True)
         m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-b", exception=RuntimeError("killed"))
         with contextlib.suppress(RuntimeError):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3005,6 +3005,106 @@ async def test_incremental_finalized_role_skips_attrs_and_perms(tmp_path: Path) 
     assert state.roles_finalized == {"r1"}
 
 
+async def test_resume_retries_colour_for_unfinalized_role(tmp_path: Path) -> None:
+    """SC-1.2: a mapped-but-unfinalized role with colour gets its colour retried."""
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv1", role_map={"r1": "stoat-r1"}, roles_finalized=set()
+    )
+    role = DCERole(id="r1", name="Admin", color="#00FF00")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    patch_body: dict[str, object] = {}
+    creates: list[object] = []
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/roles",
+            payload={"id": "should-not-happen"},
+            repeat=True,
+            callback=lambda url, **kw: creates.append(url),  # type: ignore[misc]
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            callback=lambda url, **kw: patch_body.update(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_roles(config, state, exports, lambda e: None)
+    assert creates == []
+    assert patch_body.get("colour") == 0x00FF00
+    assert "r1" in state.roles_finalized
+
+
+async def test_colour_failure_produces_warning(tmp_path: Path) -> None:
+    """SC-1.4: a failed colour PATCH records role_colour_failed and still finalizes."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="r1", name="Admin", color="#FF5733")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            status=400,
+            repeat=True,
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+        await run_roles(config, state, exports, lambda e: None)
+    colour_warnings = [w for w in state.warnings if w["type"] == "role_colour_failed"]
+    assert len(colour_warnings) == 1
+    assert "Admin" in colour_warnings[0]["message"]
+    assert "r1" in state.roles_finalized
+
+
+async def test_colour_applied_without_discord_metadata(tmp_path: Path) -> None:
+    """SC-1.6: a role with colour but no discord metadata gets colour applied."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="r1", name="Admin", color="#0000FF")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    patch_body: dict[str, object] = {}
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            callback=lambda url, **kw: patch_body.update(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_roles(config, state, exports, lambda e: None)
+    assert patch_body.get("colour") == 0x0000FF
+    assert "r1" in state.roles_finalized
+
+
+async def test_invalid_colour_does_not_block_hoist(tmp_path: Path) -> None:
+    """SC-1.7: a bad colour hex produces a warning but hoist still fires."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    role = DCERole(id="r1", name="Admin", color="not-hex")
+    exports = [_make_export(messages=[_make_message("m1", roles=[role])])]
+    meta = DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={"r1": PermissionPair(allow=1, deny=0)},
+        channel_metadata={},
+        role_metadata={"r1": RoleMeta(hoist=True, position=2, color="not-hex")},
+    )
+    save_discord_metadata(meta, tmp_path)
+    hoist_body: dict[str, object] = {}
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "Admin"})
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/stoat-r1",
+            payload={},
+            repeat=True,
+            callback=lambda url, **kw: hoist_body.update(kw.get("json", {})),  # type: ignore[misc]
+        )
+        m.put(f"{STOAT_URL}/servers/srv1/permissions/stoat-r1", payload={}, repeat=True)
+        await run_roles(config, state, exports, lambda e: None)
+    colour_warnings = [w for w in state.warnings if w["type"] == "role_colour_failed"]
+    assert len(colour_warnings) == 1
+    assert hoist_body.get("hoist") is True
+    assert "r1" in state.roles_finalized
+
+
 async def test_mark_at_end_finalizes_without_metadata(tmp_path: Path) -> None:
     """S3 SC-12: a completed run finalizes created roles even with no Discord metadata."""
     config = _make_config(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.5"
+version = "2.19.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Move role colour application from the create loop (gated on `pre_existing_role_ids`) to the
  attributes pass (gated on `roles_finalized`), so colour retries on resume alongside hoist,
  icon and permissions
- Keep colour as a separate `api_edit_role` call to avoid coupling colour parse failures with
  hoist/icon
- Add four new test scenarios: resume retries colour, failure produces warning, colour without
  discord metadata, invalid hex does not block hoist

Fixes #408

## Test plan

- [x] All 2082 existing tests pass
- [x] Four new colour-in-attributes-pass scenarios pass
- [x] Existing colour tests (`test_run_roles_colour_conversion`, `test_run_roles_colour_without_hash`) pass unchanged
- [x] Ordering interrupt-and-resume test passes with updated docstring
- [x] `ruff check .`, `ruff format --check .`, `mypy src/` clean
