### PR TITLE
docs(cli): clarify --incremental help text for re-export use case (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [2.19.15] - 2026-08-19
 
+### Changed
+
+- **`--incremental` help text now describes channel reuse and the re-export use case.** The old
+  text said "only migrate new messages since last completed run", which did not surface the
+  main reason users reach for it: continuing a migration after a partial or failed DCE export.
+  Addresses #440.
+
 ### Fixed
 
 - **GUI now shows the completion card after a cancelled migration.** When a user cancelled

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -511,7 +511,11 @@ _common_options = [
         "--incremental",
         is_flag=True,
         default=False,
-        help="Only migrate new messages since last completed run",
+        help=(
+            "Reuse channels and roles from a prior run in the same output dir,"
+            " sending only new messages. Use after a partial export or re-export"
+            " of the same server"
+        ),
     ),
     click.option("--verbose", "-v", is_flag=True, help="Debug output"),
     click.option(


### PR DESCRIPTION
## Summary

- Rewrote `--incremental` help text to describe channel reuse and the re-export use case, which is the main reason users reach for it
- Added CHANGELOG entry under 2.19.15

Addresses #440 (the reporter's scenario is already handled by `--incremental`; the gap was discoverability).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0154Hx47kGv2noZ8Kxcdwyso
