### PR TITLE
fix(gui): clear stale resume flag and handle StateError (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   so a failure on part N>1 skipped the commit entirely, losing the id, autumn references and message
   counter. The exception handler now runs inside the loop (flag-and-continue), and the commit block
   runs after it regardless. Fixes #381.
+- **GUI resume flag no longer persists across runs when no previous state exists.** The
+  `storage["resume"]` key was written only by the Resume button and never cleared, so a later run
+  with no `state.json` raised `StateError` through the generic handler with no useful message. The
+  else branch now resets the flag, and a dedicated `except StateError` handler clears it and names
+  the cause. Fixes #383.
 
 ## [2.19.6] - 2026-08-18
 

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -25,7 +25,7 @@ from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
-from discord_ferry.errors import MigrationError
+from discord_ferry.errors import MigrationError, StateError
 from discord_ferry.parser.dce_parser import (
     _ACKNOWLEDGEABLE_TYPES,
     acknowledgement_required,
@@ -1241,6 +1241,7 @@ async def migrate_page() -> None:
                     "bg-gray-400 text-white"
                 )
     else:
+        storage["resume"] = False
         resume_choice_made.set()  # No previous state — start immediately.
 
     # Build FerryConfig from stored values
@@ -1699,6 +1700,17 @@ async def migrate_page() -> None:
 
             try:
                 await run_migration(config, on_event=on_event)
+            except StateError as exc:
+                storage["resume"] = False
+                log_display.push(
+                    f"[ERROR] Could not load previous state: {exc}. "
+                    "The resume flag has been cleared. "
+                    "Re-run to start a fresh migration."
+                )
+                ui.notify(
+                    f"State error: {exc}. Re-run to start fresh.",
+                    type="negative",
+                )
             except MigrationError as exc:
                 log_display.push(f"[ERROR] Migration failed: {exc}")
                 errors_label.set_text(f"Errors: {error_count} (FAILED)")


### PR DESCRIPTION
## Summary

- Reset `storage["resume"] = False` in the else branch when no previous state exists, so the flag never outlives its session
- Add a dedicated `except StateError` handler in `_run()` that clears the stale flag and tells the user what happened, matching the CLI's existing pattern
- Bump to v2.19.7

## Root cause

`storage["resume"]` was written only by the Resume button (`_set_resume(True)`) and never cleared when no previous state was found. With `FERRY_STORAGE_SECRET` set, NiceGUI storage persists across restarts, so a later run with no `state.json` read the stale `True`, called `load_state`, and raised `StateError`. Since `StateError` is a sibling of `MigrationError` (not a subclass), it fell to the generic `except Exception` handler and showed "Unexpected error: State file not found" with no pointer to the stored flag.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy src/` pass
- [x] 2081 tests pass (1 pre-existing failure in `test_gate_scripts`, unrelated ADR index)
- [x] Audited all `storage["resume"]` and `StateError` usage across the codebase

Closes #383
