### PR TITLE
fix(avatars): add dry-run guard and improve download failure diagnostics (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.14] - 2026-08-19
+
+### Fixed
+
+- **Dry-run mode no longer crashes in the avatars phase.** The avatars phase was the only
+  mutating phase missing a `config.dry_run` early-return guard. During a dry run it attempted
+  to upload avatars to the placeholder Autumn URL (`dry-run.invalid`), producing a connection
+  error. The phase now populates `state.avatar_cache` with synthetic IDs and returns early,
+  matching the pattern used by every other phase. Fixes #438.
+
+- **Avatar download failure warnings now include the specific failure reason** (e.g.
+  "HTTP 404" or "non-image Content-Type 'text/html'") instead of the generic
+  "non-image content type or HTTP error" message.
+
 ## [2.19.13] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.13"
+version = "2.19.14"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.13"
+__version__ = "2.19.14"

--- a/src/discord_ferry/migrator/avatars.py
+++ b/src/discord_ferry/migrator/avatars.py
@@ -51,7 +51,7 @@ async def _download_remote_avatar(
     url: str,
     output_dir: Path,
     author_id: str,
-) -> Path | None:
+) -> tuple[Path | None, str]:
     """Download a remote avatar image and save it locally.
 
     Args:
@@ -61,13 +61,14 @@ async def _download_remote_avatar(
         author_id: Discord author ID, used as the filename stem.
 
     Returns:
-        Path to the downloaded file, or ``None`` if the download failed.
+        Tuple of (path to downloaded file or ``None``, failure reason or empty
+        string on success).
     """
     try:
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
             if resp.status != 200:
                 logger.warning("Avatar download returned status %d for %s", resp.status, url)
-                return None
+                return None, f"HTTP {resp.status}"
 
             content_type = resp.headers.get("Content-Type", "")
             if not content_type.startswith("image/"):
@@ -76,7 +77,7 @@ async def _download_remote_avatar(
                     content_type,
                     url,
                 )
-                return None
+                return None, f"non-image Content-Type '{content_type}'"
 
             # Derive extension from URL path, falling back to .webp.
             url_path = PurePosixPath(url.split("?")[0])
@@ -88,10 +89,10 @@ async def _download_remote_avatar(
 
             data = await resp.read()
             dest.write_bytes(data)
-            return dest
+            return dest, ""
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to download avatar from %s: %s", url, exc)
-        return None
+        return None, str(exc)
 
 
 async def run_avatars(
@@ -135,6 +136,18 @@ async def run_avatars(
         return
 
     total = len(to_upload)
+
+    if config.dry_run:
+        for author_id in to_upload:
+            state.avatar_cache[author_id] = f"dry-avatar-{author_id}"
+        on_event(
+            MigrationEvent(
+                phase="avatars",
+                status="completed",
+                message=f"[DRY RUN] Mapped {total} avatars",
+            )
+        )
+        return
     uploaded = 0
     failed = 0
     _last_save_time = time.monotonic()
@@ -170,7 +183,7 @@ async def run_avatars(
             try:
                 if avatar_url.startswith("http://") or avatar_url.startswith("https://"):
                     # Remote URL — download first.
-                    file_path = await _download_remote_avatar(
+                    file_path, fail_reason = await _download_remote_avatar(
                         session, avatar_url, config.output_dir, author_id
                     )
                     if file_path is None:
@@ -179,8 +192,7 @@ async def run_avatars(
                                 "phase": "avatars",
                                 "type": "avatar_download_failed",
                                 "message": (
-                                    f"Failed to download avatar for {author.name} "
-                                    f"(non-image content type or HTTP error)"
+                                    f"Failed to download avatar for {author.name} ({fail_reason})"
                                 ),
                             }
                         )

--- a/tests/test_avatars.py
+++ b/tests/test_avatars.py
@@ -422,3 +422,84 @@ async def test_avatars_time_throttle_no_premature_save(tmp_path: Path) -> None:
 
     assert save_mock.call_count == 0
     assert set(state.avatar_cache.values()) == {"a0", "a1", "a2"}
+
+
+# ---------------------------------------------------------------------------
+# Dry-run guard (#438)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_avatars_dry_run_maps_without_upload(tmp_path: Path) -> None:
+    """Dry-run populates avatar_cache with synthetic IDs, no network calls."""
+    author1 = _make_author("user1", "Alice", avatar_url="avatar_user1.webp")
+    author2 = _make_author("user2", "Bob", avatar_url="avatar_user2.webp")
+    export = _make_export([_make_message("m1", author1), _make_message("m2", author2)])
+    config = _make_config(tmp_path, dry_run=True)
+    state = _make_state()
+    events: list[MigrationEvent] = []
+
+    with patch(
+        "discord_ferry.migrator.avatars.upload_with_cache",
+        new=AsyncMock(return_value="should-not-be-called"),
+    ) as mock_upload:
+        await run_avatars(config, state, [export], events.append)
+
+    mock_upload.assert_not_called()
+    assert state.avatar_cache == {
+        "user1": "dry-avatar-user1",
+        "user2": "dry-avatar-user2",
+    }
+    assert state.autumn_uploads == {}
+    assert state.referenced_autumn_ids == set()
+    completed = [e for e in events if e.status == "completed"]
+    assert completed
+    assert "[DRY RUN]" in completed[-1].message
+    assert "2" in completed[-1].message
+
+
+async def test_run_avatars_dry_run_skips_cached(tmp_path: Path) -> None:
+    """Dry-run does not re-map authors already in avatar_cache."""
+    author1 = _make_author("user1", "Alice", avatar_url="avatar_user1.webp")
+    author2 = _make_author("user2", "Bob", avatar_url="avatar_user2.webp")
+    export = _make_export([_make_message("m1", author1), _make_message("m2", author2)])
+    config = _make_config(tmp_path, dry_run=True)
+    state = _make_state()
+    state.avatar_cache["user1"] = "already-cached"
+    events: list[MigrationEvent] = []
+
+    await run_avatars(config, state, [export], events.append)
+
+    assert state.avatar_cache["user1"] == "already-cached"
+    assert state.avatar_cache["user2"] == "dry-avatar-user2"
+    completed = [e for e in events if e.status == "completed"]
+    assert completed
+    assert "1" in completed[-1].message
+
+
+# ---------------------------------------------------------------------------
+# Download failure diagnostics (#438)
+# ---------------------------------------------------------------------------
+
+
+async def test_download_failure_includes_specific_reason(tmp_path: Path) -> None:
+    """Download failure warning includes specific reason, not generic text."""
+    author = _make_author("user1", "Alice", avatar_url="https://cdn.example.com/gone.webp")
+    export = _make_export([_make_message("m1", author)])
+    config = _make_config(tmp_path)
+    state = _make_state()
+    events: list[MigrationEvent] = []
+
+    async with aiohttp.ClientSession() as session:
+        config.session = session
+        with aioresponses() as mocked:
+            mocked.get("https://cdn.example.com/gone.webp", status=404)
+            with patch(
+                "discord_ferry.migrator.avatars.upload_with_cache",
+                new=AsyncMock(return_value="autumn_av1"),
+            ) as mock_upload:
+                await run_avatars(config, state, [export], events.append)
+
+    mock_upload.assert_not_called()
+    assert len(state.warnings) >= 1
+    warning_msg = state.warnings[0]["message"]
+    assert "HTTP 404" in warning_msg

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.13"
+version = "2.19.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Add `config.dry_run` early-return guard to `run_avatars`, matching the pattern in every
  other mutating phase. The phase now populates `avatar_cache` with synthetic IDs and
  returns early instead of attempting uploads to `dry-run.invalid`.
- Improve avatar download failure diagnostics: `_download_remote_avatar` now returns a
  tuple with the specific failure reason, which replaces the generic "non-image content
  type or HTTP error" message in warnings.

## Test plan

- [x] `test_run_avatars_dry_run_maps_without_upload`: dry-run populates cache, no uploads
- [x] `test_run_avatars_dry_run_skips_cached`: already-cached authors preserved
- [x] `test_download_failure_includes_specific_reason`: HTTP 404 in warning text
- [x] Full suite: 2120 passed

Fixes #438
