### PR TITLE
fix(reactions): render custom emoji in text-mode reaction summaries (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.13] - 2026-08-19
+
+### Fixed
+
+- **Custom emoji in text-mode reactions now render as actual emoji instead of plain names.**
+  When `reaction_mode` is `text`, reaction summaries appended to messages used the Discord
+  emoji name (e.g. `pepe`) for custom emoji. They now use the Stoat emoji syntax
+  (`:stoat_id:`) for migrated emoji, which Stoat renders as the image, or a `[:name:]`
+  fallback for emoji that were not migrated. Unicode emoji are unchanged. The same fix
+  applies to the `[Original counts: ...]` annotation in native mode. Fixes #439.
+
 ## [2.19.12] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.12"
+version = "2.19.13"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.12"
+__version__ = "2.19.13"

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -35,7 +35,13 @@ if TYPE_CHECKING:
 
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
-    from discord_ferry.parser.models import DCEAuthor, DCEExport, DCEMessage, DCEReaction
+    from discord_ferry.parser.models import (
+        DCEAuthor,
+        DCEEmoji,
+        DCEExport,
+        DCEMessage,
+        DCEReaction,
+    )
     from discord_ferry.state import MigrationState
 
 _THREAD_STRATEGIES = frozenset({"flatten", "merge", "archive"})
@@ -228,12 +234,31 @@ def _skip_attachment_to_result(
     return f"[{reason}]"
 
 
-def _build_reaction_text(reactions: list[DCEReaction], max_chars: int) -> str:
+def _reaction_emoji_display(emoji: DCEEmoji, emoji_map: dict[str, str]) -> str:
+    """Return the display string for a reaction emoji.
+
+    Mapped custom emoji render as ``:stoat_id:``, unmapped as ``[:name:]``,
+    and Unicode emoji pass through unchanged.
+    """
+    if emoji.id:
+        stoat_id = emoji_map.get(emoji.id)
+        if stoat_id:
+            return f":{stoat_id}:"
+        return f"[:{emoji.name}:]"
+    return emoji.name
+
+
+def _build_reaction_text(
+    reactions: list[DCEReaction],
+    max_chars: int,
+    emoji_map: dict[str, str] | None = None,
+) -> str:
     """Build a text summary of reactions within a character budget.
 
     Args:
         reactions: Parsed reactions with emoji name and count.
         max_chars: Maximum characters available.
+        emoji_map: Discord emoji ID to Stoat emoji ID mapping.
 
     Returns:
         Formatted string like ``\\n[Reactions: thumbsup 12 · tada 5]``
@@ -241,7 +266,8 @@ def _build_reaction_text(reactions: list[DCEReaction], max_chars: int) -> str:
     """
     if not reactions or max_chars <= 0:
         return ""
-    valid = [(r.emoji.name, r.count) for r in reactions if r.count > 0]
+    emap = emoji_map or {}
+    valid = [(_reaction_emoji_display(r.emoji, emap), r.count) for r in reactions if r.count > 0]
     if not valid:
         return ""
     parts = [f"{name} {count}" for name, count in valid]
@@ -1445,13 +1471,15 @@ async def _process_message(
         # Budget is best-effort — overflow text may be appended after this.
         # Step 7 truncation (2000 chars) is the true safety net.
         remaining = 2000 - len(content)
-        reaction_text = _build_reaction_text(msg.reactions, remaining)
+        reaction_text = _build_reaction_text(msg.reactions, remaining, state.emoji_map)
         content += reaction_text
 
     # Step 6b2: Append reaction count annotations in native mode (counts > 1 only).
     if _effective_mode == "native" and msg.reactions:
         count_annotations = [
-            f"{r.emoji.name} \u00d7{r.count}" for r in msg.reactions if r.count > 1
+            f"{_reaction_emoji_display(r.emoji, state.emoji_map)} \u00d7{r.count}"
+            for r in msg.reactions
+            if r.count > 1
         ]
         if count_annotations:
             annotation = f"\n[Original counts: {', '.join(count_annotations)}]"

--- a/tests/test_reactions_text.py
+++ b/tests/test_reactions_text.py
@@ -44,6 +44,27 @@ def test_all_included_with_large_budget() -> None:
         assert f"e{i}" in result
 
 
-def test_custom_emoji_uses_name() -> None:
-    result = _build_reaction_text([_r("pepe", 5, eid="12345")], 500)
-    assert "pepe" in result and "12345" not in result
+def test_custom_emoji_mapped_uses_stoat_id() -> None:
+    emoji_map = {"12345": "stoat_abc"}
+    result = _build_reaction_text([_r("pepe", 5, eid="12345")], 500, emoji_map)
+    assert ":stoat_abc:" in result
+    assert "pepe" not in result
+
+
+def test_custom_emoji_unmapped_uses_bracketed_name() -> None:
+    result = _build_reaction_text([_r("pepe", 5, eid="12345")], 500, {})
+    assert "[:pepe:]" in result
+    assert "12345" not in result
+
+
+def test_mixed_unicode_and_custom_emoji() -> None:
+    emoji_map = {"111": "stoat_fire"}
+    reactions = [
+        _r("\U0001f44d", 3),
+        _r("fire", 2, eid="111"),
+        _r("catjam", 1, eid="999"),
+    ]
+    result = _build_reaction_text(reactions, 500, emoji_map)
+    assert "\U0001f44d 3" in result
+    assert ":stoat_fire: 2" in result
+    assert "[:catjam:] 1" in result

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.12"
+version = "2.19.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Custom emoji in text-mode reaction summaries now render as actual emoji** instead of plain Discord names. Mapped emoji use `:stoat_id:` syntax (rendered by the Stoat client as the image), unmapped emoji fall back to `[:name:]`, matching the existing `remap_emoji` pattern for message content
- **Same fix applied to the native-mode `[Original counts: ...]` annotation**, which also displayed custom emoji as bare names
- **New `_reaction_emoji_display` helper** shared by both call sites, consistent with the `remap_emoji` transform in `transforms.py`

## Test plan

- [x] 10 unit tests for `_build_reaction_text`: existing tests pass with new `emoji_map` param, plus 3 new tests covering mapped custom emoji, unmapped fallback, and mixed Unicode + custom
- [x] `uv run ruff check . && ruff format --check . && mypy src/ && pytest` all green (2117 tests)
- [x] Code review: no issues found
- [x] Second opinion (Mistral): 5 findings, 0 confirmed

Closes #439

Generated with [Claude Code](https://claude.com/claude-code)