### PR TITLE
feat(gui): GUI parity phase 1 — check, repair, retry, incremental (v2.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.24.0] - 2026-08-20
+
+### Added
+
+- **GUI parity with the CLI toolchain, phase 1: the post-migration commands reach the
+  web interface.** Until now the web interface could only run a migration; verifying,
+  repairing, and retrying a migration were command-line only. A new Tools screen at
+  `/tools` adds:
+  - **Check**: verify a finished migration and see a per-entity pass or fail table,
+    with the same verdict `ferry check` gives.
+  - **Repair**: recreate missing channels, roles, and categories and resend messages,
+    with a dry-run default on and the same pass or fail rule as `ferry repair`. A
+    migration that was rolled back is refused, and shown as a neutral refusal rather
+    than a failure.
+  - **Retry**: resend the messages that failed on a prior migration, reporting how many
+    succeeded and how many are still failed.
+  - **Incremental**: a checkbox on the setup page for an incremental re-run, which the
+    engine will not accept together with resume.
+
+  Each tool page registers the Stoat token for redaction before it can log, sanitizes
+  every line and table cell it renders (the on-screen log does not pass through the
+  logging redactor), and starts the rate limiter only when it is off, so a read-only
+  tool cannot disturb a migration running in another browser tab. The preflight probe,
+  blueprint export, server build, and read-only diagnostic pages follow in a later phase.
+
 ## [2.23.0] - 2026-08-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.23.0"
+version = "2.24.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.23.0"
+__version__ = "2.24.0"

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -1803,8 +1803,9 @@ def repair_cmd(
         # forever even after the defect is fixed, while the --json document's
         # `declined` field (also from outcome.declined) correctly reports []. The
         # exit code and the document must agree. See #308 whole-branch review.
-        unrepaired = {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
-        declined = [w for w in outcome.declined if w.get("type") in unrepaired]
+        from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES
+
+        declined = [w for w in outcome.declined if w.get("type") in UNREPAIRED_WARNING_TYPES]
         code = 1 if (state.failed_messages or declined) else 0
 
     # The JSON document is emitted for BOTH exit codes, and its exit code is the

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 from nicegui import app, background_tasks, ui
 from nicegui.client import ClientConnectionTimeout
 
+from discord_ferry import gui_tools  # noqa: F401 -- registers the /tools routes as a side effect
 from discord_ferry.config import FerryConfig
 from discord_ferry.core import entry
 from discord_ferry.core.engine import PHASE_ORDER, run_migration, run_rollback

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -230,7 +230,18 @@ def _coerce_advanced_settings(storage: Mapping[str, Any]) -> dict[str, Any]:
         "max_concurrent_requests": _as_int("max_concurrent_requests", 5, 1),
         "skip_avatars": bool(storage.get("skip_avatars", False)),
         "validate_after": bool(storage.get("validate_after", False)),
+        "incremental": bool(storage.get("incremental", False)),
     }
+
+
+def _resume_incremental_conflict(storage: Mapping[str, Any]) -> bool:
+    """True when both resume and incremental are set, which the engine rejects.
+
+    ``run_migration`` raises ``--resume and --incremental are mutually exclusive``
+    (engine.py). The GUI catches it here so a stale-session user gets a clear
+    message before any phase runs.
+    """
+    return bool(storage.get("resume")) and bool(storage.get("incremental"))
 
 
 def _store_session_tokens(store: MutableMapping[str, Any], *, stoat: str, discord: str) -> None:
@@ -694,6 +705,10 @@ def setup_page() -> None:
                         "Validate after migration (verify entities by ID)",
                         value=adv_stored["validate_after"],
                     )
+                    incremental_cb = ui.checkbox(
+                        "Incremental (reuse channels and roles, send only new messages)",
+                        value=adv_stored["incremental"],
+                    )
 
                 error_label = ui.label("").classes("text-red-500 text-sm")
 
@@ -766,6 +781,7 @@ def setup_page() -> None:
                     storage["max_concurrent_requests"] = max_requests_num.value
                     storage["skip_avatars"] = skip_avatars_cb.value
                     storage["validate_after"] = validate_after_cb.value
+                    storage["incremental"] = incremental_cb.value
                     storage["skip_export"] = mode == "offline"
 
                     adv_chosen = _coerce_advanced_settings(storage)
@@ -1708,6 +1724,13 @@ async def migrate_page() -> None:
             # unreachable from a bare background task (issue #123).
             # Rebuild config with the final resume choice.
             config.resume = bool(storage.get("resume", False))
+
+            if _resume_incremental_conflict(storage):
+                log_display.push(
+                    "[ERROR] Resume and incremental cannot both be set. Uncheck one and re-run."
+                )
+                ui.notify("Resume and incremental cannot both be set.", type="negative")
+                return
 
             try:
                 await run_migration(config, on_event=on_event)

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -19,7 +19,7 @@ from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import run_repair, run_retry_failed
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
-from discord_ferry.errors import CheckError, StateError
+from discord_ferry.errors import CheckError, MigrationError, StateError
 from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, run_check
 from discord_ferry.parser.dce_parser import parse_export_directory
 from discord_ferry.state import load_state
@@ -284,7 +284,9 @@ def check_page() -> None:
                     return f"Cannot load this migration: {sanitize_secrets(str(exc))}"
                 try:
                     return await run_check(stoat_url, token, state, on_event)
-                except CheckError as exc:
+                except (CheckError, MigrationError) as exc:
+                    # MigrationError covers a rate-limit or circuit-breaker failure
+                    # from the API client; the CLI catches both here too.
                     return f"Cannot check this migration: {sanitize_secrets(str(exc))}"
 
             run_tool(client, log.push, _do_check, on_done)
@@ -329,9 +331,13 @@ def repair_page() -> None:
                     ui.label("Repair failed. See the log above.").classes("text-red-600")
                     return
                 if errors:
-                    ui.label(f"Repair did not complete: {sanitize_secrets(errors[-1])}").classes(
-                        "text-red-600"
-                    )
+                    # A refusal (a rolled-back state) is not a repair failure: the
+                    # engine correctly declined, and the CLI exits 0 for it. Show a
+                    # neutral refusal, neither a green success nor a red failure, so
+                    # neither shell claims the repair failed.
+                    ui.label(
+                        f"Repair refused, nothing changed: {sanitize_secrets(errors[-1])}"
+                    ).classes("text-amber-700")
                     return
                 _, label, colour = _repair_verdict(outcome, state_ref[0])
                 ui.label(label).classes(f"text-lg font-bold {colour}")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -9,17 +9,21 @@ any request.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from nicegui import background_tasks, ui
+from nicegui import app, background_tasks, ui
 
 import discord_ferry.migrator.api as _api
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
+from discord_ferry.migrator.verify import run_check
+from discord_ferry.state import load_state
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from discord_ferry.core.events import MigrationEvent
     from discord_ferry.migrator.verify import CheckReport
 
 T = TypeVar("T")
@@ -155,3 +159,55 @@ def tools_page() -> None:
             with ui.card().classes("w-full max-w-xl"):
                 ui.link(name, route).classes("text-lg font-bold")
                 ui.label(desc).classes("text-sm text-gray-500")
+
+
+def _tab_token() -> str | None:
+    """The Stoat token from the memory-only tab store, or None when absent."""
+    token = app.storage.tab.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+@ui.page("/tools/check")
+def check_page() -> None:
+    """Verify a finished migration by loading its state and running run_check."""
+    client = ui.context.client
+    stoat_url = str(app.storage.user.get("stoat_url", ""))
+    token = _tab_token()
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Verify a finished migration").classes("text-2xl font-bold mb-4")
+        if token is None:
+            ui.label("Session expired. Re-enter your token on the setup page.").classes(
+                "text-red-600"
+            )
+            return
+
+        default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
+        dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
+        log = ui.log(max_lines=200).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def on_event(event: MigrationEvent) -> None:
+            _safe_push(log.push, f"[{event.phase}] {event.message}")
+
+        def on_done(report: CheckReport | None) -> None:
+            results.clear()
+            with results:
+                if report is None:
+                    ui.label("Check failed. See the log above.").classes("text-red-600")
+                    return
+                render_check_report(report)
+
+        def _run() -> None:
+            results.clear()
+            output_dir = Path(dir_input.value)
+            for line in prepare_tool_call(token):
+                _safe_push(log.push, line)
+
+            async def _do_check() -> CheckReport:
+                state = load_state(output_dir)
+                return await run_check(stoat_url, token, state, on_event)
+
+            run_tool(client, log.push, _do_check, on_done)
+
+        ui.button("Run check", on_click=_run).classes("mt-2")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from nicegui import background_tasks
+from nicegui import background_tasks, ui
 
 import discord_ferry.migrator.api as _api
 from discord_ferry.core.http import format_proxy_notices
@@ -78,3 +78,29 @@ def prepare_tool_call(token: str) -> list[str]:
     if not _semaphore_is_set():
         _api.init_request_semaphore()
     return format_proxy_notices()
+
+
+#: The tool pages, listed on the /tools landing screen. Every route is present
+#: from the start; each page comes online as its plan chunk lands.
+_TOOLS: list[tuple[str, str, str]] = [
+    ("Check", "/tools/check", "Verify a finished migration"),
+    ("Repair", "/tools/repair", "Recreate what is missing and resend"),
+    ("Retry", "/tools/retry", "Resend failed messages"),
+    ("Probe", "/tools/probe", "Check API limits before migrating"),
+    ("Blueprint export", "/tools/blueprint-export", "Turn an export into a reusable blueprint"),
+    ("Build", "/tools/build", "Build a server from a template or blueprint"),
+    ("Validate", "/tools/validate", "Check an export before migrating"),
+    ("Stats", "/tools/stats", "Summarise a past migration"),
+    ("TLS check", "/tools/tls-check", "Inspect trust and proxy state"),
+]
+
+
+@ui.page("/tools")
+def tools_page() -> None:
+    """Landing screen listing every tool page."""
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Tools").classes("text-2xl font-bold mb-4")
+        for name, route, desc in _TOOLS:
+            with ui.card().classes("w-full max-w-xl"):
+                ui.link(name, route).classes("text-lg font-bold")
+                ui.label(desc).classes("text-sm text-gray-500")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -9,14 +9,59 @@ any request.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from nicegui import background_tasks
+
 import discord_ferry.migrator.api as _api
 from discord_ferry.core.http import format_proxy_notices
-from discord_ferry.core.security import register_secret
+from discord_ferry.core.security import register_secret, sanitize_secrets
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+T = TypeVar("T")
 
 
 def _semaphore_is_set() -> bool:
     """True when the module-level rate limiter already exists."""
     return _api._request_semaphore is not None
+
+
+def _safe_push(push: Callable[[str], None], line: str) -> None:
+    """Sanitize before writing to the on-screen log widget.
+
+    The redacting formatter only covers Python logging; ``log_display.push``
+    writes straight to the ``ui.log`` widget, which the formatter never sees, and
+    ``run_check`` / ``run_probe`` do no redaction of their own. So the runner
+    redacts at the push site. Proven by ``scratchpad/proto_redaction.py``.
+    """
+    push(sanitize_secrets(line))
+
+
+def run_tool(
+    client: Any,
+    log_push: Callable[[str], None],
+    coro_factory: Callable[[], Awaitable[T]],
+    on_done: Callable[[T | None], None],
+) -> None:
+    """Run one tool call in a client-scoped background task with one error path.
+
+    ``with client:`` re-enters the page's slot stack so ``ui.notify`` and friends
+    reach the right client from the background task (issue #123). Any exception is
+    sanitized and pushed to the log, and the page callback is handed ``None``.
+    """
+
+    async def _run() -> None:
+        with client:
+            try:
+                result = await coro_factory()
+                on_done(result)
+            except Exception as exc:  # noqa: BLE001 -- one uniform error surface
+                _safe_push(log_push, f"[ERROR] {exc}")
+                on_done(None)
+
+    background_tasks.create(_run())
 
 
 def prepare_tool_call(token: str) -> list[str]:

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -17,6 +17,7 @@ from nicegui import app, background_tasks, ui
 import discord_ferry.migrator.api as _api
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
+from discord_ferry.errors import CheckError, StateError
 from discord_ferry.migrator.verify import run_check
 from discord_ferry.state import load_state
 
@@ -57,6 +58,17 @@ def _check_rows(report: CheckReport) -> list[dict[str, str]]:
         }
         for r in report.results
     ]
+
+
+def _check_verdict(report: CheckReport) -> tuple[str, str]:
+    """The overall pass/fail line and its colour, from ``report.has_failures``.
+
+    Uses the same signal as the CLI check exit code (`1 if has_failures else 0`),
+    so the GUI verdict and the CLI verdict cannot diverge for the same report.
+    """
+    if report.has_failures:
+        return "Check found problems.", "text-red-600"
+    return "Check passed.", "text-green-600"
 
 
 def render_check_report(report: CheckReport) -> None:
@@ -190,13 +202,18 @@ def check_page() -> None:
         def on_event(event: MigrationEvent) -> None:
             _safe_push(log.push, f"[{event.phase}] {event.message}")
 
-        def on_done(report: CheckReport | None) -> None:
+        def on_done(result: CheckReport | str | None) -> None:
             results.clear()
             with results:
-                if report is None:
+                if result is None:
                     ui.label("Check failed. See the log above.").classes("text-red-600")
                     return
-                render_check_report(report)
+                if isinstance(result, str):
+                    ui.label(result).classes("text-amber-700")
+                    return
+                label, colour = _check_verdict(result)
+                ui.label(label).classes(f"text-lg font-bold {colour}")
+                render_check_report(result)
 
         def _run() -> None:
             results.clear()
@@ -204,9 +221,15 @@ def check_page() -> None:
             for line in prepare_tool_call(token):
                 _safe_push(log.push, line)
 
-            async def _do_check() -> CheckReport:
-                state = load_state(output_dir)
-                return await run_check(stoat_url, token, state, on_event)
+            async def _do_check() -> CheckReport | str:
+                try:
+                    state = load_state(output_dir)
+                except StateError as exc:
+                    return f"Cannot load this migration: {sanitize_secrets(str(exc))}"
+                try:
+                    return await run_check(stoat_url, token, state, on_event)
+                except CheckError as exc:
+                    return f"Cannot check this migration: {sanitize_secrets(str(exc))}"
 
             run_tool(client, log.push, _do_check, on_done)
 

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -16,7 +16,7 @@ from nicegui import app, background_tasks, ui
 
 import discord_ferry.migrator.api as _api
 from discord_ferry.config import FerryConfig
-from discord_ferry.core.engine import run_repair
+from discord_ferry.core.engine import run_repair, run_retry_failed
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, StateError
@@ -370,3 +370,77 @@ def repair_page() -> None:
             run_tool(client, log.push, _do_repair, on_done)
 
         ui.button("Run repair", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/retry")
+def retry_page() -> None:
+    """Resend the messages that failed on a prior migration."""
+    client = ui.context.client
+    stoat_url = str(app.storage.user.get("stoat_url", ""))
+    token = _tab_token()
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Resend failed messages").classes("text-2xl font-bold mb-4")
+        if token is None:
+            ui.label("Session expired. Re-enter your token on the setup page.").classes(
+                "text-red-600"
+            )
+            return
+
+        default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
+        dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
+        export_input = ui.input("Export directory (the original DCE export)").classes("w-96")
+        log = ui.log(max_lines=300).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def on_event(event: MigrationEvent) -> None:
+            _safe_push(log.push, f"[{event.phase}] {event.message}")
+
+        def on_done(counts: tuple[int, int] | None) -> None:
+            results.clear()
+            with results:
+                if counts is None:
+                    ui.label("Retry failed. See the log above.").classes("text-red-600")
+                    return
+                succeeded, still_failed = counts
+                colour = "text-red-600" if still_failed else "text-green-600"
+                ui.label(f"{succeeded} succeeded, {still_failed} still failed.").classes(
+                    f"text-lg font-bold {colour}"
+                )
+
+        def _run() -> None:
+            results.clear()
+            export_dir = export_input.value.strip()
+            if not export_dir or not Path(export_dir).is_dir():
+                ui.notify(
+                    "Enter a valid export directory. Retry needs the original export.",
+                    type="warning",
+                )
+                return
+            output_dir = Path(dir_input.value)
+            for line in prepare_tool_call(token):
+                _safe_push(log.push, line)
+
+            async def _do_retry() -> tuple[int, int]:
+                exports = parse_export_directory(Path(export_dir))
+                if not exports:
+                    # Never hand run_retry_failed an empty list: it would resolve
+                    # nothing and report success (a silent no-op). Surface it.
+                    raise ValueError("No export files found in that directory.")
+                state = load_state(output_dir)
+                before = len(state.failed_messages)
+                config = FerryConfig(
+                    export_dir=Path(export_dir),
+                    stoat_url=stoat_url,
+                    token=token,
+                    output_dir=output_dir,
+                    server_id=state.stoat_server_id or None,
+                    skip_export=True,
+                )
+                await run_retry_failed(config, state, exports, on_event)
+                after = len(state.failed_messages)
+                return before - after, after
+
+            run_tool(client, log.push, _do_retry, on_done)
+
+        ui.button("Run retry", on_click=_run).classes("mt-2")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -20,6 +20,8 @@ from discord_ferry.core.security import register_secret, sanitize_secrets
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from discord_ferry.migrator.verify import CheckReport
+
 T = TypeVar("T")
 
 
@@ -38,6 +40,38 @@ _STATUS_COLOURS: dict[str, str] = {
 def _status_colour(status: str) -> str:
     """The badge colour for a report status, grey for anything unrecognised."""
     return _STATUS_COLOURS.get(status, "grey")
+
+
+def _check_rows(report: CheckReport) -> list[dict[str, str]]:
+    """One table row per check result, carrying its badge colour."""
+    return [
+        {
+            "name": r.name,
+            "status": r.status,
+            "detail": r.detail,
+            "colour": _status_colour(r.status),
+        }
+        for r in report.results
+    ]
+
+
+def render_check_report(report: CheckReport) -> None:
+    """Render a CheckReport as a summary line and a per-result table.
+
+    Reused by the repair page for its embedded check. The report is a return
+    value, not an event stream, so this renders from the object directly.
+    """
+    counts = report.counts()
+    ui.label(
+        f"{counts['ok']} ok, {counts['warn']} warn, "
+        f"{counts['fail']} fail, {counts['unverifiable']} unverifiable"
+    ).classes("text-sm text-gray-600")
+    columns = [
+        {"name": "name", "label": "Entity", "field": "name", "align": "left"},
+        {"name": "status", "label": "Status", "field": "status", "align": "left"},
+        {"name": "detail", "label": "Detail", "field": "detail", "align": "left"},
+    ]
+    ui.table(columns=columns, rows=_check_rows(report)).classes("w-full mt-2")
 
 
 def _semaphore_is_set() -> bool:

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -18,14 +18,15 @@ import discord_ferry.migrator.api as _api
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, StateError
-from discord_ferry.migrator.verify import run_check
+from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, run_check
 from discord_ferry.state import load_state
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from discord_ferry.core.events import MigrationEvent
-    from discord_ferry.migrator.verify import CheckReport
+    from discord_ferry.migrator.verify import CheckReport, RepairOutcome
+    from discord_ferry.state import MigrationState
 
 T = TypeVar("T")
 
@@ -75,6 +76,20 @@ def _check_verdict(report: CheckReport) -> tuple[str, str]:
     if report.has_failures:
         return "Check found problems.", "text-red-600"
     return "Check passed.", "text-green-600"
+
+
+def _repair_verdict(outcome: RepairOutcome, state: MigrationState) -> tuple[bool, str, str]:
+    """Return (failed, label, colour), mirroring the CLI repair exit code exactly.
+
+    The CLI is ``1 if (state.failed_messages or declined) else 0`` where declined
+    is ``outcome.declined`` filtered to ``UNREPAIRED_WARNING_TYPES`` (cli.py, the
+    repair command). Sourced from the returned outcome, not the never-cleared
+    ``state.warnings``, per the #308 fix.
+    """
+    declined = [w for w in outcome.declined if w.get("type") in UNREPAIRED_WARNING_TYPES]
+    if state.failed_messages or declined:
+        return True, "Repair left unfixable problems.", "text-red-600"
+    return False, "Repair complete.", "text-green-600"
 
 
 def render_check_report(report: CheckReport) -> None:

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -1,0 +1,35 @@
+"""GUI tool pages and their shared safety runner (issue #484 and children).
+
+These pages let a GUI user reach the CLI's post-migration and preflight commands
+(check, repair, retry, probe, blueprint, build, and the diagnostic three) without
+a terminal. Every page that calls the Stoat API goes through :func:`prepare_tool_call`
+first, so the token is registered for redaction and the rate limiter exists before
+any request.
+"""
+
+from __future__ import annotations
+
+import discord_ferry.migrator.api as _api
+from discord_ferry.core.http import format_proxy_notices
+from discord_ferry.core.security import register_secret
+
+
+def _semaphore_is_set() -> bool:
+    """True when the module-level rate limiter already exists."""
+    return _api._request_semaphore is not None
+
+
+def prepare_tool_call(token: str) -> list[str]:
+    """Register the token, ensure the rate limiter exists, return proxy notices.
+
+    Order matters: register the secret before anything that could log or persist,
+    because the redactor returns text unchanged while nothing is registered. Init
+    the semaphore only when it is unset, so a read-only tool page cannot swap the
+    module-level object mid-flight and double a concurrent migration's cap (an
+    ``init_request_semaphore`` call builds a new object, and a coroutine already
+    holding the old one keeps running).
+    """
+    register_secret("stoat", token)
+    if not _semaphore_is_set():
+        _api.init_request_semaphore()
+    return format_proxy_notices()

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -23,6 +23,23 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+#: One colour per report status. Covers the CheckReport vocabulary
+#: (ok/warn/fail/unverifiable) and the ProbeReport subset (ok/warn/fail). The
+#: GUI's own event colour map does not cover these, so the tool pages carry
+#: their own. Unknown statuses fall back to grey rather than raising.
+_STATUS_COLOURS: dict[str, str] = {
+    "ok": "green",
+    "warn": "amber",
+    "fail": "red",
+    "unverifiable": "grey",
+}
+
+
+def _status_colour(status: str) -> str:
+    """The badge colour for a report status, grey for anything unrecognised."""
+    return _STATUS_COLOURS.get(status, "grey")
+
+
 def _semaphore_is_set() -> bool:
     """True when the module-level rate limiter already exists."""
     return _api._request_semaphore is not None

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -15,10 +15,13 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from nicegui import app, background_tasks, ui
 
 import discord_ferry.migrator.api as _api
+from discord_ferry.config import FerryConfig
+from discord_ferry.core.engine import run_repair
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, StateError
 from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, run_check
+from discord_ferry.parser.dce_parser import parse_export_directory
 from discord_ferry.state import load_state
 
 if TYPE_CHECKING:
@@ -95,8 +98,9 @@ def _repair_verdict(outcome: RepairOutcome, state: MigrationState) -> tuple[bool
 def render_check_report(report: CheckReport) -> None:
     """Render a CheckReport as a summary line and a per-result table.
 
-    Reused by the repair page for its embedded check. The report is a return
-    value, not an event stream, so this renders from the object directly.
+    The report is a return value, not an event stream, so this renders from the
+    object directly. The repair page renders its own RepairOutcome instead (that
+    object does not carry a check), see render_repair_outcome.
     """
     counts = report.counts()
     ui.label(
@@ -109,6 +113,37 @@ def render_check_report(report: CheckReport) -> None:
         {"name": "detail", "label": "Detail", "field": "detail", "align": "left"},
     ]
     ui.table(columns=columns, rows=_check_rows(report)).classes("w-full mt-2")
+
+
+def render_repair_outcome(outcome: RepairOutcome) -> None:
+    """Render what a repair did, and a table of what it could not fix.
+
+    RepairOutcome does not store a post-repair check (the engine leaves that to
+    the shell), so this renders the outcome's own fields rather than reusing the
+    check table. The declined text is server-controlled, so it is sanitized.
+    """
+    dlq = outcome.dead_letter
+    ui.label(
+        f"Recreated {len(outcome.recreated_channels)} channels, "
+        f"{len(outcome.recreated_roles)} roles, "
+        f"{len(outcome.recreated_categories)} categories. "
+        f"Restored {len(outcome.restored_tails)} tails. "
+        f"Dead-letter drained {dlq.get('drained', 0)}, {dlq.get('remaining', 0)} remaining."
+    ).classes("text-sm text-gray-600")
+    if outcome.declined:
+        ui.label("Could not fix:").classes("text-sm font-bold mt-2 text-red-600")
+        columns = [
+            {"name": "type", "label": "Kind", "field": "type", "align": "left"},
+            {"name": "detail", "label": "Detail", "field": "detail", "align": "left"},
+        ]
+        rows = [
+            {
+                "type": sanitize_secrets(str(w.get("type", ""))),
+                "detail": sanitize_secrets(str(w.get("detail", w.get("name", "")))),
+            }
+            for w in outcome.declined
+        ]
+        ui.table(columns=columns, rows=rows).classes("w-full mt-1")
 
 
 def _semaphore_is_set() -> bool:
@@ -255,3 +290,83 @@ def check_page() -> None:
             run_tool(client, log.push, _do_check, on_done)
 
         ui.button("Run check", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/repair")
+def repair_page() -> None:
+    """Verify a migration, then recreate what is missing and resend."""
+    client = ui.context.client
+    stoat_url = str(app.storage.user.get("stoat_url", ""))
+    token = _tab_token()
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Verify and fix a migration").classes("text-2xl font-bold mb-4")
+        if token is None:
+            ui.label("Session expired. Re-enter your token on the setup page.").classes(
+                "text-red-600"
+            )
+            return
+
+        default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
+        dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
+        export_input = ui.input("Export directory (the original DCE export)").classes("w-96")
+        dry_run_cb = ui.checkbox("Dry run (report only, change nothing)", value=True)
+        log = ui.log(max_lines=300).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        errors: list[str] = []
+        state_ref: list[MigrationState] = []
+
+        def on_event(event: MigrationEvent) -> None:
+            if event.status == "error":
+                errors.append(event.message)
+            _safe_push(log.push, f"[{event.phase}] {event.message}")
+
+        def on_done(outcome: RepairOutcome | None) -> None:
+            results.clear()
+            with results:
+                if outcome is None:
+                    ui.label("Repair failed. See the log above.").classes("text-red-600")
+                    return
+                if errors:
+                    ui.label(f"Repair did not complete: {sanitize_secrets(errors[-1])}").classes(
+                        "text-red-600"
+                    )
+                    return
+                _, label, colour = _repair_verdict(outcome, state_ref[0])
+                ui.label(label).classes(f"text-lg font-bold {colour}")
+                render_repair_outcome(outcome)
+
+        def _run() -> None:
+            results.clear()
+            errors.clear()
+            state_ref.clear()
+            export_dir = export_input.value.strip()
+            if not export_dir or not Path(export_dir).is_dir():
+                ui.notify(
+                    "Enter a valid export directory. Repair needs the original export.",
+                    type="warning",
+                )
+                return
+            output_dir = Path(dir_input.value)
+            for line in prepare_tool_call(token):
+                _safe_push(log.push, line)
+
+            async def _do_repair() -> RepairOutcome:
+                exports = parse_export_directory(Path(export_dir))
+                state = load_state(output_dir)
+                state_ref.append(state)
+                config = FerryConfig(
+                    export_dir=Path(export_dir),
+                    stoat_url=stoat_url,
+                    token=token,
+                    output_dir=output_dir,
+                    server_id=state.stoat_server_id or None,
+                    skip_export=True,
+                    dry_run=dry_run_cb.value,
+                )
+                return await run_repair(config, state, exports, on_event)
+
+            run_tool(client, log.push, _do_repair, on_done)
+
+        ui.button("Run repair", on_click=_run).classes("mt-2")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -48,12 +48,18 @@ def _status_colour(status: str) -> str:
 
 
 def _check_rows(report: CheckReport) -> list[dict[str, str]]:
-    """One table row per check result, carrying its badge colour."""
+    """One table row per check result, carrying its badge colour.
+
+    The name and detail are server-controlled (entity names, prose from the
+    Stoat API), and the table is a rendered sink the logging formatter does not
+    cover, so both are sanitized here, the same reason ``_safe_push`` sanitizes
+    the log widget. The status and colour are internal enums, not sanitized.
+    """
     return [
         {
-            "name": r.name,
+            "name": sanitize_secrets(r.name),
             "status": r.status,
-            "detail": r.detail,
+            "detail": sanitize_secrets(r.detail),
             "colour": _status_colour(r.status),
         }
         for r in report.results

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -123,6 +123,17 @@ class CheckResult:
     found: str | None = None
 
 
+#: Warning types repair cannot fix, so the migration is not whole while any
+#: remains. merge_thread_content_not_restored and no_discord_metadata are
+#: deliberately excluded: the first names a partial restore of something repair
+#: DID fix, and failing every merge repair on it would make the code useless;
+#: the second is a degradation rather than an unrepaired defect. Shared by the
+#: CLI repair exit code and the GUI repair page so they cannot diverge.
+UNREPAIRED_WARNING_TYPES = frozenset(
+    {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
+)
+
+
 @dataclass
 class CheckReport:
     """Every verdict from one run."""

--- a/tests/nicegui_app.py
+++ b/tests/nicegui_app.py
@@ -18,9 +18,12 @@ import importlib
 from nicegui import ui
 
 import discord_ferry.gui
+import discord_ferry.gui_tools
 
-# Re-import for its side effect: the @ui.page decorators re-register the routes
-# that nicegui_reset_globals() just cleared.
+# Re-import for their side effect: the @ui.page decorators re-register the routes
+# that nicegui_reset_globals() just cleared. gui_tools holds the /tools routes,
+# which reloading gui alone would not re-run.
+importlib.reload(discord_ferry.gui_tools)
 importlib.reload(discord_ferry.gui)
 
 # A no-op under simulation (nicegui/ui_run.py short-circuits on

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -504,6 +504,7 @@ _EXPOSED_DEFAULTS = {
     "max_concurrent_requests": 5,
     "skip_avatars": False,
     "validate_after": False,
+    "incremental": False,
 }
 
 
@@ -652,3 +653,34 @@ def test_validate_status_three_states() -> None:
     assert amber.reason is None
 
     assert _validate_status([]).colour == "green"
+
+
+def test_incremental_coerces_into_config() -> None:
+    """SC-5.1 / SC-I3: the incremental checkbox flows into FerryConfig.incremental."""
+    from pathlib import Path
+
+    from discord_ferry.config import FerryConfig
+    from discord_ferry.gui import _coerce_advanced_settings
+
+    coerced = _coerce_advanced_settings({"incremental": True})
+    assert coerced["incremental"] is True
+    config = FerryConfig(export_dir=Path("x"), stoat_url="https://s", token="t", **coerced)
+    assert config.incremental is True
+    assert config.resume is False  # SC-I3: incremental, not resume
+
+
+def test_incremental_defaults_off() -> None:
+    """SC-5.3: incremental defaults off."""
+    from discord_ferry.gui import _coerce_advanced_settings
+
+    assert _coerce_advanced_settings({})["incremental"] is False
+
+
+def test_resume_and_incremental_conflict_detected() -> None:
+    """SC-5.2: the guard catches both set, before the engine's mutual-exclusion raise."""
+    from discord_ferry.gui import _resume_incremental_conflict
+
+    assert _resume_incremental_conflict({"resume": True, "incremental": True}) is True
+    assert _resume_incremental_conflict({"resume": True, "incremental": False}) is False
+    assert _resume_incremental_conflict({"resume": False, "incremental": True}) is False
+    assert _resume_incremental_conflict({}) is False

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -295,3 +295,36 @@ def test_check_rows_sanitizes_server_controlled_text() -> None:
     # control: the token really was in the source fields
     assert _TOKEN in report.results[0].detail
     reset_secret_registry()
+
+
+class _StubState:
+    """Minimal stand-in for MigrationState: the repair verdict reads only this."""
+
+    def __init__(self, failed_messages: list) -> None:  # type: ignore[type-arg]
+        self.failed_messages = failed_messages
+
+
+def test_repair_verdict_matches_cli_failure_set() -> None:
+    """SC-3.4 / SC-I2: verdict uses state.failed_messages + declined in the shared set."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.verify import RepairOutcome
+
+    # An unrepaired type -> fail.
+    failed, _, _ = gui_tools._repair_verdict(
+        RepairOutcome(declined=[{"type": "no_recorded_name"}]), _StubState([])
+    )
+    assert failed is True
+
+    # An excluded type (partial merge restore) -> pass, matching the CLI.
+    ok, _, _ = gui_tools._repair_verdict(
+        RepairOutcome(declined=[{"type": "merge_thread_content_not_restored"}]), _StubState([])
+    )
+    assert ok is False
+
+    # Leftover failed messages -> fail.
+    failed2, _, _ = gui_tools._repair_verdict(RepairOutcome(), _StubState([{"id": "1"}]))
+    assert failed2 is True
+
+    # Nothing wrong -> pass.
+    clean, _, _ = gui_tools._repair_verdict(RepairOutcome(), _StubState([]))
+    assert clean is False

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -11,3 +11,50 @@ def test_repair_failure_set_is_shared_and_exact() -> None:
         frozenset({"no_recorded_name", "not_in_export", "forum_index_not_repairable"})
         == UNREPAIRED_WARNING_TYPES
     )
+
+
+def test_prepare_registers_secret_before_semaphore(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """SC-1.2: the token is registered before anything else the helper does."""
+    from discord_ferry import gui_tools
+
+    calls: list[str] = []
+    api = gui_tools._api
+    monkeypatch.setattr(gui_tools, "register_secret", lambda *a, **k: calls.append("secret"))
+    monkeypatch.setattr(api, "init_request_semaphore", lambda *a, **k: calls.append("sem"))
+    monkeypatch.setattr(gui_tools, "_semaphore_is_set", lambda: False)
+    monkeypatch.setattr(gui_tools, "format_proxy_notices", lambda: calls.append("proxy") or [])
+
+    gui_tools.prepare_tool_call("tok")
+
+    assert calls[0] == "secret"
+
+
+def test_prepare_inits_semaphore_only_when_unset(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """SC-1.4: a read-only page must not swap the semaphore mid-flight."""
+    from discord_ferry import gui_tools
+
+    monkeypatch.setattr(gui_tools, "register_secret", lambda *a, **k: None)
+    monkeypatch.setattr(gui_tools, "format_proxy_notices", lambda: [])
+
+    inited: list[int] = []
+    api = gui_tools._api
+    monkeypatch.setattr(api, "init_request_semaphore", lambda *a, **k: inited.append(1))
+
+    monkeypatch.setattr(gui_tools, "_semaphore_is_set", lambda: True)
+    gui_tools.prepare_tool_call("tok")
+    assert inited == []  # already set: not re-inited
+
+    monkeypatch.setattr(gui_tools, "_semaphore_is_set", lambda: False)
+    gui_tools.prepare_tool_call("tok")
+    assert inited == [1]  # unset: inited once
+
+
+def test_prepare_returns_proxy_notices(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """SC-1.5: the helper surfaces proxy notices for the page to render."""
+    from discord_ferry import gui_tools
+
+    monkeypatch.setattr(gui_tools, "register_secret", lambda *a, **k: None)
+    monkeypatch.setattr(gui_tools, "_semaphore_is_set", lambda: True)
+    monkeypatch.setattr(gui_tools, "format_proxy_notices", lambda: ["proxy: on"])
+
+    assert gui_tools.prepare_tool_call("tok") == ["proxy: on"]

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -221,3 +221,48 @@ async def test_check_page_streams_banners_and_renders_table(
         user.find("Run check").click()
         await user.should_see("Checking server structure")  # first banner streamed
         await user.should_see("1 ok")  # the report's counts line rendered after the run
+
+
+def test_check_verdict_matches_has_failures() -> None:
+    """SC-2.4 / SC-I1: the GUI verdict tracks report.has_failures, same as the CLI."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.verify import CheckReport
+
+    clean = CheckReport()
+    clean.add(name="general", status="ok", kind="channel_present", detail="present")
+    failing = CheckReport()
+    failing.add(name="mods", status="fail", kind="channel_missing", detail="missing")
+
+    clean_label, _ = gui_tools._check_verdict(clean)
+    fail_label, _ = gui_tools._check_verdict(failing)
+
+    assert clean.has_failures is False
+    assert failing.has_failures is True
+    assert clean_label != fail_label
+    # parity: the verdict is a pure function of has_failures
+    assert ("problem" in fail_label.lower()) and ("passed" in clean_label.lower())
+
+
+async def test_check_page_shows_cannot_check_on_checkerror(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-2.3: a CheckError (dry-run or server-less state) shows a clear message."""
+    from discord_ferry.errors import CheckError
+
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def raises_check_error(*a, **k):  # type: ignore[no-untyped-def]
+        raise CheckError("state is a dry run, nothing was migrated")
+
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=object()),
+        patch("discord_ferry.gui_tools.run_check", new=raises_check_error),
+    ):
+        await user.open("/tools/check")
+        user.find("Run check").click()
+        await user.should_see("Cannot check this migration")

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -4,6 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from nicegui.testing import User
+
+# The User-fixture tests below need the routes re-registered inside the
+# simulation; nicegui_app.py reloads both gui and gui_tools for that.
+pytestmark = pytest.mark.nicegui_main_file("tests/nicegui_app.py")
 
 # A realistic-length opaque Stoat token, so the redaction test can actually fail
 # (a token too short to trigger the mask would pass a broken implementation).
@@ -110,3 +120,20 @@ def test_run_tool_error_path_sanitizes_and_reports_none(monkeypatch) -> None:  #
     assert done == [None]  # callback got None on error
     assert pushed and _TOKEN not in pushed[0]  # error line was sanitized
     reset_secret_registry()
+
+
+async def test_tools_landing_lists_tools(user: User) -> None:
+    """SC-1.1: /tools is reachable and lists every tool."""
+    await user.open("/tools")
+    for name in (
+        "Check",
+        "Repair",
+        "Retry",
+        "Probe",
+        "Blueprint export",
+        "Build",
+        "Validate",
+        "Stats",
+        "TLS check",
+    ):
+        await user.should_see(name)

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+
+# A realistic-length opaque Stoat token, so the redaction test can actually fail
+# (a token too short to trigger the mask would pass a broken implementation).
+_TOKEN = "01F8MECHZX3TBDFGH4JKLMNPQR_opaque_base64url_like_secret_value"
+
 
 def test_repair_failure_set_is_shared_and_exact() -> None:
     """SC-1.8: the repair pass-or-fail set is one shared constant, exact."""
@@ -58,3 +65,48 @@ def test_prepare_returns_proxy_notices(monkeypatch) -> None:  # type: ignore[no-
     monkeypatch.setattr(gui_tools, "format_proxy_notices", lambda: ["proxy: on"])
 
     assert gui_tools.prepare_tool_call("tok") == ["proxy: on"]
+
+
+def test_safe_push_masks_token() -> None:
+    """SC-1.3: a token in a log-widget line is masked at the push site.
+
+    register_secret alone protects the Python-logging sink; the ui.log widget is
+    a separate sink the formatter never sees, and check/probe do no redaction of
+    their own. Proven by scratchpad/proto_redaction.py.
+    """
+    from discord_ferry import gui_tools
+    from discord_ferry.core.security import register_secret, reset_secret_registry
+
+    reset_secret_registry()
+    register_secret("stoat", _TOKEN)
+    pushed: list[str] = []
+
+    gui_tools._safe_push(pushed.append, f"[ERROR] boom: {_TOKEN}")
+
+    assert _TOKEN not in pushed[0]  # masked at the push site
+    assert _TOKEN in f"[ERROR] boom: {_TOKEN}"  # control: an unsanitized push would leak it
+    reset_secret_registry()
+
+
+def test_run_tool_error_path_sanitizes_and_reports_none(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """run_tool routes an exception to a sanitized log line and hands the callback None."""
+    from discord_ferry import gui_tools
+    from discord_ferry.core.security import register_secret, reset_secret_registry
+
+    reset_secret_registry()
+    register_secret("stoat", _TOKEN)
+
+    # Run the background coroutine synchronously instead of scheduling it.
+    monkeypatch.setattr(gui_tools.background_tasks, "create", lambda coro: asyncio.run(coro))
+
+    pushed: list[str] = []
+    done: list[object] = []
+
+    async def _boom() -> None:
+        raise RuntimeError(f"failed with {_TOKEN}")
+
+    gui_tools.run_tool(contextlib.nullcontext(), pushed.append, _boom, done.append)
+
+    assert done == [None]  # callback got None on error
+    assert pushed and _TOKEN not in pushed[0]  # error line was sanitized
+    reset_secret_registry()

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -298,7 +298,9 @@ def test_check_rows_sanitizes_server_controlled_text() -> None:
 
 
 class _StubState:
-    """Minimal stand-in for MigrationState: the repair verdict reads only this."""
+    """Minimal stand-in for MigrationState for the repair verdict and page."""
+
+    stoat_server_id = "srv"
 
     def __init__(self, failed_messages: list) -> None:  # type: ignore[type-arg]
         self.failed_messages = failed_messages
@@ -328,3 +330,72 @@ def test_repair_verdict_matches_cli_failure_set() -> None:
     # Nothing wrong -> pass.
     clean, _, _ = gui_tools._repair_verdict(RepairOutcome(), _StubState([]))
     assert clean is False
+
+
+async def test_repair_page_dry_run_defaults_on(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-3.2: the dry-run toggle defaults on."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    await user.open("/tools/repair")
+    await user.should_see("Dry run")
+    checkbox = user.find("Dry run").elements.pop()
+    assert checkbox.value is True
+
+
+async def test_repair_page_refuses_without_export_dir(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-3.1: repair refuses to run with no export directory; run_repair not called."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    from unittest.mock import AsyncMock
+
+    with patch("discord_ferry.gui_tools.run_repair", new=AsyncMock()) as run_repair_mock:
+        await user.open("/tools/repair")
+        # export dir left blank
+        user.find("Run repair").click()
+        await user.should_see("valid export directory")
+        assert run_repair_mock.await_count == 0
+
+
+async def test_repair_page_surfaces_rolled_back_refusal(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-3.3: a rolled-back-state refusal is shown and no success is reported."""
+    from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.migrator.verify import RepairOutcome
+
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def refusing_repair(config, state, exports, on_event, **k):  # type: ignore[no-untyped-def]
+        on_event(
+            MigrationEvent(phase="repair", status="error", message="records a rollback. Refusing.")
+        )
+        return RepairOutcome()
+
+    with (
+        patch("discord_ferry.gui_tools.parse_export_directory", return_value=[]),
+        patch("discord_ferry.gui_tools.load_state", return_value=_StubState([])),
+        patch("discord_ferry.gui_tools.run_repair", new=refusing_repair),
+    ):
+        await user.open("/tools/repair")
+        user.find("Export directory").elements.pop().set_value(str(export_dir))
+        user.find("Run repair").click()
+        await user.should_see("Refusing")
+        await user.should_see("Repair did not complete")
+        await user.should_not_see("Repair complete.")

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -170,3 +171,53 @@ def test_check_rows_one_per_result_with_status_and_detail() -> None:
     assert rows[0]["detail"] == "present"
     assert rows[1]["colour"] == gui_tools._status_colour("fail")
     assert report.counts()["fail"] == 1
+
+
+async def test_check_page_bounces_without_token(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-1.6: the session-expired guard fires from the page builder."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    await user.open("/tools/check")
+    await user.should_see("Session expired")
+    await user.should_not_see("Run check")
+
+
+async def test_check_page_streams_banners_and_renders_table(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-2.2: the two banners reach the log, then the table renders."""
+    from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.migrator.verify import CheckReport
+
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    report = CheckReport()
+    report.add(name="general", status="ok", kind="channel_present", detail="present")
+
+    async def fake_check(stoat_url, token, state, on_event, *, session=None):  # type: ignore[no-untyped-def]
+        on_event(
+            MigrationEvent(phase="check", status="started", message="Checking server structure...")
+        )
+        on_event(
+            MigrationEvent(phase="check", status="started", message="Checking each channel...")
+        )
+        return report
+
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=object()),
+        patch("discord_ferry.gui_tools.run_check", new=fake_check),
+    ):
+        await user.open("/tools/check")
+        user.find("Run check").click()
+        await user.should_see("Checking server structure")  # first banner streamed
+        await user.should_see("1 ok")  # the report's counts line rendered after the run

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -266,3 +266,32 @@ async def test_check_page_shows_cannot_check_on_checkerror(
         await user.open("/tools/check")
         user.find("Run check").click()
         await user.should_see("Cannot check this migration")
+
+
+def test_check_rows_sanitizes_server_controlled_text() -> None:
+    """Chunk-2 review: the table is a rendered sink, so name/detail are sanitized.
+
+    A token in a server-controlled field would otherwise reach the table, which
+    the logging formatter does not cover (same class as the log-widget sink).
+    """
+    from discord_ferry import gui_tools
+    from discord_ferry.core.security import register_secret, reset_secret_registry
+    from discord_ferry.migrator.verify import CheckReport
+
+    reset_secret_registry()
+    register_secret("stoat", _TOKEN)
+    report = CheckReport()
+    report.add(
+        name=f"chan-{_TOKEN}",
+        status="fail",
+        kind="channel_missing",
+        detail=f"detail with {_TOKEN} in it",
+    )
+
+    rows = gui_tools._check_rows(report)
+
+    assert _TOKEN not in rows[0]["name"]
+    assert _TOKEN not in rows[0]["detail"]
+    # control: the token really was in the source fields
+    assert _TOKEN in report.results[0].detail
+    reset_secret_registry()

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -151,3 +151,22 @@ def test_status_colour_covers_every_check_status() -> None:
         assert gui_tools._status_colour(status)
     # an unknown status resolves to a defined default, never a crash
     assert gui_tools._status_colour("nonsense")
+
+
+def test_check_rows_one_per_result_with_status_and_detail() -> None:
+    """SC-2.1: the check table has a row per result carrying status and detail."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.verify import CheckReport
+
+    report = CheckReport()
+    report.add(name="general", status="ok", kind="channel_present", detail="present")
+    report.add(name="mods", status="fail", kind="channel_missing", detail="missing on target")
+
+    rows = gui_tools._check_rows(report)
+
+    assert len(rows) == 2
+    assert rows[0]["name"] == "general"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["detail"] == "present"
+    assert rows[1]["colour"] == gui_tools._status_colour("fail")
+    assert report.counts()["fail"] == 1

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -1,0 +1,13 @@
+"""Tests for the GUI tool pages and their shared runner (issue #484 and children)."""
+
+from __future__ import annotations
+
+
+def test_repair_failure_set_is_shared_and_exact() -> None:
+    """SC-1.8: the repair pass-or-fail set is one shared constant, exact."""
+    from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES
+
+    assert (
+        frozenset({"no_recorded_name", "not_in_export", "forum_index_not_repairable"})
+        == UNREPAIRED_WARNING_TYPES
+    )

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -397,7 +397,7 @@ async def test_repair_page_surfaces_rolled_back_refusal(
         user.find("Export directory").elements.pop().set_value(str(export_dir))
         user.find("Run repair").click()
         await user.should_see("Refusing")
-        await user.should_see("Repair did not complete")
+        await user.should_see("Repair refused")
         await user.should_not_see("Repair complete.")
 
 
@@ -523,3 +523,29 @@ async def test_no_tool_page_renders_a_raw_token(
             user.find(button).click()
             await user.should_see(label)  # positive control: the error path ran
             await user.should_not_see(_TOKEN)
+
+
+async def test_check_page_shows_cannot_check_on_migration_error(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """Whole-branch review: a MigrationError (rate limit / breaker) is caught like the CLI."""
+    from discord_ferry.errors import MigrationError
+
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def raises_migration_error(*a, **k):  # type: ignore[no-untyped-def]
+        raise MigrationError("circuit breaker open")
+
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=_StubState([])),
+        patch("discord_ferry.gui_tools.run_check", new=raises_migration_error),
+    ):
+        await user.open("/tools/check")
+        user.find("Run check").click()
+        await user.should_see("Cannot check this migration")
+        await user.should_not_see("Check failed")  # not the generic error path

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -137,3 +137,17 @@ async def test_tools_landing_lists_tools(user: User) -> None:
         "TLS check",
     ):
         await user.should_see(name)
+
+
+def test_status_colour_covers_every_check_status() -> None:
+    """SC-1.7: every CheckReport status maps to a colour, none falls through."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.verify import STATUSES
+
+    for status in STATUSES:
+        assert status in gui_tools._STATUS_COLOURS
+    # probe uses ok/warn/fail, a subset already covered above
+    for status in ("ok", "warn", "fail"):
+        assert gui_tools._status_colour(status)
+    # an unknown status resolves to a defined default, never a crash
+    assert gui_tools._status_colour("nonsense")

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -399,3 +399,127 @@ async def test_repair_page_surfaces_rolled_back_refusal(
         await user.should_see("Refusing")
         await user.should_see("Repair did not complete")
         await user.should_not_see("Repair complete.")
+
+
+async def test_retry_page_refuses_without_export_dir(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-4.1: retry refuses without a valid export dir; run_retry_failed not called."""
+    from unittest.mock import AsyncMock
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    with patch("discord_ferry.gui_tools.run_retry_failed", new=AsyncMock()) as retry_mock:
+        await user.open("/tools/retry")
+        user.find("Run retry").click()
+        await user.should_see("valid export directory")
+        assert retry_mock.await_count == 0
+
+
+async def test_retry_page_reports_succeeded_and_failed(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-4.2: the page shows N succeeded, M still failed from state.failed_messages."""
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def fake_retry(config, state, exports, on_event, **k):  # type: ignore[no-untyped-def]
+        state.failed_messages.clear()  # two were pending; both now succeed
+
+    with (
+        patch("discord_ferry.gui_tools.parse_export_directory", return_value=[object()]),
+        patch(
+            "discord_ferry.gui_tools.load_state",
+            return_value=_StubState([{"id": "1"}, {"id": "2"}]),
+        ),
+        patch("discord_ferry.gui_tools.run_retry_failed", new=fake_retry),
+    ):
+        await user.open("/tools/retry")
+        user.find("Export directory").elements.pop().set_value(str(export_dir))
+        user.find("Run retry").click()
+        await user.should_see("2 succeeded, 0 still failed")
+
+
+async def test_retry_page_handles_no_failures(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-4.3: with nothing failed, the page reports 0 and 0 without erroring."""
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def fake_retry(config, state, exports, on_event, **k):  # type: ignore[no-untyped-def]
+        return None  # early return: nothing to do
+
+    with (
+        patch("discord_ferry.gui_tools.parse_export_directory", return_value=[object()]),
+        patch("discord_ferry.gui_tools.load_state", return_value=_StubState([])),
+        patch("discord_ferry.gui_tools.run_retry_failed", new=fake_retry),
+    ):
+        await user.open("/tools/retry")
+        user.find("Export directory").elements.pop().set_value(str(export_dir))
+        user.find("Run retry").click()
+        await user.should_see("0 succeeded, 0 still failed")
+
+
+async def test_no_tool_page_renders_a_raw_token(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-I4: a token in an engine exception never reaches a tool page's rendered output.
+
+    The page registers the token (prepare_tool_call) before the run, and run_tool
+    sanitizes the error at the log-widget push site. Each page is exercised; the
+    error label is the positive control (proving the flow ran) so should_not_see
+    is not vacuous for the rendered label/table surface.
+    """
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store["token"] = _TOKEN
+
+    async def boom(*a, **k):  # type: ignore[no-untyped-def]
+        raise RuntimeError(f"upstream said {_TOKEN}")
+
+    # Check page: run_check raises with the token in its message.
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=_StubState([])),
+        patch("discord_ferry.gui_tools.run_check", new=boom),
+    ):
+        await user.open("/tools/check")
+        user.find("Run check").click()
+        await user.should_see("Check failed")  # positive control: the error path ran
+        await user.should_not_see(_TOKEN)
+
+    # Repair and retry pages: same, with the export dir filled in.
+    for route, button, target, label in (
+        ("/tools/repair", "Run repair", "run_repair", "Repair failed"),
+        ("/tools/retry", "Run retry", "run_retry_failed", "Retry failed"),
+    ):
+        with (
+            patch("discord_ferry.gui_tools.parse_export_directory", return_value=[object()]),
+            patch("discord_ferry.gui_tools.load_state", return_value=_StubState([])),
+            patch(f"discord_ferry.gui_tools.{target}", new=boom),
+        ):
+            await user.open(route)
+            user.find("Export directory").elements.pop().set_value(str(export_dir))
+            user.find(button).click()
+            await user.should_see(label)  # positive control: the error path ran
+            await user.should_not_see(_TOKEN)

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.23.0"
+version = "2.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Phase 1 of bringing the CLI toolchain to the NiceGUI web interface. Until now the web interface
could only run a migration; verifying, repairing, and retrying one were command-line only. This adds
a Tools screen at `/tools` with pages for the post-migration commands, plus an incremental checkbox.

New pages:
- **Check** (`/tools/check`): verify a finished migration, per-entity pass or fail table, verdict
  matching `ferry check`.
- **Repair** (`/tools/repair`): recreate missing channels, roles, categories and resend messages,
  dry-run default on, verdict matching `ferry repair`. A rolled-back migration is refused and shown
  as a neutral refusal, not a failure.
- **Retry** (`/tools/retry`): resend the messages that failed on a prior migration.
- **Incremental**: a checkbox on the setup page, guarded against being set together with resume.

Plus a shared runner (`gui_tools.py`) every tool page uses, and the `/tools` landing screen.

## Why

A GUI-only user could not verify or fix a migration without dropping to a terminal. This closes that
gap for the highest-value commands.

## Security

The tool commands build no `FerryConfig`, so the engine's redaction hook does not fire for them, and
the on-screen log widget and result tables bypass the logging redactor. Each page therefore registers
the Stoat token before it can log and sanitizes every line and table cell it renders. A running-code
prototype during design proved the log-widget path would otherwise leak a token; the whole-branch and
per-chunk reviews confirmed every rendered sink is sanitized.

## Reviews

Built through the project chain with per-chunk reviews and a whole-branch review at ship time. The
whole-branch review found two real issues, both fixed in this branch: the check page now catches the
same errors the CLI does, and the rolled-back-state repair is shown as a neutral refusal so the two
shells agree.

## Scope

Closes the Phase 1 umbrellas: #484 (harness), #485 (check), #486 (repair), #487 (retry), #488
(incremental). All their task sub-issues are closed.

Deferred: #518 (finish-screen deep-links) waits on #524 (tool pages accepting a token when the
session store is empty), because the migrate flow clears the session token on completion.

Later phases (still open): #489 probe, #490 blueprint export, #491 build, #492 validate, #493 stats,
#494 tls-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
