### PR TITLE
feat: ferry backfill-roles for pre-#380 servers (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.22.0] - 2026-08-20
+
+### Added
+
+- **`ferry backfill-roles` corrects role ordering on a server migrated before
+  v2.21.0.** Migrations run before the ordering fix left their roles at Stoat's
+  default order, and the only correction was a full re-run. The new command reads
+  the same roles the migration built (the export unioned with
+  `discord_metadata.json`) and sets the server's role hierarchy to Discord order
+  in one call. It creates nothing, touches no role colour or icon, and is safe to
+  re-run: a server already in order gets no write, and roles added by hand after
+  the migration keep their place. Exits 0 when applied or already correct, 1 when
+  ordering was refused, 2 when the state or export cannot be read. The roles
+  collection was extracted from `run_roles` into a shared helper so the command
+  orders by exactly what the migration built. Closes #388.
+
 ## [2.21.0] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- **`ferry backfill-roles` corrects role ordering on a server migrated before
-  v2.21.0.** Migrations run before the ordering fix left their roles at Stoat's
-  default order, and the only correction was a full re-run. The new command reads
+- **`ferry backfill-roles` corrects role ordering on a server migrated before the
+  #380 ordering fix (v2.19.2).** Migrations run before that fix left their roles at
+  Stoat's default order, and the only correction was a full re-run. The new command reads
   the same roles the migration built (the export unioned with
   `discord_metadata.json`) and sets the server's role hierarchy to Discord order
   in one call. It creates nothing, touches no role colour or icon, and is safe to

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -558,9 +558,9 @@ ferry check ./ferry-output --json > result.json
 
 ## `ferry backfill-roles`
 
-Set role ordering on a server that was migrated before the ordering fix shipped in v2.21.0. Those
-servers have their roles at Stoat's default order. This command reads the same roles the migration
-built and puts them back in Discord order, in one call.
+Set role ordering on a server that was migrated before the ordering fix (#380, shipped in v2.19.2).
+Those servers have their roles at Stoat's default order. This command reads the same roles the
+migration built and puts them back in Discord order, in one call.
 
 ```bash
 ferry backfill-roles <output-dir> --export-dir <export-dir> [OPTIONS]
@@ -583,7 +583,7 @@ by hand after the migration keep their place; only the roles Ferry created are m
 
 - **A role's colour, rank-independent hoist setting or icon.** This command sets ordering only. Those
   attributes are tracked separately in issue #344.
-- **The forward migration.** Migrations run on v2.21.0 or later already order roles correctly and do
+- **The forward migration.** Migrations run on v2.19.2 or later already order roles correctly and do
   not need this.
 
 ### Exit codes

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -14,7 +14,7 @@ Ferry's command-line interface provides the same migration capability as the GUI
 
 ## Commands
 
-Ferry has eleven top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, `stats`, `check`, `repair`, `retry`, `probe`, and `tls-check`.
+Ferry has twelve top-level commands: `migrate`, `validate`, `build`, `export-blueprint`, `rollback`, `stats`, `check`, `repair`, `backfill-roles`, `retry`, `probe`, and `tls-check`.
 
 ---
 
@@ -554,6 +554,56 @@ ferry repair ./ferry-output --export-dir ./export --dry-run
 # In a script: repair, then confirm against the server rather than trusting the tool
 ferry repair ./ferry-output --export-dir ./export
 ferry check ./ferry-output --json > result.json
+```
+
+## `ferry backfill-roles`
+
+Set role ordering on a server that was migrated before the ordering fix shipped in v2.21.0. Those
+servers have their roles at Stoat's default order. This command reads the same roles the migration
+built and puts them back in Discord order, in one call.
+
+```bash
+ferry backfill-roles <output-dir> --export-dir <export-dir> [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--export-dir PATH` | **Required.** The DCE export the original migration used |
+| `--stoat-url URL` | Stoat API base URL. Or set `STOAT_URL` |
+| `--token TOKEN` | Stoat user token. Prefer the `STOAT_TOKEN` environment variable |
+| `--dry-run` | Report what would be reordered, and change nothing |
+
+The export is required because the role positions live there and in `discord_metadata.json`, not in
+the state file. Point it at the same export the migration used.
+
+It is safe to re-run. A server that is already in order gets no write. Roles you added to the server
+by hand after the migration keep their place; only the roles Ferry created are moved.
+
+### What it does not touch
+
+- **A role's colour, rank-independent hoist setting or icon.** This command sets ordering only. Those
+  attributes are tracked separately in issue #344.
+- **The forward migration.** Migrations run on v2.21.0 or later already order roles correctly and do
+  not need this.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Ordering was applied, or the server was already in order |
+| 1 | Ordering was refused: Ferry lacks the ManageRole permission, holds no role above the ones it tried to move, or a read-back failed |
+| 2 | The state file or the export directory could not be read |
+
+`--dry-run` always exits 0.
+
+### Examples
+
+```bash
+# Correct the role order on a server migrated by an older Ferry
+ferry backfill-roles ./ferry-output --export-dir ./export --stoat-url https://api.stoat.chat
+
+# Preview first
+ferry backfill-roles ./ferry-output --export-dir ./export --dry-run
 ```
 
 ## `ferry retry`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.21.0"
+version = "2.22.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.21.0"
+__version__ = "2.22.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1894,6 +1894,11 @@ def backfill_roles_cmd(
         dry_run=dry_run,
     )
 
+    # Snapshot the warning count BEFORE the run. state.warnings is cumulative and
+    # loaded from disk, so an ordering warning left by the original migration (the
+    # very situation this command fixes) would otherwise make a clean re-run exit 1
+    # forever. repair_cmd guards the same way (#308 whole-branch review).
+    warnings_before = len(state.warnings)
     reordered = False
 
     def _on_event(event: MigrationEvent) -> None:
@@ -1922,7 +1927,7 @@ def backfill_roles_cmd(
     # so both exit 1 (repair_cmd lumps warning types the same way).
     failed = [
         w
-        for w in state.warnings
+        for w in state.warnings[warnings_before:]
         if w.get("type") in {"role_ordering_not_permitted", "role_ordering_failed"}
     ]
     if failed:

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -44,6 +44,7 @@ from discord_ferry.migrator.api import (
     api_upsert_categories,
     init_request_semaphore,
 )
+from discord_ferry.migrator.structure import run_role_backfill
 from discord_ferry.parser.dce_parser import (
     acknowledgement_required,
     parse_export_directory,
@@ -1814,6 +1815,122 @@ def repair_cmd(
         _emit_repair_json(outcome, dry_run, stoat_url, token, state)
 
     sys.exit(code)
+
+
+@main.command(name="backfill-roles")
+@click.argument("output_dir", type=click.Path(exists=True))
+@click.option(
+    "--export-dir",
+    type=click.Path(file_okay=False),
+    required=True,
+    help="The DCE export directory the original migration used",
+)
+@click.option("--stoat-url", envvar="STOAT_URL", default=None, help="Stoat API base URL")
+@click.option(
+    "--token",
+    envvar="STOAT_TOKEN",
+    default=None,
+    help="Stoat user token. Prefer the STOAT_TOKEN environment variable",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report what would be reordered, and change nothing",
+)
+def backfill_roles_cmd(
+    output_dir: str,
+    export_dir: str,
+    stoat_url: str | None,
+    token: str | None,
+    dry_run: bool,
+) -> None:
+    """Re-apply Discord role ordering to a server migrated before the #380 fix.
+
+    Reads state.json and the original export, then sets the server's role
+    hierarchy to Discord order. It creates nothing, touches no role colour or
+    icon, and is safe to re-run: an already-correct server gets no write. Exits 0
+    when ordering was applied or already correct, 1 when it was refused, and 2
+    when the state or export cannot be read.
+    """
+    load_dotenv()
+    if not stoat_url:
+        console.print("[bold red]Error:[/] --stoat-url is required (or set STOAT_URL)")
+        sys.exit(1)
+    if not token:
+        console.print("[bold red]Error:[/] --token is required (or set STOAT_TOKEN)")
+        sys.exit(1)
+
+    _print_proxy_notices()
+    register_secret("stoat", token)
+    init_request_semaphore(FerryConfig.max_concurrent_requests)
+
+    out_path = Path(output_dir)
+    try:
+        state = load_state(out_path)
+    except StateError as exc:
+        console.print(f"[bold red]Error:[/] state.json not found or unreadable: {_safe(exc)}")
+        sys.exit(2)
+
+    export_path = Path(export_dir)
+    # click.echo for anything carrying a path: the module Console wraps at 80
+    # columns off a terminal and would break the path across lines (#145).
+    if not export_path.exists():
+        click.echo(f"Error: export directory not found: {export_path}", err=True)
+        sys.exit(2)
+    try:
+        exports = parse_export_directory(export_path)
+    except Exception as exc:  # noqa: BLE001 — any parse failure is the same outcome
+        click.echo(f"Error: could not read the export at {export_path}: {exc}", err=True)
+        sys.exit(2)
+
+    config = FerryConfig(
+        export_dir=export_path,
+        stoat_url=stoat_url,
+        token=token,
+        output_dir=out_path,
+        server_id=state.stoat_server_id or None,
+        skip_export=True,
+        dry_run=dry_run,
+    )
+
+    reordered = False
+
+    def _on_event(event: MigrationEvent) -> None:
+        nonlocal reordered
+        if event.status == "progress" and event.message.startswith("Applied role ordering"):
+            reordered = True
+        colour = {"error": "bold red", "warning": "yellow"}.get(event.status, "cyan")
+        console.print(f"[{colour}]{_safe(event.message)}[/]")
+
+    console.print("[bold]Discord Ferry[/] — backfilling role order\n")
+    try:
+        asyncio.run(run_role_backfill(config, state, exports, _on_event))
+    except (CheckError, MigrationError) as exc:
+        console.print(f"\n[bold red]Backfill failed:[/] {_safe(exc)}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted.[/]")
+        sys.exit(1)
+
+    # A dry run changed nothing, so it reports on the plan and always exits 0.
+    if dry_run:
+        sys.exit(0)
+
+    # Ordering did not happen if _apply_role_ordering degraded. Both the
+    # permission refusal and the generic failure mean the hierarchy was not set,
+    # so both exit 1 (repair_cmd lumps warning types the same way).
+    failed = [
+        w
+        for w in state.warnings
+        if w.get("type") in {"role_ordering_not_permitted", "role_ordering_failed"}
+    ]
+    if failed:
+        sys.exit(1)
+
+    if not reordered:
+        click.echo("Role order was already correct; nothing changed.")
+    sys.exit(0)
 
 
 @main.command("tls-check")

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -15,6 +15,7 @@ from discord_ferry.core.http import proxy_hint, tls_hint
 from discord_ferry.discord.client import download_role_icon
 from discord_ferry.discord.metadata import (
     ChannelMeta,
+    DiscordMetadata,
     PermissionPair,
     RoleMeta,
     load_discord_metadata,
@@ -617,22 +618,20 @@ async def _apply_role_ordering(
     )
 
 
-async def run_roles(
+def _collect_roles_to_order(
     config: FerryConfig,
-    state: MigrationState,
     exports: list[DCEExport],
-    on_event: EventCallback,
-) -> None:
-    """Phase 4 — Create server roles and map Discord role IDs to Stoat role IDs.
+) -> tuple[list[DCERole], set[str], DiscordMetadata | None]:
+    """Collect the roles to create and order, unioned with live discord_metadata.
 
-    Args:
-        config: Ferry configuration.
-        state: Migration state; ``role_map`` will be populated.
-        exports: Parsed DCE exports; roles are extracted from message authors.
-        on_event: Event callback for progress reporting.
+    A pure extraction of the collection-and-union block of ``run_roles``: it makes
+    no API call and mutates no state. The cap-truncation that used to follow this
+    block stays in ``run_roles`` (create-path bookkeeping), re-guarded by the
+    returned ``discord_metadata``. ``run_role_backfill`` shares this exact list so
+    it orders by what the migration built. #388.
 
-    Raises:
-        MigrationError: If any API call fails unrecoverably.
+    Returns ``(roles, export_role_ids, discord_metadata)``. ``export_role_ids`` is
+    the provenance set ``run_roles`` uses to credit recovered structural roles.
     """
     # Determine the @everyone role ID (same as guild ID) to skip it.
     guild_id = exports[0].guild.id if exports else ""
@@ -670,6 +669,35 @@ async def run_roles(
             merged_roles[role_id] = _role_from_metadata(role_id, live_rm)
         roles_to_create = list(merged_roles.values())
 
+    return roles_to_create, export_role_ids, discord_metadata
+
+
+async def run_roles(
+    config: FerryConfig,
+    state: MigrationState,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> None:
+    """Phase 4 — Create server roles and map Discord role IDs to Stoat role IDs.
+
+    Args:
+        config: Ferry configuration.
+        state: Migration state; ``role_map`` will be populated.
+        exports: Parsed DCE exports; roles are extracted from message authors.
+        on_event: Event callback for progress reporting.
+
+    Raises:
+        MigrationError: If any API call fails unrecoverably.
+    """
+    # Collect the roles to create and order. The helper is a pure collection and
+    # union: it makes no API call and mutates no state. See _collect_roles_to_order.
+    roles_to_create, export_role_ids, discord_metadata = _collect_roles_to_order(
+        config, exports
+    )
+
+    # Role cap, scoped to the union path exactly as before. The guard must stay:
+    # api_fetch_root is a request the export-only path never makes.
+    if discord_metadata is not None:
         # Role cap: read the live server_roles limit (best-effort; 200 fallback).
         # The union can exceed Stoat's cap, so pre-flight truncate by lowest
         # (position, id) and keep the top-N. Scoped to the union path only.

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -688,6 +688,18 @@ async def run_role_backfill(
     rather than raising, so this function does neither of those itself. #388.
     """
     roles, _export_role_ids, _discord_metadata = _collect_roles_to_order(config, exports)
+    if config.dry_run:
+        # `_apply_role_ordering` writes unconditionally; in `run_roles` it is
+        # reached only under `not config.dry_run`. A backfill must guard it the
+        # same way, or `--dry-run` would read the server and PATCH the ranks.
+        on_event(
+            MigrationEvent(
+                phase="roles",
+                status="progress",
+                message=f"[DRY RUN] Would re-apply role ordering to {len(roles)} roles",
+            )
+        )
+        return
     async with get_session(config) as session:
         await _apply_role_ordering(session, config, state, roles, on_event)
 

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -672,6 +672,26 @@ def _collect_roles_to_order(
     return roles_to_create, export_role_ids, discord_metadata
 
 
+async def run_role_backfill(
+    config: FerryConfig,
+    state: MigrationState,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> None:
+    """Re-apply Discord role ordering to a server migrated before #380.
+
+    Orders by the same roles list ``run_roles`` builds, via
+    ``_collect_roles_to_order``, then reuses ``_apply_role_ordering``. It creates
+    nothing and touches no role attribute. ``_apply_role_ordering`` already
+    returns early when the order is correct or fewer than two known roles are
+    present, and degrades a permission refusal to a ``state.warnings`` entry
+    rather than raising, so this function does neither of those itself. #388.
+    """
+    roles, _export_role_ids, _discord_metadata = _collect_roles_to_order(config, exports)
+    async with get_session(config) as session:
+        await _apply_role_ordering(session, config, state, roles, on_event)
+
+
 async def run_roles(
     config: FerryConfig,
     state: MigrationState,
@@ -691,9 +711,7 @@ async def run_roles(
     """
     # Collect the roles to create and order. The helper is a pure collection and
     # union: it makes no API call and mutates no state. See _collect_roles_to_order.
-    roles_to_create, export_role_ids, discord_metadata = _collect_roles_to_order(
-        config, exports
-    )
+    roles_to_create, export_role_ids, discord_metadata = _collect_roles_to_order(config, exports)
 
     # Role cap, scoped to the union path exactly as before. The guard must stay:
     # api_fetch_root is a request the export-only path never makes.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3432,3 +3432,26 @@ def test_backfill_summary_reports_a_reorder(runner: CliRunner, tmp_path: Path) -
     assert result.exit_code == 0
     assert "Applied role ordering to 3 roles" in result.output
     assert "already correct" not in result.output
+
+
+def test_backfill_stale_warning_from_prior_run_does_not_cause_false_failure(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A role_ordering warning left in state.json by the ORIGINAL migration must
+    not make a successful backfill re-run exit 1. That is the exact scenario the
+    command exists for. #388 whole-branch review."""
+    from discord_ferry.state import load_state, save_state
+
+    out_dir, export_dir = _backfill_state(tmp_path)
+    state = load_state(out_dir)
+    state.warnings.append(
+        {"phase": "roles", "type": "role_ordering_not_permitted", "message": "stale"}
+    )
+    save_state(state, out_dir)
+
+    async def _noop(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        return None  # this run succeeds
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_noop):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3259,3 +3259,176 @@ def test_repair_json_mixed_run_is_consistent(runner: CliRunner, tmp_path: Path) 
     assert doc["declined"] and doc["failed_messages"]
     assert doc["check"]["counts"]["fail"] == 1
     assert js.exit_code == plain.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# ferry backfill-roles (#388, #482)
+# ---------------------------------------------------------------------------
+
+
+def _backfill_argv(out_dir: Path, export_dir: Path, *extra: str) -> list[str]:
+    return [
+        "backfill-roles",
+        str(out_dir),
+        "--export-dir",
+        str(export_dir),
+        "--stoat-url",
+        "https://api.test",
+        "--token",
+        "t",
+        *extra,
+    ]
+
+
+def _backfill_state(tmp_path: Path) -> tuple[Path, Path]:
+    """A completed state plus a minimal export, the inputs backfill reads."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    from discord_ferry.state import save_state
+
+    save_state(MigrationState(stoat_server_id="01JSTOATSRV000000000AAA"), out_dir)
+    return out_dir, export_dir
+
+
+def test_backfill_help_lists_options(runner: CliRunner) -> None:
+    """SC-1.1."""
+    result = runner.invoke(main, ["backfill-roles", "--help"])
+    assert result.exit_code == 0
+    for opt in ("--export-dir", "--stoat-url", "--token", "--dry-run"):
+        assert opt in result.output
+
+
+def test_backfill_missing_url_errors(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.3, no URL."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+    result = runner.invoke(
+        main,
+        ["backfill-roles", str(out_dir), "--export-dir", str(export_dir), "--token", "t"],
+        env={"STOAT_URL": "", "STOAT_TOKEN": ""},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "--stoat-url is required" in result.output
+
+
+def test_backfill_missing_token_errors(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.3, no token."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "backfill-roles",
+            str(out_dir),
+            "--export-dir",
+            str(export_dir),
+            "--stoat-url",
+            "https://api.test",
+        ],
+        env={"STOAT_URL": "", "STOAT_TOKEN": ""},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "--token is required" in result.output
+
+
+def test_backfill_exits_2_on_unreadable_state(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.2. No state.json in the output dir."""
+    export_dir = _write_minimal_export(tmp_path / "export")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()  # exists, but holds no state.json
+    result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 2, result.output
+
+
+def test_backfill_exits_2_on_unreadable_export(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.4."""
+    out_dir, _ = _backfill_state(tmp_path)
+    missing = tmp_path / "nope"
+    result = runner.invoke(main, _backfill_argv(out_dir, missing))
+    assert result.exit_code == 2, result.output
+
+
+def test_backfill_dry_run_exits_0_and_passes_flag(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-1.4."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+    seen: dict[str, Any] = {}
+
+    async def _capture(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        seen["dry_run"] = config.dry_run
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_capture):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir, "--dry-run"))
+    assert seen["dry_run"] is True
+    assert result.exit_code == 0, result.output
+
+
+def test_backfill_exits_0_when_clean(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.1."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+
+    async def _noop(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        return None
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_noop):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 0, result.output
+
+
+def test_backfill_exits_1_on_permission_refusal(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.2."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+
+    async def _refused(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        state.warnings.append(
+            {"phase": "roles", "type": "role_ordering_not_permitted", "message": "x"}
+        )
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_refused):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 1, result.output
+
+
+def test_backfill_exits_1_on_generic_failure(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-4.3. A failed read-back (role_ordering_failed) must not exit 0."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+
+    async def _failed(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        state.warnings.append({"phase": "roles", "type": "role_ordering_failed", "message": "x"})
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_failed):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 1, result.output
+
+
+def test_backfill_summary_reports_already_correct(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.2. A no-op run tells the operator the order was already correct."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+
+    async def _noop(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        return None
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_noop):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 0
+    assert "already correct" in result.output
+
+
+def test_backfill_summary_reports_a_reorder(runner: CliRunner, tmp_path: Path) -> None:
+    """SC-5.1. A reorder surfaces the ordering event and not the no-op line."""
+    out_dir, export_dir = _backfill_state(tmp_path)
+
+    async def _reorder(config: Any, state: Any, exports: Any, on_event: Any) -> None:
+        from discord_ferry.core.events import MigrationEvent
+
+        on_event(
+            MigrationEvent(
+                phase="roles", status="progress", message="Applied role ordering to 3 roles"
+            )
+        )
+
+    with patch("discord_ferry.cli.run_role_backfill", new=_reorder):
+        result = runner.invoke(main, _backfill_argv(out_dir, export_dir))
+    assert result.exit_code == 0
+    assert "Applied role ordering to 3 roles" in result.output
+    assert "already correct" not in result.output

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4337,6 +4337,47 @@ async def test_run_roles_dry_run_sends_no_ordering(tmp_path: Path) -> None:
     assert state.role_map == {"a": "dry-role-a", "b": "dry-role-b"}
 
 
+async def test_run_roles_export_only_path_never_fetches_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-I2. With no discord_metadata, run_roles must not call api_fetch_root.
+
+    The cap-truncation lives inside ``if discord_metadata is not None:``. After
+    ``_collect_roles_to_order`` is extracted, ``run_roles`` re-guards it. If the
+    guard is lost, ``api_fetch_root`` fires on the export-only path, where today
+    it never runs. #388.
+    """
+    from discord_ferry.migrator import structure as _structure
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("api_fetch_root must not run on the export-only path")
+
+    monkeypatch.setattr(_structure, "api_fetch_root", _boom)
+
+    events: list[MigrationEvent] = []
+    config = _make_config(tmp_path)  # no discord_metadata saved
+    state = MigrationState(stoat_server_id="srv1")
+    roles = [
+        DCERole(id="a", name="A", position=1),
+        DCERole(id="b", name="B", position=9),
+    ]
+    exports = [_make_export(messages=[_make_message("m1", roles=roles)])]
+
+    with aioresponses() as m:
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-a", "name": "A"})
+        m.post(f"{STOAT_URL}/servers/srv1/roles", payload={"id": "stoat-b", "name": "B"})
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"stoat-a": 0, "stoat-b": 1}),
+            repeat=True,
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/ranks", payload={"_id": "srv1"}, repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-a", payload={}, repeat=True)
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/stoat-b", payload={}, repeat=True)
+        await run_roles(config, state, exports, events.append)
+    # Reaching here without the AssertionError means the guard held.
+
+
 async def test_run_roles_ordering_converges_on_a_second_run(tmp_path: Path) -> None:
     """SC-3.12. A second pass reaches the same order and creates no duplicate roles.
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4972,3 +4972,44 @@ async def test_run_role_backfill_rerun_does_not_grow_warnings(tmp_path: Path) ->
         await run_role_backfill(config, state, [export], lambda e: None)
 
     assert [w for w in state.warnings if w["type"] == "role_limit_exceeded"] == []
+
+
+async def test_run_role_backfill_dry_run_sends_no_ranks_write(tmp_path: Path) -> None:
+    """SC-1.4 at the engine level. A dry run must send no ranks write.
+
+    The read-back is registered so it succeeds; the failure this guards against is
+    the PATCH landing anyway. A bare no-route test would pass for the wrong reason,
+    because a failed read is swallowed into a warning and looks identical to a
+    dry run that changed nothing.
+    """
+    config = _make_config(tmp_path, dry_run=True)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "s-a", "b": "s-b"}
+    export = _make_export(
+        messages=[
+            _make_message(
+                "m1",
+                roles=[
+                    DCERole(id="a", name="A", position=1),
+                    DCERole(id="b", name="B", position=9),
+                ],
+            )
+        ]
+    )
+
+    patches = 0
+
+    def _count(url: object, **kw: object) -> None:
+        nonlocal patches
+        patches += 1
+
+    with aioresponses() as m:
+        # The server is in the WRONG order, so a non-dry run would PATCH.
+        m.get(
+            f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-a": 0, "s-b": 1}), repeat=True
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/ranks", payload={"_id": "srv1"}, callback=_count)
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    assert patches == 0, "a dry run must not write the role hierarchy"
+    assert [w for w in state.warnings if w["type"].startswith("role_ordering")] == []

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -27,6 +27,7 @@ from discord_ferry.migrator.structure import (
     make_unique_channel_name,
     run_categories,
     run_channels,
+    run_role_backfill,
     run_roles,
     run_server,
 )
@@ -4757,3 +4758,217 @@ async def test_run_roles_ordering_survives_an_interrupt_and_resume(tmp_path: Pat
     assert resume_bodies == clean_bodies, (
         "a resumed run must reach the same hierarchy as an uninterrupted one"
     )
+
+
+# run_role_backfill (#388, #481)
+
+
+def _backfill_meta(role_metadata: dict[str, RoleMeta]) -> DiscordMetadata:
+    return DiscordMetadata(
+        guild_id="111",
+        fetched_at="t",
+        server_default_permissions=0,
+        role_permissions={},
+        channel_metadata={},
+        role_metadata=role_metadata,
+    )
+
+
+async def test_run_role_backfill_orders_live_only_roles(tmp_path: Path) -> None:
+    """SC-2.1. A role present only in discord_metadata is placed, not dropped."""
+    config = _make_config(tmp_path)
+    save_discord_metadata(
+        _backfill_meta(
+            {"r1": RoleMeta(name="A", position=1), "r2": RoleMeta(name="B", position=9)}
+        ),
+        tmp_path,
+    )
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"r1": "s-r1", "r2": "s-r2"}
+    # Export author posts under r1 only; r2 exists only in live metadata.
+    export = _make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="A")])])
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-r1": 0, "s-r2": 1}))
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    assert bodies == [{"ranks": ["s-r2", "s-r1"]}]  # position desc, live-only r2 on top
+
+
+async def test_run_role_backfill_export_only_orders_by_export_position(tmp_path: Path) -> None:
+    """SC-2.2. With no discord_metadata, ordering uses export positions."""
+    config = _make_config(tmp_path)  # no metadata saved
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "s-a", "b": "s-b"}
+    export = _make_export(
+        messages=[
+            _make_message(
+                "m1",
+                roles=[
+                    DCERole(id="a", name="A", position=1),
+                    DCERole(id="b", name="B", position=9),
+                ],
+            )
+        ]
+    )
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-a": 0, "s-b": 1}))
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    assert bodies == [{"ranks": ["s-b", "s-a"]}]  # b has the higher export position
+
+
+async def test_run_role_backfill_never_orders_everyone(tmp_path: Path) -> None:
+    """SC-2.3. @everyone (id == guild id) is excluded and keeps its slot."""
+    config = _make_config(tmp_path)
+    save_discord_metadata(
+        _backfill_meta(
+            {"r1": RoleMeta(name="A", position=1), "r2": RoleMeta(name="B", position=9)}
+        ),
+        tmp_path,
+    )
+    state = MigrationState(stoat_server_id="srv1")
+    # role_map maps @everyone too, but the collector must exclude it from ordering.
+    state.role_map = {"111": "s-everyone", "r1": "s-r1", "r2": "s-r2"}
+    export = _make_export(
+        guild_id="111",
+        messages=[
+            _make_message(
+                "m1", roles=[DCERole(id="111", name="everyone"), DCERole(id="r1", name="A")]
+            )
+        ],
+    )
+
+    bodies: list[dict[str, object]] = []
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"s-everyone": 0, "s-r1": 1, "s-r2": 2}),
+        )
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"_id": "srv1"},
+            callback=lambda url, **kw: bodies.append(kw.get("json", {})),  # type: ignore[misc]
+        )
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    # @everyone stays at index 0; only r1 and r2 are permuted below it.
+    assert bodies == [{"ranks": ["s-everyone", "s-r2", "s-r1"]}]
+
+
+async def test_run_role_backfill_is_idempotent(tmp_path: Path) -> None:
+    """SC-3.1. A second run over an already-correct server sends no ranks write."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "s-a", "b": "s-b"}
+    export = _make_export(
+        messages=[
+            _make_message(
+                "m1",
+                roles=[
+                    DCERole(id="a", name="A", position=9),
+                    DCERole(id="b", name="B", position=1),
+                ],
+            )
+        ]
+    )
+
+    patches = 0
+
+    def _count(url: object, **kw: object) -> None:
+        nonlocal patches
+        patches += 1
+
+    with aioresponses() as m:
+        # Already position-desc: s-a rank 0, s-b rank 1.
+        m.get(
+            f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-a": 0, "s-b": 1}), repeat=True
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/ranks", payload={"_id": "srv1"}, callback=_count)
+        await run_role_backfill(config, state, [export], lambda e: None)
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    assert patches == 0
+
+
+async def test_run_role_backfill_single_known_role_makes_no_write(tmp_path: Path) -> None:
+    """SC-3.2. Fewer than two known roles cannot permute, so no write is sent."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "s-a"}
+    export = _make_export(messages=[_make_message("m1", roles=[DCERole(id="a", name="A")])])
+
+    with aioresponses() as m:
+        # No PATCH route registered: aioresponses raises if a write is attempted.
+        m.get(f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-a": 0}), repeat=True)
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+
+async def test_run_role_backfill_permission_refusal_warns(tmp_path: Path) -> None:
+    """SC-3.3. A NotElevated refusal degrades to a warning, not an exception."""
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"a": "s-a", "b": "s-b"}
+    export = _make_export(
+        messages=[
+            _make_message(
+                "m1",
+                roles=[
+                    DCERole(id="a", name="A", position=1),
+                    DCERole(id="b", name="B", position=9),
+                ],
+            )
+        ]
+    )
+
+    with aioresponses() as m:
+        m.get(f"{STOAT_URL}/servers/srv1", payload=_server_payload({"s-a": 0, "s-b": 1}))
+        m.patch(
+            f"{STOAT_URL}/servers/srv1/roles/ranks",
+            payload={"type": "NotElevated"},
+            status=403,
+        )
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    warned = [w for w in state.warnings if w["type"] == "role_ordering_not_permitted"]
+    assert len(warned) == 1
+    assert not [w for w in state.warnings if w["type"] == "role_ordering_failed"]
+
+
+async def test_run_role_backfill_rerun_does_not_grow_warnings(tmp_path: Path) -> None:
+    """SC-I1. The backfill path carries no cap-truncation, so no warning grows."""
+    config = _make_config(tmp_path)
+    save_discord_metadata(
+        _backfill_meta(
+            {"r1": RoleMeta(name="A", position=1), "r2": RoleMeta(name="B", position=9)}
+        ),
+        tmp_path,
+    )
+    state = MigrationState(stoat_server_id="srv1")
+    state.role_map = {"r1": "s-r1", "r2": "s-r2"}
+    export = _make_export(messages=[_make_message("m1", roles=[DCERole(id="r1", name="A")])])
+
+    with aioresponses() as m:
+        m.get(
+            f"{STOAT_URL}/servers/srv1",
+            payload=_server_payload({"s-r1": 0, "s-r2": 1}),
+            repeat=True,
+        )
+        m.patch(f"{STOAT_URL}/servers/srv1/roles/ranks", payload={"_id": "srv1"}, repeat=True)
+        await run_role_backfill(config, state, [export], lambda e: None)
+        await run_role_backfill(config, state, [export], lambda e: None)
+
+    assert [w for w in state.warnings if w["type"] == "role_limit_exceeded"] == []

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.21.0"
+version = "2.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Adds `ferry backfill-roles`, a standalone CLI command that re-applies Discord role hierarchy to a server migrated before the #380 ordering fix (v2.19.2). Those servers have their roles at Stoat's default order, and the only correction was a full re-run. Closes #388.

## How

- Extract the roles collection-and-union block out of `run_roles` into a pure `_collect_roles_to_order` helper (no API call, no state mutation), so the command orders by exactly the list the migration built. `run_roles` keeps its own cap-truncation, re-guarded by the returned `discord_metadata`.
- New engine function `run_role_backfill` reuses the existing `_apply_role_ordering`. It creates nothing, touches no role attribute, is idempotent, and honors `--dry-run`.
- New CLI command modelled on `repair_cmd`: exit 0 applied-or-already-correct, 1 when ordering was refused, 2 when state or the export is unreadable.

## Ship review found two real bugs, both fixed here

- **Dry-run wrote to the server.** `run_role_backfill` called `_apply_role_ordering` with no `dry_run` guard, so `--dry-run` would read the server and PATCH the ranks. Guarded, with a test that registers the read and counts writes.
- **A stale ordering warning failed a clean re-run.** The command scanned the whole cumulative `state.warnings` (loaded from disk), so a warning left by the original migration kept the exit code at 1. Scoped to warnings this run produced, the way `repair_cmd` does.

## Non-goals

Role colour, hoist and icon (tracked by #344); roles added by hand after the migration (they keep their slot); a GUI surface.

## Tests

7 engine tests + 13 CLI tests, plus the two ship-review regression tests. Full suite: 2178 passed. Both chunk reviews and the whole-branch review posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
