### PR TITLE
fix(gui): show completion card after cancelled migration (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.15] - 2026-08-19
+
+### Fixed
+
+- **GUI now shows the completion card after a cancelled migration.** When a user cancelled
+  a migration mid-run, the Pause and Cancel buttons stayed on screen indefinitely and the
+  completion card (which carries the Rollback button) never appeared. The GUI now detects
+  that `cancel_event` was set after `run_migration` returns and transitions to a
+  "Migration Cancelled" view with the Rollback button enabled and Open Report disabled
+  (no report exists for a cancelled run). Fixes #385.
+
 ## [2.19.14] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.14"
+version = "2.19.15"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.14"
+__version__ = "2.19.15"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -1328,7 +1328,9 @@ async def migrate_page() -> None:
 
             # Completion card (hidden initially)
             with ui.card().classes("w-full mt-4 hidden") as completion_card:
-                ui.label("Migration Complete").classes("text-xl font-bold text-green-600")
+                completion_title = ui.label("Migration Complete").classes(
+                    "text-xl font-bold text-green-600"
+                )
                 ui.label("").classes("text-sm text-gray-500").bind_text_from(errors_label, "text")
                 native_fidelity_label = ui.label("").classes("text-sm text-gray-500")
                 native_fidelity_label.set_visibility(False)
@@ -1644,6 +1646,14 @@ async def migrate_page() -> None:
         progress_bar.set_value(1.0)
         ui.notify("Migration complete!", type="positive")
 
+    def _on_migration_cancelled() -> None:
+        controls_row.classes(add="hidden")
+        completion_card.classes(remove="hidden")
+        completion_title.set_text("Migration Cancelled")
+        completion_title.classes(remove="text-green-600", add="text-yellow-600")
+        open_report_btn.disable()
+        ui.notify("Migration cancelled. You can roll back the partial migration.", type="warning")
+
     def _start_rollback() -> None:
         """Launch a rollback in a background task.
 
@@ -1700,6 +1710,8 @@ async def migrate_page() -> None:
 
             try:
                 await run_migration(config, on_event=on_event)
+                if config.cancel_event and config.cancel_event.is_set():
+                    _on_migration_cancelled()
             except StateError as exc:
                 storage["resume"] = False
                 log_display.push(

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.14"
+version = "2.19.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- When a user cancelled a migration in the GUI, the completion card (which holds the Rollback button) never appeared because the engine skips the report phase on cancel, so the event that triggers the UI transition was never emitted
- After `run_migration` returns, `_run()` now checks `cancel_event.is_set()` and transitions to a "Migration Cancelled" view with Rollback enabled and Open Report disabled
- The CLI path is unaffected (it already handled cancellation correctly via state file + `ferry rollback`)

## Test plan

- [x] All 2120 tests pass
- [x] mypy, ruff lint and ruff format clean
- [ ] Manual: start a migration in the GUI, cancel mid-run, verify the completion card appears with "Migration Cancelled" in yellow and Rollback enabled

Closes #385
