### PR TITLE
feat(probe): implement deep boundary-upload probe (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.20.0] - 2026-08-20
+
+### Added
+
+- **`ferry probe --deep` now runs a boundary-upload probe against the Autumn file server.** For
+  each of the six upload tags (attachments, avatars, backgrounds, icons, banners, emojis), it
+  uploads a test file at the advertised size limit and one byte over, then reports whether the
+  server enforces the limit. Probe entities are torn down after each tag. Avatars and backgrounds
+  leave orphaned files because Autumn has no delete endpoint for them; the help text documents
+  this. Fixes #142.
+
 ## [2.19.17] - 2026-08-20
 
 ### Fixed

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -601,13 +601,14 @@ Probe creates its test entities (channels, uploads) on the server you point it a
 | `--stoat-url TEXT` | `STOAT_URL` | Stoat API base URL *(required)* |
 | `--token TEXT` | `STOAT_TOKEN` | Your Stoat user token *(required)* |
 | `--test-server-id TEXT` | | ID of a throwaway Stoat server to create test entities on *(required)* |
-| `--deep` | | Reserved for a deeper upload-boundary probe — currently reports "not yet implemented" |
+| `--deep` | | Upload test files at each Autumn size boundary and report where enforced limits disagree with advertised ones. Creates and tears down probe entities (channels, emoji, server icon/banner). Leaves a small number of orphaned files in Autumn storage. |
 | `--json` | | Print results as machine-readable JSON instead of a table |
 | `--verbose` / `-v` | | Verbose output |
 
 ### What it checks
 
 - **Upload size limits** — the limits the instance's file server (Autumn) advertises per upload category, compared against the values Ferry assumes. A mismatch is reported as a warning.
+- **Upload boundary enforcement** *(with `--deep`)* — uploads test files at the exact advertised limit and one byte over for each upload category. Reports whether the server accepts or rejects each. Non-attachment tags require valid image files, which the probe generates as padded PNGs. Probe entities are torn down afterwards, but uploaded bytes persist in Autumn.
 - **Voice channels** — creates a test voice channel and checks whether the instance actually supports voice (Stoat Bug #194). If not, Discord voice channels will become text channels.
 - **Webhooks** — creates a test channel and checks whether webhooks can be created on the instance.
 - **Rate limiting** — what rate-limit information the instance exposes in its responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.19.17"
+version = "2.20.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.19.17"
+__version__ = "2.20.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1328,7 +1328,15 @@ def rollback_cmd(
 @click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
 @click.option("--token", envvar="STOAT_TOKEN", default=None, help="Stoat user token")
 @click.option("--test-server-id", required=True, help="Throwaway server for probe entities")
-@click.option("--deep", is_flag=True, default=False, help="Probe Autumn size boundaries by upload")
+@click.option(
+    "--deep",
+    is_flag=True,
+    default=False,
+    help=(
+        "Upload test files at each Autumn size boundary and report enforced vs "
+        "advertised limits. Leaves orphaned files in Autumn storage."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
 def probe_cmd(

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -134,19 +134,23 @@ async def run_probe(
     own_session = session is None
     sess = session or new_session()
     try:
-        await _check_autumn(sess, stoat_url, report)
+        autumn_url = await _check_autumn(sess, stoat_url, report)
         await _check_voice_bug(sess, stoat_url, token, test_server_id, report)
         await _check_webhook(sess, stoat_url, token, test_server_id, report)
         await _check_rate_limit(sess, stoat_url, token, test_server_id, report)
         if deep:
-            report.add("deep_probe", "warn", "deep boundary-upload probe not yet implemented")
+            await _check_deep_uploads(
+                sess, stoat_url, autumn_url, token, test_server_id, report
+            )
     finally:
         if own_session:
             await sess.close()
     return report
 
 
-async def _check_autumn(sess: aiohttp.ClientSession, stoat_url: str, report: ProbeReport) -> None:
+async def _check_autumn(
+    sess: aiohttp.ClientSession, stoat_url: str, report: ProbeReport
+) -> str | None:
     """Diff our assumed upload limits against the ones this instance advertises.
 
     The limits live on the **Stoat** root under
@@ -168,11 +172,14 @@ async def _check_autumn(sess: aiohttp.ClientSession, stoat_url: str, report: Pro
         detail = f"{type(exc).__name__}: {exc}"
         report.add("autumn_limits", "fail", detail)
         report.add("autumn_reachable", "fail", f"Stoat root unreachable: {detail}")
-        return
+        return None
 
     features = _sub_dict(root, "features")
     _report_autumn_limits(features, report)
     await _report_autumn_reachable(sess, features, report)
+
+    autumn_url = _sub_dict(features, "autumn").get("url")
+    return autumn_url if isinstance(autumn_url, str) and autumn_url else None
 
 
 def _report_autumn_limits(features: dict[str, Any], report: ProbeReport) -> None:
@@ -344,3 +351,21 @@ async def _check_rate_limit(
         report.add("rate_limit", "ok", f"headers={rl or 'none observed'}")
     except Exception as exc:  # noqa: BLE001
         report.add("rate_limit", "fail", f"{type(exc).__name__}: {exc}")
+
+
+async def _check_deep_uploads(
+    sess: aiohttp.ClientSession,
+    stoat_url: str,
+    autumn_url: str | None,
+    token: str,
+    server_id: str,
+    report: ProbeReport,
+) -> None:
+    """Upload test files at each TAG_SIZE_LIMITS boundary and report enforcement.
+
+    Stub: the full implementation lands in the next task.
+    """
+    if not autumn_url:
+        report.add("deep_probe", "fail", "cannot run deep probe without Autumn URL")
+        return
+    report.add("deep_probe", "warn", "deep boundary-upload probe not yet implemented")

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -68,6 +68,26 @@ def _make_test_file(directory: Path, tag: str, size: int) -> Path:
     return path
 
 
+async def _raw_autumn_upload(
+    session: aiohttp.ClientSession,
+    autumn_url: str,
+    tag: str,
+    file_path: Path,
+    token: str,
+) -> int:
+    """Upload a file to Autumn and return the HTTP status code.
+
+    No client-side size check, no retry. Used by the deep probe to test
+    whether the server enforces its advertised limit.
+    """
+    url = f"{autumn_url.rstrip('/')}/{tag}"
+    headers = {"x-session-token": token}
+    form = aiohttp.FormData()
+    form.add_field("file", file_path.open("rb"), filename=file_path.name)
+    async with session.post(url, data=form, headers=headers) as resp:
+        return resp.status
+
+
 def _sub_dict(obj: Any, key: str) -> dict[str, Any]:
     """``obj[key]`` when both it and ``obj`` are dicts, else ``{}``.
 

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import struct
+import zlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -21,10 +23,49 @@ from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
 # Tiers on the Stoat root that may carry upload limits. `global` carries none today; it
 # is listed so that it would be compared rather than missed if it ever gained them.
 _LIMIT_TIERS = ("global", "new_user", "default")
+
+
+def _make_test_file(directory: Path, tag: str, size: int) -> Path:
+    """Generate a test file of exactly *size* bytes for an Autumn upload probe.
+
+    Non-``attachments`` tags reject non-images, so those get a minimal valid PNG
+    padded with a ``tEXt`` chunk. ``attachments`` gets raw zero bytes.
+    """
+    path = directory / f"probe_{tag}_{size}.{'png' if tag != 'attachments' else 'bin'}"
+    if tag == "attachments":
+        path.write_bytes(b"\x00" * size)
+        return path
+
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    def _chunk(name: bytes, data: bytes) -> bytes:
+        raw = name + data
+        return struct.pack(">I", len(data)) + raw + struct.pack(">I", zlib.crc32(raw) & 0xFFFFFFFF)
+
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    ihdr = _chunk(b"IHDR", ihdr_data)
+    raw_pixel = zlib.compress(b"\x00\x00\x00\x00")
+    idat = _chunk(b"IDAT", raw_pixel)
+    iend = _chunk(b"IEND", b"")
+    core = sig + ihdr + idat + iend
+    core_size = len(core)
+
+    if size <= core_size:
+        path.write_bytes(core)
+        return path
+
+    keyword = b"probe"
+    text_overhead = 4 + 4 + len(keyword) + 1 + 4  # length + "tEXt" + keyword + null + CRC
+    pad_data_len = size - core_size - text_overhead
+    text_chunk = _chunk(b"tEXt", keyword + b"\x00" + b"x" * pad_data_len)
+    content = sig + ihdr + idat + text_chunk + iend
+    path.write_bytes(content)
+    return path
 
 
 def _sub_dict(obj: Any, key: str) -> dict[str, Any]:

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import struct
+import tempfile
 import zlib
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import aiohttp  # noqa: TCH002
@@ -13,17 +15,19 @@ import aiohttp  # noqa: TCH002
 from discord_ferry.core.http import new_session
 from discord_ferry.migrator.api import (
     api_create_channel,
+    api_create_emoji,
     api_create_webhook,
     api_delete_channel,
+    api_delete_emoji,
     api_delete_webhook,
+    api_edit_server,
     api_execute_webhook,
     api_fetch_channel,
 )
-from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
+from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS, upload_to_autumn
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 # Tiers on the Stoat root that may carry upload limits. `global` carries none today; it
 # is listed so that it would be compared rather than missed if it ever gained them.
@@ -139,9 +143,7 @@ async def run_probe(
         await _check_webhook(sess, stoat_url, token, test_server_id, report)
         await _check_rate_limit(sess, stoat_url, token, test_server_id, report)
         if deep:
-            await _check_deep_uploads(
-                sess, stoat_url, autumn_url, token, test_server_id, report
-            )
+            await _check_deep_uploads(sess, stoat_url, autumn_url, token, test_server_id, report)
     finally:
         if own_session:
             await sess.close()
@@ -361,11 +363,101 @@ async def _check_deep_uploads(
     server_id: str,
     report: ProbeReport,
 ) -> None:
-    """Upload test files at each TAG_SIZE_LIMITS boundary and report enforcement.
-
-    Stub: the full implementation lands in the next task.
-    """
+    """Upload test files at each TAG_SIZE_LIMITS boundary and report enforcement."""
     if not autumn_url:
         report.add("deep_probe", "fail", "cannot run deep probe without Autumn URL")
         return
-    report.add("deep_probe", "warn", "deep boundary-upload probe not yet implemented")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        for tag, limit in TAG_SIZE_LIMITS.items():
+            await _probe_one_tag(
+                sess, stoat_url, autumn_url, token, server_id, tag, limit, tmp, report
+            )
+
+
+async def _probe_one_tag(
+    sess: aiohttp.ClientSession,
+    stoat_url: str,
+    autumn_url: str,
+    token: str,
+    server_id: str,
+    tag: str,
+    limit: int,
+    tmp: Path,
+    report: ProbeReport,
+) -> None:
+    """Probe one Autumn tag at its size boundary."""
+    channel_id: str | None = None
+    emoji_id: str | None = None
+    icon_set = False
+    banner_set = False
+
+    try:
+        at_file = _make_test_file(tmp, tag, limit)
+        at_status: int | str = "skipped"
+        file_id: str | None = None
+        try:
+            file_id = await upload_to_autumn(sess, autumn_url, tag, at_file, token)
+            at_status = 200
+        except Exception as exc:  # noqa: BLE001
+            at_status = getattr(exc, "status", str(exc))
+
+        report.add(
+            f"deep_{tag}_at_limit",
+            "ok" if at_status == 200 else "warn",
+            f"size={limit}, limit={limit}, status={at_status}",
+        )
+
+        if file_id:
+            if tag == "attachments":
+                ch = await api_create_channel(
+                    sess,
+                    stoat_url,
+                    token,
+                    server_id,
+                    name="ferry-probe-deep",
+                    channel_type="Text",
+                )
+                channel_id = ch.get("_id")
+            elif tag == "emojis":
+                await api_create_emoji(
+                    sess,
+                    stoat_url,
+                    token,
+                    file_id,
+                    "ferryprobe",
+                    server_id,
+                )
+                emoji_id = file_id
+            elif tag == "icons":
+                await api_edit_server(sess, stoat_url, token, server_id, icon=file_id)
+                icon_set = True
+            elif tag == "banners":
+                await api_edit_server(sess, stoat_url, token, server_id, banner=file_id)
+                banner_set = True
+
+        over_file = _make_test_file(tmp, tag, limit + 1)
+        over_status = await _raw_autumn_upload(sess, autumn_url, tag, over_file, token)
+
+        report.add(
+            f"deep_{tag}_over_limit",
+            "ok" if over_status != 200 else "warn",
+            f"size={limit + 1}, limit={limit}, status={over_status}"
+            + ("" if over_status != 200 else " (limit NOT enforced)"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        report.add(f"deep_{tag}_at_limit", "fail", f"{type(exc).__name__}: {exc}")
+    finally:
+        if channel_id:
+            with contextlib.suppress(Exception):
+                await api_delete_channel(sess, stoat_url, token, channel_id)
+        if emoji_id:
+            with contextlib.suppress(Exception):
+                await api_delete_emoji(sess, stoat_url, token, emoji_id)
+        if icon_set:
+            with contextlib.suppress(Exception):
+                await api_edit_server(sess, stoat_url, token, server_id, remove=["Icon"])
+        if banner_set:
+            with contextlib.suppress(Exception):
+                await api_edit_server(sess, stoat_url, token, server_id, remove=["Banner"])

--- a/src/discord_ferry/migrator/probe.py
+++ b/src/discord_ferry/migrator/probe.py
@@ -87,9 +87,13 @@ async def _raw_autumn_upload(
     url = f"{autumn_url.rstrip('/')}/{tag}"
     headers = {"x-session-token": token}
     form = aiohttp.FormData()
-    form.add_field("file", file_path.open("rb"), filename=file_path.name)
-    async with session.post(url, data=form, headers=headers) as resp:
-        return resp.status
+    fh = file_path.open("rb")
+    try:
+        form.add_field("file", fh, filename=file_path.name)
+        async with session.post(url, data=form, headers=headers) as resp:
+            return resp.status
+    finally:
+        fh.close()
 
 
 def _sub_dict(obj: Any, key: str) -> dict[str, Any]:
@@ -447,7 +451,7 @@ async def _probe_one_tag(
             + ("" if over_status != 200 else " (limit NOT enforced)"),
         )
     except Exception as exc:  # noqa: BLE001
-        report.add(f"deep_{tag}_at_limit", "fail", f"{type(exc).__name__}: {exc}")
+        report.add(f"deep_{tag}_error", "fail", f"{type(exc).__name__}: {exc}")
     finally:
         if channel_id:
             with contextlib.suppress(Exception):

--- a/tests/test_probe_deep.py
+++ b/tests/test_probe_deep.py
@@ -7,7 +7,12 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 
-from discord_ferry.migrator.probe import ProbeReport, _make_test_file, _raw_autumn_upload
+from discord_ferry.migrator.probe import (
+    ProbeReport,
+    _check_autumn,
+    _make_test_file,
+    _raw_autumn_upload,
+)
 
 BASE_URL = "https://api.test"
 AUTUMN_URL = "https://cdn.test"
@@ -54,6 +59,28 @@ def test_make_test_file_png_various_tags(tmp_path: Path) -> None:
         assert path.stat().st_size == target, f"{tag} size mismatch"
         with open(path, "rb") as f:
             assert f.read(8) == b"\x89PNG\r\n\x1a\n", f"{tag} not valid PNG"
+
+
+async def test_check_autumn_returns_autumn_url(mock_aiohttp: aioresponses) -> None:
+    """_check_autumn returns the discovered autumn_url for deep probe reuse."""
+    mock_aiohttp.get(
+        f"{BASE_URL}/",
+        payload={"features": {"autumn": {"url": AUTUMN_URL}}},
+    )
+    mock_aiohttp.get(f"{AUTUMN_URL}/", payload={"autumn": "0.5.0", "version": "0.5.0"})
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        result = await _check_autumn(sess, BASE_URL, report)
+    assert result == AUTUMN_URL
+
+
+async def test_check_autumn_returns_none_on_failure(mock_aiohttp: aioresponses) -> None:
+    """_check_autumn returns None when the root is unreachable."""
+    mock_aiohttp.get(f"{BASE_URL}/", exception=aiohttp.ClientError("conn refused"))
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        result = await _check_autumn(sess, BASE_URL, report)
+    assert result is None
 
 
 async def test_raw_upload_returns_status_without_raising(

--- a/tests/test_probe_deep.py
+++ b/tests/test_probe_deep.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from discord_ferry.migrator.probe import ProbeReport, _make_test_file
+
+BASE_URL = "https://api.test"
+AUTUMN_URL = "https://cdn.test"
+TOKEN = "test-token"
+SERVER_ID = "srv_test"
+
+
+def _check(report: ProbeReport, name: str) -> str:
+    for c in report.checks:
+        if c.name == name:
+            return f"{c.status}: {c.detail}"
+    raise AssertionError(f"no check named {name!r} in {[c.name for c in report.checks]}")
+
+
+@pytest.fixture
+def mock_aiohttp() -> aioresponses:
+    with aioresponses() as m:
+        yield m
+
+
+def test_make_test_file_png_exact_size(tmp_path: Path) -> None:
+    """Non-attachments tags produce a valid PNG at the exact requested size."""
+    target = 1000
+    path = _make_test_file(tmp_path, "icons", target)
+    assert path.stat().st_size == target
+    with open(path, "rb") as f:
+        assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+
+def test_make_test_file_attachments_raw_bytes(tmp_path: Path) -> None:
+    """Attachments tag produces raw zero bytes, not a PNG."""
+    target = 500
+    path = _make_test_file(tmp_path, "attachments", target)
+    assert path.stat().st_size == target
+    with open(path, "rb") as f:
+        assert f.read(8) != b"\x89PNG\r\n\x1a\n"
+
+
+def test_make_test_file_png_various_tags(tmp_path: Path) -> None:
+    """All non-attachment tags produce exact-sized valid PNGs."""
+    for tag in ("emojis", "avatars", "banners", "backgrounds"):
+        target = 2000
+        path = _make_test_file(tmp_path, tag, target)
+        assert path.stat().st_size == target, f"{tag} size mismatch"
+        with open(path, "rb") as f:
+            assert f.read(8) == b"\x89PNG\r\n\x1a\n", f"{tag} not valid PNG"

--- a/tests/test_probe_deep.py
+++ b/tests/test_probe_deep.py
@@ -7,7 +7,7 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 
-from discord_ferry.migrator.probe import ProbeReport, _make_test_file
+from discord_ferry.migrator.probe import ProbeReport, _make_test_file, _raw_autumn_upload
 
 BASE_URL = "https://api.test"
 AUTUMN_URL = "https://cdn.test"
@@ -54,3 +54,27 @@ def test_make_test_file_png_various_tags(tmp_path: Path) -> None:
         assert path.stat().st_size == target, f"{tag} size mismatch"
         with open(path, "rb") as f:
             assert f.read(8) == b"\x89PNG\r\n\x1a\n", f"{tag} not valid PNG"
+
+
+async def test_raw_upload_returns_status_without_raising(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """Over-limit upload returns the HTTP status, never raises."""
+    mock_aiohttp.post(f"{AUTUMN_URL}/attachments", status=413)
+    test_file = tmp_path / "over.bin"
+    test_file.write_bytes(b"\x00" * 100)
+    async with aiohttp.ClientSession() as sess:
+        status = await _raw_autumn_upload(sess, AUTUMN_URL, "attachments", test_file, TOKEN)
+    assert status == 413
+
+
+async def test_raw_upload_returns_200_on_success(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """Successful upload returns 200."""
+    mock_aiohttp.post(f"{AUTUMN_URL}/icons", status=200, payload={"id": "abc123"})
+    test_file = tmp_path / "ok.png"
+    test_file.write_bytes(b"\x89PNG" + b"\x00" * 96)
+    async with aiohttp.ClientSession() as sess:
+        status = await _raw_autumn_upload(sess, AUTUMN_URL, "icons", test_file, TOKEN)
+    assert status == 200

--- a/tests/test_probe_deep.py
+++ b/tests/test_probe_deep.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
-import struct
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import aiohttp
 import pytest
 from aioresponses import aioresponses
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 from discord_ferry.migrator.probe import (
     ProbeReport,
     _check_autumn,
+    _check_deep_uploads,
     _make_test_file,
+    _probe_one_tag,
     _raw_autumn_upload,
 )
+from discord_ferry.uploader.autumn import TAG_SIZE_LIMITS
 
 BASE_URL = "https://api.test"
 AUTUMN_URL = "https://cdn.test"
@@ -105,3 +110,223 @@ async def test_raw_upload_returns_200_on_success(
     async with aiohttp.ClientSession() as sess:
         status = await _raw_autumn_upload(sess, AUTUMN_URL, "icons", test_file, TOKEN)
     assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# _check_deep_uploads
+# ---------------------------------------------------------------------------
+
+
+def _mock_at_limit_accept(m: aioresponses, tag: str) -> None:
+    """Mock the at-limit upload as accepted (200)."""
+    m.post(f"{AUTUMN_URL}/{tag}", status=200, payload={"id": f"file_{tag}"})
+
+
+def _mock_over_limit_reject(m: aioresponses, tag: str) -> None:
+    """Mock the over-limit upload as rejected (413)."""
+    m.post(f"{AUTUMN_URL}/{tag}", status=413)
+
+
+def _mock_over_limit_accept(m: aioresponses, tag: str) -> None:
+    """Mock the over-limit upload as accepted (200, limit NOT enforced)."""
+    m.post(f"{AUTUMN_URL}/{tag}", status=200, payload={"id": f"over_{tag}"})
+
+
+def _mock_all_tags_normal(m: aioresponses) -> None:
+    """Mock every tag: at-limit accepted, over-limit rejected, teardown succeeds."""
+    for tag in TAG_SIZE_LIMITS:
+        _mock_at_limit_accept(m, tag)
+        _mock_over_limit_reject(m, tag)
+    # Teardown mocks for entity-backed tags.
+    m.post(f"{BASE_URL}/servers/{SERVER_ID}/channels", payload={"_id": "ch_probe"})
+    m.delete(f"{BASE_URL}/channels/ch_probe", status=204)
+    m.put(f"{AUTUMN_URL.replace('cdn', 'api')}/custom/emoji/file_emojis", status=200, payload={})
+    m.put(f"{BASE_URL}/custom/emoji/file_emojis", status=200, payload={"_id": "file_emojis"})
+    m.delete(f"{BASE_URL}/custom/emoji/file_emojis", status=204)
+    m.patch(f"{BASE_URL}/servers/{SERVER_ID}", status=200, payload={}, repeat=True)
+
+
+async def test_deep_skipped_when_autumn_url_none(mock_aiohttp: aioresponses) -> None:
+    """Returns a single fail row when autumn_url is None."""
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _check_deep_uploads(sess, BASE_URL, None, TOKEN, SERVER_ID, report)
+    assert len(report.checks) == 1
+    assert _check(report, "deep_probe").startswith("fail:")
+
+
+ICON_LIMIT = TAG_SIZE_LIMITS["icons"]
+ATTACH_LIMIT = TAG_SIZE_LIMITS["attachments"]
+EMOJI_LIMIT = TAG_SIZE_LIMITS["emojis"]
+BANNER_LIMIT = TAG_SIZE_LIMITS["banners"]
+
+
+async def test_deep_at_limit_accepted_reports_ok(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """An at-limit upload that the server accepts is 'ok'."""
+    _mock_at_limit_accept(mock_aiohttp, "icons")
+    _mock_over_limit_reject(mock_aiohttp, "icons")
+    mock_aiohttp.patch(f"{BASE_URL}/servers/{SERVER_ID}", status=200, payload={}, repeat=True)
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "icons", ICON_LIMIT, tmp_path, report
+        )
+    result = _check(report, "deep_icons_at_limit")
+    assert result.startswith("ok:")
+
+
+async def test_deep_over_limit_rejected_reports_ok(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """An over-limit upload rejected by the server is 'ok'."""
+    _mock_at_limit_accept(mock_aiohttp, "icons")
+    _mock_over_limit_reject(mock_aiohttp, "icons")
+    mock_aiohttp.patch(f"{BASE_URL}/servers/{SERVER_ID}", status=200, payload={}, repeat=True)
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "icons", ICON_LIMIT, tmp_path, report
+        )
+    result = _check(report, "deep_icons_over_limit")
+    assert result.startswith("ok:")
+
+
+async def test_deep_over_limit_accepted_reports_warn(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """An over-limit upload accepted by the server is 'warn' (limit NOT enforced)."""
+    _mock_at_limit_accept(mock_aiohttp, "icons")
+    _mock_over_limit_accept(mock_aiohttp, "icons")
+    mock_aiohttp.patch(f"{BASE_URL}/servers/{SERVER_ID}", status=200, payload={}, repeat=True)
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "icons", ICON_LIMIT, tmp_path, report
+        )
+    result = _check(report, "deep_icons_over_limit")
+    assert result.startswith("warn:")
+    assert "limit NOT enforced" in result
+
+
+async def test_deep_attachments_channel_deleted_on_success(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """Attachment probe creates and deletes a channel for teardown."""
+    _mock_at_limit_accept(mock_aiohttp, "attachments")
+    _mock_over_limit_reject(mock_aiohttp, "attachments")
+    mock_aiohttp.post(f"{BASE_URL}/servers/{SERVER_ID}/channels", payload={"_id": "ch_probe"})
+    delete_called = {"n": 0}
+    mock_aiohttp.delete(
+        f"{BASE_URL}/channels/ch_probe",
+        callback=lambda u, **k: delete_called.__setitem__("n", 1),
+        status=204,
+    )
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess,
+            BASE_URL,
+            AUTUMN_URL,
+            TOKEN,
+            SERVER_ID,
+            "attachments",
+            ATTACH_LIMIT,
+            tmp_path,
+            report,
+        )
+    assert delete_called["n"] == 1
+
+
+async def test_deep_emoji_deleted_after_probe(mock_aiohttp: aioresponses, tmp_path: Path) -> None:
+    """Emoji probe creates and deletes the emoji."""
+    _mock_at_limit_accept(mock_aiohttp, "emojis")
+    _mock_over_limit_reject(mock_aiohttp, "emojis")
+    mock_aiohttp.put(
+        f"{BASE_URL}/custom/emoji/file_emojis", status=200, payload={"_id": "file_emojis"}
+    )
+    delete_called = {"n": 0}
+    mock_aiohttp.delete(
+        f"{BASE_URL}/custom/emoji/file_emojis",
+        callback=lambda u, **k: delete_called.__setitem__("n", 1),
+        status=204,
+    )
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "emojis", EMOJI_LIMIT, tmp_path, report
+        )
+    assert delete_called["n"] == 1
+
+
+async def test_deep_icon_reset_uses_remove(mock_aiohttp: aioresponses, tmp_path: Path) -> None:
+    """Icon probe resets the server icon via remove=['Icon']."""
+    _mock_at_limit_accept(mock_aiohttp, "icons")
+    _mock_over_limit_reject(mock_aiohttp, "icons")
+    patch_calls: list[dict[str, object]] = []
+
+    def capture_patch(url: object, **kwargs: object) -> None:
+        patch_calls.append(kwargs.get("json", {}))  # type: ignore[arg-type]
+
+    mock_aiohttp.patch(
+        f"{BASE_URL}/servers/{SERVER_ID}",
+        callback=capture_patch,
+        status=200,
+        repeat=True,
+    )
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "icons", ICON_LIMIT, tmp_path, report
+        )
+    removes = [c for c in patch_calls if "remove" in c]
+    assert any("Icon" in c.get("remove", []) for c in removes)  # type: ignore[union-attr]
+
+
+async def test_deep_banner_reset_uses_remove(mock_aiohttp: aioresponses, tmp_path: Path) -> None:
+    """Banner probe resets via remove=['Banner']."""
+    _mock_at_limit_accept(mock_aiohttp, "banners")
+    _mock_over_limit_reject(mock_aiohttp, "banners")
+    patch_calls: list[dict[str, object]] = []
+
+    def capture_patch(url: object, **kwargs: object) -> None:
+        patch_calls.append(kwargs.get("json", {}))  # type: ignore[arg-type]
+
+    mock_aiohttp.patch(
+        f"{BASE_URL}/servers/{SERVER_ID}",
+        callback=capture_patch,
+        status=200,
+        repeat=True,
+    )
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess, BASE_URL, AUTUMN_URL, TOKEN, SERVER_ID, "banners", BANNER_LIMIT, tmp_path, report
+        )
+    removes = [c for c in patch_calls if "remove" in c]
+    assert any("Banner" in c.get("remove", []) for c in removes)  # type: ignore[union-attr]
+
+
+async def test_deep_teardown_suppresses_exceptions(
+    mock_aiohttp: aioresponses, tmp_path: Path
+) -> None:
+    """Teardown failures are suppressed and do not block other tags."""
+    _mock_at_limit_accept(mock_aiohttp, "attachments")
+    _mock_over_limit_reject(mock_aiohttp, "attachments")
+    mock_aiohttp.post(f"{BASE_URL}/servers/{SERVER_ID}/channels", payload={"_id": "ch_probe"})
+    mock_aiohttp.delete(f"{BASE_URL}/channels/ch_probe", status=500)
+    report = ProbeReport()
+    async with aiohttp.ClientSession() as sess:
+        await _probe_one_tag(
+            sess,
+            BASE_URL,
+            AUTUMN_URL,
+            TOKEN,
+            SERVER_ID,
+            "attachments",
+            ATTACH_LIMIT,
+            tmp_path,
+            report,
+        )
+    assert _check(report, "deep_attachments_at_limit").startswith("ok:")

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.19.17"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Implement `ferry probe --deep` boundary-upload probe against the Autumn file server
- For each of the six upload tags, uploads a test file at the advertised size limit and one byte over, reports whether the server enforces the limit
- Entity-backed teardown per tag type (emojis via create/delete, icons/banners via server edit with `remove=[]`)
- Avatars and backgrounds leave orphaned files (Autumn has no delete endpoint); help text documents this
- 16 new tests covering PNG generation, raw upload, boundary reporting, and teardown

## Review fixes

- Fixed file handle leak in `_raw_autumn_upload` (explicit close in `finally`)
- Fixed outer exception report name from `at_limit` to `error` to avoid confusing duplicate entries

## Test plan

- [x] All 2138 tests pass
- [x] Ruff, format, mypy clean
- [x] Code review (3 findings, 2 fixed, 1 noted)
- [x] Second opinion (0 findings)

Closes #142

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
