### PR TITLE
fix(channels): cap channel topic at 1024 chars before sending to Stoat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.11] - 2026-08-19
+
+### Fixed
+
+- **Channel topics are capped at 1024 characters before reaching the Stoat API.**
+  Discord and Stoat both enforce a 1024-character limit on channel descriptions, so a
+  valid export never exceeds it. The cap is defense-in-depth for corrupt or hand-edited
+  exports, applied at both the migration and repair create paths. Fixes #343.
+
 ## [2.19.10] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.10"
+version = "2.19.11"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.10"
+__version__ = "2.19.11"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1719,7 +1719,7 @@ async def _recreate_channel(
         state.stoat_server_id,
         name=unique_name,
         channel_type=_stoat_channel_type(export.channel.type),
-        description=export.channel.topic or None,
+        description=export.channel.topic[:1024] or None,
     )
     # `_id` here, `id` for roles. Upstream's spelling, not ours.
     new_id: str = created["_id"]

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -1278,7 +1278,7 @@ async def run_channels(
             channels_to_create, start=1
         ):
             ch: DCEChannel = channel
-            description = ch.topic if ch.topic else None
+            description = ch.topic[:1024] if ch.topic else None
 
             ch_meta = discord_metadata.channel_metadata.get(ch.id) if discord_metadata else None
             nsfw = ch_meta.nsfw if ch_meta else False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3312,6 +3312,18 @@ async def test_a_recreated_voice_channel_is_recreated_as_voice(tmp_path: Path) -
     assert sent.get("type") == "Voice", f"a voice channel was recreated as {sent.get('type')}"
 
 
+async def test_repair_truncates_a_long_channel_topic(tmp_path: Path) -> None:
+    """A topic longer than 1024 chars is truncated before reaching the Stoat API."""
+    long_topic = "t" * 2000
+    _, sent, _ = await _repair_recreating_channel(
+        tmp_path, exports=[_export_for(R_D_CHANNEL, topic=long_topic)]
+    )
+    assert sent is not None, "no channel was created"
+    desc = sent.get("description")
+    assert desc is not None, "description was not sent"
+    assert len(desc) == 1024
+
+
 async def test_repair_declines_a_channel_missing_from_the_export(tmp_path: Path) -> None:
     """A KNOWN LIMIT, not a missing feature.
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1380,6 +1380,33 @@ async def test_run_channels_passes_nsfw_flag(tmp_path: Path) -> None:
     assert created_bodies[0].get("nsfw") is True
 
 
+async def test_run_channels_truncates_long_topic(tmp_path: Path) -> None:
+    """A channel topic longer than 1024 chars is truncated before reaching Stoat."""
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+
+    export = _make_export(channel_id="ch1", channel_name="chatty", category_id="")
+    export.channel.topic = "x" * 2000
+
+    created_bodies: list[dict[str, object]] = []
+
+    with aioresponses() as m:
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch1", "name": "chatty"},
+            callback=lambda url, **kwargs: created_bodies.append(  # type: ignore[misc]
+                kwargs.get("json", {})
+            ),
+        )
+        await run_channels(config, state, [export], events.append)
+
+    assert len(created_bodies) == 1
+    desc = created_bodies[0].get("description")
+    assert desc is not None
+    assert len(desc) == 1024  # type: ignore[arg-type]
+
+
 async def test_channel_slowmode_and_user_limit_applied(tmp_path: Path) -> None:
     """CHANNELS phase PATCHes slowmode (text) and voice.max_users (voice)."""
     events: list[MigrationEvent] = []

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.10"
+version = "2.19.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Cap channel topics at 1024 characters before sending to the Stoat API, at both the migration (`structure.py`) and repair (`engine.py`) create paths
- Stoat's server-side limit is 1024 (verified against `revoltchat/backend` main, `DataCreateServerChannel.description` validated `length(min = 0, max = 1024)`), matching Discord's own 1024-char topic limit
- Defense-in-depth for corrupt or hand-edited DCE exports; a valid export never exceeds the limit

## Test plan

- [x] New test: `test_run_channels_truncates_long_topic` (2000-char topic truncated to 1024 at channel create)
- [x] New test: `test_repair_truncates_a_long_channel_topic` (same for the repair recreate path)
- [x] Full suite passes (2103 tests)
- [x] Audited all `.topic` references reaching Stoat API: two call sites, both capped
- [x] Voice-fallback retry reuses the same already-truncated variable

Closes #343

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
