### PR TITLE
fix(structure): hard-kill durability for role and channel creation (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.19.16] - 2026-08-19
+
+### Fixed
+
+- **Hard-kill mid-creation no longer duplicates roles or channels on resume.** `run_roles`
+  previously saved state every 10th role, and `run_channels` had no mid-loop saves at all. A
+  SIGKILL, OOM or power loss lost the in-memory ID maps, so resume recreated everything from
+  scratch as duplicates. Both functions now persist `state.json` after every structural create
+  call, matching the existing server-create pattern. During structural phases `message_map` is
+  empty, so each write is cheap. Fixes #389.
+
 ## [2.19.15] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.15"
+version = "2.19.16"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.15"
+__version__ = "2.19.16"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -511,7 +511,11 @@ _common_options = [
         "--incremental",
         is_flag=True,
         default=False,
-        help="Only migrate new messages since last completed run",
+        help=(
+            "Reuse channels and roles from a prior run in the same output dir,"
+            " sending only new messages. Use after a partial export or re-export"
+            " of the same server"
+        ),
     ),
     click.option("--verbose", "-v", is_flag=True, help="Debug output"),
     click.option(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -1440,6 +1440,8 @@ async def run_channels(
                 stoat_cat_id = state.category_map[discord_cat_id]
                 category_channels.setdefault(stoat_cat_id, []).append(stoat_channel_id)
 
+            save_state(state, config.output_dir)
+
             on_event(
                 MigrationEvent(
                     phase="channels",
@@ -1535,6 +1537,8 @@ async def run_channels(
                 state.created_channel_names[f"forum-index-{forum_key}"] = (
                     idx_result.get("name") or index_name
                 )
+
+                save_state(state, config.output_dir)
 
                 on_event(
                     MigrationEvent(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -748,10 +748,7 @@ async def run_roles(
             # actually sent: recording role.name would report a rename for every
             # role whose Discord name exceeds the cap.
             state.created_role_names[role.id] = result.get("name") or truncate_name(role.name)
-            # S3: persist periodically so a hard-kill mid-create leaves role_map durable
-            # (resume then skips already-created roles instead of duplicating them).
-            if idx % 10 == 0:
-                save_state(state, config.output_dir)
+            save_state(state, config.output_dir)
 
             # Credit recovered structural roles: created THIS run (the
             # pre_existing_role_ids guard above already excludes prior-run roles)

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -514,9 +514,7 @@ async def _apply_role_ordering(
     is why the sort is descending.
 
     The route rejects any list that does not name every role on the server, so the
-    list comes from a read-back rather than from ``role_map``. That map can lag the
-    server: the create loop persists state every ten roles, so a hard kill strands
-    created roles outside it (#389).
+    list comes from a read-back rather than from ``role_map``.
 
     Only roles Ferry knows about move. Every other role keeps its exact index,
     which leaves a ``--server-id`` target's own hierarchy alone and keeps the

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -38,7 +38,8 @@ from discord_ferry.parser.models import (
     DCEMessage,
     DCERole,
 )
-from discord_ferry.state import MigrationState
+from discord_ferry.state import MigrationState, load_state
+from discord_ferry.state import save_state as save_state_real
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -3171,6 +3172,50 @@ async def test_run_roles_mid_phase_save(tmp_path: Path) -> None:
         await run_roles(config, state, exports, lambda e: None)
     # One save per role (2) + one finalize-at-end save (1) = 3.
     assert spy.call_count == 3
+
+
+async def test_role_kill_and_resume_no_duplicates(tmp_path: Path) -> None:
+    """A hard kill after role 2 of 3 persists both mappings; resume creates only role 3."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [DCERole(id="r1", name="A"), DCERole(id="r2", name="B"), DCERole(id="r3", name="C")]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    call_count = 0
+
+    def kill_after_two(s: MigrationState, d: Path) -> None:
+        nonlocal call_count
+        save_state_real(s, d)
+        call_count += 1
+        if call_count == 2:
+            raise KeyboardInterrupt
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.save_state",
+            side_effect=kill_after_two,
+        ),
+    ):
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r1", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r2", "name": "B"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r3", "name": "C"})
+        with contextlib.suppress(KeyboardInterrupt):
+            await run_roles(config, state, exports, lambda e: None)
+
+    loaded = load_state(tmp_path)
+    assert len(loaded.role_map) == 2
+    assert loaded.role_map == {"r1": "stoat-r1", "r2": "stoat-r2"}
+    assert set(loaded.created_role_names) == {"r1", "r2"}
+
+    # Resume: only role 3 should be created.
+    resumed_state = loaded
+    with aioresponses() as m2:
+        m2.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-r3", "name": "C"})
+        await run_roles(config, resumed_state, exports, lambda e: None)
+
+    assert len(resumed_state.role_map) == 3
+    assert resumed_state.role_map["r3"] == "stoat-r3"
 
 
 async def test_too_many_roles_break_leaves_unmapped_unfinalized(tmp_path: Path) -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3157,11 +3157,11 @@ async def test_completed_run_finalizes_all_created_roles(tmp_path: Path) -> None
     assert state.roles_finalized == {"r1", "r2"}
 
 
-async def test_create_loop_saves_state_periodically(tmp_path: Path) -> None:
-    """S3 SC-14: the create loop persists mid-phase (hard-kill durability)."""
+async def test_run_roles_mid_phase_save(tmp_path: Path) -> None:
+    """S3 SC-14: the create loop persists after every role (hard-kill durability)."""
     config = _make_config(tmp_path)
     state = MigrationState(stoat_server_id="srv1")
-    roles = [DCERole(id=f"r{i}", name=f"R{i}") for i in range(1, 11)]  # 10 roles -> idx%10 fires
+    roles = [DCERole(id=f"r{i}", name=f"R{i}") for i in range(1, 3)]
     exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
     with (
         aioresponses() as m,
@@ -3169,8 +3169,8 @@ async def test_create_loop_saves_state_periodically(tmp_path: Path) -> None:
     ):
         m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-x"}, repeat=True)
         await run_roles(config, state, exports, lambda e: None)
-    # One intra-loop save (at idx==10) + one finalize-at-end save.
-    assert spy.call_count >= 2
+    # One save per role (2) + one finalize-at-end save (1) = 3.
+    assert spy.call_count == 3
 
 
 async def test_too_many_roles_break_leaves_unmapped_unfinalized(tmp_path: Path) -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1315,6 +1315,65 @@ async def test_run_channels_deduplicates_channel_ids(tmp_path: Path) -> None:
     assert len(state.channel_map) == 1
 
 
+async def test_channel_kill_and_resume_no_duplicates(tmp_path: Path) -> None:
+    """A hard kill after channel 2 of 3 persists both mappings; resume creates only channel 3."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    exports = [
+        _make_export(channel_id="ch1", channel_name="one", category_id=""),
+        _make_export(channel_id="ch2", channel_name="two", category_id=""),
+        _make_export(channel_id="ch3", channel_name="three", category_id=""),
+    ]
+
+    call_count = 0
+
+    def kill_after_two(s: MigrationState, d: Path) -> None:
+        nonlocal call_count
+        save_state_real(s, d)
+        call_count += 1
+        if call_count == 2:
+            raise KeyboardInterrupt
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.save_state",
+            side_effect=kill_after_two,
+        ),
+    ):
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch1", "name": "one"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch2", "name": "two"},
+        )
+        m.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch3", "name": "three"},
+        )
+        with contextlib.suppress(KeyboardInterrupt):
+            await run_channels(config, state, exports, lambda e: None)
+
+    loaded = load_state(tmp_path)
+    assert len(loaded.channel_map) == 2
+    assert loaded.channel_map == {"ch1": "stoat-ch1", "ch2": "stoat-ch2"}
+    assert set(loaded.created_channel_names) == {"ch1", "ch2"}
+
+    # Resume: only channel 3 should be created.
+    resumed_state = loaded
+    with aioresponses() as m2:
+        m2.post(
+            f"{STOAT_URL}/servers/srv1/channels",
+            payload={"_id": "stoat-ch3", "name": "three"},
+        )
+        await run_channels(config, resumed_state, exports, lambda e: None)
+
+    assert len(resumed_state.channel_map) == 3
+    assert resumed_state.channel_map["ch3"] == "stoat-ch3"
+
+
 async def test_run_channels_voice_fallback_to_text(tmp_path: Path) -> None:
     """CHANNELS phase retries a failed voice channel creation as text and warns."""
     events: list[MigrationEvent] = []

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.15"
+version = "2.19.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `run_roles` saved state every 10th role; now saves after every create
- `run_channels` had zero mid-loop saves; now saves after every channel create (regular + forum-index)
- Both match the existing server-create pattern at line 181; writes are cheap because `message_map` is empty during structural phases

## Test plan

- [x] SC-14 tightened: 2 roles, exact save count (3 = 2 per-role + 1 end-of-phase)
- [x] Role kill-and-resume: hard kill after role 2 of 3, verify disk persistence, resume creates only role 3
- [x] Channel kill-and-resume: hard kill after channel 2 of 3 (uncategorized path), verify disk persistence, resume creates only channel 3
- [x] Full suite: 2121 passed, lint clean, types clean

Fixes #389. Closes #450.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zPzcycbBosrRxFZjqBhCU
