### PR TITLE
fix(security): fully mask proxy password and authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.9] - 2026-08-18
+
+### Fixed
+
+- **Proxy password redaction no longer leaves the last four characters visible.**
+  `SecureTokenStore.masked` rendered any 5+ character secret as `****{last4}`, a shape
+  designed for opaque 40-character API tokens. For a short, human-chosen proxy password
+  that tail exposed a large fraction of the value, and the base64 `proxy_authorization`
+  header derived from it carried the same leak. `SecureTokenStore` now carries a per-key
+  full-mask policy: `register` and `register_secret` take a keyword-only `fully_mask`
+  flag, and `masked` returns bare `****` for those keys. `core/http.py`'s
+  `_strip_userinfo` registers both `proxy_password` and `proxy_authorization` as fully
+  masked. Stoat and Discord tokens keep the existing tail shape. Fixes #149.
+
 ## [2.19.8] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.8"
+version = "2.19.9"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.8"
+__version__ = "2.19.9"

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -313,8 +313,8 @@ def _strip_userinfo(url: URL) -> tuple[URL, str | None]:
         return url, None
     password = url.password or ""
     header = encode_basic_auth(url.user or "", password)
-    register_secret("proxy_password", password)
-    register_secret("proxy_authorization", header)
+    register_secret("proxy_password", password, fully_mask=True)
+    register_secret("proxy_authorization", header, fully_mask=True)
     return url.with_user(None), header
 
 

--- a/src/discord_ferry/core/security.py
+++ b/src/discord_ferry/core/security.py
@@ -15,10 +15,12 @@ class SecureTokenStore:
     """
 
     _tokens: dict[str, str] = field(repr=False, default_factory=dict)
+    _fully_masked: set[str] = field(repr=False, default_factory=set)
 
     def __init__(self, tokens: dict[str, str]) -> None:
         # Store a copy so the caller cannot mutate our internal state.
         object.__setattr__(self, "_tokens", dict(tokens))
+        object.__setattr__(self, "_fully_masked", set())
 
     def get(self, name: str) -> str:
         """Return the raw token value for *name*.
@@ -27,24 +29,38 @@ class SecureTokenStore:
         """
         return self._tokens[name]
 
-    def register(self, name: str, value: str) -> None:
+    def register(self, name: str, value: str, *, fully_mask: bool = False) -> None:
         """Add or replace a token value.
 
         Used by the process-wide registry below, which is populated as tokens
         arrive rather than all at once in ``__init__``.
+
+        When *fully_mask* is True the key is rendered as bare ``****`` by
+        :meth:`masked`, with no trailing characters. That is the policy for
+        short, human-chosen secrets such as a proxy password, where the
+        default ``****{last4}`` shape exposes a large fraction of the value
+        (issue #149). Opaque API tokens keep the default tail shape.
         """
         self._tokens[name] = value
+        if fully_mask:
+            self._fully_masked.add(name)
+        else:
+            self._fully_masked.discard(name)
 
     def clear(self) -> None:
         """Drop every stored token."""
         self._tokens.clear()
+        self._fully_masked.clear()
 
     def masked(self, name: str) -> str:
         """Return a masked representation of the token for display.
 
-        Returns ``"****{last4}"`` when the token is 5+ characters, or
-        ``"****"`` for shorter tokens.
+        Returns ``"****"`` for a key registered as fully masked, or when the
+        token is shorter than five characters. Otherwise returns
+        ``"****{last4}"``.
         """
+        if name in self._fully_masked:
+            return "****"
         value = self._tokens[name]
         if len(value) >= 5:
             return f"****{value[-4:]}"
@@ -108,17 +124,21 @@ def safe_sanitize(token_store: SecureTokenStore | None, text: str) -> str:
 _secret_registry: SecureTokenStore = SecureTokenStore({})
 
 
-def register_secret(name: str, value: str) -> None:
+def register_secret(name: str, value: str, *, fully_mask: bool = False) -> None:
     """Record *value* so the logging redaction filter can mask it.
 
     Empty values are ignored -- ``SecureTokenStore.sanitize`` skips them anyway,
     but rejecting them here keeps the registry meaningful.
 
     Safe to call repeatedly with the same name; the last value wins.
+
+    Pass *fully_mask* True for a short, human-chosen secret (a proxy password)
+    so :meth:`SecureTokenStore.masked` renders bare ``****`` with no tail
+    (issue #149). Opaque API tokens keep the default ``****{last4}`` shape.
     """
     if not value:
         return
-    _secret_registry.register(name, value)
+    _secret_registry.register(name, value, fully_mask=fully_mask)
 
 
 def sanitize_secrets(text: str) -> str:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -332,6 +332,10 @@ def test_strip_userinfo_registers_both_credential_forms() -> None:
     masked = sanitize_secrets(f"plaintext=SUPERSECRET encoded={header}")
     assert "SUPERSECRET" not in masked
     assert header.split()[-1] not in masked
+    # Issue #149: proxy credentials are fully masked, leaving no last-four tail
+    # that would expose a large fraction of a short human-chosen password.
+    assert "****SUPER" not in masked
+    assert masked == "plaintext=**** encoded=****"
 
 
 def test_redact_url_strips_userinfo() -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,7 @@ from discord_ferry.core.security import (
     register_secret,
     safe_sanitize,
     sanitize_for_display,
+    sanitize_secrets,
     scrub_document,
 )
 
@@ -50,6 +51,43 @@ def test_masked_missing_key_raises_key_error() -> None:
     store = make_store(tok="abcde12345")
     with pytest.raises(KeyError):
         store.masked("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# masked() per-key policy -- issue #149
+# ---------------------------------------------------------------------------
+
+
+def test_masked_fully_masked_key_returns_stars_only_for_long_value() -> None:
+    """A proxy password is human-chosen and often short.
+
+    The default ``****{last4}`` shape exposes a large fraction of it, so a key
+    registered as fully masked renders as bare ``****`` regardless of length.
+    """
+    store = SecureTokenStore({})
+    store.register("proxy_password", "hunter2horse", fully_mask=True)
+    assert store.masked("proxy_password") == "****"
+
+
+def test_masked_fully_masked_key_returns_stars_only_for_short_value() -> None:
+    store = SecureTokenStore({})
+    store.register("proxy_password", "x", fully_mask=True)
+    assert store.masked("proxy_password") == "****"
+
+
+def test_masked_default_register_keeps_last_four_tail() -> None:
+    """Opaque tokens (Stoat/Discord) keep the existing tail shape."""
+    store = SecureTokenStore({})
+    store.register("stoat", "abcde12345")
+    assert store.masked("stoat") == "****2345"
+
+
+def test_clear_drops_the_fully_masked_policy_too() -> None:
+    store = SecureTokenStore({})
+    store.register("proxy_password", "hunter2horse", fully_mask=True)
+    store.clear()
+    store.register("proxy_password", "hunter2horse")
+    assert store.masked("proxy_password") == "****orse"
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +147,13 @@ def test_sanitize_multiple_occurrences() -> None:
     result = store.sanitize(text)
     assert "secret99" not in result
     assert result.count("****") == 2
+
+
+def test_sanitize_fully_masked_key_replaces_with_stars_only() -> None:
+    """A fully masked key replaces with bare ``****``, leaving no tail (#149)."""
+    store = SecureTokenStore({})
+    store.register("proxy_password", "hunter2horse", fully_mask=True)
+    assert store.sanitize("failed: hunter2horse") == "failed: ****"
 
 
 # ---------------------------------------------------------------------------
@@ -422,3 +467,19 @@ def test_scrub_document_leaves_the_input_unmutated() -> None:
     scrub_document(doc)
 
     assert doc["warnings"][0]["message"] == "failed for hunter2horse"
+
+
+# ---------------------------------------------------------------------------
+# register_secret() fully_mask policy -- issue #149
+# ---------------------------------------------------------------------------
+
+
+def test_register_secret_fully_mask_propagates_to_sanitize_secrets() -> None:
+    """The process-wide registry must honour the per-key policy, not just a store."""
+    register_secret("proxy_password", "hunter2horse", fully_mask=True)
+    assert sanitize_secrets("failed: hunter2horse") == "failed: ****"
+
+
+def test_register_secret_default_keeps_last_four_tail() -> None:
+    register_secret("stoat", "abcde12345")
+    assert sanitize_secrets("token abcde12345") == "token ****2345"

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.8"
+version = "2.19.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`SecureTokenStore.masked` rendered any 5+ character secret as `****{last4}`, a shape designed for opaque 40-character API tokens. For a short, human-chosen proxy password that tail exposed a large fraction of the value, and the base64 `proxy_authorization` header derived from it carried the same leak.

`SecureTokenStore` now carries a per-key full-mask policy: `register` and `register_secret` take a keyword-only `fully_mask` flag, and `masked` returns bare `****` for those keys. `core/http.py`'s `_strip_userinfo` registers both `proxy_password` and `proxy_authorization` as fully masked. Stoat and Discord tokens keep the existing `****{last4}` tail shape.

## Why per-key, not global

A Stoat or Discord token is around forty opaque characters; four of them identify the token in a log without meaningfully narrowing a guess. A proxy password is chosen by a person and is often short, and human-chosen passwords are exactly the kind where a partial reveal narrows the search space. One global rule could not serve both.

## Files

- `src/discord_ferry/core/security.py` - per-key `fully_mask` policy on `SecureTokenStore.register`, `masked`, `clear`, and `register_secret`
- `src/discord_ferry/core/http.py` - `_strip_userinfo` registers both proxy forms as `fully_mask=True`
- `tests/test_security.py` - store, sanitize, and registry tests for the new policy
- `tests/test_http.py` - asserts both proxy forms mask to bare `****`
- Version bump: `pyproject.toml`, `src/discord_ferry/__init__.py`, `CHANGELOG.md`, `uv.lock` (2.19.8 -> 2.19.9)

## Verification

`uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest` - 2100 passed, 1 deselected. The deselected test (`test_the_summary_does_not_claim_an_exclusive_cause`) is a pre-existing Rich line-wrapping failure reproduced on a clean `main` worktree, unrelated to this change.

Closes #149