### PR TITLE
feat(repair): machine-readable --json outcome document (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.21.0] - 2026-08-20
+
+### Added
+
+- **`ferry repair --json` prints a machine-readable outcome document.** Alongside
+  repair's human output and its exit code, `--json` emits one JSON document to
+  stdout describing the run: the channels, roles and categories it recreated
+  (with per-channel re-sent message counts), the tails it restored, the
+  dead-letter drain, everything it declined, the residual failed messages, and a
+  post-repair `ferry check` of the live server. Under the flag all human output
+  goes to stderr, so stdout stays parseable, and the document is printed through
+  `click.echo` (never the Rich console, which wraps at 80 columns and can split a
+  string value). The exit-code contract is unchanged. A new `RepairOutcome`
+  dataclass carries the result out of `run_repair`; every free-text field is
+  stripped of control characters, and residual failures carry only identifiers,
+  never message content. Closes #308.
+
 ## [2.20.0] - 2026-08-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.20.0"
+version = "2.21.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.20.0"
+__version__ = "2.21.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1796,8 +1796,14 @@ def repair_cmd(
     if dry_run:
         code = 0
     else:
+        # Source the declined set from THIS run's outcome, not the raw
+        # state.warnings list. state.warnings is never cleared, so a stale
+        # not_in_export from an earlier run would keep this exit code at 1
+        # forever even after the defect is fixed, while the --json document's
+        # `declined` field (also from outcome.declined) correctly reports []. The
+        # exit code and the document must agree. See #308 whole-branch review.
         unrepaired = {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
-        declined = [w for w in state.warnings if w.get("type") in unrepaired]
+        declined = [w for w in outcome.declined if w.get("type") in unrepaired]
         code = 1 if (state.failed_messages or declined) else 0
 
     # The JSON document is emitted for BOTH exit codes, and its exit code is the

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -54,7 +54,7 @@ from discord_ferry.stats import summarize_state
 
 if TYPE_CHECKING:
     from discord_ferry.core.events import MigrationEvent
-    from discord_ferry.migrator.verify import CheckReport
+    from discord_ferry.migrator.verify import CheckReport, RepairOutcome
     from discord_ferry.parser.models import DCEExport
     from discord_ferry.review import RollbackSummary
     from discord_ferry.stats import StateSummary
@@ -1647,6 +1647,38 @@ def retry_cmd(output_dir: str, export_dir: str, stoat_url: str | None, token: st
     sys.exit(1 if state.failed_messages else 0)
 
 
+def _emit_repair_json(
+    outcome: RepairOutcome,
+    dry_run: bool,
+    stoat_url: str,
+    token: str,
+    state: MigrationState,
+) -> None:
+    """Assemble and print the repair --json outcome document (#308).
+
+    click.echo, never the module-level Console: the Console has soft_wrap=False
+    and falls back to 80 columns off a terminal, so it inserts a real newline
+    wherever the wrap lands, including inside a JSON string value, which makes
+    the output unparseable (issue #145).
+
+    The post-repair check runs only for a real run: run_check refuses a dry-run
+    state, so under --dry-run the check section stays null. A failure of that
+    follow-up check is recorded as check_error and the check section stays null,
+    rather than crashing after repair has already written.
+    """
+    from discord_ferry.migrator.verify import _strip_control, run_check
+
+    document = outcome.to_dict()
+    document["check"] = None
+    if not dry_run:
+        try:
+            post = asyncio.run(run_check(stoat_url, token, state, lambda _e: None))
+            document["check"] = post.to_dict()
+        except (CheckError, MigrationError) as exc:
+            document["check_error"] = _strip_control(str(exc))
+    click.echo(json.dumps(document))
+
+
 @main.command(name="repair")
 @click.argument("output_dir", type=click.Path(exists=True))
 @click.option(
@@ -1668,12 +1700,14 @@ def retry_cmd(output_dir: str, export_dir: str, stoat_url: str | None, token: st
     default=False,
     help="Report what would be repaired, and change nothing",
 )
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON")
 def repair_cmd(
     output_dir: str,
     export_dir: str,
     stoat_url: str | None,
     token: str | None,
     dry_run: bool,
+    as_json: bool,
 ) -> None:
     """Restore what `ferry check` found missing.
 
@@ -1693,7 +1727,7 @@ def repair_cmd(
         console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
         sys.exit(1)
 
-    _print_proxy_notices()
+    _print_proxy_notices(to_stderr=as_json)
     register_secret("stoat", token)
     init_request_semaphore(FerryConfig.max_concurrent_requests)
 
@@ -1726,28 +1760,29 @@ def repair_cmd(
         dry_run=dry_run,
     )
 
+    # Under --json, stdout must carry ONLY the JSON document, so every human
+    # line goes to a stderr console instead. _print_proxy_notices above already
+    # took to_stderr=as_json for the same reason.
+    human = Console(stderr=True) if as_json else console
+
     def _on_event(event: MigrationEvent) -> None:
         colour = {"error": "bold red", "warning": "yellow"}.get(event.status, "cyan")
-        console.print(f"[{colour}]{_safe(event.message)}[/]")
+        human.print(f"[{colour}]{_safe(event.message)}[/]")
 
-    console.print("[bold]Discord Ferry[/] — repairing\n")
+    human.print("[bold]Discord Ferry[/] — repairing\n")
     try:
-        asyncio.run(run_repair(config, state, exports, _on_event))
+        outcome = asyncio.run(run_repair(config, state, exports, _on_event))
     except (CheckError, MigrationError) as exc:
-        console.print(f"\n[bold red]Repair failed:[/] {_safe(exc)}")
+        human.print(f"\n[bold red]Repair failed:[/] {_safe(exc)}")
         sys.exit(1)
     except KeyboardInterrupt:
-        console.print(
-            "\n[yellow]Interrupted.[/] State saved after each repair — re-run to continue."
-        )
+        human.print("\n[yellow]Interrupted.[/] State saved after each repair — re-run to continue.")
         sys.exit(130)
 
     # A dry run changed nothing, so it reports on the plan rather than on an
     # outcome and always exits 0. Anything else would make --dry-run unusable in
     # a script that treats non-zero as "act now".
-    if dry_run:
-        sys.exit(0)
-
+    #
     # "Non-zero when any defect remains", and a defect repair DECLINED remains
     # just as surely as a message that would not send. A channel with no
     # recorded name, one missing from the export, and a forum index are all
@@ -1758,11 +1793,21 @@ def repair_cmd(
     # partial restore of something repair DID fix, and failing every merge
     # repair on it would make the code useless. no_discord_metadata is likewise
     # a degradation rather than an unrepaired defect.
-    unrepaired = {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
-    declined = [w for w in state.warnings if w.get("type") in unrepaired]
-    if state.failed_messages or declined:
-        sys.exit(1)
-    sys.exit(0)
+    if dry_run:
+        code = 0
+    else:
+        unrepaired = {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
+        declined = [w for w in state.warnings if w.get("type") in unrepaired]
+        code = 1 if (state.failed_messages or declined) else 0
+
+    # The JSON document is emitted for BOTH exit codes, and its exit code is the
+    # same one the human path produces. The post-repair check is a --json-only
+    # follow-up; a failure of it must not change the exit code or lose the
+    # outcome repair already produced.
+    if as_json:
+        _emit_repair_json(outcome, dry_run, stoat_url, token, state)
+
+    sys.exit(code)
 
 
 @main.command("tls-check")

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2104,6 +2104,13 @@ async def run_repair(
                         # exists, because the attributes are lost either way.
                         # Deferred as #344.
                         role_label = state.created_role_names.get(discord_id, discord_id)
+                        outcome.recreated_roles.append(
+                            {
+                                "discord_id": discord_id,
+                                "stoat_id": state.role_map.get(discord_id),
+                                "name": role_label,
+                            }
+                        )
                         state.warnings.append(
                             {
                                 "phase": "repair",
@@ -2132,7 +2139,17 @@ async def run_repair(
                             phase="repair",
                         )
                 elif result.kind == "category_missing":
-                    await _recreate_category(sess, config, state, result, live_categories, on_event)
+                    cat_created = await _recreate_category(
+                        sess, config, state, result, live_categories, on_event
+                    )
+                    if cat_created:
+                        outcome.recreated_categories.append(
+                            {
+                                "discord_id": discord_id,
+                                "stoat_id": state.category_map.get(discord_id),
+                                "title": state.category_names.get(discord_id),
+                            }
+                        )
                 elif result.kind == "channel_missing":
                     created = await _recreate_channel(
                         sess, config, state, result, exports, existing_names, on_event
@@ -2140,6 +2157,7 @@ async def run_repair(
                     if created:
                         matching = next((e for e in exports if e.channel.id == discord_id), None)
                         label = state.created_channel_names.get(discord_id, discord_id)
+                        count = 0
                         if matching is not None:
                             if state.thread_strategy == "merge":
                                 _warn_unrestored_merge_threads(state, matching, exports, on_event)
@@ -2151,6 +2169,14 @@ async def run_repair(
                                     message=f"Re-sent {count} message(s) into {label}.",
                                 )
                             )
+                        outcome.recreated_channels.append(
+                            {
+                                "discord_id": discord_id,
+                                "stoat_id": state.channel_map.get(discord_id),
+                                "name": label,
+                                "resent_count": count,
+                            }
+                        )
                     if created:
                         await _reattach_to_category(
                             sess,
@@ -2193,6 +2219,15 @@ async def run_repair(
             for result in tail_work:
                 if await _repair_tail(tail_sess, config, state, result, exports, on_event):
                     restored += 1
+                    outcome.restored_tails.append(
+                        {
+                            "discord_id": result.discord_id,
+                            "stoat_id": result.stoat_id,
+                            "name": state.created_channel_names.get(
+                                result.discord_id or "", result.discord_id or ""
+                            ),
+                        }
+                    )
                     save_state(state, config.output_dir)
             on_event(
                 MigrationEvent(
@@ -2211,7 +2246,12 @@ async def run_repair(
     # rebuilds the queue from what still fails, and saves. It returns early on an
     # empty queue, so this costs nothing when there is nothing to drain.
     if state.failed_messages:
+        before = len(state.failed_messages)
         await run_retry_failed(config, state, exports, on_event)
+        outcome.dead_letter = {
+            "drained": before - len(state.failed_messages),
+            "remaining": len(state.failed_messages),
+        }
 
     # One save, at the end. Never under --dry-run, and not merely a save that
     # happens to change nothing: run_check REFUSES a dry-run state outright,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -90,7 +90,7 @@ if TYPE_CHECKING:
     # Type-only: run_check itself is imported inside run_repair, matching how
     # check_cmd reaches it, so the verify module stays off the engine's import
     # path at runtime.
-    from discord_ferry.migrator.verify import CheckResult
+    from discord_ferry.migrator.verify import CheckResult, RepairOutcome
 
 PhaseFunction = Callable[
     [FerryConfig, MigrationState, list[DCEExport], EventCallback],
@@ -1916,7 +1916,7 @@ async def run_repair(
     on_event: EventCallback,
     *,
     session: aiohttp.ClientSession | None = None,
-) -> None:
+) -> RepairOutcome:
     """Act on a CheckReport: restore missing structure and lost messages.
 
     A sibling of :func:`run_retry_failed` and :func:`run_rollback`, not a phase.
@@ -1929,6 +1929,16 @@ async def run_repair(
             from ``run_check`` and are deliberately not caught here, because the
             shell turns them into an exit code and a sentence.
     """
+    # #308: accumulate what this run does into a structured outcome and return
+    # it on every path. warnings_start is snapshotted before any work, so the
+    # declined set is scoped to THIS run's repair-phase warnings and never
+    # includes the migration's own historical warnings, which state.warnings
+    # keeps and never clears.
+    from discord_ferry.migrator.verify import RepairOutcome
+
+    outcome = RepairOutcome(dry_run=config.dry_run)
+    warnings_start = len(state.warnings)
+
     # Rollback preserves the id maps as an audit trail and NEVER clears them
     # (RollbackProgress' own docstring in state.py says so), which means a check
     # on a rolled-back state reports channel_missing for every channel it
@@ -1952,7 +1962,7 @@ async def run_repair(
                 ),
             )
         )
-        return
+        return outcome
 
     _ensure_token_store(config)
     init_request_semaphore(config.max_concurrent_requests)
@@ -2032,7 +2042,8 @@ async def run_repair(
                 message="[DRY RUN] Nothing was created, sent or written.",
             )
         )
-        return
+        outcome.declined = _repair_declined(state, warnings_start)
+        return outcome
 
     if structure_work:
         # Only when something is actually being recreated. A repair with nothing
@@ -2207,7 +2218,29 @@ async def run_repair(
     # because a dry run fills the id maps with `dry-` sentinels naming entities
     # nobody created. Writing those into a real state file would leave the user
     # with a migration that can never be checked again.
+    outcome.declined = _repair_declined(state, warnings_start)
+    outcome.failed_messages = [
+        {"discord_msg_id": fm.discord_msg_id, "stoat_channel_id": fm.stoat_channel_id}
+        for fm in state.failed_messages
+    ]
     save_state(state, config.output_dir)
+    return outcome
+
+
+def _repair_declined(state: MigrationState, warnings_start: int) -> list[dict[str, Any]]:
+    """This run's repair-phase warnings, scoped by a length snapshot (#308).
+
+    state.warnings accumulates across the whole migration and is never cleared,
+    so the raw list carries legacy entries (proxy_notice, thread_filtered and
+    the rest) that a repair outcome must not surface. Taking the tail from
+    warnings_start and filtering to phase == "repair" leaves exactly what this
+    run declined or degraded.
+    """
+    return [
+        {"type": w.get("type", ""), "message": w.get("message", "")}
+        for w in state.warnings[warnings_start:]
+        if w.get("phase") == "repair"
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -201,6 +201,52 @@ class CheckReport:
         }
 
 
+@dataclass
+class RepairOutcome:
+    """Everything one ``run_repair`` did, plus what it could not.
+
+    Sibling of :class:`CheckReport`: the machine-readable contract for the repair
+    side, consumed by ``ferry repair --json`` (#308). ``run_repair`` returns one
+    of these on every path, including its early returns.
+
+    The post-repair ``check`` section is deliberately NOT stored here. The CLI
+    attaches it, because a check measured against the live server after the
+    writes is the shell's concern, and ``run_check`` refuses a dry-run state, so
+    only the shell knows whether to run it at all.
+    """
+
+    dry_run: bool = False
+    recreated_channels: list[dict[str, Any]] = field(default_factory=list)
+    recreated_roles: list[dict[str, Any]] = field(default_factory=list)
+    recreated_categories: list[dict[str, Any]] = field(default_factory=list)
+    restored_tails: list[dict[str, Any]] = field(default_factory=list)
+    dead_letter: dict[str, int] = field(default_factory=lambda: {"drained": 0, "remaining": 0})
+    declined: list[dict[str, Any]] = field(default_factory=list)
+    failed_messages: list[dict[str, Any]] = field(default_factory=list)
+
+    def _clean(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Strip control characters from every string value, matching CheckReport."""
+        return [
+            {k: (_strip_control(v) if isinstance(v, str) else v) for k, v in row.items()}
+            for row in rows
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Sanitized, JSON-ready dict. Every free-text field goes through _strip_control."""
+        return {
+            "dry_run": self.dry_run,
+            "actions": {
+                "recreated_channels": self._clean(self.recreated_channels),
+                "recreated_roles": self._clean(self.recreated_roles),
+                "recreated_categories": self._clean(self.recreated_categories),
+                "restored_tails": self._clean(self.restored_tails),
+                "dead_letter": dict(self.dead_letter),
+            },
+            "declined": self._clean(self.declined),
+            "failed_messages": self._clean(self.failed_messages),
+        }
+
+
 async def run_check(
     stoat_url: str,
     token: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from discord_ferry.cli import main
 from discord_ferry.core.http import reset_http_state
 from discord_ferry.errors import MigrationError
 from discord_ferry.migrator.verify import CheckReport, RepairOutcome
-from discord_ferry.state import MigrationState
+from discord_ferry.state import FailedMessage, MigrationState
 
 if TYPE_CHECKING:
     from discord_ferry.config import FerryConfig
@@ -3136,3 +3136,103 @@ def test_repair_json_survives_a_failing_post_check(runner: CliRunner, tmp_path: 
     doc = json.loads(result.stdout)
     assert doc["check"] is None
     assert "check_error" in doc
+
+
+def test_repair_exit_code_identical_with_and_without_json(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-1.4. The --json flag never changes the exit code."""
+    clean = MigrationState(stoat_server_id="srv1")
+    failing = MigrationState(stoat_server_id="srv1")
+    failing.failed_messages = [FailedMessage(discord_msg_id="m1", stoat_channel_id="c1", error="x")]
+
+    for state, expected in ((clean, 0), (failing, 1)):
+        plain = _invoke_repair(runner, tmp_path, RepairOutcome(), state=state)
+        js = _invoke_repair(runner, tmp_path, RepairOutcome(), "--json", state=state)
+        assert plain.exit_code == expected
+        assert js.exit_code == expected
+
+
+def test_repair_json_empty_sections_are_lists(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-3.3. A clean run serialises declined and failed_messages as []."""
+    result = _invoke_repair(runner, tmp_path, RepairOutcome(), "--json")
+    doc = json.loads(result.stdout)
+    assert doc["declined"] == []
+    assert doc["failed_messages"] == []
+
+
+def test_repair_json_failed_messages_carry_ids_only(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-3.2. Residual failures expose identifying fields, never message content."""
+    outcome = RepairOutcome(failed_messages=[{"discord_msg_id": "m1", "stoat_channel_id": "c1"}])
+    result = _invoke_repair(runner, tmp_path, outcome, "--json")
+    doc = json.loads(result.stdout)
+    assert doc["failed_messages"] == [{"discord_msg_id": "m1", "stoat_channel_id": "c1"}]
+    assert "content_preview" not in doc["failed_messages"][0]
+
+
+def test_repair_json_stdout_survives_a_realistic_payload(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.2. Modelled on the probe #145 test: force a payload past 200 chars.
+
+    The empty-payload tests above never wrap, which is exactly how #145 shipped
+    unnoticed. This one asserts its own length so shortening it later fails loud.
+    """
+    long_msg = (
+        "Role 'moderators' was recreated with its name and permissions. Its colour, "
+        "rank, hoist setting and icon are not restored: set them by hand (see #344)."
+    )
+    outcome = RepairOutcome(
+        recreated_channels=[
+            {
+                "discord_id": "d1",
+                "stoat_id": "s1",
+                "name": "announcements-general",
+                "resent_count": 42,
+            }
+        ],
+        declined=[{"type": "role_attributes_not_restored", "message": long_msg}],
+    )
+    result = _invoke_repair(runner, tmp_path, outcome, "--json")
+    doc = json.loads(result.stdout)
+    assert len(result.stdout) > 200
+    assert doc["declined"][0]["message"] == long_msg
+    assert long_msg in result.stdout  # intact on one line, no injected newline
+
+
+def test_repair_json_strips_control_chars_from_stdout(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.3. A control char in a recorded name never reaches stdout."""
+    outcome = RepairOutcome(
+        recreated_channels=[
+            {"discord_id": "d1", "stoat_id": "s1", "name": "gen\x07eral", "resent_count": 0}
+        ]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome, "--json")
+    assert "\x07" not in result.stdout
+    doc = json.loads(result.stdout)
+    assert doc["actions"]["recreated_channels"][0]["name"] == "general"
+
+
+def test_repair_json_mixed_run_is_consistent(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-I1. Every section populated; exit code equals the non-json run's."""
+    state = MigrationState(stoat_server_id="srv1")
+    state.failed_messages = [FailedMessage(discord_msg_id="m1", stoat_channel_id="c1", error="x")]
+    outcome = RepairOutcome(
+        recreated_channels=[
+            {"discord_id": "d1", "stoat_id": "s1", "name": "general", "resent_count": 5}
+        ],
+        restored_tails=[{"discord_id": "d2", "stoat_id": "s2", "name": "notices"}],
+        dead_letter={"drained": 2, "remaining": 1},
+        declined=[{"type": "role_attributes_not_restored", "message": "colour not restored"}],
+        failed_messages=[{"discord_msg_id": "m1", "stoat_channel_id": "c1"}],
+    )
+    post = CheckReport()
+    post.add(name="c", status="fail", kind="channel_missing", detail="still gone", discord_id="d3")
+
+    js = _invoke_repair(runner, tmp_path, outcome, "--json", state=state, post_check=post)
+    plain = _invoke_repair(runner, tmp_path, outcome, state=state, post_check=post)
+    doc = json.loads(js.stdout)
+
+    assert doc["actions"]["recreated_channels"] and doc["actions"]["restored_tails"]
+    assert doc["actions"]["dead_letter"] == {"drained": 2, "remaining": 1}
+    assert doc["declined"] and doc["failed_messages"]
+    assert doc["check"]["counts"]["fail"] == 1
+    assert js.exit_code == plain.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 from discord_ferry.cli import main
 from discord_ferry.core.http import reset_http_state
 from discord_ferry.errors import MigrationError
-from discord_ferry.migrator.verify import CheckReport
+from discord_ferry.migrator.verify import CheckReport, RepairOutcome
 from discord_ferry.state import MigrationState
 
 if TYPE_CHECKING:
@@ -3032,3 +3032,107 @@ def test_repair_still_exits_zero_on_a_documented_partial_restore(
     assert result.exit_code == 0, (
         f"a documented partial restore exited {result.exit_code}, which fails every merge repair"
     )
+
+
+# ---------------------------------------------------------------------------
+# ferry repair --json (#308)
+# ---------------------------------------------------------------------------
+
+
+def _invoke_repair(
+    runner: CliRunner,
+    tmp_path: Path,
+    outcome: RepairOutcome,
+    *extra: str,
+    state: MigrationState | None = None,
+    post_check: CheckReport | None = None,
+    post_check_error: Exception | None = None,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> Any:
+    """Drive repair_cmd with a mocked run_repair outcome and post-repair check."""
+    st = state if state is not None else MigrationState(stoat_server_id="srv1")
+    check_mock = (
+        AsyncMock(side_effect=post_check_error)
+        if post_check_error is not None
+        else AsyncMock(return_value=post_check if post_check is not None else CheckReport())
+    )
+    with (
+        patch("discord_ferry.cli.register_secret", lambda *_a: None),
+        patch("discord_ferry.cli.init_request_semaphore", lambda *_a: None),
+        patch("discord_ferry.cli.load_state", return_value=st),
+        patch("discord_ferry.cli.parse_export_directory", return_value=[]),
+        patch("discord_ferry.cli.run_repair", new=AsyncMock(return_value=outcome)),
+        patch("discord_ferry.migrator.verify.run_check", new=check_mock),
+    ):
+        return runner.invoke(
+            main,
+            [
+                "repair",
+                str(tmp_path),
+                "--export-dir",
+                str(tmp_path),
+                "--stoat-url",
+                "https://api.test",
+                "--token",
+                "t",
+                *extra,
+            ],
+        )
+
+
+def test_repair_json_prints_one_parseable_document(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.1, SC-4.1. Asserted by parsing, never by inspecting the string (#145)."""
+    outcome = RepairOutcome(
+        recreated_channels=[
+            {"discord_id": "d1", "stoat_id": "s1", "name": "general", "resent_count": 2}
+        ]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome, "--json")
+    doc = json.loads(result.stdout)
+    assert set(doc) >= {"dry_run", "actions", "declined", "failed_messages", "check"}
+    assert doc["actions"]["recreated_channels"][0]["name"] == "general"
+    assert doc["check"] is not None
+
+
+def test_repair_json_keeps_human_output_off_stdout(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-1.2. The banner and proxy notices go to stderr; stdout is pure JSON."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.test:8080")
+    monkeypatch.setenv("COLUMNS", "200")
+    outcome = RepairOutcome()
+    result = _invoke_repair(runner, tmp_path, outcome, "--json")
+    json.loads(result.stdout)  # stdout parses as JSON
+    assert "Discord Ferry" not in result.stdout
+    assert "Discord Ferry" in result.stderr
+
+
+def test_repair_without_json_prints_the_banner_on_stdout(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.3. Without --json the human banner is unchanged on stdout."""
+    result = _invoke_repair(runner, tmp_path, RepairOutcome())
+    assert "Discord Ferry" in result.output
+
+
+def test_repair_dry_run_json_has_null_check_and_exits_zero(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """SC-4.3. --dry-run --json emits a valid document, check null, exit 0."""
+    result = _invoke_repair(runner, tmp_path, RepairOutcome(dry_run=True), "--json", "--dry-run")
+    doc = json.loads(result.stdout)
+    assert doc["dry_run"] is True
+    assert doc["check"] is None
+    assert result.exit_code == 0
+
+
+def test_repair_json_survives_a_failing_post_check(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.4. A failing post-repair check yields check null + check_error, no crash."""
+    result = _invoke_repair(
+        runner,
+        tmp_path,
+        RepairOutcome(),
+        "--json",
+        post_check_error=MigrationError("boom"),
+    )
+    doc = json.loads(result.stdout)
+    assert doc["check"] is None
+    assert "check_error" in doc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2823,8 +2823,8 @@ def test_repair_exits_zero_when_nothing_is_left_failing(runner: CliRunner, tmp_p
 
     save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
 
-    async def _noop(*_a: Any, **_k: Any) -> None:
-        return None
+    async def _noop(*_a: Any, **_k: Any) -> RepairOutcome:
+        return RepairOutcome()
 
     with patch("discord_ferry.cli.run_repair", new=_noop):
         result = runner.invoke(main, _repair_argv(out_dir, export_dir))
@@ -2838,8 +2838,8 @@ def test_repair_exits_non_zero_when_a_message_is_still_failed(
     export_dir = _write_minimal_export(tmp_path / "export")
     out_dir = _write_state_with_one_failure(tmp_path / "out")
 
-    async def _leaves_it(config: Any, state: Any, exports: Any, on_event: Any) -> None:
-        return None
+    async def _leaves_it(config: Any, state: Any, exports: Any, on_event: Any) -> RepairOutcome:
+        return RepairOutcome()
 
     with patch("discord_ferry.cli.run_repair", new=_leaves_it):
         result = runner.invoke(main, _repair_argv(out_dir, export_dir))
@@ -2884,8 +2884,9 @@ def test_repair_passes_a_real_export_to_the_coroutine(runner: CliRunner, tmp_pat
     save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
     seen: dict[str, Any] = {}
 
-    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> RepairOutcome:
         seen["exports"] = exports
+        return RepairOutcome()
 
     with patch("discord_ferry.cli.run_repair", new=_capture):
         runner.invoke(main, _repair_argv(out_dir, export_dir))
@@ -2905,8 +2906,9 @@ def test_repair_registers_the_token_and_the_semaphore_before_any_request(
     save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
     order: list[str] = []
 
-    async def _noop(*_a: Any, **_k: Any) -> None:
+    async def _noop(*_a: Any, **_k: Any) -> RepairOutcome:
         order.append("request")
+        return RepairOutcome()
 
     with (
         patch(
@@ -2985,19 +2987,40 @@ def test_repair_exits_non_zero_when_it_declined_a_repair(runner: CliRunner, tmp_
 
     save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
 
-    async def _declines(config: Any, state: Any, exports: Any, on_event: Any) -> None:
-        state.warnings.append(
-            {
-                "phase": "repair",
-                "type": "no_recorded_name",
-                "message": "Cannot recreate channel 800000000000000001",
-            }
-        )
+    async def _declines(config: Any, state: Any, exports: Any, on_event: Any) -> RepairOutcome:
+        decline = {
+            "phase": "repair",
+            "type": "no_recorded_name",
+            "message": "Cannot recreate channel 800000000000000001",
+        }
+        state.warnings.append(decline)
+        return RepairOutcome(declined=[{"type": "no_recorded_name", "message": decline["message"]}])
 
     with patch("discord_ferry.cli.run_repair", new=_declines):
         result = runner.invoke(main, _repair_argv(out_dir, export_dir))
     assert result.exit_code == 1, (
         f"a declined repair exited {result.exit_code}, which reads as success"
+    )
+
+
+def test_repair_exit_code_ignores_a_stale_decline_from_an_earlier_run(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """#308 whole-branch review. The exit code reflects THIS run, not history.
+
+    state.warnings is never cleared, so a not_in_export from an earlier run
+    persists on disk. If the exit code rescanned that list, it would report 1
+    forever, while the --json document's `declined` (scoped to this run) reports
+    []. The two must agree. This run declines nothing new and fails nothing, so
+    it must exit 0 and its document must show declined == [].
+    """
+    state = MigrationState(stoat_server_id="srv1")
+    state.warnings.append({"phase": "repair", "type": "not_in_export", "message": "old run"})
+    result = _invoke_repair(runner, tmp_path, RepairOutcome(), "--json", state=state)
+    doc = json.loads(result.stdout)
+    assert doc["declined"] == []
+    assert result.exit_code == 0, (
+        f"a stale decline from an earlier run made this run exit {result.exit_code}"
     )
 
 
@@ -3018,14 +3041,14 @@ def test_repair_still_exits_zero_on_a_documented_partial_restore(
 
     save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
 
-    async def _partial(config: Any, state: Any, exports: Any, on_event: Any) -> None:
-        state.warnings.append(
-            {
-                "phase": "repair",
-                "type": "merge_thread_content_not_restored",
-                "message": "thread content not restored",
-            }
-        )
+    async def _partial(config: Any, state: Any, exports: Any, on_event: Any) -> RepairOutcome:
+        decline = {
+            "phase": "repair",
+            "type": "merge_thread_content_not_restored",
+            "message": "thread content not restored",
+        }
+        state.warnings.append(decline)
+        return RepairOutcome(declined=[{"type": decline["type"], "message": decline["message"]}])
 
     with patch("discord_ferry.cli.run_repair", new=_partial):
         result = runner.invoke(main, _repair_argv(out_dir, export_dir))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2636,6 +2636,109 @@ async def test_run_repair_rollback_refusal_returns_empty_outcome(tmp_path: Path)
     assert outcome.declined == []
 
 
+async def test_run_repair_records_recreated_entities(tmp_path: Path) -> None:
+    """#308. Each recreation is recorded with its discord id, new stoat id and name."""
+    config = _make_repair_config(tmp_path)
+    d_ch, d_role, d_cat = "d-ch-1", "d-role-1", "d-cat-1"
+    state = MigrationState(stoat_server_id=R_SERVER)
+    state.channel_map[d_ch] = "01JSTOATCHNOLD"
+    state.role_map[d_role] = "01JSTOATROLEOLD"
+    state.category_map[d_cat] = "01JSTOATCATOLD"
+    state.created_channel_names[d_ch] = "general"
+    state.created_role_names[d_role] = "mods"
+    state.category_names[d_cat] = "Text Channels"
+
+    report = CheckReport()
+    report.add(name="general", status="fail", kind="channel_missing", detail="x", discord_id=d_ch)
+    report.add(name="mods", status="fail", kind="role_missing", detail="x", discord_id=d_role)
+    report.add(
+        name="Text Channels", status="fail", kind="category_missing", detail="x", discord_id=d_cat
+    )
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    async def _fake_view(*_a: Any, **_k: Any) -> tuple[set[str], dict[str, Any]]:
+        return set(), {}
+
+    async def _fake_ch(sess: Any, cfg: Any, st: Any, result: Any, *_a: Any, **_k: Any) -> bool:
+        st.channel_map[result.discord_id] = "01JSTOATCHNNEW"
+        return True
+
+    async def _fake_role(sess: Any, cfg: Any, st: Any, result: Any, *_a: Any, **_k: Any) -> bool:
+        st.role_map[result.discord_id] = "01JSTOATROLENEW"
+        return True
+
+    async def _fake_cat(sess: Any, cfg: Any, st: Any, result: Any, *_a: Any, **_k: Any) -> bool:
+        st.category_map[result.discord_id] = "01JSTOATCATNEW"
+        return True
+
+    async def _fake_resend(*_a: Any, **_k: Any) -> int:
+        return 3
+
+    async def _fake_reattach(*_a: Any, **_k: Any) -> None:
+        return None
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "_live_server_view", _fake_view),
+        patch.object(engine_module, "load_discord_metadata", lambda *a, **k: None),
+        patch.object(engine_module, "_recreate_channel", _fake_ch),
+        patch.object(engine_module, "_recreate_role", _fake_role),
+        patch.object(engine_module, "_recreate_category", _fake_cat),
+        patch.object(engine_module, "_resend_channel", _fake_resend),
+        patch.object(engine_module, "_reattach_to_category", _fake_reattach),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+    ):
+        outcome = await run_repair(config, state, [_export_for(d_ch)], lambda _e: None)
+
+    assert len(outcome.recreated_channels) == 1
+    ch = outcome.recreated_channels[0]
+    assert ch["discord_id"] == d_ch
+    assert ch["stoat_id"] == "01JSTOATCHNNEW"
+    assert ch["name"] == "general"
+    assert ch["resent_count"] == 3
+    assert len(outcome.recreated_roles) == 1
+    assert outcome.recreated_roles[0]["stoat_id"] == "01JSTOATROLENEW"
+    assert len(outcome.recreated_categories) == 1
+    assert outcome.recreated_categories[0]["stoat_id"] == "01JSTOATCATNEW"
+    assert outcome.recreated_categories[0]["title"] == "Text Channels"
+
+
+async def test_run_repair_records_dead_letter_and_scoped_declined(tmp_path: Path) -> None:
+    """#308. dead_letter counts the drain; declined excludes legacy non-repair warnings."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    # A legacy warning from the original migration, present before this run starts.
+    state.warnings.append({"phase": "structure", "type": "proxy_notice", "message": "legacy"})
+    state.failed_messages = [
+        FailedMessage(discord_msg_id="m1", stoat_channel_id="c1", error="boom"),
+        FailedMessage(discord_msg_id="m2", stoat_channel_id="c2", error="boom"),
+    ]
+    # A forum-index result: run_repair declines it (a repair-phase warning appended this run).
+    report = _report_with("channel_missing", "fail", discord_id="forum-index-800000000000000009")
+
+    async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
+        return report
+
+    async def _fake_retry(cfg: Any, st: Any, exports: Any, on_event: Any) -> None:
+        st.failed_messages = [st.failed_messages[0]]  # one now succeeds
+
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
+        patch.object(engine_module, "run_retry_failed", _fake_retry),
+        patch.object(engine_module, "save_state", lambda *a, **k: None),
+    ):
+        outcome = await run_repair(config, state, [], lambda _e: None)
+
+    assert outcome.dead_letter == {"drained": 1, "remaining": 1}
+    assert any(d["type"] == "forum_index_not_repairable" for d in outcome.declined)
+    assert all(d["type"] != "proxy_notice" for d in outcome.declined), (
+        "the legacy non-repair warning leaked into the repair outcome"
+    )
+    assert outcome.failed_messages == [{"discord_msg_id": "m1", "stoat_channel_id": "c1"}]
+
+
 async def test_repair_populates_the_token_store_and_the_semaphore(tmp_path: Path) -> None:
     """Both asserted as CALLS, for the reason recorded on the retry path.
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -25,7 +25,7 @@ from discord_ferry.core.engine import (
 from discord_ferry.core.events import EventCallback, MigrationEvent
 from discord_ferry.errors import CheckError, DuplicateSendError, MigrationError
 from discord_ferry.migrator import messages as messages_module
-from discord_ferry.migrator.verify import CheckReport
+from discord_ferry.migrator.verify import CheckReport, RepairOutcome
 from discord_ferry.parser.models import (
     DCEAuthor,
     DCEChannel,
@@ -2599,6 +2599,41 @@ async def test_repair_runs_the_check_when_the_state_was_never_rolled_back(
         await run_repair(config, state, [], events.append)
 
     assert seen.get("called"), "repair refused a state that was never rolled back"
+
+
+async def test_run_repair_returns_a_repair_outcome(tmp_path: Path) -> None:
+    """#308. A clean run returns a RepairOutcome, not None, on the normal path."""
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+
+    async def _fake_check(*_a: Any, **_k: Any) -> Any:
+        return CheckReport()
+
+    with patch("discord_ferry.migrator.verify.run_check", new=_fake_check):
+        outcome = await run_repair(config, state, [], lambda _e: None)
+
+    assert isinstance(outcome, RepairOutcome)
+    assert outcome.dry_run is False
+
+
+async def test_run_repair_rollback_refusal_returns_empty_outcome(tmp_path: Path) -> None:
+    """#308. The rollback-refusal early return still hands back a valid, empty outcome."""
+    from discord_ferry.state import RollbackProgress
+
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id=R_SERVER,
+        channel_map={R_D_CHANNEL: R_S_CHANNEL},
+        rollback_progress=RollbackProgress(started_at="2026-08-13T00:00:00+00:00"),
+    )
+
+    with aioresponses() as m:
+        outcome = await run_repair(config, state, [], lambda _e: None)
+        assert not m.requests, "refusal path must make no request"
+
+    assert isinstance(outcome, RepairOutcome)
+    assert outcome.recreated_channels == []
+    assert outcome.declined == []
 
 
 async def test_repair_populates_the_token_store_and_the_semaphore(tmp_path: Path) -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -17,7 +17,12 @@ import pytest
 from aioresponses import aioresponses
 
 from discord_ferry.errors import CheckError
-from discord_ferry.migrator.verify import CheckReport, CheckResult, run_check
+from discord_ferry.migrator.verify import (
+    CheckReport,
+    CheckResult,
+    RepairOutcome,
+    run_check,
+)
 from discord_ferry.state import MigrationState
 
 BASE_URL = "https://api.test"
@@ -1958,3 +1963,38 @@ class TestCheckReportToDict:
         d = report.to_dict()
         assert d["results"] == []
         assert all(v == 0 for v in d["counts"].values())
+
+
+class TestRepairOutcome:
+    """RepairOutcome.to_dict is the machine-readable contract for repair --json (#308)."""
+
+    def test_to_dict_strips_control_characters(self) -> None:
+        """Free-text fields pass through _strip_control on the way out."""
+        outcome = RepairOutcome(
+            recreated_channels=[
+                {
+                    "discord_id": "d-100",
+                    "stoat_id": "01JSTOAT",
+                    "name": "gen\x07eral",
+                    "resent_count": 3,
+                }
+            ],
+            declined=[{"type": "no_recorded_name", "message": "bad\x00name"}],
+        )
+        doc = outcome.to_dict()
+        assert doc["actions"]["recreated_channels"][0]["name"] == "general"
+        assert "\x00" not in doc["declined"][0]["message"]
+        # Non-string fields are untouched.
+        assert doc["actions"]["recreated_channels"][0]["resent_count"] == 3
+
+    def test_to_dict_empty_sets_are_lists(self) -> None:
+        """Empty sets serialise as [] with the keys present, never omitted."""
+        doc = RepairOutcome().to_dict()
+        assert doc["actions"]["recreated_channels"] == []
+        assert doc["actions"]["recreated_roles"] == []
+        assert doc["actions"]["recreated_categories"] == []
+        assert doc["actions"]["restored_tails"] == []
+        assert doc["declined"] == []
+        assert doc["failed_messages"] == []
+        assert doc["dry_run"] is False
+        assert doc["actions"]["dead_letter"] == {"drained": 0, "remaining": 0}

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.20.0"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Adds `ferry repair --json`, a machine-readable outcome document printed to stdout alongside repair's existing human output and exit code. Closes #308.

The document reports, for one repair run:
- **actions**: recreated channels (with per-channel re-sent message counts), roles and categories, restored tails, and the dead-letter drain (drained and remaining counts)
- **declined**: what repair could not fix this run, scoped to this run's repair-phase warnings
- **failed_messages**: residual failures, carrying only `discord_msg_id` and `stoat_channel_id`, never message content
- **check**: a fresh `ferry check` of the live server after repair wrote, or `null` under `--dry-run`

## How

- A new `RepairOutcome` dataclass in `verify.py`, a sibling of `CheckReport`. `run_repair` returns it instead of `None`, accumulating each action at the site that performs it. `to_dict` strips control characters from every free-text field, matching the `check --json` contract.
- The declined set is scoped to this run by a `warnings_start` length snapshot taken at function entry, because `state.warnings` is never cleared across runs.
- Under `--json`, all human output (banner, events, proxy notices) goes to stderr, so stdout carries only the document, emitted through `click.echo` (never the Rich console, which wraps at 80 columns and can split a JSON string value, #145).

## Exit code

Unchanged contract (0 clean, 1 any defect remains, 2 unreadable state or export). The whole-branch review found that the exit code was scanning the never-cleared `state.warnings` history while the document's `declined` field was scoped to this run, so a stale `not_in_export` from an earlier run kept the exit code at 1 forever while the document reported `declined: []`. The exit code now derives its declined set from `outcome.declined`, the same scoped source, so the two always agree.

## Deferrals

Both carry all four ADR-005 fields and are filed:
- A `schema_version` key in the document: #303.
- A consumer of the output: #308 itself (the deferral trigger).

## Verification

`ruff check .`, `ruff format --check`, `mypy src/`, and 2157 tests pass. Two chunk reviews and a whole-branch second opinion returned no findings; the whole-branch code review found the exit-code contradiction above, now fixed with a regression test.

Plan chunks: #470, #471. Rebased onto `origin/main` (v2.20.0); this bumps to v2.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
