### PR TITLE
feat(proxy): honour ALL_PROXY as an http/https fallback (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.23.0] - 2026-08-20
+
+### Added
+
+- **`ALL_PROXY` is now honoured as a fallback for HTTP and HTTPS.** DiscordChatExporter,
+  which Ferry runs as a subprocess, reads `ALL_PROXY`; Ferry did not, so a user whose only
+  proxy setting was `ALL_PROXY` got a successful export followed by every later phase
+  connecting direct and failing. Ferry now uses the `ALL_PROXY` proxy for http and https
+  when no scheme-specific `HTTP_PROXY`/`HTTPS_PROXY` is set, so a single
+  `ALL_PROXY=http://host:port` reaches every phase. A scheme-specific proxy still wins, an
+  explicitly-emptied scheme (`HTTPS_PROXY=""`) is not rescued by the fallback, `NO_PROXY`
+  and `FERRY_DISABLE_PROXY` still apply, and the proxy credential is stripped from logs and
+  the connection URL as before. SOCKS proxies remain unsupported, including a SOCKS value in
+  `ALL_PROXY`, which is reported in the startup notice and in `ferry tls-check`. Closes #141.
+
 ## [2.22.0] - 2026-08-20
 
 ### Added

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -331,13 +331,13 @@ Ferry reads `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` the way most command-line
 | **Cause** | When Ferry resolves a proxy from the system settings and that proxy needs a username and password, Ferry authenticates itself but cannot hand the credential to DiscordChatExporter. A password sitting in a child process's environment is readable by other processes on some systems, so Ferry withholds it and DCE receives only the proxy address. |
 | **Solution** | Set `HTTPS_PROXY` yourself with the credential in the URL (`https://user:pass@host:port`) if that trade-off is acceptable. DCE inherits a variable you set directly; it only misses the one Ferry resolved on your behalf. |
 
-### SOCKS and ALL_PROXY are not supported
+### SOCKS proxies are not supported
 
 | | |
 |---|---|
-| **Symptom** | A proxy notice at startup or in `ferry tls-check` names a SOCKS proxy or `ALL_PROXY`, and Ferry connects direct anyway |
-| **Cause** | Ferry supports HTTP and HTTPS proxies only. A SOCKS proxy, or a proxy set exclusively through `ALL_PROXY`, falls outside what Ferry can use ([issue #141](https://github.com/nordscope-fi/Discord-stoat-ferry/issues/141)). |
-| **Solution** | Set `HTTP_PROXY` and `HTTPS_PROXY` directly if an HTTP or HTTPS proxy is available for the same server. Ferry writes a notice naming what it found, so the direct connection has a stated cause. There is no workaround for a SOCKS-only setup today; issue #141 tracks it. |
+| **Symptom** | A proxy notice at startup or in `ferry tls-check` names a SOCKS proxy, and Ferry connects direct anyway |
+| **Cause** | Ferry speaks HTTP and HTTPS to a proxy, not SOCKS. A SOCKS proxy set through any variable, including `ALL_PROXY`, falls outside what Ferry can use. |
+| **Solution** | Point `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` at an HTTP or HTTPS proxy for the same server. `ALL_PROXY` is honoured as a fallback for http and https when no scheme-specific proxy is set, so a single `ALL_PROXY=http://host:port` reaches every phase. There is no workaround for a SOCKS-only setup; Ferry writes a notice naming what it found, so the direct connection has a stated cause. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.22.0"
+version = "2.23.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.22.0"
+__version__ = "2.23.0"

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -452,6 +452,17 @@ def resolve_proxy_or_raise(url: str | URL) -> ProxyChoice | None:
         raw, source = env[scheme], "env"
     elif scheme in os_side:
         raw, source = os_side[scheme], "os"
+    elif "all" in env and scheme not in _suppressed_schemes():
+        # ALL_PROXY is the fallback curl and DCE (via .NET) both honour: used
+        # only when no scheme-specific proxy resolves. Issue #141. The
+        # suppression clause is load-bearing, not decorative. stdlib pops an
+        # empty `HTTPS_PROXY=""` from the proxy dict in getproxies_environment's
+        # second pass, so `"all" in env` alone cannot tell "https unset" from
+        # "https explicitly turned off". _suppressed_schemes() re-reads the raw
+        # environment, the only place that off switch survives. Everything below
+        # (socks guard, _strip_userinfo, _is_bypassed) then applies unchanged, so
+        # a socks ALL_PROXY connects direct and a NO_PROXY host is still exempt.
+        raw, source = env["all"], "env"
     else:
         return None
 

--- a/src/discord_ferry/core/http.py
+++ b/src/discord_ferry/core/http.py
@@ -241,7 +241,7 @@ class ProxyChoice:
 class ProxyNotice:
     """A proxy configuration Ferry found but cannot use."""
 
-    kind: str  # stable identifier, e.g. "all_proxy_only", "socks", "malformed"
+    kind: str  # stable identifier, e.g. "socks", "malformed"
     scheme: str
     display: str  # redacted, never carries userinfo
     outcome: str  # what Ferry did instead, e.g. "used the OS proxy", "connected direct"
@@ -586,38 +586,40 @@ def _scan_notices() -> tuple[ProxyNotice, ...]:
     found: list[ProxyNotice] = []
 
     if "all" in env:
-        # "Covered" means a scheme that actually RESOLVES, not one whose key is
-        # merely present. Key membership alone produces a self-contradicting
-        # notice on the commonest SOCKS setup, where shadowsocks, v2ray, `ssh -D`
-        # and Tor all document exporting ALL_PROXY, HTTP_PROXY and HTTPS_PROXY
-        # together as socks5. Ferry connects direct for both schemes
-        # (resolve_proxy returns None at the socks guard), yet a membership test
-        # reports "Used the proxy configured for http, https instead." on the
-        # line directly above two notices saying "Connected direct."
-        covered = [s for s in ("http", "https") if _usable(env.get(s) or os_side.get(s))]
-        found.append(
-            ProxyNotice(
-                kind="all_proxy_only",
-                scheme="all",
-                display=_safe_display(env["all"]),
-                # Name the schemes, never a single source. The source is
-                # per-scheme: HTTP_PROXY in the environment with https from the
-                # OS would make any one-word answer wrong for one of them.
-                #
-                # This comment used to hand off to `ferry tls-check` as
-                # reporting the source PER SCHEME. It does not. describe_proxy
-                # writes one `proxy-source` key inside its scheme loop, so on a
-                # mixed configuration the last scheme to resolve wins. Corrected
-                # at the final review; the handoff promise is dropped rather
-                # than the diagnostic widened, because release.yml asserts on
-                # the single key name.
-                outcome=(
-                    f"Used the proxy configured for {', '.join(covered)} instead."
-                    if covered
-                    else "Connected direct. ALL_PROXY is not supported (see issue #141)."
-                ),
+        # ALL_PROXY is now honoured as an http/https fallback (issue #141,
+        # resolve_proxy_or_raise). A value Ferry can use needs no notice, because
+        # it is used. Only a value Ferry still cannot use is reported, for the
+        # same two reasons the per-scheme loop below reports one: a SOCKS scheme,
+        # or a URL that will not process. `_strip_userinfo` is part of "will not
+        # process" here: resolution returns direct when it raises, so a proxy
+        # whose credential cannot be parsed is unusable exactly as a malformed
+        # URL is, and the ALL_PROXY path has always surfaced that case (its
+        # display was built unconditionally before this change).
+        raw_all = env["all"]
+        try:
+            parsed_all = URL(raw_all)
+            socks_all = parsed_all.scheme.startswith("socks")
+            if not socks_all:
+                _strip_userinfo(parsed_all)
+        except (ValueError, TypeError):
+            found.append(
+                ProxyNotice(
+                    kind="malformed",
+                    scheme="all",
+                    display=_safe_display(raw_all),
+                    outcome="Connected direct.",
+                )
             )
-        )
+        else:
+            if socks_all:
+                found.append(
+                    ProxyNotice(
+                        kind="socks",
+                        scheme="all",
+                        display=_safe_display(raw_all),
+                        outcome="Connected direct. SOCKS is not supported (see issue #141).",
+                    )
+                )
 
     for scheme, raw in (*env.items(), *os_side.items()):
         if scheme not in ("http", "https"):
@@ -645,27 +647,6 @@ def _scan_notices() -> tuple[ProxyNotice, ...]:
             )
 
     return tuple(found)
-
-
-def _usable(raw: str | None) -> bool:
-    """True when `raw` is a proxy Ferry can actually use. Never raises.
-
-    The `raw is None` guard is what makes the call below type-check. `raw` is
-    `str | None`, and deleting the guard removes the narrowing, so mypy reports
-    `Argument 1 to "URL" has incompatible type "str | None"` [arg-type].
-    Measured, and `mypy src/` is in the project verification command, so the gate
-    catches that mutant even though no pytest assertion can: at runtime the
-    except arm would catch the resulting TypeError from URL(None) and return the
-    same False. An earlier version of this comment called the guard
-    "documentation rather than behaviour", which was wrong for having checked
-    only one of the two tools that guard this file.
-    """
-    if raw is None:
-        return False
-    try:
-        return not URL(raw).scheme.startswith("socks")
-    except (ValueError, TypeError):
-        return False
 
 
 def _safe_display(raw: str) -> str:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -613,7 +613,7 @@ def test_proxy_notice_lines_formats_for_the_log_panel(proxy_env, os_proxy) -> No
         lines = _proxy_notice_lines()
     assert lines == [
         "[notice] Proxy configuration Ferry cannot use: socks5://sock:1080 (all). "
-        "Connected direct. ALL_PROXY is not supported (see issue #141)."
+        "Connected direct. SOCKS is not supported (see issue #141)."
     ]
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1153,77 +1153,48 @@ async def test_no_credential_reaches_the_exception(fake_proxy, proxy_env, os_pro
 # rollback redaction in v2.6.16.
 
 
-def test_all_proxy_only_is_reported(proxy_env, os_proxy) -> None:
-    """SC-135-18. Killing TWO implementations.
-
-    First: delegating to get_env_proxy_for_url, which filters ALL_PROXY out
-    before Ferry can see it.
-
-    Second, and this is why the test does NOT call resolve_proxy first:
-    recording notices as a side effect of resolution. Every reader of
-    proxy_notices() -- engine preflight, build, rollback, probe, and the GUI
-    export screen -- runs BEFORE any request is made, so a resolve-time
-    implementation returns () at all five and the feature ships inert. A test
-    that called resolve_proxy first would create the condition it then asserts,
-    which is the shape that let this repo ship inert rollback redaction.
-    """
+def test_a_socks_all_proxy_is_reported_as_socks(proxy_env, os_proxy) -> None:
+    """SC-2.2. proxy_notices() must NOT call resolve_proxy first: every reader
+    (engine preflight, build, rollback, probe, GUI export) runs BEFORE any
+    request, so a resolve-time implementation returns () at all five and the
+    feature ships inert, the shape that let this repo ship inert rollback
+    redaction. Killing: routing a socks ALL_PROXY into a generic
+    'ALL_PROXY unsupported' text instead of the SOCKS message, now that a usable
+    ALL_PROXY is honoured (issue #141) and needs no notice."""
     with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080"):
         notices = http.proxy_notices()
-    assert any(n.kind == "all_proxy_only" for n in notices)
+    socks = [n for n in notices if n.kind == "socks" and n.scheme == "all"]
+    assert socks
+    assert "SOCKS is not supported" in socks[0].outcome
 
 
-def test_the_notice_outcome_is_true(proxy_env, os_proxy) -> None:
-    """SC-135-18. Killing: a notice claiming 'connected direct' when an OS proxy
-    was in fact used."""
-    with os_proxy(CORP), proxy_env(ALL_PROXY="socks5://sock:1080"):
+def test_a_usable_all_proxy_emits_no_notice(proxy_env, os_proxy) -> None:
+    """SC-2.1. Killing: leaving the old always-emit ALL_PROXY notice in place,
+    which would declare the proxy unsupported while resolution now uses it."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://p:8080"):
         notices = http.proxy_notices()
-    assert any("http" in n.outcome and "https" in n.outcome for n in notices)
+    assert all(n.scheme != "all" for n in notices)
+    assert all("ALL_PROXY is not supported" not in n.outcome for n in notices)
 
 
-def test_the_all_proxy_outcome_is_not_contradicted_by_its_own_siblings(proxy_env, os_proxy) -> None:
-    """Killing: `covered` built from key membership rather than usability.
-
-    The canonical SOCKS setup exports all three variables together, which
-    shadowsocks, v2ray, `ssh -D` and Tor all document. Under a membership test
-    the ALL_PROXY notice claims "Used the proxy configured for http, https
-    instead." while the two notices printed directly after it say "Connected
-    direct. SOCKS is not supported." The first line is false and contradicts the
-    other two.
-
-    `test_the_notice_outcome_is_true` cannot see this: it is the mirror case,
-    and its docstring names only the direction where an OS proxy WAS used.
-    """
-    with (
-        os_proxy({}),
-        proxy_env(
-            ALL_PROXY="socks5://127.0.0.1:1080",
-            HTTP_PROXY="socks5://127.0.0.1:1080",
-            HTTPS_PROXY="socks5://127.0.0.1:1080",
-        ),
-    ):
-        lines = http.format_proxy_notices()
-    joined = " ".join(lines)
-    assert "Used the proxy configured for" not in joined
-    assert any("ALL_PROXY is not supported" in line for line in lines)
-
-
-def test_the_all_proxy_outcome_does_not_name_a_single_source(proxy_env, os_proxy) -> None:
-    """Killing: an outcome that picks one source word for a mixed configuration.
-
-    With HTTP_PROXY in the environment and https from the OS, the two covered
-    schemes have different sources, so any one-word answer is wrong for one of
-    them. The outcome names the schemes and leaves the source to
-    `ferry tls-check`, which reports it per scheme.
-    """
-    with (
-        os_proxy({"https": "http://corp:8080"}),
-        proxy_env(ALL_PROXY="socks5://sock:1080", HTTP_PROXY="http://env:3128"),
-    ):
+def test_a_malformed_all_proxy_is_reported(proxy_env, os_proxy) -> None:
+    """SC-2.3. Killing: an unguarded URL(env['all']) that raises instead of
+    degrading to a notice."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://host:notaport"):
         notices = http.proxy_notices()
-    outcomes = " ".join(n.outcome for n in notices)
-    assert "http" in outcomes
-    assert "OS" not in outcomes
-    assert "environment" not in outcomes
+    assert any(n.kind == "malformed" and n.scheme == "all" for n in notices)
+
+
+def test_all_proxy_is_consistent_across_resolution_and_notices(proxy_env, os_proxy) -> None:
+    """SC-I1. Killing: any component disagreeing -- resolution uses the proxy
+    while a notice says 'connected direct', the contradiction the old covered
+    logic risked."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://p:8080"):
+        choice = http.resolve_proxy(TARGET)
+        notices = http.proxy_notices()
+    assert choice is not None
+    assert str(choice.url) == "http://p:8080"
+    assert all(n.scheme != "all" for n in notices)
 
 
 @pytest.mark.parametrize(
@@ -1327,7 +1298,7 @@ def test_a_malformed_proxy_url_is_reported(proxy_env, os_proxy) -> None:
 def test_a_notice_display_never_carries_userinfo(proxy_env, os_proxy, variable) -> None:
     """Constraint 5, at BOTH _safe_display call sites.
 
-    The ALL_PROXY case covers the display built in the all_proxy_only branch and
+    The ALL_PROXY case covers the display built in the "all" notice branch and
     the HTTPS_PROXY case the one built in the socks branch; a `display=raw`
     mutant at either site survives the other test. Notices reach ferry.log and
     the GUI, and a proxy password is a credential like any other.
@@ -1354,28 +1325,6 @@ def test_building_a_display_never_raises(proxy_env, os_proxy, bad: str) -> None:
     assert [n.display for n in notices] == ["<unparseable>"]
 
 
-def test_the_all_proxy_outcome_names_a_scheme_the_environment_supplies(proxy_env, os_proxy) -> None:
-    """The `s in env` half of the `covered` comprehension, which nothing else pins.
-
-    Dropping that half leaves test_the_notice_outcome_is_true green, because both
-    of its schemes come from the OS. It also survives
-    test_the_all_proxy_outcome_does_not_name_a_single_source: that test's
-    `"http" in outcomes` is satisfied by the substring inside "https", so an
-    outcome naming https alone still passes it. An exact outcome on an
-    environment-only configuration is what fails.
-    """
-    with (
-        os_proxy({}),
-        proxy_env(
-            ALL_PROXY="socks5://sock:1080",
-            HTTP_PROXY="http://env:3128",
-            HTTPS_PROXY="http://env:3128",
-        ),
-    ):
-        notices = http.proxy_notices()
-    assert [n.outcome for n in notices] == ["Used the proxy configured for http, https instead."]
-
-
 def test_the_kill_switch_silences_the_notices(proxy_env, os_proxy) -> None:
     """FERRY_DISABLE_PROXY, the one early return in proxy_notices nothing else
     takes. With the kill switch on, Ferry connects direct by instruction, so a
@@ -1395,7 +1344,7 @@ def test_format_proxy_notices_renders_one_line_per_notice(proxy_env, os_proxy) -
         lines = http.format_proxy_notices()
     assert lines == [
         "Proxy configuration Ferry cannot use: socks5://sock:1080 (all). "
-        "Connected direct. ALL_PROXY is not supported (see issue #141)."
+        "Connected direct. SOCKS is not supported (see issue #141)."
     ]
 
 
@@ -1404,28 +1353,6 @@ def test_format_proxy_notices_is_empty_on_a_clean_configuration(proxy_env, os_pr
     a shell would print as a blank row."""
     with os_proxy({}), proxy_env():
         assert http.format_proxy_notices() == []
-
-
-def test_a_malformed_scheme_proxy_does_not_count_as_covered(proxy_env, os_proxy) -> None:
-    """_usable's except arm, which nothing else enters.
-
-    test_a_malformed_proxy_url_is_reported sets no ALL_PROXY, so it never
-    evaluates `covered` at all. Without the guard here the ALL_PROXY notice
-    would claim a scheme was used that cannot even be parsed, on the same
-    configuration whose next line reports it as malformed.
-    """
-    with os_proxy({}), proxy_env(ALL_PROXY="socks5://sock:1080", HTTPS_PROXY="http://[::1"):
-        notices = http.proxy_notices()
-    # A list and an assertion, NOT next(). Under the mutant this test kills, the
-    # raise from _usable is caught by proxy_notices' never-raises boundary and
-    # the result is (), so next() died with a bare StopIteration that named
-    # neither the test's subject nor its expectation.
-    all_notices = [n for n in notices if n.kind == "all_proxy_only"]
-    assert all_notices, "the ALL_PROXY notice must survive an unparseable sibling"
-    assert all_notices[0].outcome == (
-        "Connected direct. ALL_PROXY is not supported (see issue #141)."
-    )
-    assert any(n.kind == "malformed" for n in notices)
 
 
 def test_the_kill_switch_wins_over_a_populated_cache(proxy_env, os_proxy) -> None:
@@ -1489,7 +1416,7 @@ def test_an_unreadable_configuration_is_not_cached(proxy_env, os_proxy) -> None:
         with patch("discord_ferry.core.http._scheme_map", side_effect=re.error("boom")):
             assert [n.kind for n in http.proxy_notices()] == ["unreadable"]
         assert http._proxy_notices == ()
-        assert [n.kind for n in http.proxy_notices()] == ["all_proxy_only"]
+        assert [n.kind for n in http.proxy_notices()] == ["socks"]
 
 
 # --- Proxy hints and the permanence gate (Task 6) ----------------------------
@@ -1922,6 +1849,21 @@ def test_a_resolved_source_wins_over_a_failing_sibling_scheme(proxy_env) -> None
 
     assert out["proxy-http"] == "envcorp:8080"
     assert out["proxy-https"] == "unreadable"
+    assert out["proxy-source"] == "env"
+
+
+def test_describe_proxy_reports_an_all_proxy(proxy_env) -> None:
+    """SC-2.5. Killing: a claim that describe_proxy needs its own ALL_PROXY
+    handling; it must inherit the fallback through resolve_proxy_or_raise. Also
+    guards release.yml's single proxy-source key."""
+    with (
+        proxy_env(ALL_PROXY="http://p:8080"),
+        patch.object(http, "_os_proxies", return_value={}),
+        patch.object(http, "_os_proxy_bypass", return_value=False),
+    ):
+        out = http.describe_proxy()
+    assert out["proxy-http"] == "p:8080"
+    assert out["proxy-https"] == "p:8080"
     assert out["proxy-source"] == "env"
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -559,6 +559,75 @@ def test_an_uppercase_empty_variable_does_not_suppress_a_lowercase_one(proxy_env
     assert str(choice.url) == "http://mine:3128"
 
 
+def test_all_proxy_is_the_fallback_for_a_scheme_target(proxy_env, os_proxy) -> None:
+    """SC-1.1. Killing: consulting only env[scheme]/os_side[scheme] and never
+    the 'all' key, which is the pre-#141 behaviour (returns None here)."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://p:8080"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://p:8080"
+    assert choice.source == "env"
+
+
+def test_a_scheme_proxy_wins_over_all_proxy(proxy_env, os_proxy) -> None:
+    """SC-1.2. Killing: a fallback placed before the scheme lookups, or one that
+    overwrites a resolved scheme proxy with the 'all' value."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="http://env:3128", ALL_PROXY="http://p:8080"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://env:3128"
+    assert choice.source == "env"
+
+
+def test_a_socks_all_proxy_resolves_to_none(proxy_env, os_proxy) -> None:
+    """SC-1.3. Killing: a fallback that returns the 'all' value without passing
+    it through the socks guard."""
+    with os_proxy({}), proxy_env(ALL_PROXY="socks5://s:1080"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_no_proxy_exempts_a_host_reached_via_all_proxy(proxy_env, os_proxy) -> None:
+    """SC-1.4. Killing: a fallback that returns before reaching _is_bypassed."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://p:8080", NO_PROXY="api.stoat.chat"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_the_kill_switch_wins_over_all_proxy(proxy_env, os_proxy) -> None:
+    """SC-1.5. Killing: a fallback added above the FERRY_DISABLE_PROXY guard."""
+    with os_proxy({}), proxy_env(ALL_PROXY="http://p:8080", FERRY_DISABLE_PROXY="1"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_an_emptied_scheme_is_not_rescued_by_all_proxy(proxy_env, os_proxy) -> None:
+    """SC-1.6, the design's central correctness point. Killing: a fallback that
+    branches on `"all" in env` alone. stdlib pops an empty HTTPS_PROXY="" from
+    the proxy dict, leaving {'all': ...}, so only _suppressed_schemes()'s raw
+    re-scan sees that https was turned off."""
+    with os_proxy({}), proxy_env(HTTPS_PROXY="", ALL_PROXY="http://p:8080"):
+        assert http.resolve_proxy(TARGET) is None
+
+
+def test_an_unrelated_emptied_scheme_does_not_block_the_fallback(proxy_env, os_proxy) -> None:
+    """SC-1.7. Killing: `if _suppressed_schemes()` (any suppression) instead of
+    `scheme not in _suppressed_schemes()` (the target scheme only)."""
+    with os_proxy({}), proxy_env(HTTP_PROXY="", ALL_PROXY="http://p:8080"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert str(choice.url) == "http://p:8080"
+
+
+def test_all_proxy_userinfo_is_stripped_and_registered(proxy_env, os_proxy) -> None:
+    """SC-1.8. Killing: a fallback that assigns raw = env["all"] but bypasses the
+    shared _strip_userinfo path, leaking the credential into the URL or the log."""
+    reset_secret_registry()
+    with os_proxy({}), proxy_env(ALL_PROXY="http://user:SUPERSECRET@p:8080"):
+        choice = http.resolve_proxy(TARGET)
+    assert choice is not None
+    assert "SUPERSECRET" not in str(choice.url)
+    assert choice.authorization is not None
+    assert "SUPERSECRET" not in sanitize_secrets("token SUPERSECRET")
+
+
 @pytest.mark.parametrize("bad", ["http://host:notaport", "http://[::1"])
 def test_a_malformed_proxy_never_raises(proxy_env, os_proxy, bad: str) -> None:
     """SC-135-22. Killing: an unguarded parse. Resolution runs inside

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.22.0"
+version = "2.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Honour `ALL_PROXY`/`all_proxy` as a fallback proxy for http and https when no scheme-specific
`HTTP_PROXY`/`HTTPS_PROXY` is set. Closes #141. Its blocker #135 is already merged.

## Why

DiscordChatExporter runs as a Ferry subprocess and reads `ALL_PROXY`; Ferry did not. A user whose
only proxy setting was `ALL_PROXY` got a successful export followed by every later phase connecting
direct and failing, which reads as "my proxy works, Ferry is broken."

## How

- `resolve_proxy_or_raise` consults the `"all"` entry when no scheme-specific proxy resolves,
  gated by `_suppressed_schemes()` so an explicitly-emptied scheme (`HTTPS_PROXY=""`) is not
  rescued. stdlib pops the empty scheme from the proxy dict, so the guard re-reads the raw
  environment, the only place that off switch survives. The socks guard, `_strip_userinfo`
  (credential stripping and secret registration), and `_is_bypassed` (`NO_PROXY`) all apply
  unchanged.
- `_scan_notices` reports an `ALL_PROXY` value only when Ferry still cannot use it: a SOCKS scheme,
  or a URL/credential that will not process. A usable value now produces no notice because it is
  used. The old `covered`/`all_proxy_only` logic and the `_usable` helper are removed.
- Docs: the troubleshooting section split so SOCKS stays unsupported and `ALL_PROXY` is described
  as a working http/https fallback.

## Verification

- Full suite green: 2185 passed. `ruff`, `ruff format --check`, `mypy src/` clean.
- Chunk review (mistral security-reviewer) and a fresh code review both returned zero findings.
- New tests cover the fallback, precedence, SOCKS-to-direct, `NO_PROXY`, the kill switch, the
  suppression scoping, credential stripping, and the narrowed notices.

Plan chunk #519, tasks #520/#521/#522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
