### PR TITLE
fix(test): normalise whitespace in check summary assertion (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.10] - 2026-08-19
+
+### Fixed
+
+- **`ferry check` summary assertion no longer fails at narrow terminal widths.**
+  Rich wraps text inside its panel at the panel's own width, not the terminal's, so
+  the substring match on the summary phrase broke when a newline landed mid-phrase.
+  The test now normalises whitespace before the check. Fixes #437.
+
 ## [2.19.9] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.9"
+version = "2.19.10"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.9"
+__version__ = "2.19.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2521,7 +2521,8 @@ def test_the_summary_does_not_claim_an_exclusive_cause(runner: CliRunner, tmp_pa
             result = runner.invoke(
                 main, ["check", str(tmp_path), "--stoat-url", "https://api.test", "--token", "t"]
             )
-        assert "Each result above says which cause applies" in result.output, (
+        normalised = " ".join(result.output.split())
+        assert "Each result above says which cause applies" in normalised, (
             f"the {strategy} summary does not point at the per-result detail"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.9"
+version = "2.19.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Normalise whitespace before the substring assertion in `test_the_summary_does_not_claim_an_exclusive_cause`.** Rich wraps text inside its Panel at the panel's own width, not the terminal's, so the phrase "Each result above says which cause applies" gets split by a newline at narrow widths and the `in` check fails.
- The fix collapses whitespace with `" ".join(result.output.split())` before the assertion.

## Test plan

- [x] Reproduced: `COLUMNS=60 uv run pytest tests/test_cli.py::test_the_summary_does_not_claim_an_exclusive_cause` fails on main
- [x] Fixed: same command passes on this branch
- [x] Full suite: 2101 passed

Closes #437

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VXKnkmtW3Pdao8aLvMVCdU
