### PR TITLE
ci: bump actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Cache DCE binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.discord-ferry/bin/dce/2.47.3
           key: dce-${{ runner.os }}-2.47.3


### PR DESCRIPTION
## Summary

The Contract test (DCE binary) job pinned `actions/cache@v4`, which targets the deprecated Node 20 runtime. GitHub currently force-runs it on Node 24 with a warning; that will become a hard failure once the shim is removed.

`actions/cache@v5.0.1` is the first Node-24 major (requires runner 2.327.1+ per the upstream release notes). This matches the "lowest-Node-24-major principle" `architecture.md` already documents for `actions/checkout@v6` and `actions/upload-artifact@v6`.

One line, one file: `.github/workflows/ci.yml`. All other action pins in the workflow tree were already at Node-24 majors.

## Test plan

- [x] Every other `uses:` in `.github/**/*.yml` sits at a Node-24 major
- [ ] CI passes on this branch (particularly the Contract test job that touches the cache action)