### PR TITLE
fix(threads): sanitize thread archive filenames for cross-platform safety (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.12] - 2026-08-19
+
+### Fixed
+
+- **Thread archive no longer crashes on thread names with filesystem-illegal characters.**
+  Discord thread names are free-form and can contain characters that are illegal in
+  filenames on Windows (`< > : " \ | ? *`) or that create subdirectories on POSIX (`/`).
+  Both the parent channel name and thread name are now sanitized before constructing the
+  archive path. Win32 reserved device names (`CON`, `NUL`, etc.) are also handled.
+  Two threads whose names sanitize to the same string now produce distinct files instead
+  of silently overwriting each other. Fixes #173.
+
 ## [2.19.11] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.11"
+version = "2.19.12"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.11"
+__version__ = "2.19.12"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -12,7 +12,7 @@ from discord_ferry.core.events import MigrationEvent
 from discord_ferry.core.security import safe_sanitize
 from discord_ferry.errors import DuplicateSendError
 from discord_ferry.migrator.api import api_send_message, get_rate_multiplier, get_session
-from discord_ferry.migrator.sanitize import truncate_name
+from discord_ferry.migrator.sanitize import sanitize_filename, truncate_name
 from discord_ferry.parser.dce_parser import check_cdn_url_expiry, stream_messages
 from discord_ferry.parser.transforms import (
     convert_spoilers,
@@ -851,12 +851,21 @@ def _archive_threads(
     Creates ``{output_dir}/threads/{parent_channel_name}/{thread_name}.md``
     with each message formatted as a markdown heading with author and timestamp.
     """
+    used_names: dict[str, dict[str, int]] = {}
     for export in thread_exports:
-        parent_name = export.parent_channel_name or "uncategorized"
+        parent_name = sanitize_filename(export.parent_channel_name or "uncategorized")
         thread_dir = config.output_dir / "threads" / parent_name
         thread_dir.mkdir(parents=True, exist_ok=True)
 
-        md_path = thread_dir / f"{export.channel.name}.md"
+        base_name = sanitize_filename(export.channel.name)
+        dir_used = used_names.setdefault(parent_name, {})
+        if base_name in dir_used:
+            dir_used[base_name] += 1
+            final_name = f"{base_name}_{dir_used[base_name]}"
+        else:
+            dir_used[base_name] = 1
+            final_name = base_name
+        md_path = thread_dir / f"{final_name}.md"
 
         if export.json_path is not None:
             message_source = stream_messages(export.json_path)

--- a/src/discord_ferry/migrator/sanitize.py
+++ b/src/discord_ferry/migrator/sanitize.py
@@ -1,4 +1,4 @@
-"""String sanitization helpers for Stoat API field limits."""
+"""String sanitization helpers for Stoat API field limits and filesystem safety."""
 
 from __future__ import annotations
 
@@ -9,6 +9,35 @@ _DEFAULT_MAX_LENGTH = 32
 
 # Emoji names must match ^[a-z0-9_]+$ per OpenAPI spec.
 _EMOJI_NAME_RE = re.compile(r"[^a-z0-9_]")
+
+# Characters illegal in filenames on Windows (and / on all platforms).
+_FS_ILLEGAL_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+# Win32 reserved device names (case-insensitive, with or without extension).
+_WIN32_RESERVED = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
+
+def sanitize_filename(name: str, *, max_length: int = 200) -> str:
+    """Make a string safe for use as a filename on all platforms.
+
+    Replaces Windows-illegal characters and forward slash with underscores,
+    strips leading/trailing dots and spaces (invalid on Windows), avoids
+    reserved device names, and truncates to *max_length*.
+
+    Returns ``"_"`` for an empty or all-whitespace input.
+    """
+    sanitized = _FS_ILLEGAL_RE.sub("_", name)
+    sanitized = sanitized.strip(". ")
+    if not sanitized:
+        return "_"
+    stem = sanitized.rsplit(".", 1)[0] if "." in sanitized else sanitized
+    if stem.upper() in _WIN32_RESERVED:
+        sanitized = f"_{sanitized}"
+    return sanitized[:max_length]
 
 
 def truncate_name(name: str, max_length: int = _DEFAULT_MAX_LENGTH, *, author_id: str = "") -> str:

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,6 +1,6 @@
 """Tests for string sanitization helpers."""
 
-from discord_ferry.migrator.sanitize import sanitize_emoji_name, truncate_name
+from discord_ferry.migrator.sanitize import sanitize_emoji_name, sanitize_filename, truncate_name
 
 # ---------------------------------------------------------------------------
 # truncate_name
@@ -188,3 +188,65 @@ def test_sanitize_emoji_non_colliding_unchanged() -> None:
     """SC-26: a non-colliding name is unchanged."""
     used: dict[str, int] = {}
     assert sanitize_emoji_name("unique", used) == "unique"
+
+
+# ---------------------------------------------------------------------------
+# sanitize_filename
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_filename_safe_name_unchanged() -> None:
+    """A name with no illegal characters passes through."""
+    assert sanitize_filename("my-thread") == "my-thread"
+
+
+def test_sanitize_filename_replaces_windows_illegal_chars() -> None:
+    """Characters illegal on Windows are replaced with underscores."""
+    assert sanitize_filename('bug: crash? "yes"') == "bug_ crash_ _yes_"
+
+
+def test_sanitize_filename_replaces_slash() -> None:
+    """Forward slash would create a subdirectory on POSIX."""
+    assert sanitize_filename("a/b") == "a_b"
+
+
+def test_sanitize_filename_replaces_backslash() -> None:
+    """Backslash is illegal on Windows."""
+    assert sanitize_filename("a\\b") == "a_b"
+
+
+def test_sanitize_filename_strips_dots_and_spaces() -> None:
+    """Leading/trailing dots and spaces are invalid on Windows."""
+    assert sanitize_filename("...hidden...") == "hidden"
+    assert sanitize_filename("  spaced  ") == "spaced"
+
+
+def test_sanitize_filename_empty_fallback() -> None:
+    """Empty or whitespace-only input returns underscore."""
+    assert sanitize_filename("") == "_"
+    assert sanitize_filename("   ") == "_"
+
+
+def test_sanitize_filename_reserved_device_name() -> None:
+    """Win32 reserved names are prefixed with underscore."""
+    assert sanitize_filename("CON") == "_CON"
+    assert sanitize_filename("com1") == "_com1"
+    assert sanitize_filename("NUL.txt") == "_NUL.txt"
+
+
+def test_sanitize_filename_truncates() -> None:
+    """Long names are truncated to max_length."""
+    name = "a" * 300
+    assert len(sanitize_filename(name)) == 200
+    assert len(sanitize_filename(name, max_length=50)) == 50
+
+
+def test_sanitize_filename_control_characters() -> None:
+    """Control characters (0x00-0x1f) are replaced."""
+    assert sanitize_filename("hello\x00world\x1f") == "hello_world_"
+
+
+def test_sanitize_filename_preserves_unicode() -> None:
+    """Emoji, CJK, and other Unicode characters pass through unchanged."""
+    assert sanitize_filename("thread-\U0001f680-launch") == "thread-\U0001f680-launch"
+    assert sanitize_filename("测试线程") == "测试线程"

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -322,6 +322,86 @@ async def test_archive_mode_no_api_calls(tmp_path: Path) -> None:
     assert md_path.exists()
 
 
+async def test_archive_mode_sanitizes_hostile_thread_name(tmp_path: Path) -> None:
+    """A thread named with filesystem-illegal characters writes without error."""
+    config = _make_config(tmp_path, thread_strategy="archive", message_rate_limit=0.0)
+    state = MigrationState(
+        stoat_server_id="srv1",
+        autumn_url=AUTUMN_URL,
+    )
+    state.channel_map["100"] = "stoat-ch-100"
+    events: list[MigrationEvent] = []
+
+    parent = _make_export(
+        channel_id="100",
+        channel_name="general",
+        messages=[],
+        message_count=0,
+    )
+    thread = _make_export(
+        channel_id="200",
+        channel_name='bug: crash? "yes"',
+        is_thread=True,
+        parent_channel_name="genera/l",
+        messages=[_make_message("m2", "hostile name msg")],
+        message_count=1,
+    )
+
+    with aioresponses():
+        await run_messages(config, state, [parent, thread], events.append)
+
+    threads_dir = tmp_path / "threads"
+    assert threads_dir.exists(), "threads directory was not created"
+    parent_dirs = list(threads_dir.iterdir())
+    assert len(parent_dirs) == 1
+    md_files = list(parent_dirs[0].iterdir())
+    assert len(md_files) == 1
+    content = md_files[0].read_text(encoding="utf-8")
+    assert "hostile name msg" in content
+
+
+async def test_archive_mode_collision_produces_distinct_files(tmp_path: Path) -> None:
+    """Two threads that sanitize to the same filename get distinct archive files."""
+    config = _make_config(tmp_path, thread_strategy="archive", message_rate_limit=0.0)
+    state = MigrationState(
+        stoat_server_id="srv1",
+        autumn_url=AUTUMN_URL,
+    )
+    state.channel_map["100"] = "stoat-ch-100"
+
+    parent = _make_export(
+        channel_id="100",
+        channel_name="general",
+        messages=[],
+        message_count=0,
+    )
+    thread_a = _make_export(
+        channel_id="200",
+        channel_name="Q&A?",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("m1", "first thread")],
+        message_count=1,
+    )
+    thread_b = _make_export(
+        channel_id="300",
+        channel_name="Q&A/",
+        is_thread=True,
+        parent_channel_name="general",
+        messages=[_make_message("m2", "second thread")],
+        message_count=1,
+    )
+
+    with aioresponses():
+        await run_messages(config, state, [parent, thread_a, thread_b], lambda e: None)
+
+    md_files = sorted((tmp_path / "threads" / "general").iterdir())
+    assert len(md_files) == 2, f"expected 2 archive files, got {[f.name for f in md_files]}"
+    contents = [f.read_text(encoding="utf-8") for f in md_files]
+    assert any("first thread" in c for c in contents)
+    assert any("second thread" in c for c in contents)
+
+
 # ---------------------------------------------------------------------------
 # Thread sorting tests
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.11"
+version = "2.19.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Sanitize thread and parent channel names** before using them as filesystem paths in the thread archive writer, replacing Windows-illegal characters, forward slashes, control characters, and Win32 reserved device names
- **Add per-directory collision tracking** so two threads whose names sanitize to the same string produce distinct files instead of silently overwriting each other
- **New `sanitize_filename` helper** in `sanitize.py`, alongside the existing `sanitize_emoji_name` and `truncate_name`

## Test plan

- [x] 10 unit tests for `sanitize_filename` covering: safe passthrough, Windows-illegal chars, slashes, backslashes, dots/spaces stripping, empty fallback, reserved device names, truncation, control characters, Unicode preservation
- [x] Integration test with hostile thread name and hostile parent
- [x] Integration test for name collision (two threads producing distinct archive files)
- [x] `uv run ruff check . && ruff format --check . && mypy src/ && pytest` all green

Closes #173

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXKnkmtW3Pdao8aLvMVCdU
