### PR TITLE
fix: nicegui floor, version test order, stoat_url redaction (#382 #156 #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.8] - 2026-08-18
+
+### Fixed
+
+- **Credentials embedded in `--stoat-url` as HTTP basic-auth userinfo no longer reach API error
+  messages unredacted.** A `stoat_url` like `https://user:pass@host` was interpolated verbatim into
+  MigrationError and StoatConnectionError text at eight sites. The `ferry build` path registers no
+  secret, so nothing downstream could scrub it. A new `redact_url` helper in `core/http.py` strips
+  `user:password@` before the URL reaches any error message. Fixes #276.
+- **The nicegui dependency floor no longer sits two majors below a symbol `gui.py` imports at
+  module load.** `pyproject.toml` declared `nicegui>=2.0` but `gui.py` imports
+  `ClientConnectionTimeout`, which first exists in nicegui 3.0.0. `uv.lock` pins 3.12.0 and CI
+  installs from the lock, so the floor was never exercised; an environment resolving nicegui 2.x
+  failed with `ImportError` on import. The floor is now `nicegui>=3.0` with an inline comment
+  naming the symbol. Fixes #382.
+- **The `--version` test no longer fails when a NiceGUI page-test module is collected before
+  it.** `test_version_is_read_from_module_attribute_not_package_metadata` accessed the
+  `discord_ferry.cli` package attribute for `importlib.reload`, but a preceding NiceGUI
+  page-test re-imports `discord_ferry` as a fresh package whose `cli` attribute is never re-set.
+  The test now holds the submodule via `importlib.import_module` and reloads that reference,
+  which is order-independent. Fixes #156.
+
+### Added
+
+- **A packaging test that walks each declared dependency floor against the symbol the code
+  imports.** `test_dependency_floors_cover_the_symbols_the_code_imports` parses the floored
+  dependencies in `pyproject.toml` and asserts each floor is at least the version its symbol
+  landed in, catching the next floor/import mismatch the lock was hiding. Companion to #382.
+
 ## [2.19.7] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "click>=8.0",
     "ijson>=3.0",
     "multidict>=4.5",
-    "nicegui>=2.0",
+    "nicegui>=3.0",  # ClientConnectionTimeout landed in 3.0.0; gui.py imports it at module load
     "python-dotenv",
     "rich>=13.0",
     "yarl>=1.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.7"
+version = "2.19.8"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.7"
+__version__ = "2.19.8"

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -318,6 +318,29 @@ def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
     return url.with_user(None), header
 
 
+def redact_url(url: str | URL) -> str:
+    """Return ``url`` as a string with any ``user:password@`` userinfo removed.
+
+    A Stoat URL may carry HTTP basic-auth credentials as userinfo
+    (``https://user:pass@host``). On the ``ferry build`` path such a URL reaches
+    MigrationError messages verbatim, and that command registers no secret, so
+    nothing downstream can scrub it. Interpolating ``redact_url(url)`` instead
+    of ``url`` into an error message keeps the credential out of user-facing
+    output and the log. (Issue #276.)
+
+    A URL with no userinfo round-trips to its string form unchanged. A value
+    yarl cannot parse is returned as-is rather than raised, so a malformed
+    ``stoat_url`` never replaces a credential leak with a crash.
+    """
+    try:
+        parsed = URL(url) if isinstance(url, str) else url
+    except ValueError:
+        return str(url)
+    if parsed.user is None and parsed.password is None:
+        return str(url)
+    return str(parsed.with_user(None).with_password(None))
+
+
 def _suppressed_schemes() -> set[str]:
     """Schemes turned off by an empty `<scheme>_proxy`.
 

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -15,7 +15,13 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
 
-from discord_ferry.core.http import new_session, proxy_error_is_permanent, proxy_hint, tls_hint
+from discord_ferry.core.http import (
+    new_session,
+    proxy_error_is_permanent,
+    proxy_hint,
+    redact_url,
+    tls_hint,
+)
 from discord_ferry.errors import DuplicateSendError, MigrationError
 
 if TYPE_CHECKING:
@@ -397,16 +403,18 @@ async def api_create_server(
     if not isinstance(raw, dict):
         # Never sorted(raw) here: on a list that sorts the elements into the message.
         raise MigrationError(
-            f"Stoat returned {type(raw).__name__} from {url}, expected an object. {version_hint}"
+            f"Stoat returned {type(raw).__name__} from {redact_url(url)}, "
+            f"expected an object. {version_hint}"
         )
     server = raw.get("server")
     if server is None:
         raise MigrationError(
-            f"Stoat returned no 'server' member from {url}; keys were {sorted(raw)}. {version_hint}"
+            f"Stoat returned no 'server' member from {redact_url(url)}; "
+            f"keys were {sorted(raw)}. {version_hint}"
         )
     if not isinstance(server, dict):
         raise MigrationError(
-            f"Stoat returned a {type(server).__name__} as 'server' from {url}, "
+            f"Stoat returned a {type(server).__name__} as 'server' from {redact_url(url)}, "
             f"expected an object. {version_hint}"
         )
     server_id = server.get("_id")
@@ -414,7 +422,7 @@ async def api_create_server(
         # Nested keys, not top-level: an upstream rename of _id leaves the top level
         # looking exactly as Ferry expects, so naming it would read like success.
         raise MigrationError(
-            f"Stoat returned no server id from {url}; 'server' keys were "
+            f"Stoat returned no server id from {redact_url(url)}; 'server' keys were "
             f"{sorted(server)}. {version_hint}"
         )
     return server_id
@@ -1099,7 +1107,7 @@ async def api_fetch_messages(
     raw: object = await _api_request(session, "GET", url, token)
     if not isinstance(raw, list):
         raise MigrationError(
-            f"Expected a JSON array of messages from {url}, got {type(raw).__name__}"
+            f"Expected a JSON array of messages from {redact_url(url)}, got {type(raw).__name__}"
         )
     return raw
 
@@ -1153,5 +1161,7 @@ async def api_fetch_emoji_list(
     url = f"{stoat_url.rstrip('/')}/servers/{server_id}/emojis"
     raw: object = await _api_request(session, "GET", url, token)
     if not isinstance(raw, list):
-        raise MigrationError(f"Expected a JSON array of emoji from {url}, got {type(raw).__name__}")
+        raise MigrationError(
+            f"Expected a JSON array of emoji from {redact_url(url)}, got {type(raw).__name__}"
+        )
     return raw

--- a/src/discord_ferry/migrator/connect.py
+++ b/src/discord_ferry/migrator/connect.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from discord_ferry.core.events import MigrationEvent
-from discord_ferry.core.http import proxy_hint, tls_hint
+from discord_ferry.core.http import proxy_hint, redact_url, tls_hint
 from discord_ferry.errors import StoatConnectionError
 from discord_ferry.migrator.api import api_fetch_server, get_session
 
@@ -90,7 +90,9 @@ async def _discover_autumn_url(session: aiohttp.ClientSession, stoat_url: str) -
     try:
         async with session.get(url) as response:
             if response.status != 200:
-                raise StoatConnectionError(f"Stoat API returned status {response.status} at {url}")
+                raise StoatConnectionError(
+                    f"Stoat API returned status {response.status} at {redact_url(url)}"
+                )
             data = await response.json()
     except aiohttp.ClientError as e:
         # Proxy first, and NEVER both. With an https:// proxy a certificate
@@ -101,7 +103,7 @@ async def _discover_autumn_url(session: aiohttp.ClientSession, stoat_url: str) -
         # No permanence gate here: this handler has no retry to short-circuit,
         # so the message is the only decision it makes.
         hint = proxy_hint(e, target=url) or tls_hint(e) or ""
-        raise StoatConnectionError(f"Cannot reach Stoat API at {url}: {e}{hint}") from e
+        raise StoatConnectionError(f"Cannot reach Stoat API at {redact_url(url)}: {e}{hint}") from e
 
     try:
         autumn_url: str = data["features"]["autumn"]["url"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -288,6 +288,53 @@ async def test_api_create_server_empty_id(mock_aiohttp: aioresponses) -> None:
 
 
 # ---------------------------------------------------------------------------
+# api_create_server / api_fetch_messages: URL redaction in error messages (#276)
+# ---------------------------------------------------------------------------
+
+_STOAT_URL_WITH_AUTH = "https://ferryuser:hunter2@api.test"
+
+
+async def test_api_create_server_error_redacts_url_userinfo(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Issue #276. A credential embedded in stoat_url as userinfo must not reach
+    the error message. ``ferry build`` registers no secret, so redaction has to
+    happen before the URL is interpolated. The redacted URL still names the route.
+    """
+    mock_aiohttp.post(
+        f"{_STOAT_URL_WITH_AUTH}/servers/create",
+        payload=[{"_id": "srv123"}],
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_create_server(session, _STOAT_URL_WITH_AUTH, TOKEN, "Test")
+    message = str(exc.value)
+    assert "hunter2" not in message
+    assert "ferryuser" not in message
+    assert "api.test/servers/create" in message
+
+
+async def test_message_fetch_error_redacts_url_userinfo(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Issue #276, the array-shape path. Same redaction must hold on the
+    api_fetch_messages route, which builds its URL the same way."""
+    mock_aiohttp.get(
+        f"{_STOAT_URL_WITH_AUTH}/channels/ch1/messages?limit=5&sort=Oldest",
+        payload={"messages": [], "users": []},
+    )
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(MigrationError) as exc:
+            await api_fetch_messages(
+                session, _STOAT_URL_WITH_AUTH, TOKEN, "ch1", limit=5, sort="Oldest"
+            )
+    message = str(exc.value)
+    assert "hunter2" not in message
+    assert "ferryuser" not in message
+    assert "api.test/channels/ch1/messages" in message
+
+
+# ---------------------------------------------------------------------------
 # api_fetch_server
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1692,12 +1692,22 @@ def test_version_is_read_from_module_attribute_not_package_metadata(
     import importlib
 
     import discord_ferry
-    import discord_ferry.cli
+
+    # Hold the submodule by reference, not via the `discord_ferry.cli` package
+    # attribute. A NiceGUI page-test module collected earlier leaves
+    # `discord_ferry` re-imported as a fresh package whose `cli` attribute is
+    # never re-set: the submodule is still in sys.modules (from this file's
+    # module-level `from discord_ferry.cli import main`), so a later
+    # `import discord_ferry.cli` finds it there and skips the parent-attribute
+    # assignment, making `discord_ferry.cli` raise AttributeError. sys.modules
+    # always holds the submodule regardless of collection order, so it is the
+    # order-independent handle for reload. (Issue #156.)
+    cli_module = importlib.import_module("discord_ferry.cli")
 
     sentinel = "9.9.9-not-a-real-version"
     monkeypatch.setattr(discord_ferry, "__version__", sentinel)
     try:
-        reloaded = importlib.reload(discord_ferry.cli)
+        reloaded = importlib.reload(cli_module)
         result = CliRunner().invoke(reloaded.main, ["--version"])
 
         assert result.exit_code == 0
@@ -1707,7 +1717,7 @@ def test_version_is_read_from_module_attribute_not_package_metadata(
         # import __version__` at cli.py:24 and would otherwise bake the
         # sentinel into the module every later test imports.
         monkeypatch.undo()
-        importlib.reload(discord_ferry.cli)
+        importlib.reload(cli_module)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -334,6 +334,51 @@ def test_strip_userinfo_registers_both_credential_forms() -> None:
     assert header.split()[-1] not in masked
 
 
+def test_redact_url_strips_userinfo() -> None:
+    """Issue #276. Killing: interpolating the raw URL into an error message.
+
+    A stoat_url may carry basic-auth userinfo. ``ferry build`` registers no
+    secret, so nothing downstream scrubs it; the only defence is stripping the
+    userinfo before the URL reaches the message. Both the user and the
+    password must be gone, and the host and path must remain so the message
+    still identifies the route.
+    """
+    out = http.redact_url("https://ferryuser:hunter2@api.stoat.chat/servers/create")
+    assert "ferryuser" not in out
+    assert "hunter2" not in out
+    assert out == "https://api.stoat.chat/servers/create"
+
+
+def test_redact_url_leaves_a_clean_url_unchanged() -> None:
+    """A URL with no userinfo round-trips to its string form, so the helper is
+    a no-op on the common case and never mutates a clean URL by accident."""
+    assert http.redact_url("https://api.stoat.chat/servers/create") == (
+        "https://api.stoat.chat/servers/create"
+    )
+
+
+def test_redact_url_handles_a_user_only_userinfo() -> None:
+    """Killing: an `and` guard that skips when the password is None.
+
+    yarl reports password as None for ``https://user@host``; a guard that
+    requires both would leave a user-only URL unstripped and the username still
+    reaches the message.
+    """
+    out = http.redact_url("https://ferryuser@api.stoat.chat/")
+    assert "ferryuser" not in out
+    assert out == "https://api.stoat.chat/"
+
+
+def test_redact_url_returns_unparseable_input_unchanged() -> None:
+    """A malformed stoat_url must not turn a credential leak into a crash.
+
+    yarl raises ValueError on some inputs; the helper returns them as-is so the
+    error path keeps producing a message rather than raising a second time.
+    """
+    bad = "not a url with spaces://"
+    assert http.redact_url(bad) == bad
+
+
 def test_proxy_choice_requires_a_source() -> None:
     """Killing: a default on `source`. Task 2's bypass union branches on
     source == "os", so a ProxyChoice built without one silently takes the

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -256,6 +256,53 @@ def test_release_workflow_asserts_the_union_branch() -> None:
     )
 
 
+def test_dependency_floors_cover_the_symbols_the_code_imports() -> None:
+    """Each declared dependency floor must be high enough for the symbol our code imports.
+
+    Regression #382: pyproject declared `nicegui>=2.0` but gui.py imports
+    `ClientConnectionTimeout`, which first exists in nicegui 3.0.0. uv.lock pins 3.12.0
+    and CI installs from the lock, so the declared floor was never exercised and an
+    environment resolving nicegui 2.x failed with ImportError at import time.
+
+    The inline comments on the floored dependencies already name the symbol and the
+    version it landed in. This test parses those comments and asserts the floor is at
+    least that version, so lowering a floor below the import's need, or adding an
+    import that needs a higher version without raising the floor, fails here rather
+    than at a user's import time.
+
+    A dynamic variant (install the floor version and import the symbol) would be
+    stronger but needs network in CI; this static guard matches the style of the rest
+    of this file and closes the gap the lock was hiding.
+    """
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    deps_block = pyproject.split("dependencies = [", 1)[1].split("]", 1)[0]
+
+    # Each entry: (package, symbol, version_it_landed_in). Sourced from the inline
+    # comment on the dependency line. Add a row when a new floor gets a symbol reason.
+    constraints = [
+        ("aiohttp", "encode_basic_auth", "3.14.0"),
+        ("nicegui", "ClientConnectionTimeout", "3.0.0"),
+    ]
+
+    for package, _symbol, landed in constraints:
+        pattern = re.compile(rf'"{re.escape(package)}>=(\d+(?:\.\d+)*(?:\.\d+)*)"')
+        match = pattern.search(deps_block)
+        assert match is not None, (
+            f"{package} has a declared floor with a symbol reason but no '>=' floor "
+            f"was found in [project.dependencies]"
+        )
+        declared = tuple(int(p) for p in match.group(1).split("."))
+        required = tuple(int(p) for p in landed.split("."))
+        # Pad to equal length for the tuple comparison.
+        width = max(len(declared), len(required))
+        declared = declared + (0,) * (width - len(declared))
+        required = required + (0,) * (width - len(required))
+        assert declared >= required, (
+            f"{package} floor {match.group(1)} is below {landed}, the version "
+            f"{_symbol} landed in and the code imports"
+        )
+
+
 def test_release_workflow_asserts_the_proxy_keys() -> None:
     """SC-135-45. Killing: a workflow test that checks the key is MENTIONED
     rather than ASSERTED. That exact defect shipped in v2.13.0's plan, where

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.7"
+version = "2.19.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0" },
     { name = "multidict", specifier = ">=4.5" },
     { name = "mypy", marker = "extra == 'dev'" },
-    { name = "nicegui", specifier = ">=2.0" },
+    { name = "nicegui", specifier = ">=3.0" },
     { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },


### PR DESCRIPTION
Three small, independently-shipped fixes plus a patch version bump to 2.19.8.

## #382 — nicegui floor too low
`pyproject.toml` declared `nicegui>=2.0` but `gui.py` imports `ClientConnectionTimeout` at module load, a class that first exists in nicegui 3.0.0. `uv.lock` pins 3.12.0 and CI installs from the lock, so the floor was never exercised; an environment resolving nicegui 2.x failed with `ImportError` on import. Raised the floor to `nicegui>=3.0` with an inline comment, and added a packaging test that walks each declared floor against the symbol requiring it.

## #156 — version test was collection-order sensitive
`test_version_is_read_from_module_attribute_not_package_metadata` accessed the `discord_ferry.cli` package attribute for `importlib.reload`, but a NiceGUI page-test collected earlier re-imports `discord_ferry` as a fresh package whose `cli` attribute is never re-set. The test now holds the submodule via `importlib.import_module` and reloads that reference, which is order-independent.

## #276 — credentials in --stoat_url leaked into API error messages
A credential embedded in `--stoat-url` as HTTP basic-auth userinfo (`https://user:pass@host`) reached `MigrationError` and `StoatConnectionError` text verbatim at eight sites. The `ferry build` path registers no secret, so nothing downstream could scrub it. New `redact_url` helper in `core/http.py` strips `user:password@` before the URL reaches any error message, applied at all eight sites.

## Verification
`ruff check`, `ruff format --check`, `mypy src/` clean. `pytest` 2093 passed, 1 pre-existing failure unrelated to this branch (`test_the_summary_does_not_claim_an_exclusive_cause`, a Rich line-wrap issue in `cli.py` which these changes do not touch; fails in isolation on the unmodified tree).

## Deferrals
None. The `Connecting to {config.stoat_url}` progress message at `connect.py:43` is intentionally not redacted: it is a progress event, not an error message, and issue #276 scopes to "API error messages".