### PR TITLE
GUI-CLI parity phase 2: probe, blueprint-export, and build tool pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.25.0] - 2026-08-21
+
+### Added
+
+- **GUI parity with the CLI toolchain, phase 2: the preflight and build commands reach the
+  web interface.** The Tools screen at `/tools` gains three more pages:
+  - **Probe**: check a Stoat instance before migrating, showing Autumn upload limits, the
+    rate-limit window, voice-channel support, and whether webhooks are enabled, as a
+    per-check pass, warn, or fail table. A deeper probe that uploads a test file at each
+    size boundary is available behind a confirmation, because it leaves those files in
+    Autumn storage.
+  - **Blueprint export**: turn a Discord export directory into a reusable server blueprint
+    file, and confirm before replacing an existing file.
+  - **Build**: create a Stoat server from a preset template or a blueprint file. The page
+    states up front that a server built this way cannot be rolled back, because it records
+    no migration state.
+
+### Changed
+
+- The Discord-to-blueprint channel mapping and the server-build sequence each now live in
+  one place, shared by the command line and the web interface, so the two cannot drift
+  apart on them. Behaviour is unchanged.
+
 ## [2.24.0] - 2026-08-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.24.0"
+version = "2.25.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.24.0"
+__version__ = "2.25.0"

--- a/src/discord_ferry/blueprint.py
+++ b/src/discord_ferry/blueprint.py
@@ -1,11 +1,17 @@
 """Server blueprint export, import, and build — portable server structure definitions."""
 
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from discord_ferry.core.atomicio import atomic_write_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from discord_ferry.parser.models import DCEExport
 
 
 @dataclass
@@ -44,6 +50,42 @@ class ServerBlueprint:
     roles: list[BlueprintRole] = field(default_factory=list)
     categories: list[BlueprintCategory] = field(default_factory=list)
     uncategorized_channels: list[BlueprintChannel] = field(default_factory=list)
+
+
+def blueprint_from_exports(exports: list[DCEExport], name: str | None = None) -> ServerBlueprint:
+    """Build a ServerBlueprint from parsed DCE exports.
+
+    The single home for the channel-mapping rule both shells depend on: a
+    category-type channel (DCE ``type == 4``) is skipped, a voice channel
+    (``type == 2``) maps to a Stoat ``"Voice"`` channel and everything else to
+    ``"Text"``, and a channel with no category lands in
+    ``uncategorized_channels``. Keeping it here, rather than a copy in each
+    shell, is why the CLI and GUI cannot diverge on the mapping.
+    """
+    guild_name = name or exports[0].guild.name
+    categories: dict[str, list[BlueprintChannel]] = {}
+    uncategorized: list[BlueprintChannel] = []
+
+    for export in exports:
+        ch = export.channel
+        if ch.type == 4:  # category-type channel, not a real channel
+            continue
+        stoat_type = "Voice" if ch.type == 2 else "Text"
+        bp_channel = BlueprintChannel(name=ch.name, type=stoat_type)
+        if ch.category:
+            categories.setdefault(ch.category, []).append(bp_channel)
+        else:
+            uncategorized.append(bp_channel)
+
+    return ServerBlueprint(
+        name=guild_name,
+        description=f"Exported from Discord server '{guild_name}'",
+        categories=[
+            BlueprintCategory(name=cat_name, channels=channels)
+            for cat_name, channels in categories.items()
+        ],
+        uncategorized_channels=uncategorized,
+    )
 
 
 def export_blueprint(blueprint: ServerBlueprint, output_path: Path) -> None:

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -965,51 +965,20 @@ def build(
 @click.option("--name", default=None, help="Override server name in blueprint")
 def export_blueprint_cmd(from_dir: str, output: str, name: str | None) -> None:
     """Export a DCE export directory as a reusable blueprint."""
-    from discord_ferry.blueprint import (
-        BlueprintCategory,
-        BlueprintChannel,
-        ServerBlueprint,
-        export_blueprint,
-    )
+    from discord_ferry.blueprint import blueprint_from_exports, export_blueprint
 
     exports = parse_export_directory(Path(from_dir))
     if not exports:
         console.print("[bold red]Error:[/] No valid DCE JSON files found.")
         sys.exit(1)
 
-    guild_name = name or exports[0].guild.name
-
-    # Collect categories and channels
-    categories: dict[str, list[BlueprintChannel]] = {}
-    uncategorized: list[BlueprintChannel] = []
-
-    for export in exports:
-        ch = export.channel
-        if ch.type == 4:  # Skip category-type channels
-            continue
-        stoat_type = "Voice" if ch.type == 2 else "Text"
-        bp_channel = BlueprintChannel(name=ch.name, type=stoat_type)
-
-        if ch.category:
-            categories.setdefault(ch.category, []).append(bp_channel)
-        else:
-            uncategorized.append(bp_channel)
-
-    bp = ServerBlueprint(
-        name=guild_name,
-        description=f"Exported from Discord server '{guild_name}'",
-        categories=[
-            BlueprintCategory(name=cat_name, channels=channels)
-            for cat_name, channels in categories.items()
-        ],
-        uncategorized_channels=uncategorized,
-    )
+    bp = blueprint_from_exports(exports, name)
 
     export_blueprint(bp, Path(output))
     console.print(
         f"[bold green]Blueprint exported[/] to {_safe(output)} "
         f"({len(bp.categories)} categories, "
-        f"{sum(len(c.channels) for c in bp.categories) + len(uncategorized)} channels)"
+        f"{sum(len(c.channels) for c in bp.categories) + len(bp.uncategorized_channels)} channels)"
     )
 
 

--- a/src/discord_ferry/cli.py
+++ b/src/discord_ferry/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse
 
-import aiohttp  # noqa: TCH002
 import click
 from dotenv import load_dotenv
 from rich.console import Console
@@ -30,20 +29,11 @@ from discord_ferry.core.engine import (
     run_retry_failed,
     run_rollback,
 )
-from discord_ferry.core.http import format_proxy_notices, new_session
+from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.logging_setup import configure_logging
 from discord_ferry.core.security import register_secret
 from discord_ferry.errors import CheckError, MigrationError, StateError
-from discord_ferry.migrator.api import (
-    api_create_channel,
-    api_create_role,
-    api_create_server,
-    api_edit_role,
-    api_edit_role_ranks,
-    api_set_role_permissions,
-    api_upsert_categories,
-    init_request_semaphore,
-)
+from discord_ferry.migrator.api import init_request_semaphore
 from discord_ferry.migrator.structure import run_role_backfill
 from discord_ferry.parser.dce_parser import (
     acknowledgement_required,
@@ -267,40 +257,6 @@ def _safe(value: object) -> str:
     abort the whole migration. Escaping neutralises the metacharacters.
     """
     return escape(str(value))
-
-
-async def _build_blueprint_channel(
-    session: aiohttp.ClientSession,
-    stoat_url: str,
-    token: str,
-    server_id: str,
-    ch: Any,
-) -> str:
-    """Create a blueprint channel, retrying a failed Voice channel as Text (Stoat Bug #194).
-
-    Mirrors the migration path's voice fallback (``structure.py``). Only a ``"Voice"``-type
-    create failure is retried as ``"Text"``; any other ``MigrationError`` propagates. Returns
-    the created channel's Stoat ``_id``.
-    """
-    try:
-        result = await api_create_channel(
-            session, stoat_url, token, server_id, name=ch.name, channel_type=ch.type, nsfw=ch.nsfw
-        )
-    except MigrationError:
-        if ch.type == "Voice":
-            console.print(f"  [yellow]Voice channel '{_safe(ch.name)}' failed, retrying as text[/]")
-            result = await api_create_channel(
-                session,
-                stoat_url,
-                token,
-                server_id,
-                name=ch.name,
-                channel_type="Text",
-                nsfw=ch.nsfw,
-            )
-        else:
-            raise
-    return str(result["_id"])
 
 
 class _ProgressTracker:
@@ -848,6 +804,7 @@ def build(
     import importlib.resources
 
     from discord_ferry.blueprint import ServerBlueprint, import_blueprint
+    from discord_ferry.core.engine import run_build
 
     if not template and not blueprint:
         console.print("[bold red]Error:[/] Provide --template or --blueprint")
@@ -869,82 +826,24 @@ def build(
     _print_proxy_notices()
     console.print(f"[bold]Discord Ferry[/] — building server '{_safe(bp.name)}'\n")
 
-    async def _build() -> None:
-        async with new_session() as session:
-            # Create server
-            server_id = await api_create_server(session, stoat_url, token, bp.name)
-            console.print(f"  Created server '{_safe(bp.name)}' ({server_id})")
-
-            # Create roles
-            created_roles: list[tuple[int, str]] = []
-            for role in bp.roles:
-                role_result = await api_create_role(session, stoat_url, token, server_id, role.name)
-                role_id = role_result["id"]
-                created_roles.append((role.rank, role_id))
-                if role.colour:
-                    await api_edit_role(
-                        session, stoat_url, token, server_id, role_id, colour=role.colour
-                    )
-                if role.permissions:
-                    await api_set_role_permissions(
-                        session,
-                        stoat_url,
-                        token,
-                        server_id,
-                        role_id,
-                        allow=role.permissions,
-                        deny=0,
-                    )
-                console.print(f"  Created role '{_safe(role.name)}'")
-
-            # Apply role ordering
-            if any(rank > 0 for rank, _ in created_roles):
-                ranked = [(r, rid) for r, rid in created_roles if r > 0]
-                ranked.sort(key=lambda item: item[0], reverse=True)
-                unranked = [rid for r, rid in created_roles if r == 0]
-                ordered = [rid for _, rid in ranked] + unranked
-                try:
-                    await api_edit_role_ranks(session, stoat_url, token, server_id, ordered)
-                    console.print("  Applied role ordering")
-                except MigrationError as exc:
-                    console.print(f"  [yellow]Warning:[/] Role ordering failed: {_safe(exc)}")
-
-            # Create categories and channels
-            import uuid
-
-            all_categories: list[dict[str, Any]] = []
-            for category in bp.categories:
-                cat_id = uuid.uuid4().hex[:26]
-                channel_ids: list[str] = []
-                for ch in category.channels:
-                    channel_ids.append(
-                        await _build_blueprint_channel(session, stoat_url, token, server_id, ch)
-                    )
-                    console.print(
-                        f"  Created channel '{_safe(ch.name)}' in '{_safe(category.name)}'"
-                    )
-                all_categories.append(
-                    {
-                        "id": cat_id,
-                        "title": category.name[:32],
-                        "channels": channel_ids,
-                    }
-                )
-            if all_categories:
-                await api_upsert_categories(session, stoat_url, token, server_id, all_categories)
-
-            # Create uncategorized channels
-            for ch in bp.uncategorized_channels:
-                await _build_blueprint_channel(session, stoat_url, token, server_id, ch)
-                console.print(f"  Created channel '{_safe(ch.name)}'")
-
-            console.print(f"\n[bold green]Done![/] Server '{_safe(bp.name)}' created ({server_id})")
+    def _on_event(event: MigrationEvent) -> None:
+        line = _safe(event.message)
+        if event.status == "warning":
+            console.print(f"  [yellow]Warning:[/] {line}")
+        elif event.status == "error":
+            console.print(f"  [red]{line}[/]")
+        else:
+            console.print(f"  {line}")
 
     try:
-        asyncio.run(_build())
+        # The build sequence lives in engine.run_build so the CLI and the GUI build
+        # page cannot diverge on it; this shell only renders the events and the
+        # final line. A built server writes no state.json and cannot be rolled back.
+        server_id = asyncio.run(run_build(stoat_url, token, bp, _on_event))
     except MigrationError as exc:
         console.print(f"\n[bold red]Build failed:[/] {_safe(exc)}")
         sys.exit(1)
+    console.print(f"\n[bold green]Done![/] Server '{_safe(bp.name)}' created ({server_id})")
 
 
 @main.command(name="export-blueprint")

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -34,16 +34,20 @@ from discord_ferry.migrator.api import (
     api_create_channel,
     api_create_invite,
     api_create_role,
+    api_create_server,
     api_delete_channel,
     api_delete_emoji,
     api_delete_role,
     api_edit_channel,
     api_edit_message,
+    api_edit_role,
+    api_edit_role_ranks,
     api_edit_server,
     api_fetch_server,
     api_fetch_server_with_channels,
     api_pin_message,
     api_send_message,
+    api_set_role_permissions,
     api_upsert_categories,
     get_session,
     init_request_semaphore,
@@ -85,6 +89,7 @@ from discord_ferry.state import (
 )
 
 if TYPE_CHECKING:
+    from discord_ferry.blueprint import BlueprintChannel, ServerBlueprint
     from discord_ferry.discord.metadata import ChannelMeta
 
     # Type-only: run_check itself is imported inside run_repair, matching how
@@ -2874,3 +2879,149 @@ async def run_rollback(
         config.session = None
 
     return state
+
+
+async def _build_blueprint_channel(
+    session: aiohttp.ClientSession,
+    stoat_url: str,
+    token: str,
+    server_id: str,
+    ch: BlueprintChannel,
+    on_event: EventCallback,
+) -> str:
+    """Create a blueprint channel, retrying a failed Voice channel as Text (Stoat Bug #194).
+
+    Mirrors the migration path's voice fallback (``structure.py``). Only a ``"Voice"``-type
+    create failure is retried as ``"Text"``; any other ``MigrationError`` propagates. Returns
+    the created channel's Stoat ``_id``.
+    """
+    try:
+        result = await api_create_channel(
+            session, stoat_url, token, server_id, name=ch.name, channel_type=ch.type, nsfw=ch.nsfw
+        )
+    except MigrationError:
+        if ch.type == "Voice":
+            on_event(
+                MigrationEvent(
+                    phase="build",
+                    status="warning",
+                    message=f"Voice channel '{ch.name}' failed, retrying as text",
+                )
+            )
+            result = await api_create_channel(
+                session,
+                stoat_url,
+                token,
+                server_id,
+                name=ch.name,
+                channel_type="Text",
+                nsfw=ch.nsfw,
+            )
+        else:
+            raise
+    return str(result["_id"])
+
+
+async def run_build(
+    stoat_url: str,
+    token: str,
+    blueprint: ServerBlueprint,
+    on_event: EventCallback,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> str:
+    """Build a Stoat server from a blueprint, shared by the CLI and the GUI build page.
+
+    Emits progress events and returns the created server id. A role-ordering
+    failure is a warning event, not a raise: the server is already usable, so
+    matching the CLI, the build does not abort on it. Any other ``MigrationError``
+    propagates to the caller.
+
+    Writes no ``state.json``, so a server built this way cannot be rolled back by
+    ``run_rollback`` -- there is no recorded id map to undo.
+    """
+    import uuid
+
+    own_session = session is None
+    sess = session or new_session()
+    try:
+        server_id = await api_create_server(sess, stoat_url, token, blueprint.name)
+        on_event(
+            MigrationEvent(
+                phase="build",
+                status="started",
+                message=f"Created server '{blueprint.name}' ({server_id})",
+            )
+        )
+
+        created_roles: list[tuple[int, str]] = []
+        for role in blueprint.roles:
+            role_result = await api_create_role(sess, stoat_url, token, server_id, role.name)
+            role_id = role_result["id"]
+            created_roles.append((role.rank, role_id))
+            if role.colour:
+                await api_edit_role(sess, stoat_url, token, server_id, role_id, colour=role.colour)
+            if role.permissions:
+                await api_set_role_permissions(
+                    sess, stoat_url, token, server_id, role_id, allow=role.permissions, deny=0
+                )
+            on_event(
+                MigrationEvent(
+                    phase="build", status="progress", message=f"Created role '{role.name}'"
+                )
+            )
+
+        if any(rank > 0 for rank, _ in created_roles):
+            ranked = [(r, rid) for r, rid in created_roles if r > 0]
+            ranked.sort(key=lambda item: item[0], reverse=True)
+            unranked = [rid for r, rid in created_roles if r == 0]
+            ordered = [rid for _, rid in ranked] + unranked
+            try:
+                await api_edit_role_ranks(sess, stoat_url, token, server_id, ordered)
+                on_event(
+                    MigrationEvent(
+                        phase="build", status="progress", message="Applied role ordering"
+                    )
+                )
+            except MigrationError as exc:
+                on_event(
+                    MigrationEvent(
+                        phase="build",
+                        status="warning",
+                        message=f"Role ordering failed: {exc}",
+                    )
+                )
+
+        all_categories: list[dict[str, Any]] = []
+        for category in blueprint.categories:
+            cat_id = uuid.uuid4().hex[:26]
+            channel_ids: list[str] = []
+            for ch in category.channels:
+                channel_ids.append(
+                    await _build_blueprint_channel(sess, stoat_url, token, server_id, ch, on_event)
+                )
+                on_event(
+                    MigrationEvent(
+                        phase="build",
+                        status="progress",
+                        message=f"Created channel '{ch.name}' in '{category.name}'",
+                    )
+                )
+            all_categories.append(
+                {"id": cat_id, "title": category.name[:32], "channels": channel_ids}
+            )
+        if all_categories:
+            await api_upsert_categories(sess, stoat_url, token, server_id, all_categories)
+
+        for ch in blueprint.uncategorized_channels:
+            await _build_blueprint_channel(sess, stoat_url, token, server_id, ch, on_event)
+            on_event(
+                MigrationEvent(
+                    phase="build", status="progress", message=f"Created channel '{ch.name}'"
+                )
+            )
+
+        return server_id
+    finally:
+        if own_session:
+            await sess.close()

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -511,19 +511,23 @@ def retry_page() -> None:
 def probe_page() -> None:
     """Preflight a live Stoat instance for Autumn limits, rate window, voice, webhooks.
 
-    A self-contained preflight: it collects its own URL and token rather than a
-    prior migration's session (design line 83), so it works before any migration
-    exists. No session-expired guard, for the same reason.
+    Reads stoat_url from the user store and the token from the tab store, with a
+    session-expired guard when the tab store is empty (design: every tool page
+    sources credentials this way; entering a token when the store is empty is the
+    deferred #524). Needs a throwaway test server id and an optional deep toggle.
     """
     client = ui.context.client
-    default_url = str(app.storage.user.get("stoat_url", ""))
-    default_token = _tab_token() or ""
+    stoat_url = str(app.storage.user.get("stoat_url", ""))
+    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Preflight a Stoat instance").classes("text-2xl font-bold mb-4")
+        if token is None:
+            ui.label("Session expired. Re-enter your token on the setup page.").classes(
+                "text-red-600"
+            )
+            return
 
-        url_input = ui.input("Stoat URL", value=default_url).classes("w-96")
-        token_input = ui.input("Stoat token", value=default_token, password=True).classes("w-96")
         server_input = ui.input("Throwaway test server ID").classes("w-96")
         deep_cb = ui.checkbox("Deep probe (upload test files at each Autumn size boundary)")
         deep_warning = ui.label(
@@ -547,12 +551,7 @@ def probe_page() -> None:
 
         def _run() -> None:
             results.clear()
-            stoat_url = url_input.value.strip()
-            token = token_input.value.strip()
             server_id = server_input.value.strip()
-            if not stoat_url or not token:
-                ui.notify("Enter a Stoat URL and token.", type="warning")
-                return
             if not server_id:
                 ui.notify(
                     "Enter a throwaway test server ID. Probe creates and deletes entities in it.",

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -9,15 +9,16 @@ any request.
 
 from __future__ import annotations
 
+import importlib.resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from nicegui import app, background_tasks, ui
 
 import discord_ferry.migrator.api as _api
-from discord_ferry.blueprint import blueprint_from_exports, export_blueprint
+from discord_ferry.blueprint import blueprint_from_exports, export_blueprint, import_blueprint
 from discord_ferry.config import FerryConfig
-from discord_ferry.core.engine import run_repair, run_retry_failed
+from discord_ferry.core.engine import run_build, run_repair, run_retry_failed
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, MigrationError, StateError
@@ -638,3 +639,85 @@ def blueprint_export_page() -> None:
             _write(bp, output_path)
 
         ui.button("Export blueprint", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/build")
+def build_page() -> None:
+    """Build a Stoat server from a preset template or a blueprint file.
+
+    Makes live API calls, so it goes through the runner (register the token, init
+    the semaphore only when unset). Reads stoat_url from the user store and the
+    token from the tab store, with a session-expired guard. Exactly one source,
+    a template or a blueprint file, is required.
+    """
+    client = ui.context.client
+    stoat_url = str(app.storage.user.get("stoat_url", ""))
+    token = _tab_token()
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Build a server").classes("text-2xl font-bold mb-4")
+        if token is None:
+            ui.label("Session expired. Re-enter your token on the setup page.").classes(
+                "text-red-600"
+            )
+            return
+
+        ui.label(
+            "A server built here writes no state.json, so the rollback tool cannot undo it: "
+            "there is no recorded id map to reverse."
+        ).classes("text-amber-700 text-sm max-w-2xl")
+
+        template_select = ui.select(
+            ["gaming", "community", "education"], label="Template", clearable=True
+        ).classes("w-96")
+        blueprint_input = ui.input("Blueprint file (JSON), instead of a template").classes("w-96")
+        name_input = ui.input("Server name (optional, overrides the source's)").classes("w-96")
+        log = ui.log(max_lines=300).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def on_event(event: MigrationEvent) -> None:
+            _safe_push(log.push, f"[{event.phase}] {event.message}")
+
+        def on_done(server_id: str | None) -> None:
+            results.clear()
+            with results:
+                if server_id is None:
+                    ui.label("Build failed. See the log above.").classes("text-red-600")
+                    return
+                # server_id is a Stoat-assigned ULID, not free text, so no sanitizing.
+                ui.label(f"Server built ({server_id}).").classes("text-lg font-bold text-green-600")
+
+        def _run() -> None:
+            results.clear()
+            template = (template_select.value or "").strip()
+            blueprint_file = blueprint_input.value.strip()
+            if bool(template) == bool(blueprint_file):
+                # Reject neither and both: the CLI requires exactly one source.
+                ui.notify(
+                    "Choose exactly one source: a template or a blueprint file.",
+                    type="warning",
+                )
+                return
+            if blueprint_file and not Path(blueprint_file).is_file():
+                ui.notify("That blueprint file does not exist.", type="warning")
+                return
+            name = name_input.value.strip() or None
+            for line in prepare_tool_call(token):
+                _safe_push(log.push, line)
+
+            async def _do_build() -> str:
+                if template:
+                    templates_dir = importlib.resources.files("discord_ferry.templates")
+                    bp = import_blueprint(Path(str(templates_dir / f"{template}.json")))
+                else:
+                    bp = import_blueprint(Path(blueprint_file))
+                if name:
+                    bp.name = name
+                # A role-ordering failure is a warning event inside run_build, not a
+                # raise, so the build completes and on_done reports success, matching
+                # the CLI.
+                return await run_build(stoat_url, token, bp, on_event)
+
+            run_tool(client, log.push, _do_build, on_done)
+
+        ui.button("Build server", on_click=_run).classes("mt-2")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.migrator.probe import ProbeReport
     from discord_ferry.migrator.verify import CheckReport, RepairOutcome
     from discord_ferry.state import MigrationState
 
@@ -144,6 +145,57 @@ def render_repair_outcome(outcome: RepairOutcome) -> None:
             for w in outcome.declined
         ]
         ui.table(columns=columns, rows=rows).classes("w-full mt-1")
+
+
+def _probe_rows(report: ProbeReport) -> list[dict[str, str]]:
+    """One table row per probe check, carrying its badge colour.
+
+    ``ProbeCheck.detail`` is instance-controlled prose (limits, header dumps,
+    exception messages from a Stoat we do not run), and the table bypasses the
+    logging formatter, so the detail and name are sanitized here, the same reason
+    ``_check_rows`` sanitizes the check table. The status is an internal enum.
+    """
+    return [
+        {
+            "name": sanitize_secrets(c.name),
+            "status": c.status,
+            "detail": sanitize_secrets(c.detail),
+            "colour": _status_colour(c.status),
+        }
+        for c in report.checks
+    ]
+
+
+def _probe_counts(report: ProbeReport) -> dict[str, int]:
+    """Count the probe checks by status (ok/warn/fail).
+
+    ProbeReport carries no ``counts()`` of its own (unlike CheckReport), so the
+    summary line computes them here.
+    """
+    counts = {"ok": 0, "warn": 0, "fail": 0}
+    for c in report.checks:
+        if c.status in counts:
+            counts[c.status] += 1
+    return counts
+
+
+def render_probe_report(report: ProbeReport) -> None:
+    """Render a ProbeReport as a summary line and a per-check table.
+
+    Probe is a return value, not an event stream (``run_probe`` never calls
+    ``on_event``), so this renders from the object directly, like
+    ``render_check_report``.
+    """
+    counts = _probe_counts(report)
+    ui.label(f"{counts['ok']} ok, {counts['warn']} warn, {counts['fail']} fail").classes(
+        "text-sm text-gray-600"
+    )
+    columns = [
+        {"name": "name", "label": "Check", "field": "name", "align": "left"},
+        {"name": "status", "label": "Status", "field": "status", "align": "left"},
+        {"name": "detail", "label": "Detail", "field": "detail", "align": "left"},
+    ]
+    ui.table(columns=columns, rows=_probe_rows(report)).classes("w-full mt-2")
 
 
 def _semaphore_is_set() -> bool:

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from nicegui import app, background_tasks, ui
 
 import discord_ferry.migrator.api as _api
+from discord_ferry.blueprint import blueprint_from_exports, export_blueprint
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import run_repair, run_retry_failed
 from discord_ferry.core.http import format_proxy_notices
@@ -28,6 +29,7 @@ from discord_ferry.state import load_state
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from discord_ferry.blueprint import ServerBlueprint
     from discord_ferry.core.events import MigrationEvent
     from discord_ferry.migrator.probe import ProbeReport
     from discord_ferry.migrator.verify import CheckReport, RepairOutcome
@@ -575,3 +577,65 @@ def probe_page() -> None:
             run_tool(client, log.push, _do_probe, on_done)
 
         ui.button("Run probe", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/blueprint-export")
+def blueprint_export_page() -> None:
+    """Turn a DCE export directory into a reusable server blueprint.
+
+    Offline: it reads local export files and writes a JSON blueprint, making no
+    API call, so there is no token and no runner. Unlike the CLI, which
+    overwrites the output silently, this asks before replacing an existing file.
+    """
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Export a blueprint").classes("text-2xl font-bold mb-4")
+        from_input = ui.input("Export directory (the DCE export)").classes("w-96")
+        output_input = ui.input("Output path (blueprint JSON)", value="blueprint.json").classes(
+            "w-96"
+        )
+        name_input = ui.input("Server name (optional, overrides the export's)").classes("w-96")
+        overwrite_cb = ui.checkbox("Overwrite the output file if it already exists")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def _write(bp: ServerBlueprint, output_path: Path) -> None:
+            export_blueprint(bp, output_path)
+            channels = sum(len(c.channels) for c in bp.categories) + len(bp.uncategorized_channels)
+            results.clear()
+            with results:
+                # Counts are integers and the path is user-supplied, so neither is
+                # server-controlled text; no sanitizing needed here.
+                ui.label(
+                    f"Blueprint written to {output_path} "
+                    f"({len(bp.categories)} categories, {channels} channels)."
+                ).classes("text-green-600")
+
+        def _run() -> None:
+            results.clear()
+            from_dir = from_input.value.strip()
+            output = output_input.value.strip()
+            if not from_dir or not Path(from_dir).is_dir():
+                ui.notify("Enter a valid export directory.", type="warning")
+                return
+            if not output:
+                ui.notify("Enter an output path for the blueprint.", type="warning")
+                return
+            exports = parse_export_directory(Path(from_dir))
+            if not exports:
+                with results:
+                    ui.label("No valid DCE JSON files found in that directory.").classes(
+                        "text-red-600"
+                    )
+                return
+            output_path = Path(output)
+            if output_path.exists() and not overwrite_cb.value:
+                # The CLI overwrites silently; here the write waits on an explicit
+                # confirmation so a user cannot lose an existing blueprint by accident.
+                with results:
+                    ui.label(
+                        f"{output_path} already exists. Tick 'Overwrite' to replace it."
+                    ).classes("text-amber-700")
+                return
+            bp = blueprint_from_exports(exports, name_input.value.strip() or None)
+            _write(bp, output_path)
+
+        ui.button("Export blueprint", on_click=_run).classes("mt-2")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -538,6 +538,10 @@ def probe_page() -> None:
         deep_warning.bind_visibility_from(deep_cb, "value")
         deep_confirm = ui.checkbox("I understand the deep probe leaves orphaned files in Autumn")
         deep_confirm.bind_visibility_from(deep_cb, "value")
+        # Reset the confirmation whenever the deep toggle changes, so turning deep
+        # off and on again cannot carry a stale tick past the guard: binding only
+        # its visibility would hide the box while keeping its value True.
+        deep_cb.on_value_change(lambda: deep_confirm.set_value(False))
 
         log = ui.log(max_lines=200).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
         results = ui.column().classes("w-full max-w-2xl")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -20,6 +20,7 @@ from discord_ferry.core.engine import run_repair, run_retry_failed
 from discord_ferry.core.http import format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, MigrationError, StateError
+from discord_ferry.migrator.probe import run_probe
 from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, run_check
 from discord_ferry.parser.dce_parser import parse_export_directory
 from discord_ferry.state import load_state
@@ -502,3 +503,75 @@ def retry_page() -> None:
             run_tool(client, log.push, _do_retry, on_done)
 
         ui.button("Run retry", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/probe")
+def probe_page() -> None:
+    """Preflight a live Stoat instance for Autumn limits, rate window, voice, webhooks.
+
+    A self-contained preflight: it collects its own URL and token rather than a
+    prior migration's session (design line 83), so it works before any migration
+    exists. No session-expired guard, for the same reason.
+    """
+    client = ui.context.client
+    default_url = str(app.storage.user.get("stoat_url", ""))
+    default_token = _tab_token() or ""
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Preflight a Stoat instance").classes("text-2xl font-bold mb-4")
+
+        url_input = ui.input("Stoat URL", value=default_url).classes("w-96")
+        token_input = ui.input("Stoat token", value=default_token, password=True).classes("w-96")
+        server_input = ui.input("Throwaway test server ID").classes("w-96")
+        deep_cb = ui.checkbox("Deep probe (upload test files at each Autumn size boundary)")
+        deep_warning = ui.label(
+            "Deep probe uploads test files to Autumn and cannot delete them, so it "
+            "leaves orphaned files in storage. Tick the box below to confirm."
+        ).classes("text-amber-700 text-sm max-w-2xl")
+        deep_warning.bind_visibility_from(deep_cb, "value")
+        deep_confirm = ui.checkbox("I understand the deep probe leaves orphaned files in Autumn")
+        deep_confirm.bind_visibility_from(deep_cb, "value")
+
+        log = ui.log(max_lines=200).classes("w-full max-w-2xl h-48 font-mono text-xs mt-2")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def on_done(report: ProbeReport | None) -> None:
+            results.clear()
+            with results:
+                if report is None:
+                    ui.label("Probe failed. See the log above.").classes("text-red-600")
+                    return
+                render_probe_report(report)
+
+        def _run() -> None:
+            results.clear()
+            stoat_url = url_input.value.strip()
+            token = token_input.value.strip()
+            server_id = server_input.value.strip()
+            if not stoat_url or not token:
+                ui.notify("Enter a Stoat URL and token.", type="warning")
+                return
+            if not server_id:
+                ui.notify(
+                    "Enter a throwaway test server ID. Probe creates and deletes entities in it.",
+                    type="warning",
+                )
+                return
+            deep = deep_cb.value
+            if deep and not deep_confirm.value:
+                ui.notify(
+                    "Confirm the deep-probe warning before running a deep probe.",
+                    type="warning",
+                )
+                return
+            for line in prepare_tool_call(token):
+                _safe_push(log.push, line)
+
+            async def _do_probe() -> ProbeReport:
+                # run_probe never calls its on_event (it returns a report), so a
+                # no-op callback matches the CLI's `lambda _e: None`.
+                return await run_probe(stoat_url, token, server_id, lambda _e: None, deep=deep)
+
+            run_tool(client, log.push, _do_probe, on_done)
+
+        ui.button("Run probe", on_click=_run).classes("mt-2")

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -10,9 +10,47 @@ from discord_ferry.blueprint import (
     BlueprintChannel,
     BlueprintRole,
     ServerBlueprint,
+    blueprint_from_exports,
     export_blueprint,
     import_blueprint,
 )
+from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
+
+
+def _export(name: str, ch_type: int, category: str = "") -> DCEExport:
+    """A minimal DCEExport carrying one channel, for the mapping test."""
+    return DCEExport(
+        guild=DCEGuild(id="g1", name="My Guild"),
+        channel=DCEChannel(id=name, type=ch_type, name=name, category=category),
+    )
+
+
+def test_blueprint_from_exports_maps_channels_and_categories() -> None:
+    """The shared mapping: type 4 skipped, type 2 -> Voice, empty category -> uncategorized."""
+    exports = [
+        _export("general", 0, category="Text Channels"),
+        _export("lounge", 2, category="Voice Channels"),
+        _export("rules", 0),  # no category -> uncategorized
+        _export("a-category", 4, category=""),  # category-type channel, skipped
+    ]
+
+    bp = blueprint_from_exports(exports)
+
+    assert bp.name == "My Guild"  # from the first export's guild
+    assert {c.name for c in bp.categories} == {"Text Channels", "Voice Channels"}
+    voice_cat = next(c for c in bp.categories if c.name == "Voice Channels")
+    assert voice_cat.channels[0].type == "Voice"
+    assert [c.name for c in bp.uncategorized_channels] == ["rules"]
+    all_names = [ch.name for cat in bp.categories for ch in cat.channels] + [
+        c.name for c in bp.uncategorized_channels
+    ]
+    assert "a-category" not in all_names  # the type-4 channel was skipped
+
+
+def test_blueprint_from_exports_name_override() -> None:
+    """An explicit name overrides the guild name."""
+    bp = blueprint_from_exports([_export("general", 0)], name="Renamed")
+    assert bp.name == "Renamed"
 
 
 def _make_blueprint() -> ServerBlueprint:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -466,7 +466,7 @@ def test_build_prints_proxy_notice(runner: CliRunner, tmp_path: Path, proxy_env,
     with (
         os_proxy({}),
         proxy_env(ALL_PROXY="socks5://sock:1080"),
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
     ):
         result = runner.invoke(
             main,
@@ -1192,8 +1192,11 @@ def test_progress_tracker_only_markup_name() -> None:  # SC-22
     assert "[/]" in buf.getvalue()
 
 
-def test_cli_exposes_api_helpers_module_level() -> None:  # SC-20 (C1)
-    from discord_ferry.cli import api_create_channel, api_edit_role
+def test_engine_exposes_build_api_helpers_module_level() -> None:  # SC-20 (C1)
+    # The build sequence moved from cli to engine.run_build (#491), so the api
+    # helpers it patches are now module-level in engine, not cli. This guards
+    # that patchability at its new home.
+    from discord_ferry.core.engine import api_create_channel, api_edit_role
 
     assert callable(api_create_channel)
     assert callable(api_edit_role)
@@ -1216,12 +1219,12 @@ def test_build_channel_voice_retries_as_text() -> None:  # SC-9
     import asyncio
 
     from discord_ferry.blueprint import BlueprintChannel
-    from discord_ferry.cli import _build_blueprint_channel
+    from discord_ferry.core.engine import _build_blueprint_channel
 
     ch = BlueprintChannel(name="VC", type="Voice")
     mock = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
-    with patch("discord_ferry.cli.api_create_channel", mock):
-        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+    with patch("discord_ferry.core.engine.api_create_channel", mock):
+        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch, lambda _e: None))
     assert rid == "ch_text"
     assert mock.await_count == 2
     assert mock.await_args_list[0].kwargs["channel_type"] == "Voice"
@@ -1232,15 +1235,15 @@ def test_build_channel_non_voice_propagates() -> None:  # SC-10
     import asyncio
 
     from discord_ferry.blueprint import BlueprintChannel
-    from discord_ferry.cli import _build_blueprint_channel
+    from discord_ferry.core.engine import _build_blueprint_channel
 
     ch = BlueprintChannel(name="TC", type="Text")
     mock = AsyncMock(side_effect=MigrationError("text fail"))
     with (
-        patch("discord_ferry.cli.api_create_channel", mock),
+        patch("discord_ferry.core.engine.api_create_channel", mock),
         pytest.raises(MigrationError),
     ):
-        asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+        asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch, lambda _e: None))
     assert mock.await_count == 1
 
 
@@ -1248,12 +1251,12 @@ def test_build_channel_voice_happy_path() -> None:  # SC-11
     import asyncio
 
     from discord_ferry.blueprint import BlueprintChannel
-    from discord_ferry.cli import _build_blueprint_channel
+    from discord_ferry.core.engine import _build_blueprint_channel
 
     ch = BlueprintChannel(name="VC", type="Voice")
     mock = AsyncMock(return_value={"_id": "ch1"})
-    with patch("discord_ferry.cli.api_create_channel", mock):
-        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch))
+    with patch("discord_ferry.core.engine.api_create_channel", mock):
+        rid = asyncio.run(_build_blueprint_channel(None, "u", "t", "srv", ch, lambda _e: None))
     assert rid == "ch1"
     assert mock.await_count == 1
 
@@ -1271,9 +1274,9 @@ def test_build_categorized_voice_preserves_id(runner: CliRunner, tmp_path: Path)
     create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
     upsert = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_channel", create),
-        patch("discord_ferry.cli.api_upsert_categories", upsert),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_channel", create),
+        patch("discord_ferry.core.engine.api_upsert_categories", upsert),
     ):
         result = runner.invoke(
             main,
@@ -1294,8 +1297,8 @@ def test_build_uncategorized_voice_fallback(runner: CliRunner, tmp_path: Path) -
     p = _write_bp(tmp_path, bp)
     create = AsyncMock(side_effect=[MigrationError("voice fail"), {"_id": "ch_text"}])
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_channel", create),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_channel", create),
     ):
         result = runner.invoke(
             main,
@@ -1314,9 +1317,10 @@ def test_build_non_voice_failure_aborts(runner: CliRunner, tmp_path: Path) -> No
     )
     p = _write_bp(tmp_path, bp)
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
         patch(
-            "discord_ferry.cli.api_create_channel", AsyncMock(side_effect=MigrationError("boom"))
+            "discord_ferry.core.engine.api_create_channel",
+            AsyncMock(side_effect=MigrationError("boom")),
         ),
     ):
         result = runner.invoke(
@@ -1334,8 +1338,8 @@ def test_build_empty_blueprint(runner: CliRunner, tmp_path: Path) -> None:  # SC
     p = _write_bp(tmp_path, bp)
     create = AsyncMock(return_value={"_id": "ch"})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_channel", create),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_channel", create),
     ):
         result = runner.invoke(
             main,
@@ -1367,11 +1371,11 @@ def test_build_applies_distinct_ranks(runner: CliRunner, tmp_path: Path) -> None
     ranks_mock = AsyncMock(return_value={})
     edit = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", create_role),
-        patch("discord_ferry.cli.api_edit_role", edit),
-        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
-        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", create_role),
+        patch("discord_ferry.core.engine.api_edit_role", edit),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", ranks_mock),
+        patch("discord_ferry.core.engine.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         result = runner.invoke(
             main,
@@ -1391,11 +1395,11 @@ def test_build_skips_rank_zero(runner: CliRunner, tmp_path: Path) -> None:  # SC
     p = _write_bp(tmp_path, bp)
     ranks_mock = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
-        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
-        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
-        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.core.engine.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", ranks_mock),
+        patch("discord_ferry.core.engine.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         runner.invoke(
             main,
@@ -1413,11 +1417,11 @@ def test_build_separates_colour_and_rank(runner: CliRunner, tmp_path: Path) -> N
     edit = AsyncMock(return_value={})
     ranks_mock = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r-a"})),
-        patch("discord_ferry.cli.api_edit_role", edit),
-        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
-        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r-a"})),
+        patch("discord_ferry.core.engine.api_edit_role", edit),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", ranks_mock),
+        patch("discord_ferry.core.engine.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         runner.invoke(
             main,
@@ -1439,11 +1443,11 @@ def test_build_ordering_failure_degrades(runner: CliRunner, tmp_path: Path) -> N
     p = _write_bp(tmp_path, bp)
     ranks_mock = AsyncMock(side_effect=MigrationError("test ordering failure"))
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r-a"})),
-        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
-        patch("discord_ferry.cli.api_edit_role_ranks", ranks_mock),
-        patch("discord_ferry.cli.api_set_role_permissions", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r-a"})),
+        patch("discord_ferry.core.engine.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", ranks_mock),
+        patch("discord_ferry.core.engine.api_set_role_permissions", AsyncMock(return_value={})),
     ):
         result = runner.invoke(
             main,
@@ -1462,11 +1466,11 @@ def test_build_preserves_permissions(runner: CliRunner, tmp_path: Path) -> None:
     p = _write_bp(tmp_path, bp)
     perms = AsyncMock(return_value={})
     with (
-        patch("discord_ferry.cli.api_create_server", AsyncMock(return_value="srv")),
-        patch("discord_ferry.cli.api_create_role", AsyncMock(return_value={"id": "r"})),
-        patch("discord_ferry.cli.api_edit_role", AsyncMock(return_value={})),
-        patch("discord_ferry.cli.api_edit_role_ranks", AsyncMock(return_value={})),
-        patch("discord_ferry.cli.api_set_role_permissions", perms),
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r"})),
+        patch("discord_ferry.core.engine.api_edit_role", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.api_set_role_permissions", perms),
     ):
         runner.invoke(
             main,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4869,3 +4869,71 @@ async def test_re_attaching_removes_the_dead_channel_id(tmp_path: Path) -> None:
     )
     assert "01JSTOATCHN000000000NEW" in mine["channels"]
     assert "01JSTOATCHN0000000OTHER" in mine["channels"], "an unrelated channel was evicted"
+
+
+# ---------------------------------------------------------------------------
+# run_build — the shared build sequence (#491)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_build_returns_server_id_and_emits_progress() -> None:
+    """The happy path returns the created server id and emits a started event."""
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+    from discord_ferry.core.engine import run_build
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", rank=1)])
+    events: list[MigrationEvent] = []
+    with (
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r-a"})),
+        patch("discord_ferry.core.engine.api_edit_role_ranks", AsyncMock(return_value={})),
+        patch("discord_ferry.core.engine.new_session", lambda: AsyncMock()),
+    ):
+        server_id = await run_build("http://x", "t", bp, events.append)
+
+    assert server_id == "srv"
+    assert any(e.status == "started" for e in events)
+    assert any("Created role 'A'" in e.message for e in events)
+
+
+async def test_run_build_role_ordering_failure_is_a_warning_not_a_raise() -> None:
+    """A role-ordering MigrationError surfaces as a warning event; the build still returns."""
+    from discord_ferry.blueprint import BlueprintRole, ServerBlueprint
+    from discord_ferry.core.engine import run_build
+
+    bp = ServerBlueprint(name="S", roles=[BlueprintRole(name="A", rank=2)])
+    events: list[MigrationEvent] = []
+    with (
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch("discord_ferry.core.engine.api_create_role", AsyncMock(return_value={"id": "r-a"})),
+        patch(
+            "discord_ferry.core.engine.api_edit_role_ranks",
+            AsyncMock(side_effect=MigrationError("ordering failed")),
+        ),
+        patch("discord_ferry.core.engine.new_session", lambda: AsyncMock()),
+    ):
+        server_id = await run_build("http://x", "t", bp, events.append)
+
+    assert server_id == "srv"  # did not abort
+    warnings = [e for e in events if e.status == "warning"]
+    assert warnings and "ordering failed" in warnings[0].message
+
+
+async def test_run_build_non_voice_channel_failure_propagates() -> None:
+    """A non-voice channel create failure aborts the build with the MigrationError."""
+    from discord_ferry.blueprint import BlueprintChannel, ServerBlueprint
+    from discord_ferry.core.engine import run_build
+
+    bp = ServerBlueprint(
+        name="S", uncategorized_channels=[BlueprintChannel(name="TC", type="Text")]
+    )
+    with (
+        patch("discord_ferry.core.engine.api_create_server", AsyncMock(return_value="srv")),
+        patch(
+            "discord_ferry.core.engine.api_create_channel",
+            AsyncMock(side_effect=MigrationError("boom")),
+        ),
+        patch("discord_ferry.core.engine.new_session", lambda: AsyncMock()),
+        pytest.raises(MigrationError),
+    ):
+        await run_build("http://x", "t", bp, lambda _e: None)

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -495,6 +495,97 @@ async def test_blueprint_export_page_confirms_before_overwrite(
     assert output.read_text(encoding="utf-8") != "OLD"  # overwritten after ticking Overwrite
 
 
+async def test_build_page_bounces_without_token(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Chunk 8 Task 16: the build page shows the session-expired guard with no token."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    await user.open("/tools/build")
+    await user.should_see("Session expired")
+    await user.should_not_see("Build server")
+
+
+async def test_build_page_shows_no_rollback_notice(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Chunk 8 Task 16: the page states the built server cannot be rolled back."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    await user.open("/tools/build")
+    await user.should_see("rollback tool cannot undo it")
+
+
+async def test_build_page_requires_exactly_one_source(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 8 Task 16: neither and both are rejected; run_build is not called."""
+    from unittest.mock import AsyncMock
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    with patch("discord_ferry.gui_tools.run_build", new=AsyncMock()) as build_mock:
+        await user.open("/tools/build")
+        # Neither a template nor a blueprint file.
+        user.find("Build server").click()
+        await user.should_see("exactly one source")
+
+        # Both a template and a blueprint file.
+        user.find("Template").elements.pop().set_value("gaming")
+        user.find("Blueprint file").elements.pop().set_value(str(tmp_path / "bp.json"))
+        user.find("Build server").click()
+        await user.should_see("exactly one source")
+
+        assert build_mock.await_count == 0
+
+
+async def test_build_page_runs_and_soft_role_warning_still_succeeds(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 8 Task 17: a build with a role-ordering warning still reports success.
+
+    The role-ordering failure is a warning event inside run_build, not a raise,
+    so the page renders the success label rather than the error path. The token is
+    registered via the runner before the call.
+    """
+    from discord_ferry import gui_tools
+    from discord_ferry.core.events import MigrationEvent
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    registered: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        gui_tools, "register_secret", lambda name, value: registered.append((name, value))
+    )
+
+    async def fake_build(stoat_url, token, bp, on_event, *, session=None):  # type: ignore[no-untyped-def]
+        on_event(MigrationEvent(phase="build", status="warning", message="Role ordering failed: x"))
+        return "srv-123"
+
+    with patch("discord_ferry.gui_tools.run_build", new=fake_build):
+        await user.open("/tools/build")
+        user.find("Template").elements.pop().set_value("gaming")
+        user.find("Build server").click()
+        await user.should_see("Server built (srv-123)")
+        await user.should_not_see("Build failed")
+
+    assert ("stoat", _TOKEN) in registered  # token registered before the build
+
+
 class _StubState:
     """Minimal stand-in for MigrationState for the repair verdict and page."""
 

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -346,6 +346,79 @@ def test_probe_report_summary_counts_by_status() -> None:
     assert gui_tools._probe_counts(report) == {"ok": 1, "warn": 1, "fail": 1}
 
 
+async def test_probe_page_requires_test_server_id(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Chunk 6 Task 14: probe refuses to run with no test server id; run_probe not called."""
+    from unittest.mock import AsyncMock
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    with patch("discord_ferry.gui_tools.run_probe", new=AsyncMock()) as probe_mock:
+        await user.open("/tools/probe")
+        # URL and token defaulted from storage; test-server-id left blank.
+        user.find("Run probe").click()
+        await user.should_see("throwaway test server ID")
+        assert probe_mock.await_count == 0
+
+
+async def test_probe_page_deep_requires_confirmation(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Chunk 6 Task 14: deep shows the orphan warning and blocks the call until confirmed."""
+    from unittest.mock import AsyncMock
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    with patch("discord_ferry.gui_tools.run_probe", new=AsyncMock()) as probe_mock:
+        await user.open("/tools/probe")
+        user.find("Throwaway test server ID").elements.pop().set_value("srv-throwaway")
+        user.find("Deep probe").elements.pop().set_value(True)
+        await user.should_see("leaves orphaned files")  # warning shown before any call
+        user.find("Run probe").click()
+        await user.should_see("Confirm the deep-probe warning")
+        assert probe_mock.await_count == 0  # blocked until confirmed
+
+
+async def test_probe_page_registers_token_and_renders(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 6 Task 14: a valid run registers the token via the runner and renders the table."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.probe import ProbeReport
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    registered: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        gui_tools, "register_secret", lambda name, value: registered.append((name, value))
+    )
+
+    report = ProbeReport()
+    report.add("autumn_reachable", "ok", "https://autumn (version 1)")
+
+    async def fake_probe(stoat_url, token, server_id, on_event, *, deep=False, session=None):  # type: ignore[no-untyped-def]
+        return report
+
+    with patch("discord_ferry.gui_tools.run_probe", new=fake_probe):
+        await user.open("/tools/probe")
+        user.find("Throwaway test server ID").elements.pop().set_value("srv-throwaway")
+        user.find("Run probe").click()
+        await user.should_see("1 ok, 0 warn, 0 fail")  # the table's summary rendered
+
+    assert ("stoat", _TOKEN) in registered  # the runner registered the token before the call
+
+
 class _StubState:
     """Minimal stand-in for MigrationState for the repair verdict and page."""
 

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -400,6 +400,37 @@ async def test_probe_page_deep_requires_confirmation(
         assert probe_mock.await_count == 0  # blocked until confirmed
 
 
+async def test_probe_page_deep_confirm_resets_when_toggled_off(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Whole-branch review: turning deep off then on again must not carry a stale confirm.
+
+    Binding only the confirm box's visibility would hide it while keeping value True,
+    so a re-tick of deep could run a deep probe without a fresh acknowledgement.
+    """
+    from unittest.mock import AsyncMock
+
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = _TOKEN
+
+    with patch("discord_ferry.gui_tools.run_probe", new=AsyncMock()) as probe_mock:
+        await user.open("/tools/probe")
+        user.find("Throwaway test server ID").elements.pop().set_value("srv-throwaway")
+        deep = user.find("Deep probe").elements.pop()
+        deep.set_value(True)  # confirm box is now visible, so it can be found
+        confirm = user.find("I understand the deep probe").elements.pop()
+        confirm.set_value(True)
+        deep.set_value(False)  # toggling deep off resets the confirmation
+        assert confirm.value is False
+        deep.set_value(True)  # re-enabling deep still shows an unconfirmed box
+        assert confirm.value is False
+        user.find("Run probe").click()
+        await user.should_see("Confirm the deep-probe warning")
+        assert probe_mock.await_count == 0  # blocked: the stale tick did not carry
+
+
 async def test_probe_page_registers_token_and_renders(
     user: User,
     user_store: dict[str, object],

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -297,6 +297,55 @@ def test_check_rows_sanitizes_server_controlled_text() -> None:
     reset_secret_registry()
 
 
+def test_probe_rows_one_per_check_with_status_and_detail() -> None:
+    """Chunk 6 Task 13: the probe table has a row per check carrying status and detail."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.probe import ProbeReport
+
+    report = ProbeReport()
+    report.add("autumn_reachable", "ok", "https://autumn (version 1)")
+    report.add("voice_channel", "warn", "voice unsupported on this instance")
+
+    rows = gui_tools._probe_rows(report)
+
+    assert len(rows) == 2
+    assert rows[0]["name"] == "autumn_reachable"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["detail"] == "https://autumn (version 1)"
+    assert rows[1]["colour"] == gui_tools._status_colour("warn")
+
+
+def test_probe_rows_sanitizes_server_controlled_text() -> None:
+    """The probe detail is instance-controlled text, so it is sanitized at the sink."""
+    from discord_ferry import gui_tools
+    from discord_ferry.core.security import register_secret, reset_secret_registry
+    from discord_ferry.migrator.probe import ProbeReport
+
+    reset_secret_registry()
+    register_secret("stoat", _TOKEN)
+    report = ProbeReport()
+    report.add("rate_limit", "ok", f"headers leaked {_TOKEN}")
+
+    rows = gui_tools._probe_rows(report)
+
+    assert _TOKEN not in rows[0]["detail"]
+    assert _TOKEN in report.checks[0].detail  # control: the token really was in the source
+    reset_secret_registry()
+
+
+def test_probe_report_summary_counts_by_status() -> None:
+    """render_probe_report's summary line counts ok/warn/fail from the checks."""
+    from discord_ferry import gui_tools
+    from discord_ferry.migrator.probe import ProbeReport
+
+    report = ProbeReport()
+    report.add("a", "ok", "x")
+    report.add("b", "warn", "y")
+    report.add("c", "fail", "z")
+
+    assert gui_tools._probe_counts(report) == {"ok": 1, "warn": 1, "fail": 1}
+
+
 class _StubState:
     """Minimal stand-in for MigrationState for the repair verdict and page."""
 

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -346,6 +346,20 @@ def test_probe_report_summary_counts_by_status() -> None:
     assert gui_tools._probe_counts(report) == {"ok": 1, "warn": 1, "fail": 1}
 
 
+async def test_probe_page_bounces_without_token(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """Chunk 6 Task 14: probe shows the session-expired guard when the tab store is empty."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    await user.open("/tools/probe")
+    await user.should_see("Session expired")
+    await user.should_not_see("Run probe")
+
+
 async def test_probe_page_requires_test_server_id(
     user: User,
     user_store: dict[str, object],

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -419,6 +419,68 @@ async def test_probe_page_registers_token_and_renders(
     assert ("stoat", _TOKEN) in registered  # the runner registered the token before the call
 
 
+def _one_export():  # type: ignore[no-untyped-def]
+    """A single parsed export with one text channel, for the blueprint page."""
+    from discord_ferry.parser.models import DCEChannel, DCEExport, DCEGuild
+
+    return DCEExport(
+        guild=DCEGuild(id="g1", name="My Guild"),
+        channel=DCEChannel(id="general", type=0, name="general", category="Text"),
+    )
+
+
+async def test_blueprint_export_page_writes_file(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 7 Task 15b: a valid run writes the blueprint file and reports it."""
+    output = tmp_path / "bp.json"
+
+    with patch("discord_ferry.gui_tools.parse_export_directory", return_value=[_one_export()]):
+        await user.open("/tools/blueprint-export")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Output path").elements.pop().set_value(str(output))
+        user.find("Export blueprint").click()
+        await user.should_see("Blueprint written")
+
+    assert output.exists()
+
+
+async def test_blueprint_export_page_no_dce_json_error(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 7 Task 15b: an empty parse shows a clear error, not a crash."""
+    with patch("discord_ferry.gui_tools.parse_export_directory", return_value=[]):
+        await user.open("/tools/blueprint-export")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Export blueprint").click()
+        await user.should_see("No valid DCE JSON files found")
+
+
+async def test_blueprint_export_page_confirms_before_overwrite(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """Chunk 7 Task 15b: an existing output is not overwritten until confirmed."""
+    output = tmp_path / "bp.json"
+    output.write_text("OLD", encoding="utf-8")
+
+    with patch("discord_ferry.gui_tools.parse_export_directory", return_value=[_one_export()]):
+        await user.open("/tools/blueprint-export")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Output path").elements.pop().set_value(str(output))
+        user.find("Export blueprint").click()
+        await user.should_see("already exists")
+        assert output.read_text(encoding="utf-8") == "OLD"  # not overwritten without confirmation
+
+        user.find("Overwrite the output file").elements.pop().set_value(True)
+        user.find("Export blueprint").click()
+        await user.should_see("Blueprint written")
+
+    assert output.read_text(encoding="utf-8") != "OLD"  # overwritten after ticking Overwrite
+
+
 class _StubState:
     """Minimal stand-in for MigrationState for the repair verdict and page."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.24.0"
+version = "2.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## GUI-CLI parity, phase 2

Brings the preflight and build commands to the NiceGUI web interface. Three new pages on the Tools screen at `/tools`:

- **Probe** (`/tools/probe`): check a Stoat instance before migrating (Autumn limits, rate-limit window, voice support, webhooks) as a pass/warn/fail table. A deeper probe that uploads a test file at each size boundary sits behind a confirmation, because it leaves those files in Autumn storage.
- **Blueprint export** (`/tools/blueprint-export`): turn a Discord export directory into a reusable blueprint file, with a confirmation before replacing an existing file. Offline, no token.
- **Build** (`/tools/build`): create a Stoat server from a preset template or a blueprint file, stating up front that a built server records no migration state and cannot be rolled back.

### Shared extractions (no behaviour change)

To stop the command line and the web interface drifting apart, two pieces of logic each moved to one home, called by both shells:

- `blueprint_from_exports` in `blueprint.py` (the DCE channel mapping).
- `run_build` in `core/engine.py` (the whole server-build sequence, emitting events; a role-ordering failure is a warning, not a raise). `_build_blueprint_channel` moved with it, since the engine never imports the CLI.

The 16 CLI build tests pass unchanged in intent, with their API-mock patch targets repointed from `cli` to `engine`.

### Verification

- Full suite: 2231 passed. Ruff and mypy clean.
- Second opinion (Mistral, code-reviewer): 0 findings on the diff, and 0 on a dedicated behaviour-preservation pass over the `run_build` extraction.
- Whole-branch review (`feature-dev:code-reviewer`): nothing above its confidence bar. It flagged one sub-threshold UX gap in the deep-probe confirmation (a stale tick could survive a toggle); fixed in this PR with a test.
- Chunk reviews posted to #489, #490, #491; task sub-issues #510-#514 closed.

Closes #489
Closes #490
Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
