### PR TITLE
fix(build): apply role ordering via api_edit_role_ranks (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [2.19.17] - 2026-08-20
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`ferry build` now applies blueprint and template role ordering.** The build
+  path sent `rank` through `api_edit_role`, where Stoat's handler discards it.
+  Role hierarchy was lost on every built server. The build path now collects all
+  role ids during creation and calls `api_edit_role_ranks` once with the full
+  ordered list. A failure in the ordering call prints a warning and continues
+  rather than aborting the build. Fixes #387.
+
 ## [2.19.16] - 2026-08-19
 
 ### Fixed
@@ -297,9 +308,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   for years against a field the server threw away, because an assertion about what Ferry sent can
   never observe what the server kept.
 
-  **Not covered by this change:** `ferry build` replays blueprint and template role ranks through
-  the same discarded field (#387), and correcting ordering on a server migrated by an earlier
-  release needs its own path (#388).
 
 
 ## [2.19.1] - 2026-08-17
@@ -1610,7 +1618,7 @@ CLI display & blueprint round-trip robustness — the fifth batch from the 2026-
 
 - **A markup-hostile channel/server/guild name can no longer abort a migration** (`cli.py`, S1/F5a). `Console` renders with markup enabled, so a Discord name containing Rich metacharacters (`spam[/]`, `[bold]news`, an unbalanced `]`) interpolated into a progress line raised `rich.errors.MarkupError`. Because `_ProgressTracker.on_event` runs synchronously inside the engine's `emit`, that exception unwound into the engine and was re-raised as a `MigrationError`, aborting an otherwise-healthy migration over a cosmetic display string. Every user-controlled value (event message, channel name, server/guild name, warnings, exception text, rollback suspect names, failure errors, the `ferry stats` error/warning previews) is now escaped via a new `_safe()` helper before markup interpolation; static format tags and integer/ID values are left live. A narrow `except MarkupError` guard around each tracker's render body is a defense-in-depth net (it falls back to an unstyled print and never swallows control flow — the rollback confirm/pause path is deliberately kept outside it).
 - **`build` no longer aborts mid-build and orphans a server on a voice-channel failure** (`cli.py`, S2/F5b). The blueprint `build` command POSTed `channel_type="Voice"` with no error handling; a voice-create failure (Stoat "Bug #194") propagated and `sys.exit`ed after the server, roles, and earlier channels were already created — leaving an orphan server with no rollback. A new `_build_blueprint_channel()` helper mirrors the main migration path's voice→Text fallback (retry the channel as Text with a warning; non-voice errors still propagate); both build loops use it, and the categorized loop preserves the recovered channel's id into its category. This also un-breaks `ferry build --template gaming|community|education`, whose shipped templates contain Voice channels.
-- **`build` now replays a blueprint's role hierarchy** (`cli.py`, S4/F5d). `BlueprintRole.rank` survived the export→import JSON round-trip but the build role loop applied only colour and permissions, so every built role got Stoat's default rank and the hierarchy was silently lost. The role loop now folds colour + rank into a single `api_edit_role` PATCH. This also restores the shipped templates' role ranks (Admin/Moderator/Member ordering).
+- **`build` now replays a blueprint's role hierarchy** (`cli.py`, S4/F5d). `BlueprintRole.rank` survived the export→import JSON round-trip but the build role loop applied only colour and permissions, so every built role got Stoat's default rank and the hierarchy was silently lost. The role loop applied colour via `api_edit_role` but sent `rank` through the same endpoint, where Stoat discards it; role ordering on the build path remained broken until #387. This also restores the shipped templates' role ranks (Admin/Moderator/Member ordering).
 - **`export-blueprint` is unchanged** (S3/F5c, decision A1). A Discord voice channel is still exported as `type="Voice"`, consistent with the migration path and the shipped templates; S2's new `build` fallback makes that value build-safe.
 
 Internal: the build command's six Stoat API helpers were hoisted from a function-local import to module level (no import-cost change — the module already loads them via `run_migration`), giving the new module-level channel helper access to them and a single uniform mock-patch target for tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.16"
+version = "2.19.17"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.16"
+__version__ = "2.19.17"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -39,6 +39,7 @@ from discord_ferry.migrator.api import (
     api_create_role,
     api_create_server,
     api_edit_role,
+    api_edit_role_ranks,
     api_set_role_permissions,
     api_upsert_categories,
     init_request_semaphore,
@@ -874,19 +875,14 @@ def build(
             console.print(f"  Created server '{_safe(bp.name)}' ({server_id})")
 
             # Create roles
+            created_roles: list[tuple[int, str]] = []
             for role in bp.roles:
                 role_result = await api_create_role(session, stoat_url, token, server_id, role.name)
                 role_id = role_result["id"]
-                # Replay colour + rank in a single PATCH. Skip rank 0 (the default) so an
-                # unranked blueprint role keeps Stoat's default ordering rather than being pinned.
-                edit_kwargs: dict[str, Any] = {}
+                created_roles.append((role.rank, role_id))
                 if role.colour:
-                    edit_kwargs["colour"] = role.colour
-                if role.rank:
-                    edit_kwargs["rank"] = role.rank
-                if edit_kwargs:
                     await api_edit_role(
-                        session, stoat_url, token, server_id, role_id, **edit_kwargs
+                        session, stoat_url, token, server_id, role_id, colour=role.colour
                     )
                 if role.permissions:
                     await api_set_role_permissions(
@@ -899,6 +895,18 @@ def build(
                         deny=0,
                     )
                 console.print(f"  Created role '{_safe(role.name)}'")
+
+            # Apply role ordering
+            if any(rank > 0 for rank, _ in created_roles):
+                ranked = [(r, rid) for r, rid in created_roles if r > 0]
+                ranked.sort(key=lambda item: item[0], reverse=True)
+                unranked = [rid for r, rid in created_roles if r == 0]
+                ordered = [rid for _, rid in ranked] + unranked
+                try:
+                    await api_edit_role_ranks(session, stoat_url, token, server_id, ordered)
+                    console.print("  Applied role ordering")
+                except MigrationError as exc:
+                    console.print(f"  [yellow]Warning:[/] Role ordering failed: {_safe(exc)}")
 
             # Create categories and channels
             import uuid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1359,14 +1359,18 @@ def test_build_applies_distinct_ranks(runner: CliRunner, tmp_path: Path) -> None
         roles=[
             BlueprintRole(name="Admin", colour=0xFF0000, rank=3),
             BlueprintRole(name="Mod", rank=2),
+            BlueprintRole(name="Plain", rank=0),
         ],
     )
     p = _write_bp(tmp_path, bp)
+    create_role = AsyncMock(side_effect=[{"id": "r-admin"}, {"id": "r-mod"}, {"id": "r-plain"}])
+    ranks_mock = AsyncMock(return_value={})
     edit = AsyncMock(return_value={})
     with (
         patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_create_role", create_role),
         patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         result = runner.invoke(
@@ -1375,8 +1379,9 @@ def test_build_applies_distinct_ranks(runner: CliRunner, tmp_path: Path) -> None
             catch_exceptions=False,
         )
     assert result.exit_code == 0
-    ranks = {c.kwargs.get("rank") for c in edit.await_args_list}
-    assert {2, 3} <= ranks
+    ranks_mock.assert_awaited_once()
+    ordered = ranks_mock.await_args.args[4]
+    assert ordered == ["r-admin", "r-mod", "r-plain"]
 
 
 def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC-16
@@ -1384,11 +1389,12 @@ def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC
 
     bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="Plain", rank=0)])
     p = _write_bp(tmp_path, bp)
-    edit = AsyncMock(return_value={})
+    ranks_mock = AsyncMock(return_value={})
     with (
         patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
-        patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         runner.invoke(
@@ -1396,19 +1402,21 @@ def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC
             ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
             catch_exceptions=False,
         )
-    assert edit.await_count == 0  # no colour, no rank -> no edit call
+    ranks_mock.assert_not_awaited()
 
 
-def test_build_folds_colour_and_rank_one_patch(runner: CliRunner, tmp_path: Path) -> None:  # SC-17
+def test_build_separates_colour_and_rank(runner: CliRunner, tmp_path: Path) -> None:  # SC-17
     from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
 
     bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", colour=0x00FF00, rank=5)])
     p = _write_bp(tmp_path, bp)
     edit = AsyncMock(return_value={})
+    ranks_mock = AsyncMock(return_value={})
     with (
         patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r-a"})),
         patch("discord_ferry.cli.api_edit_role", edit),
+        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
         patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         runner.invoke(
@@ -1419,7 +1427,32 @@ def test_build_folds_colour_and_rank_one_patch(runner: CliRunner, tmp_path: Path
     assert edit.await_count == 1
     kw = edit.await_args.kwargs
     assert kw.get("colour") == 0x00FF00
-    assert kw.get("rank") == 5
+    assert "rank" not in kw
+    ranks_mock.assert_awaited_once()
+    assert ranks_mock.await_args.args[4] == ["r-a"]
+
+
+def test_build_ordering_failure_degrades(runner: CliRunner, tmp_path: Path) -> None:
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", rank=2)])
+    p = _write_bp(tmp_path, bp)
+    ranks_mock = AsyncMock(side_effect=MigrationError("test ordering failure"))
+    with (
+        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r-a"})),
+        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
+        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+    ):
+        result = runner.invoke(
+            main,
+            ["build", "--blueprint", str(p), "--stoat-url", "http://x", "--token", "t"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "Warning" in result.output
+    assert "Done!" in result.output
 
 
 def test_build_preserves_permissions(runner: CliRunner, tmp_path: Path) -> None:  # SC-18
@@ -1432,6 +1465,7 @@ def test_build_preserves_permissions(runner: CliRunner, tmp_path: Path) -> None:
         patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
         patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
         patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.cli.api_edit_role_ranks", AsyncMock(return_value={})),
         patch("discord_ferry.cli.api_set_role_permissions", perms),
     ):
         runner.invoke(

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.16"
+version = "2.19.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **`ferry build` now applies blueprint and template role ordering.** The build path sent `rank` through `api_edit_role`, where Stoat's handler discards it via a rest pattern. Role hierarchy was lost on every built server.
- Collects role ids during the create loop and calls `api_edit_role_ranks` once with the full ordered list. A failure prints a warning and continues rather than aborting.
- Corrects a false CHANGELOG claim from v2.6.11 that said the role loop "folds colour + rank into a single `api_edit_role` PATCH".

## Test plan

- [x] SC-15: distinct ranks sorted correctly (ranked descending, unranked appended)
- [x] SC-16: all rank-0 roles skip the ordering call entirely
- [x] SC-17: colour and rank are separate API calls (no `rank` in edit kwargs)
- [x] SC-18: permissions preserved (patched for new import)
- [x] Degradation: ordering failure produces exit 0 + warning, build continues
- [x] 2123 tests pass, lint/format/mypy clean

Fixes #387.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JZNCDK35Y6bhEK2eYUed19
