### PR TITLE
feat(repair): restore a missing emoji and rewrite its references (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.26.0] - 2026-08-21
+
+### Added
+
+- **`ferry repair` restores a missing emoji.** When `ferry check` reports an emoji that was
+  migrated but is now gone from the Stoat server, repair recreates it from the export and
+  rewrites every message Ferry sent that referenced the old copy, so those references point at
+  the restored emoji instead of a dead id. Recreating an emoji mints a new id, so the rewrite
+  is the half that makes the restoration real.
+  - A crash partway through is finished on the next run. The recreation and a small resume
+    record are written in one step, and a later run completes any messages that were not yet
+    rewritten, so an interrupted repair never leaves a half-updated server behind.
+  - An emoji whose image is not in the export is reported as unrepairable rather than guessed
+    at. A reference in a later send of a message split across the 2000-character limit is left
+    as is, because only the first send can be addressed.
+  - A dry run previews the work without changing anything, and the result appears in both the
+    plain output and `ferry repair --json`.
+
 ## [2.25.0] - 2026-08-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.25.0"
+version = "2.26.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.25.0"
+__version__ = "2.26.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2019,8 +2019,13 @@ async def _run_emoji_repair_pass(
     # exists because that run recreated the emoji (emoji_map already points at the
     # new id) but crashed before every reference was rewritten. A fresh check
     # reports the emoji present and would never revisit these, so this must run
-    # from the record, not the check. Disjoint from emoji_work by construction: a
-    # recorded emoji reads as present, so it is never in this run's emoji_work.
+    # from the record, not the check. Usually disjoint from emoji_work: a recorded
+    # emoji reads as present, so it is normally not in this run's emoji_work. The
+    # one overlap is a recreated emoji deleted AGAIN between runs, which reads as
+    # missing and enters both. That is self-correcting, not a conflict: the resume
+    # rewrites to the (now dead) recorded id and clears the record, then the
+    # emoji_work loop recreates a fresh id and rewrites again. Extra edits, correct
+    # final state. So this loop must not assume disjointness.
     for pending_id, pending in list(state.pending_emoji_rewrites.items()):
         rewritten, declined, failed = await _rewrite_emoji_references(
             session, config, state, pending_id, pending["new"], exports, on_event

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -60,7 +60,13 @@ from discord_ferry.migrator.emoji import (
     run_emoji,
     upload_and_create_emoji,
 )
-from discord_ferry.migrator.messages import _THREAD_STRATEGIES, _process_message, run_messages
+from discord_ferry.migrator.messages import (
+    _THREAD_STRATEGIES,
+    _build_content,
+    _process_message,
+    _split_message,
+    run_messages,
+)
 from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
 from discord_ferry.migrator.structure import (
@@ -1924,6 +1930,72 @@ async def _recreate_category(
     return True
 
 
+async def _rewrite_emoji_references(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    discord_id: str,
+    new_id: str,
+    exports: list[DCEExport],
+    on_event: EventCallback,
+) -> tuple[int, int, int]:
+    """Edit every Ferry-sent message that used the emoji so it points at ``new_id``.
+
+    Returns ``(rewritten, declined, failed)``. Each referencing message is
+    re-rendered with :func:`_build_content`, which reads the now-updated
+    ``emoji_map``, so the text matches what was sent except the emoji reference.
+    A message whose reference lands in a split tail is declined rather than
+    corrupted: ``message_map`` addresses only the first send.
+    """
+    rewritten = declined = failed = 0
+    token = f":{new_id}:"
+    for channel_discord_id, msg in messages_using_emoji(exports, discord_id):
+        stoat_channel = state.channel_map.get(channel_discord_id)
+        stoat_msg = state.message_map.get(msg.id)
+        if stoat_msg is None or stoat_channel is None:
+            # Not a message Ferry sent, or its channel is unmapped. Never edited.
+            continue
+
+        parts = _split_message(_build_content(msg, state))
+        part_index = next((i for i, part in enumerate(parts) if token in part), None)
+        if part_index is None:
+            # The emoji did not survive rendering (should not happen); skip safely.
+            continue
+        if part_index != 0:
+            declined += 1
+            message = (
+                f"Emoji reference in message {msg.id} falls in a later send of a split "
+                "message; only the first send is addressable, so it was left as is."
+            )
+            state.warnings.append(
+                {"phase": "repair", "type": "emoji_in_split_tail", "message": message}
+            )
+            on_event(MigrationEvent(phase="repair", status="warning", message=message))
+            continue
+
+        try:
+            await api_edit_message(
+                session,
+                config.stoat_url,
+                config.token,
+                stoat_channel,
+                stoat_msg,
+                content=parts[0],
+            )
+            rewritten += 1
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            message = safe_sanitize(
+                config.token_store,
+                f"Failed to rewrite emoji reference in message {msg.id}: {exc}",
+            )
+            state.warnings.append(
+                {"phase": "repair", "type": "emoji_rewrite_failed", "message": message}
+            )
+            on_event(MigrationEvent(phase="repair", status="error", message=message))
+    return rewritten, declined, failed
+
+
 async def _run_emoji_repair_pass(
     session: aiohttp.ClientSession,
     config: FerryConfig,
@@ -1986,9 +2058,7 @@ async def _run_emoji_repair_pass(
 
         if record["is_animated"]:
             warning = f"Emoji :{name}: is animated — animation is lost on Stoat."
-            state.warnings.append(
-                {"phase": "repair", "type": "animated_emoji", "message": warning}
-            )
+            state.warnings.append({"phase": "repair", "type": "animated_emoji", "message": warning})
             on_event(MigrationEvent(phase="repair", status="warning", message=warning))
 
         row: dict[str, Any] = {
@@ -2007,8 +2077,29 @@ async def _run_emoji_repair_pass(
                 message=f"Recreated emoji :{name}: as {new_id}.",
             )
         )
-        # Task 3.2 adds the reference rewrite here: it updates row's counts and
-        # clears the resume record for this emoji once no message holds the old id.
+
+        rewritten, declined, failed = await _rewrite_emoji_references(
+            session, config, state, discord_id, new_id, exports, on_event
+        )
+        row["messages_rewritten"] = rewritten
+        row["messages_declined"] = declined
+        row["messages_failed"] = failed
+        # Clear the resume record only when nothing FAILED. A failed edit is
+        # retried on the next run, so its record must stay. A split-tail decline
+        # is permanent, not a failure, and never holds the record open.
+        if failed == 0:
+            state.pending_emoji_rewrites.pop(discord_id, None)
+            save_state(state, config.output_dir)
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="progress",
+                message=(
+                    f"Rewrote {rewritten} reference(s) to :{name}: "
+                    f"({declined} declined, {failed} failed)."
+                ),
+            )
+        )
 
 
 async def run_repair(

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2015,6 +2015,30 @@ async def _run_emoji_repair_pass(
     never leave the map pointing at the new emoji without a record to finish the
     rewrite from, nor the record without the new id.
     """
+    # Resume first: finish any rewrite a previous run left unfinished. The record
+    # exists because that run recreated the emoji (emoji_map already points at the
+    # new id) but crashed before every reference was rewritten. A fresh check
+    # reports the emoji present and would never revisit these, so this must run
+    # from the record, not the check. Disjoint from emoji_work by construction: a
+    # recorded emoji reads as present, so it is never in this run's emoji_work.
+    for pending_id, pending in list(state.pending_emoji_rewrites.items()):
+        rewritten, declined, failed = await _rewrite_emoji_references(
+            session, config, state, pending_id, pending["new"], exports, on_event
+        )
+        if failed == 0:
+            state.pending_emoji_rewrites.pop(pending_id, None)
+            save_state(state, config.output_dir)
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="progress",
+                message=(
+                    f"Resumed emoji rewrite for {pending_id}: {rewritten} rewritten, "
+                    f"{declined} declined, {failed} failed."
+                ),
+            )
+        )
+
     used_names: dict[str, int] = {}
     for result in emoji_work:
         discord_id = result.discord_id or ""
@@ -2114,8 +2138,14 @@ async def run_repair(
 
     A sibling of :func:`run_retry_failed` and :func:`run_rollback`, not a phase.
     ``PHASE_ORDER``, the phase list and the resume-by-name comparison are
-    untouched, and repair is not resumable by design: it re-derives its work
-    from a fresh check on every run, so there is nothing to checkpoint.
+    untouched. Most of repair re-derives its work from a fresh check on every
+    run and checkpoints nothing. The one exception is the emoji pass (#307):
+    recreating a missing emoji mints a NEW id, and a fresh check cannot re-derive
+    which already-sent messages still point at the OLD one. So that pass keeps a
+    scoped resume record, ``state.pending_emoji_rewrites``, written in the same
+    save that switches ``emoji_map`` to the new id, and finishes any leftover
+    record at the start of the next run before the fresh check re-derives new
+    work.
 
     Raises:
         CheckError: the state is from a dry run, or records no server. Both come
@@ -2267,7 +2297,7 @@ async def run_repair(
     # the emoji rather than sweeping in a reference a structure repair just
     # changed in the same run. See
     # docs/plans/designs/2026-08-20-repair-emoji-missing.md.
-    if emoji_work:
+    if emoji_work or state.pending_emoji_rewrites:
         own_emoji_session = session is None
         emoji_sess = session or new_session()
         try:

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -54,7 +54,12 @@ from discord_ferry.migrator.api import (
 )
 from discord_ferry.migrator.avatars import run_avatars
 from discord_ferry.migrator.connect import run_connect
-from discord_ferry.migrator.emoji import run_emoji
+from discord_ferry.migrator.emoji import (
+    find_emoji_in_exports,
+    messages_using_emoji,
+    run_emoji,
+    upload_and_create_emoji,
+)
 from discord_ferry.migrator.messages import _THREAD_STRATEGIES, _process_message, run_messages
 from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
@@ -1199,6 +1204,11 @@ _REPAIRABLE_STRUCTURE = frozenset({"channel_missing", "role_missing", "category_
 #: there is nothing to act on and acting anyway is guessing at a live server.
 _REPAIRABLE_TAIL = frozenset({"tail_absent", "tail_and_after_absent"})
 
+#: The only emoji kind repair acts on. ``emoji_missing`` carries the emoji's
+#: Discord id and its old (now dead) Stoat id, both from ``emoji_map``, which is
+#: all the emoji pass needs to recreate it and rewrite its references (#307).
+_REPAIRABLE_EMOJI = frozenset({"emoji_missing"})
+
 #: A synthetic channel key repair declines even when the kind matches.
 #:
 #: The forum index writer stores ``channel_map["forum-index-{key}"]`` whose
@@ -1914,6 +1924,93 @@ async def _recreate_category(
     return True
 
 
+async def _run_emoji_repair_pass(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    emoji_work: list[CheckResult],
+    exports: list[DCEExport],
+    outcome: RepairOutcome,
+    on_event: EventCallback,
+) -> None:
+    """Recreate each missing emoji, then rewrite the messages that referenced it.
+
+    Runs before the structure and tail passes (see :func:`run_repair`) so the
+    re-render in the rewrite reproduces the sent text with only the emoji
+    changed. Per emoji: recover its name and image from the export, decline if
+    the image is not usable, else recreate it and, in ONE save, switch
+    ``emoji_map`` to the new id and write the resume record. A crash can then
+    never leave the map pointing at the new emoji without a record to finish the
+    rewrite from, nor the record without the new id.
+    """
+    used_names: dict[str, int] = {}
+    for result in emoji_work:
+        discord_id = result.discord_id or ""
+        old_id = result.stoat_id or ""
+        record = find_emoji_in_exports(exports, discord_id)
+
+        if record is None or not record["image_url"] or record["image_url"].startswith("http"):
+            reason = (
+                "its image is not in the export"
+                if record is None or not record["image_url"]
+                else "its image URL was never downloaded"
+            )
+            label = record["name"] if record is not None else discord_id
+            message = f"Cannot recreate emoji :{label}: — {reason}."
+            state.warnings.append(
+                {"phase": "repair", "type": "emoji_missing_media", "message": message}
+            )
+            on_event(MigrationEvent(phase="repair", status="warning", message=message))
+            continue
+
+        file_path = config.export_dir / record["image_url"]
+        if not file_path.exists():
+            message = f"Cannot recreate emoji :{record['name']}: — image file not found."
+            state.warnings.append(
+                {"phase": "repair", "type": "emoji_missing_media", "message": message}
+            )
+            on_event(MigrationEvent(phase="repair", status="warning", message=message))
+            continue
+
+        name = record["name"]
+        new_id = await upload_and_create_emoji(
+            session, config, state, file_path=file_path, name=name, used_names=used_names
+        )
+        # ONE save writes the new map value AND the resume record together, so a
+        # crash between here and the rewrite strands neither without the other.
+        # From this point emoji_map already points at the new emoji, so a re-run's
+        # check reports it present and never recreates a second one.
+        state.emoji_map[discord_id] = new_id
+        state.pending_emoji_rewrites[discord_id] = {"old": old_id, "new": new_id}
+        save_state(state, config.output_dir)
+
+        if record["is_animated"]:
+            warning = f"Emoji :{name}: is animated — animation is lost on Stoat."
+            state.warnings.append(
+                {"phase": "repair", "type": "animated_emoji", "message": warning}
+            )
+            on_event(MigrationEvent(phase="repair", status="warning", message=warning))
+
+        row: dict[str, Any] = {
+            "discord_id": discord_id,
+            "name": name,
+            "new_id": new_id,
+            "messages_rewritten": 0,
+            "messages_declined": 0,
+            "messages_failed": 0,
+        }
+        outcome.recreated_emoji.append(row)
+        on_event(
+            MigrationEvent(
+                phase="repair",
+                status="progress",
+                message=f"Recreated emoji :{name}: as {new_id}.",
+            )
+        )
+        # Task 3.2 adds the reference rewrite here: it updates row's counts and
+        # clears the resume record for this emoji once no message holds the old id.
+
+
 async def run_repair(
     config: FerryConfig,
     state: MigrationState,
@@ -1989,9 +2086,11 @@ async def run_repair(
 
     structure_work: list[CheckResult] = []
     tail_work: list[CheckResult] = []
+    emoji_work: list[CheckResult] = []
     for result in report.results:
         is_structure = result.kind in _REPAIRABLE_STRUCTURE
-        if not is_structure and result.kind not in _REPAIRABLE_TAIL:
+        is_emoji = result.kind in _REPAIRABLE_EMOJI
+        if not is_structure and not is_emoji and result.kind not in _REPAIRABLE_TAIL:
             continue
 
         # The exclusion is tested ONCE, against both families, and that placement
@@ -2024,6 +2123,8 @@ async def run_repair(
 
         if is_structure:
             structure_work.append(result)
+        elif is_emoji:
+            emoji_work.append(result)
         else:
             tail_work.append(result)
 
@@ -2034,12 +2135,31 @@ async def run_repair(
             status="progress",
             message=(
                 f"{prefix}{len(structure_work)} entities to recreate, "
-                f"{len(tail_work)} channels with a lost tail."
+                f"{len(tail_work)} channels with a lost tail, "
+                f"{len(emoji_work)} missing emoji."
             ),
         )
     )
 
     if config.dry_run:
+        for result in emoji_work:
+            discord_id = result.discord_id or ""
+            record = find_emoji_in_exports(exports, discord_id)
+            would_rewrite = (
+                sum(1 for _ in messages_using_emoji(exports, discord_id))
+                if record is not None
+                else 0
+            )
+            outcome.recreated_emoji.append(
+                {
+                    "discord_id": discord_id,
+                    "name": record["name"] if record is not None else discord_id,
+                    "new_id": "",
+                    "messages_rewritten": would_rewrite,
+                    "messages_declined": 0,
+                    "messages_failed": 0,
+                }
+            )
         on_event(
             MigrationEvent(
                 phase="repair",
@@ -2049,6 +2169,23 @@ async def run_repair(
         )
         outcome.declined = _repair_declined(state, warnings_start)
         return outcome
+
+    # Emoji pass, ordered BEFORE structure and tail so channel_map, role_map and
+    # author_names still hold their migration-time values when a referencing
+    # message is re-rendered. That ordering is what keeps the rewrite scoped to
+    # the emoji rather than sweeping in a reference a structure repair just
+    # changed in the same run. See
+    # docs/plans/designs/2026-08-20-repair-emoji-missing.md.
+    if emoji_work:
+        own_emoji_session = session is None
+        emoji_sess = session or new_session()
+        try:
+            await _run_emoji_repair_pass(
+                emoji_sess, config, state, emoji_work, exports, outcome, on_event
+            )
+        finally:
+            if own_emoji_session:
+                await emoji_sess.close()
 
     if structure_work:
         # Only when something is actually being recreated. A repair with nothing

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -258,6 +258,13 @@ async def run_migration(
             state.roles_finalized = set(prior.roles_finalized)
             state.category_map = dict(prior.category_map)
             state.emoji_map = dict(prior.emoji_map)
+            # A repair resume record, carried BESIDE emoji_map for the same reason:
+            # emoji_map now points at a recreated emoji, and this records which
+            # messages still hold the old id. Dropping it while carrying emoji_map
+            # would strand those messages with no check able to catch it (#307).
+            state.pending_emoji_rewrites = {
+                k: dict(v) for k, v in prior.pending_emoji_rewrites.items()
+            }
             state.avatar_cache = dict(prior.avatar_cache)
             state.author_names = dict(prior.author_names)
             state.upload_cache = dict(prior.upload_cache)
@@ -296,6 +303,9 @@ async def run_migration(
             state.native_fidelity_counts = dict(prior.native_fidelity_counts)
             # Carry-over audit (every MigrationState field classified):
             #   CARRY: role_map / channel_map / category_map / emoji_map,
+            #     pending_emoji_rewrites (repair resume record, carried beside
+            #     emoji_map so a carried recreated emoji keeps its record of which
+            #     messages still hold the old id — #307),
             #     created_channel_names / created_role_names (a carried entity
             #     skips creation, so nothing re-records its name; omitting these
             #     makes ferry check report ok for a renamed channel),
@@ -2030,6 +2040,21 @@ async def _run_emoji_repair_pass(
         rewritten, declined, failed = await _rewrite_emoji_references(
             session, config, state, pending_id, pending["new"], exports, on_event
         )
+        # Record the resume work in the outcome too, so a run that only finishes a
+        # leftover record still reports what it edited (RepairOutcome is "everything
+        # one run_repair did"). The name is recovered from the export; the emoji
+        # itself was recreated on a prior run.
+        record = find_emoji_in_exports(exports, pending_id)
+        outcome.recreated_emoji.append(
+            {
+                "discord_id": pending_id,
+                "name": record["name"] if record is not None else pending_id,
+                "new_id": pending["new"],
+                "messages_rewritten": rewritten,
+                "messages_declined": declined,
+                "messages_failed": failed,
+            }
+        )
         if failed == 0:
             state.pending_emoji_rewrites.pop(pending_id, None)
             save_state(state, config.output_dir)
@@ -2282,6 +2307,20 @@ async def run_repair(
                     "name": record["name"] if record is not None else discord_id,
                     "new_id": "",
                     "messages_rewritten": would_rewrite,
+                    "messages_declined": 0,
+                    "messages_failed": 0,
+                }
+            )
+        # An outstanding resume record from a crashed run is work a real run would
+        # do first. The preview must name it, or it reads as "nothing to do".
+        for pending_id, pending in state.pending_emoji_rewrites.items():
+            record = find_emoji_in_exports(exports, pending_id)
+            outcome.recreated_emoji.append(
+                {
+                    "discord_id": pending_id,
+                    "name": record["name"] if record is not None else pending_id,
+                    "new_id": pending["new"],
+                    "messages_rewritten": sum(1 for _ in messages_using_emoji(exports, pending_id)),
                     "messages_declined": 0,
                     "messages_failed": 0,
                 }

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -100,14 +100,19 @@ def _numeric_id_key(value: str) -> tuple[int, int | str]:
     return (0, int(value)) if value.isdigit() else (1, value)
 
 
-def messages_using_emoji(exports: list[DCEExport], discord_emoji_id: str) -> Iterator[DCEMessage]:
-    """Yield every message whose CONTENT uses the given custom emoji.
+def messages_using_emoji(
+    exports: list[DCEExport], discord_emoji_id: str
+) -> Iterator[tuple[str, DCEMessage]]:
+    """Yield ``(discord_channel_id, message)`` for messages whose CONTENT uses the emoji.
 
+    The channel id comes from the owning export, since a DCE export is per
+    channel; the rewrite needs it to map the message to its Stoat channel.
     Reaction-only uses are not yielded: there is nothing in the message text to
     rewrite. Streams the same way ``run_emoji`` does, so it works on both eager
     and ``json_path``-backed exports.
     """
     for export in exports:
+        channel_id = export.channel.id
         msg_iter = (
             stream_messages(export.json_path)
             if export.json_path is not None
@@ -120,12 +125,10 @@ def messages_using_emoji(exports: list[DCEExport], discord_emoji_id: str) -> Ite
                 eid == discord_emoji_id
                 for eid, _name, _animated in _extract_emoji_from_content(msg.content)
             ):
-                yield msg
+                yield channel_id, msg
 
 
-def find_emoji_in_exports(
-    exports: list[DCEExport], discord_emoji_id: str
-) -> _EmojiRecord | None:
+def find_emoji_in_exports(exports: list[DCEExport], discord_emoji_id: str) -> _EmojiRecord | None:
     """Return the discovered record (name, image, animated) for one emoji id.
 
     Runs the same reaction-then-content discovery as ``run_emoji``, so the image

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -123,6 +123,37 @@ def messages_using_emoji(exports: list[DCEExport], discord_emoji_id: str) -> Ite
                 yield msg
 
 
+def find_emoji_in_exports(
+    exports: list[DCEExport], discord_emoji_id: str
+) -> _EmojiRecord | None:
+    """Return the discovered record (name, image, animated) for one emoji id.
+
+    Runs the same reaction-then-content discovery as ``run_emoji``, so the image
+    source is upgraded from a reaction (which carries the downloaded asset) over
+    a content-only sighting (which carries none). The emoji-repair pass uses this
+    to recover a missing emoji's name and image, which the migration records
+    nowhere on the id map. Returns ``None`` when the id is not in the export.
+    """
+    discovered: dict[str, _EmojiRecord] = {}
+    for export in exports:
+        msg_iter = (
+            stream_messages(export.json_path)
+            if export.json_path is not None
+            else iter(export.messages)
+        )
+        for msg in msg_iter:
+            for reaction in msg.reactions:
+                emoji = reaction.emoji
+                if emoji.id:
+                    _record_emoji(
+                        discovered, emoji.id, emoji.name, emoji.is_animated, emoji.image_url
+                    )
+            if msg.content:
+                for eid, name, is_animated in _extract_emoji_from_content(msg.content):
+                    _record_emoji(discovered, eid, name, is_animated, "")
+    return discovered.get(discord_emoji_id)
+
+
 async def upload_and_create_emoji(
     session: aiohttp.ClientSession,
     config: FerryConfig,

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -15,13 +15,14 @@ from discord_ferry.parser.dce_parser import stream_messages
 from discord_ferry.uploader.autumn import upload_with_cache
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     import aiohttp
 
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
-    from discord_ferry.parser.models import DCEExport
+    from discord_ferry.parser.models import DCEExport, DCEMessage
     from discord_ferry.state import MigrationState
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,29 @@ def _numeric_id_key(value: str) -> tuple[int, int | str]:
     after, lexicographically. The ``0``/``1`` tuple head prevents any int-vs-str comparison.
     """
     return (0, int(value)) if value.isdigit() else (1, value)
+
+
+def messages_using_emoji(exports: list[DCEExport], discord_emoji_id: str) -> Iterator[DCEMessage]:
+    """Yield every message whose CONTENT uses the given custom emoji.
+
+    Reaction-only uses are not yielded: there is nothing in the message text to
+    rewrite. Streams the same way ``run_emoji`` does, so it works on both eager
+    and ``json_path``-backed exports.
+    """
+    for export in exports:
+        msg_iter = (
+            stream_messages(export.json_path)
+            if export.json_path is not None
+            else iter(export.messages)
+        )
+        for msg in msg_iter:
+            if not msg.content:
+                continue
+            if any(
+                eid == discord_emoji_id
+                for eid, _name, _animated in _extract_emoji_from_content(msg.content)
+            ):
+                yield msg
 
 
 async def upload_and_create_emoji(

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -17,6 +17,8 @@ from discord_ferry.uploader.autumn import upload_with_cache
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import aiohttp
+
     from discord_ferry.config import FerryConfig
     from discord_ferry.core.events import EventCallback
     from discord_ferry.parser.models import DCEExport
@@ -95,6 +97,49 @@ def _numeric_id_key(value: str) -> tuple[int, int | str]:
     after, lexicographically. The ``0``/``1`` tuple head prevents any int-vs-str comparison.
     """
     return (0, int(value)) if value.isdigit() else (1, value)
+
+
+async def upload_and_create_emoji(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    *,
+    file_path: Path,
+    name: str,
+    used_names: dict[str, int],
+) -> str:
+    """Upload an emoji image to Autumn and register it on the Stoat server.
+
+    Returns the new Autumn file id, which IS the emoji's Stoat id. Shared by the
+    emoji migration phase and ``run_repair``'s emoji pass, so both mint emoji
+    identically. The caller checks that the image is usable and emits its own
+    progress; this does the upload-then-create and nothing else.
+    """
+    autumn_id = await upload_with_cache(
+        session,
+        state.autumn_url,
+        "emojis",
+        file_path,
+        config.token,
+        state.upload_cache,
+        config.upload_delay,
+    )
+    sanitized_name = sanitize_emoji_name(name, used_names)
+    if sanitized_name != sanitize_emoji_name(name):
+        logger.warning(
+            "Emoji name collision: :%s: → :%s: (duplicate sanitized name)",
+            name,
+            sanitized_name,
+        )
+    await api_create_emoji(
+        session,
+        config.stoat_url,
+        config.token,
+        autumn_id,
+        sanitized_name,
+        state.stoat_server_id,
+    )
+    return autumn_id
 
 
 async def run_emoji(
@@ -284,30 +329,13 @@ async def run_emoji(
                 continue
 
             try:
-                autumn_id = await upload_with_cache(
+                autumn_id = await upload_and_create_emoji(
                     session,
-                    state.autumn_url,
-                    "emojis",
-                    file_path,
-                    config.token,
-                    state.upload_cache,
-                    config.upload_delay,
-                )
-
-                sanitized_name = sanitize_emoji_name(name, used_names)
-                if sanitized_name != sanitize_emoji_name(name):
-                    logger.warning(
-                        "Emoji name collision: :%s: → :%s: (duplicate sanitized name)",
-                        name,
-                        sanitized_name,
-                    )
-                await api_create_emoji(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    autumn_id,
-                    sanitized_name,
-                    state.stoat_server_id,
+                    config,
+                    state,
+                    file_path=file_path,
+                    name=name,
+                    used_names=used_names,
                 )
                 state.emoji_map[discord_id] = autumn_id
 

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -130,7 +130,17 @@ class CheckResult:
 #: the second is a degradation rather than an unrepaired defect. Shared by the
 #: CLI repair exit code and the GUI repair page so they cannot diverge.
 UNREPAIRED_WARNING_TYPES = frozenset(
-    {"no_recorded_name", "not_in_export", "forum_index_not_repairable"}
+    {
+        "no_recorded_name",
+        "not_in_export",
+        "forum_index_not_repairable",
+        # A missing emoji repair could not recreate (its image is not in the
+        # export). emoji_in_split_tail is deliberately absent, like a merge
+        # partial restore: the emoji WAS recreated and its addressable reference
+        # fixed; only an unaddressable later send of a split message keeps the
+        # old id (#307).
+        "emoji_missing_media",
+    }
 )
 
 

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -135,11 +135,14 @@ UNREPAIRED_WARNING_TYPES = frozenset(
         "not_in_export",
         "forum_index_not_repairable",
         # A missing emoji repair could not recreate (its image is not in the
-        # export). emoji_in_split_tail is deliberately absent, like a merge
-        # partial restore: the emoji WAS recreated and its addressable reference
-        # fixed; only an unaddressable later send of a split message keeps the
-        # old id (#307).
+        # export). emoji_rewrite_failed too: a reference edit failed, so a message
+        # still points at the dead id and the resume record stays open. Both leave
+        # something failing. emoji_in_split_tail is deliberately absent, like a
+        # merge partial restore: the emoji WAS recreated and its addressable
+        # reference fixed; only an unaddressable later send of a split message
+        # keeps the old id (#307).
         "emoji_missing_media",
+        "emoji_rewrite_failed",
     }
 )
 

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -231,6 +231,7 @@ class RepairOutcome:
     recreated_roles: list[dict[str, Any]] = field(default_factory=list)
     recreated_categories: list[dict[str, Any]] = field(default_factory=list)
     restored_tails: list[dict[str, Any]] = field(default_factory=list)
+    recreated_emoji: list[dict[str, Any]] = field(default_factory=list)
     dead_letter: dict[str, int] = field(default_factory=lambda: {"drained": 0, "remaining": 0})
     declined: list[dict[str, Any]] = field(default_factory=list)
     failed_messages: list[dict[str, Any]] = field(default_factory=list)
@@ -251,6 +252,7 @@ class RepairOutcome:
                 "recreated_roles": self._clean(self.recreated_roles),
                 "recreated_categories": self._clean(self.recreated_categories),
                 "restored_tails": self._clean(self.restored_tails),
+                "recreated_emoji": self._clean(self.recreated_emoji),
                 "dead_letter": dict(self.dead_letter),
             },
             "declined": self._clean(self.declined),

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -86,6 +86,12 @@ class MigrationState:
     message_map: dict[str, str] = field(default_factory=dict)
     emoji_map: dict[str, str] = field(default_factory=dict)
 
+    # discord_emoji_id -> {"old": <old stoat id>, "new": <new stoat id>}.
+    # A repair resume record: written the moment a missing emoji is recreated,
+    # cleared once every referencing message has been rewritten. Identifiers
+    # only, never free text, so it is structural and NOT in _TEXT_MEMBERS.
+    pending_emoji_rewrites: dict[str, dict[str, str]] = field(default_factory=dict)
+
     # Author ID -> uploaded Autumn avatar ID
     avatar_cache: dict[str, str] = field(default_factory=dict)
 
@@ -290,6 +296,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "channel_categories": state.channel_categories,
         "message_map": state.message_map,
         "emoji_map": state.emoji_map,
+        "pending_emoji_rewrites": state.pending_emoji_rewrites,
         "avatar_cache": state.avatar_cache,
         "upload_cache": state.upload_cache,
         "author_names": state.author_names,
@@ -367,6 +374,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             channel_categories=data.get("channel_categories", {}),
             message_map=data.get("message_map", {}),
             emoji_map=data.get("emoji_map", {}),
+            pending_emoji_rewrites=data.get("pending_emoji_rewrites", {}),
             avatar_cache=data.get("avatar_cache", {}),
             upload_cache=data.get("upload_cache", {}),
             author_names=data.get("author_names", {}),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3007,6 +3007,37 @@ def test_repair_exits_non_zero_when_it_declined_a_repair(runner: CliRunner, tmp_
     )
 
 
+def test_repair_exits_non_zero_when_an_emoji_could_not_be_recreated(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """emoji_missing_media is an unrepaired defect: the emoji stays missing (#307)."""
+    outcome = RepairOutcome(
+        declined=[{"type": "emoji_missing_media", "message": "no usable image"}]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome)
+    assert result.exit_code == 1, (
+        f"an unrecreatable emoji exited {result.exit_code}, which reads as success"
+    )
+
+
+def test_repair_exits_zero_on_a_split_tail_emoji_decline(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """emoji_in_split_tail is a partial restore of an emoji repair DID recreate (#307).
+
+    Like merge_thread_content_not_restored, it must not exit non-zero: the emoji
+    is back and its addressable reference fixed; only an unaddressable later send
+    of a split message keeps the old id.
+    """
+    outcome = RepairOutcome(
+        declined=[{"type": "emoji_in_split_tail", "message": "later send"}]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome)
+    assert result.exit_code == 0, (
+        f"a partial split-tail decline exited {result.exit_code}, which reads as failure"
+    )
+
+
 def test_repair_exit_code_ignores_a_stale_decline_from_an_earlier_run(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3020,18 +3020,14 @@ def test_repair_exits_non_zero_when_an_emoji_could_not_be_recreated(
     )
 
 
-def test_repair_exits_zero_on_a_split_tail_emoji_decline(
-    runner: CliRunner, tmp_path: Path
-) -> None:
+def test_repair_exits_zero_on_a_split_tail_emoji_decline(runner: CliRunner, tmp_path: Path) -> None:
     """emoji_in_split_tail is a partial restore of an emoji repair DID recreate (#307).
 
     Like merge_thread_content_not_restored, it must not exit non-zero: the emoji
     is back and its addressable reference fixed; only an unaddressable later send
     of a split message keeps the old id.
     """
-    outcome = RepairOutcome(
-        declined=[{"type": "emoji_in_split_tail", "message": "later send"}]
-    )
+    outcome = RepairOutcome(declined=[{"type": "emoji_in_split_tail", "message": "later send"}])
     result = _invoke_repair(runner, tmp_path, outcome)
     assert result.exit_code == 0, (
         f"a partial split-tail decline exited {result.exit_code}, which reads as failure"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3020,6 +3020,17 @@ def test_repair_exits_non_zero_when_an_emoji_could_not_be_recreated(
     )
 
 
+def test_repair_exits_non_zero_when_an_emoji_rewrite_failed(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """emoji_rewrite_failed leaves a message on the dead id and the record open (#307)."""
+    outcome = RepairOutcome(declined=[{"type": "emoji_rewrite_failed", "message": "edit boom"}])
+    result = _invoke_repair(runner, tmp_path, outcome)
+    assert result.exit_code == 1, (
+        f"a failed emoji rewrite exited {result.exit_code}, which reads as success"
+    )
+
+
 def test_repair_exits_zero_on_a_split_tail_emoji_decline(runner: CliRunner, tmp_path: Path) -> None:
     """emoji_in_split_tail is a partial restore of an emoji repair DID recreate (#307).
 

--- a/tests/test_delta_migration.py
+++ b/tests/test_delta_migration.py
@@ -292,6 +292,23 @@ async def test_incremental_carried_failed_messages_are_independent_copies(tmp_pa
     assert state.failed_messages[0] is not prior.failed_messages[0]
 
 
+async def test_incremental_carries_pending_emoji_rewrites(tmp_path: Path) -> None:
+    """#307: a repair resume record survives an incremental run.
+
+    emoji_map is carried, so a recreated emoji reads as present. Dropping its
+    resume record would strand the messages that still hold the old id, and no
+    check would catch it. The record must ride along beside emoji_map.
+    """
+    _make_prior_state(
+        tmp_path,
+        emoji_map={"e1": "new_stoat"},
+        pending_emoji_rewrites={"e1": {"old": "old_stoat", "new": "new_stoat"}},
+    )
+    config = _make_config(tmp_path, incremental=True)
+    state = await run_migration(config, lambda e: None, phase_overrides=_NOOP_OVERRIDES)
+    assert state.pending_emoji_rewrites == {"e1": {"old": "old_stoat", "new": "new_stoat"}}
+
+
 async def test_incremental_carries_roles_finalized(tmp_path: Path) -> None:
     """SC-19: incremental carry-over copies prior.roles_finalized (C1)."""
     _make_prior_state(

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 from discord_ferry.config import FerryConfig
 from discord_ferry.migrator.emoji import (
     _extract_emoji_from_content,
+    messages_using_emoji,
     run_emoji,
     upload_and_create_emoji,
 )
@@ -797,3 +798,23 @@ async def test_upload_and_create_emoji_uploads_then_creates(tmp_path: Path) -> N
     # api_create_emoji(session, stoat_url, token, autumn_id, name, server_id)
     assert cr.await_args.args[3] == "new_autumn"
     assert cr.await_args.args[5] == "srv1"
+
+
+def test_messages_using_emoji_finds_content_not_reaction() -> None:
+    """SC-2.1/2.5: content uses are found; a reaction-only use is excluded."""
+    m1 = _make_message(msg_id="m1", content="hi <:smile:123> there")
+    m2 = _make_message(msg_id="m2", content="plain text")
+    m3 = _make_message(
+        msg_id="m3",
+        reactions=[DCEReaction(emoji=DCEEmoji(id="123", name="smile", image_url="e.png"), count=1)],
+    )
+    exp = _make_export([m1, m2, m3])
+    hits = list(messages_using_emoji([exp], "123"))
+    assert [m.id for m in hits] == ["m1"]
+
+
+def test_messages_using_emoji_ignores_other_emoji() -> None:
+    """A message using a different custom emoji is not yielded."""
+    m1 = _make_message(msg_id="m1", content="<:other:999>")
+    exp = _make_export([m1])
+    assert list(messages_using_emoji([exp], "123")) == []

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 from discord_ferry.config import FerryConfig
 from discord_ferry.migrator.emoji import (
     _extract_emoji_from_content,
+    find_emoji_in_exports,
     messages_using_emoji,
     run_emoji,
     upload_and_create_emoji,
@@ -818,3 +819,25 @@ def test_messages_using_emoji_ignores_other_emoji() -> None:
     m1 = _make_message(msg_id="m1", content="<:other:999>")
     exp = _make_export([m1])
     assert list(messages_using_emoji([exp], "123")) == []
+
+
+def test_find_emoji_in_exports_recovers_name_and_image() -> None:
+    """The recreate step needs the name and image the id map never stored."""
+    m = _make_message(
+        msg_id="m1",
+        content="<:smile:123>",
+        reactions=[
+            DCEReaction(emoji=DCEEmoji(id="123", name="smile", image_url="smile.png"), count=1)
+        ],
+    )
+    exp = _make_export([m])
+    rec = find_emoji_in_exports([exp], "123")
+    assert rec is not None
+    assert rec["name"] == "smile"
+    assert rec["image_url"] == "smile.png"
+    assert rec["is_animated"] is False
+
+
+def test_find_emoji_in_exports_none_when_absent() -> None:
+    exp = _make_export([_make_message(content="plain text")])
+    assert find_emoji_in_exports([exp], "123") is None

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -811,7 +811,7 @@ def test_messages_using_emoji_finds_content_not_reaction() -> None:
     )
     exp = _make_export([m1, m2, m3])
     hits = list(messages_using_emoji([exp], "123"))
-    assert [m.id for m in hits] == ["m1"]
+    assert [(chan, m.id) for chan, m in hits] == [("ch1", "m1")]
 
 
 def test_messages_using_emoji_ignores_other_emoji() -> None:

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -8,7 +8,11 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from discord_ferry.config import FerryConfig
-from discord_ferry.migrator.emoji import _extract_emoji_from_content, run_emoji
+from discord_ferry.migrator.emoji import (
+    _extract_emoji_from_content,
+    run_emoji,
+    upload_and_create_emoji,
+)
 from discord_ferry.parser.models import (
     DCEAuthor,
     DCEChannel,
@@ -769,3 +773,27 @@ async def test_emoji_cap_prefers_uploadable_over_high_use_assetless(tmp_path: Pa
         await run_emoji(config, state, exports, [].append)
     assert "100" in state.emoji_map  # uploadable kept despite fewer uses
     assert "999" not in state.emoji_map  # asset-less high-use one dropped (would be unuploadable)
+
+
+async def test_upload_and_create_emoji_uploads_then_creates(tmp_path: Path) -> None:
+    """SC-1.2 (unit): the shared helper uploads to Autumn then registers the emoji."""
+    img = tmp_path / "emo.png"
+    img.write_bytes(b"x")
+    config = _make_config(tmp_path)
+    state = _make_state()
+    with (
+        patch(
+            "discord_ferry.migrator.emoji.upload_with_cache",
+            new=AsyncMock(return_value="new_autumn"),
+        ) as up,
+        patch("discord_ferry.migrator.emoji.api_create_emoji", new=AsyncMock()) as cr,
+    ):
+        new_id = await upload_and_create_emoji(
+            None, config, state, file_path=img, name="smile", used_names={}
+        )
+    assert new_id == "new_autumn"
+    up.assert_awaited_once()
+    cr.assert_awaited_once()
+    # api_create_emoji(session, stoat_url, token, autumn_id, name, server_id)
+    assert cr.await_args.args[3] == "new_autumn"
+    assert cr.await_args.args[5] == "srv1"

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -26,7 +26,18 @@ def test_repair_failure_set_is_shared_and_exact() -> None:
     from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES
 
     assert (
-        frozenset({"no_recorded_name", "not_in_export", "forum_index_not_repairable"})
+        frozenset(
+            {
+                "no_recorded_name",
+                "not_in_export",
+                "forum_index_not_repairable",
+                # #307 emoji repair: could-not-recreate and failed-rewrite both
+                # leave something failing. emoji_in_split_tail is excluded (partial
+                # restore of a recreated emoji), matching the CLI comment.
+                "emoji_missing_media",
+                "emoji_rewrite_failed",
+            }
+        )
         == UNREPAIRED_WARNING_TYPES
     )
 

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -237,6 +237,21 @@ async def test_rewrite_split_first_edits_first_part(tmp_path: Path) -> None:
     assert outcome.recreated_emoji[0]["messages_rewritten"] == 1
 
 
+async def test_rewrite_split_first_edits_even_when_emoji_also_in_tail(tmp_path: Path) -> None:
+    """Chunk-3 review guard: emoji in the first part AND a later part still edits.
+
+    The addressable first send is fixed; a second, unaddressable send is left as
+    is. Declining the whole message (as a naive 'token in any later part' check
+    would) refuses a fixable rewrite.
+    """
+    long_mid = " ".join(["word"] * 600)
+    m = _message(content=f"<:smile:123> {long_mid} <:smile:123>")
+    outcome, edit, _ = await _run_with_messages(tmp_path, [m])
+    assert edit.await_count == 1
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 1
+    assert outcome.recreated_emoji[0]["messages_declined"] == 0
+
+
 async def test_rewrite_split_tail_declines(tmp_path: Path) -> None:
     """SC-2.4: emoji in a later split part is declined, not edited."""
     long_head = " ".join(["word"] * 600)

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -1,0 +1,181 @@
+"""Tests for the emoji-repair pass in run_repair (#307)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from discord_ferry.config import FerryConfig
+from discord_ferry.core.engine import run_repair
+from discord_ferry.migrator.verify import CheckReport
+from discord_ferry.parser.models import (
+    DCEAuthor,
+    DCEChannel,
+    DCEEmoji,
+    DCEExport,
+    DCEGuild,
+    DCEMessage,
+    DCEReaction,
+)
+from discord_ferry.state import MigrationState, load_state
+
+EMOJI_ID = "123"
+OLD_ID = "old_id"
+NEW_ID = "new_id"
+
+_ENGINE = "discord_ferry.core.engine"
+_UPLOAD = f"{_ENGINE}.upload_and_create_emoji"
+_EDIT = f"{_ENGINE}.api_edit_message"
+_CHECK = "discord_ferry.migrator.verify.run_check"
+
+
+def _config(tmp_path: Path) -> FerryConfig:
+    return FerryConfig(
+        export_dir=tmp_path,
+        stoat_url="https://api.test",
+        token="t",
+        upload_delay=0.0,
+        output_dir=tmp_path,
+    )
+
+
+def _state() -> MigrationState:
+    state = MigrationState()
+    state.stoat_server_id = "srv"
+    state.autumn_url = "https://autumn.test"
+    state.emoji_map = {EMOJI_ID: OLD_ID}
+    state.channel_map = {"ch1": "stoat_ch"}
+    state.message_map = {"m1": "stoat_msg"}
+    return state
+
+
+def _message(content: str = "hi <:smile:123>", *, with_reaction: bool = True) -> DCEMessage:
+    reactions = (
+        [DCEReaction(emoji=DCEEmoji(id=EMOJI_ID, name="smile", image_url="smile.png"), count=1)]
+        if with_reaction
+        else []
+    )
+    return DCEMessage(
+        id="m1",
+        type="Default",
+        timestamp="2024-01-01T00:00:00Z",
+        content=content,
+        author=DCEAuthor(id="u", name="U"),
+        reactions=reactions,
+    )
+
+
+def _export(messages: list[DCEMessage]) -> DCEExport:
+    return DCEExport(
+        guild=DCEGuild(id="g", name="G", icon_url=""),
+        channel=DCEChannel(id="ch1", type=0, category_id="", category="", name="general", topic=""),
+        messages=messages,
+    )
+
+
+def _with_image(tmp_path: Path) -> None:
+    (tmp_path / "smile.png").write_bytes(b"img")
+
+
+def _missing_report() -> CheckReport:
+    report = CheckReport()
+    report.add(
+        name=f"emoji:{EMOJI_ID}",
+        status="fail",
+        kind="emoji_missing",
+        detail="the server does not list this emoji",
+        discord_id=EMOJI_ID,
+        stoat_id=OLD_ID,
+    )
+    return report
+
+
+def _present_report() -> CheckReport:
+    report = CheckReport()
+    report.add(
+        name=f"emoji:{EMOJI_ID}",
+        status="ok",
+        kind="emoji_present",
+        detail="emoji exists under its recorded id",
+        discord_id=EMOJI_ID,
+        stoat_id=NEW_ID,
+    )
+    return report
+
+
+async def test_repair_acts_on_emoji_missing(tmp_path: Path) -> None:
+    """SC-1.1: repair recreates a missing emoji instead of declining it."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    events: list[Any] = []
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_EDIT, new=AsyncMock()),
+    ):
+        outcome = await run_repair(config, state, [_export([_message()])], events.append)
+    up.assert_awaited_once()
+    assert not any(d.get("type") == "emoji_missing_media" for d in outcome.declined)
+    assert [r["discord_id"] for r in outcome.recreated_emoji] == [EMOJI_ID]
+    assert outcome.recreated_emoji[0]["new_id"] == NEW_ID
+
+
+async def test_recreate_writes_map_and_record_in_one_save(tmp_path: Path) -> None:
+    """SC-1.3: the new id and the resume record land in a single save_state."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    saves: list[dict[str, Any]] = []
+    from discord_ferry.core.engine import save_state as real_save
+
+    def capture(st: MigrationState, out: Path) -> None:
+        saves.append(
+            {
+                "emoji_map": dict(st.emoji_map),
+                "pending": {k: dict(v) for k, v in st.pending_emoji_rewrites.items()},
+            }
+        )
+        real_save(st, out)
+
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock()),
+        patch(f"{_ENGINE}.save_state", side_effect=capture),
+    ):
+        await run_repair(config, state, [_export([_message()])], [].append)
+
+    first_new = next(s for s in saves if s["emoji_map"].get(EMOJI_ID) == NEW_ID)
+    assert first_new["pending"].get(EMOJI_ID) == {"old": OLD_ID, "new": NEW_ID}
+
+
+async def test_missing_image_declines_no_record(tmp_path: Path) -> None:
+    """SC-1.5: no usable export image declines, writes no resume record."""
+    # No image file on disk; the reaction still names smile.png but it is absent.
+    config, state = _config(tmp_path), _state()
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_EDIT, new=AsyncMock()),
+    ):
+        outcome = await run_repair(config, state, [_export([_message()])], [].append)
+    up.assert_not_awaited()
+    assert any(d.get("type") == "emoji_missing_media" for d in outcome.declined)
+    assert state.emoji_map[EMOJI_ID] == OLD_ID
+    assert EMOJI_ID not in state.pending_emoji_rewrites
+    assert outcome.recreated_emoji == []
+
+
+async def test_rerun_when_present_makes_no_second_emoji(tmp_path: Path) -> None:
+    """SC-3.1: a check that reports the emoji present recreates nothing."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    state.emoji_map[EMOJI_ID] = NEW_ID
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_present_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_EDIT, new=AsyncMock()),
+    ):
+        outcome = await run_repair(config, state, [_export([_message()])], [].append)
+    up.assert_not_awaited()
+    assert outcome.recreated_emoji == []

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -289,3 +289,63 @@ async def test_rewrite_counts_all_referencing_messages(tmp_path: Path) -> None:
     assert edit.await_count == 3
     assert outcome.recreated_emoji[0]["messages_rewritten"] == 3
     assert EMOJI_ID not in state.pending_emoji_rewrites  # cleared on full success
+
+
+# ---------------------------------------------------------------------------
+# Task 3.3: resume step and docstring
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_finishes_a_crashed_rewrite(tmp_path: Path) -> None:
+    """SC-3.2: a pending record from a prior crash is finished before the check."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    # A prior run recreated the emoji (map already points at new) and crashed
+    # mid-rewrite, leaving the resume record. The server already has the new id,
+    # so this run's check reports it present (no recreation to do).
+    state.emoji_map[EMOJI_ID] = NEW_ID
+    state.pending_emoji_rewrites[EMOJI_ID] = {"old": OLD_ID, "new": NEW_ID}
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_present_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_EDIT, new=AsyncMock()) as edit,
+    ):
+        await run_repair(config, state, [_export([_message()])], [].append)
+    up.assert_not_awaited()  # no second emoji
+    edit.assert_awaited_once()  # the stranded message is finished
+    assert EMOJI_ID not in state.pending_emoji_rewrites
+
+
+async def test_edit_failure_keeps_the_record(tmp_path: Path) -> None:
+    """SC-3.3: a failed edit keeps the resume record and counts the failure."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    state.message_map = {"m1": "s1", "m2": "s2"}
+    msgs = [
+        _message(),  # id m1, carries the reaction/image
+        DCEMessage(
+            id="m2",
+            type="Default",
+            timestamp="2024-01-01T00:00:00Z",
+            content="more <:smile:123>",
+            author=DCEAuthor(id="u", name="U"),
+            reactions=[],
+        ),
+    ]
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("boom")])),
+    ):
+        outcome = await run_repair(config, state, [_export(msgs)], [].append)
+    row = outcome.recreated_emoji[0]
+    assert row["messages_rewritten"] == 1
+    assert row["messages_failed"] == 1
+    assert state.pending_emoji_rewrites[EMOJI_ID] == {"old": OLD_ID, "new": NEW_ID}
+
+
+def test_run_repair_docstring_admits_the_checkpoint() -> None:
+    """SC-3.4: the docstring no longer claims nothing is checkpointed."""
+    doc = run_repair.__doc__ or ""
+    assert "nothing to checkpoint" not in doc
+    assert "pending_emoji_rewrites" in doc

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -364,3 +364,33 @@ def test_run_repair_docstring_admits_the_checkpoint() -> None:
     doc = run_repair.__doc__ or ""
     assert "nothing to checkpoint" not in doc
     assert "pending_emoji_rewrites" in doc
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1: outcome surface
+# ---------------------------------------------------------------------------
+
+
+async def test_human_output_names_emoji_and_rewrite_count(tmp_path: Path) -> None:
+    """SC-4.1: progress events name the recreated emoji and the rewrite count."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    events: list[Any] = []
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock()),
+    ):
+        await run_repair(config, state, [_export([_message()])], events.append)
+    messages = [e.message for e in events]
+    assert any("Recreated emoji :smile:" in m for m in messages)
+    assert any("Rewrote 1 reference" in m for m in messages)
+
+
+async def test_outcome_to_dict_carries_recreated_emoji_end_to_end(tmp_path: Path) -> None:
+    """SC-4.2: a real run's outcome document carries recreated_emoji under actions."""
+    outcome, _, _ = await _run_with_messages(tmp_path, [_message()])
+    row = outcome.to_dict()["actions"]["recreated_emoji"][0]
+    assert row["discord_id"] == EMOJI_ID
+    assert row["new_id"] == NEW_ID
+    assert row["messages_rewritten"] == 1

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -327,10 +327,15 @@ async def test_resume_finishes_a_crashed_rewrite(tmp_path: Path) -> None:
         patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
-        await run_repair(config, state, [_export([_message()])], [].append)
+        outcome = await run_repair(config, state, [_export([_message()])], [].append)
     up.assert_not_awaited()  # no second emoji
     edit.assert_awaited_once()  # the stranded message is finished
     assert EMOJI_ID not in state.pending_emoji_rewrites
+    # A resume-only run still reports the rewrite work in the outcome document.
+    row = outcome.recreated_emoji[0]
+    assert row["discord_id"] == EMOJI_ID
+    assert row["new_id"] == NEW_ID
+    assert row["messages_rewritten"] == 1
 
 
 async def test_edit_failure_keeps_the_record(tmp_path: Path) -> None:
@@ -536,3 +541,31 @@ async def test_integration_dry_run_writes_nothing(tmp_path: Path) -> None:
     assert outcome.recreated_emoji[0]["discord_id"] == EMOJI_ID
     assert outcome.recreated_emoji[0]["messages_rewritten"] == 1  # would-rewrite count
     assert state.emoji_map[EMOJI_ID] == OLD_ID  # unchanged
+
+
+async def test_dry_run_lists_an_outstanding_resume_record(tmp_path: Path) -> None:
+    """F4: a dry run names a leftover resume record a real run would finish first."""
+    _with_image(tmp_path)
+    config = FerryConfig(
+        export_dir=tmp_path,
+        stoat_url="https://api.test",
+        token="t",
+        upload_delay=0.0,
+        output_dir=tmp_path,
+        dry_run=True,
+    )
+    state = _state()
+    state.emoji_map[EMOJI_ID] = NEW_ID
+    state.pending_emoji_rewrites[EMOJI_ID] = {"old": OLD_ID, "new": NEW_ID}
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_present_report())),
+        patch(_UPLOAD, new=AsyncMock()) as up,
+        patch(_EDIT, new=AsyncMock()) as edit,
+        patch(f"{_ENGINE}.save_state", side_effect=AssertionError("dry run must not save")),
+    ):
+        outcome = await run_repair(config, state, [_export([_message()])], [].append)
+    up.assert_not_awaited()
+    edit.assert_not_awaited()
+    row = next(r for r in outcome.recreated_emoji if r["discord_id"] == EMOJI_ID)
+    assert row["new_id"] == NEW_ID
+    assert row["messages_rewritten"] == 1  # would finish the stranded message

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 from discord_ferry.config import FerryConfig
@@ -18,7 +17,10 @@ from discord_ferry.parser.models import (
     DCEMessage,
     DCEReaction,
 )
-from discord_ferry.state import MigrationState, load_state
+from discord_ferry.state import MigrationState
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 EMOJI_ID = "123"
 OLD_ID = "old_id"
@@ -179,3 +181,111 @@ async def test_rerun_when_present_makes_no_second_emoji(tmp_path: Path) -> None:
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
     up.assert_not_awaited()
     assert outcome.recreated_emoji == []
+
+
+# ---------------------------------------------------------------------------
+# Task 3.2: rewrite references
+# ---------------------------------------------------------------------------
+
+
+async def _run_with_messages(tmp_path: Path, messages: list[DCEMessage]) -> Any:
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock()) as edit,
+    ):
+        outcome = await run_repair(config, state, [_export(messages)], [].append)
+    return outcome, edit, state
+
+
+async def test_rewrite_only_edits_message_map_messages(tmp_path: Path) -> None:
+    """SC-2.1: a referencing message not in message_map is never edited."""
+    m1 = _message()  # id "m1", in message_map
+    m2 = DCEMessage(
+        id="m2",  # NOT in message_map
+        type="Default",
+        timestamp="2024-01-01T00:00:00Z",
+        content="also <:smile:123>",
+        author=DCEAuthor(id="u", name="U"),
+        reactions=[],
+    )
+    outcome, edit, _ = await _run_with_messages(tmp_path, [m1, m2])
+    edited_ids = [call.args[4] for call in edit.await_args_list]
+    assert edited_ids == ["stoat_msg"]  # only m1's mapped id
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 1
+
+
+async def test_rewrite_content_points_at_new_id(tmp_path: Path) -> None:
+    """SC-2.2: the edited content carries the new emoji id, not the old one."""
+    outcome, edit, _ = await _run_with_messages(tmp_path, [_message()])
+    content = edit.await_args_list[0].kwargs["content"]
+    assert f":{NEW_ID}:" in content
+    assert f":{OLD_ID}:" not in content
+
+
+async def test_rewrite_split_first_edits_first_part(tmp_path: Path) -> None:
+    """SC-2.3: emoji in the first split part edits that part."""
+    long_tail = " ".join(["word"] * 600)  # well over 2000 chars once rendered
+    m = _message(content=f"<:smile:123> {long_tail}")
+    outcome, edit, _ = await _run_with_messages(tmp_path, [m])
+    assert edit.await_count == 1
+    content = edit.await_args_list[0].kwargs["content"]
+    assert f":{NEW_ID}:" in content
+    assert len(content) <= 2000
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 1
+
+
+async def test_rewrite_split_tail_declines(tmp_path: Path) -> None:
+    """SC-2.4: emoji in a later split part is declined, not edited."""
+    long_head = " ".join(["word"] * 600)
+    m = _message(content=f"{long_head} <:smile:123>")
+    outcome, edit, state = await _run_with_messages(tmp_path, [m])
+    edit.assert_not_awaited()
+    assert outcome.recreated_emoji[0]["messages_declined"] == 1
+    assert any(d.get("type") == "emoji_in_split_tail" for d in outcome.declined)
+
+
+async def test_rewrite_reaction_only_makes_no_edit(tmp_path: Path) -> None:
+    """SC-2.5: an emoji used only in a reaction rewrites nothing."""
+    m = _message(content="no emoji here", with_reaction=True)
+    outcome, edit, _ = await _run_with_messages(tmp_path, [m])
+    edit.assert_not_awaited()
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 0
+
+
+async def test_rewrite_counts_all_referencing_messages(tmp_path: Path) -> None:
+    """SC-2.6: every mapped referencing message is counted."""
+    msgs = []
+    config_state_ids = {"m1": "stoat_msg", "m2": "s2", "m3": "s3"}
+    for i, mid in enumerate(config_state_ids):
+        # The first message carries the reaction so the image is recoverable;
+        # all three reference the emoji in content and so are rewritten.
+        reactions = (
+            [DCEReaction(emoji=DCEEmoji(id=EMOJI_ID, name="smile", image_url="smile.png"), count=1)]
+            if i == 0
+            else []
+        )
+        msgs.append(
+            DCEMessage(
+                id=mid,
+                type="Default",
+                timestamp="2024-01-01T00:00:00Z",
+                content="x <:smile:123>",
+                author=DCEAuthor(id="u", name="U"),
+                reactions=reactions,
+            )
+        )
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    state.message_map = dict(config_state_ids)
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock()) as edit,
+    ):
+        outcome = await run_repair(config, state, [_export(msgs)], [].append)
+    assert edit.await_count == 3
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 3
+    assert EMOJI_ID not in state.pending_emoji_rewrites  # cleared on full success

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import run_repair
 from discord_ferry.migrator.verify import CheckReport
@@ -394,3 +396,143 @@ async def test_outcome_to_dict_carries_recreated_emoji_end_to_end(tmp_path: Path
     assert row["discord_id"] == EMOJI_ID
     assert row["new_id"] == NEW_ID
     assert row["messages_rewritten"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2: integration
+# ---------------------------------------------------------------------------
+
+
+def _two_referencing_messages() -> list[DCEMessage]:
+    return [
+        _message(),  # m1, carries the reaction/image
+        DCEMessage(
+            id="m2",
+            type="Default",
+            timestamp="2024-01-01T00:00:00Z",
+            content="again <:smile:123>",
+            author=DCEAuthor(id="u", name="U"),
+            reactions=[],
+        ),
+    ]
+
+
+async def test_integration_recreate_rewrite_and_verifiable(tmp_path: Path) -> None:
+    """SC-I1: end to end. The emoji is recreated once, both messages rewritten, and
+    emoji_map now points at the new id, which is exactly what makes a later check
+    report emoji_present.
+    """
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    state.message_map = {"m1": "s1", "m2": "s2"}
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_EDIT, new=AsyncMock()) as edit,
+    ):
+        outcome = await run_repair(config, state, [_export(_two_referencing_messages())], [].append)
+    assert up.await_count == 1
+    assert edit.await_count == 2
+    assert all(f":{NEW_ID}:" in c.kwargs["content"] for c in edit.await_args_list)
+    assert state.emoji_map[EMOJI_ID] == NEW_ID  # a follow-up check would report present
+    assert EMOJI_ID not in state.pending_emoji_rewrites
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 2
+
+
+async def test_integration_interrupted_run_matches_clean_run(tmp_path: Path) -> None:
+    """SC-I2: a failed edit keeps the record; a second run resumes to the same end
+    state as an uninterrupted run (both messages on the new id, one emoji, cleared).
+    """
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    state.message_map = {"m1": "s1", "m2": "s2"}
+    exports = [_export(_two_referencing_messages())]
+
+    # Run 1: the second edit fails, standing in for a crash mid-rewrite.
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("crash")])),
+    ):
+        await run_repair(config, state, exports, [].append)
+    assert state.pending_emoji_rewrites[EMOJI_ID] == {"old": OLD_ID, "new": NEW_ID}
+
+    # Run 2: the emoji is present now, so the resume step finishes the stragglers.
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_present_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value="should-not-run")) as up2,
+        patch(_EDIT, new=AsyncMock()) as edit2,
+    ):
+        await run_repair(config, state, exports, [].append)
+    up2.assert_not_awaited()  # no second emoji
+    assert edit2.await_count >= 1  # the stranded message is finished
+    assert EMOJI_ID not in state.pending_emoji_rewrites  # same end state as a clean run
+
+
+async def test_integration_emoji_pass_runs_before_structure(tmp_path: Path) -> None:
+    """SC-I3 (ordering): the load-bearing guarantee behind the self-healing channel
+    case. When both an emoji and a channel are missing, the emoji pass runs before
+    the structure pass, so the rewrite re-renders through pristine maps.
+    """
+    order: list[str] = []
+
+    async def emoji_pass(*_a: Any, **_k: Any) -> None:
+        order.append("emoji")
+
+    async def live_view(*_a: Any, **_k: Any) -> Any:
+        order.append("structure")
+        raise RuntimeError("stop after recording order")
+
+    report = CheckReport()
+    report.add(
+        name="emoji:123",
+        status="fail",
+        kind="emoji_missing",
+        detail="",
+        discord_id="123",
+        stoat_id="old_id",
+    )
+    report.add(
+        name="channel:ch1",
+        status="fail",
+        kind="channel_missing",
+        detail="",
+        discord_id="ch1",
+        stoat_id="sc",
+    )
+    config, state = _config(tmp_path), _state()
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=report)),
+        patch(f"{_ENGINE}._run_emoji_repair_pass", new=emoji_pass),
+        patch(f"{_ENGINE}._live_server_view", new=live_view),
+        pytest.raises(RuntimeError),
+    ):
+        await run_repair(config, state, [_export([_message()])], [].append)
+    assert order == ["emoji", "structure"]
+
+
+async def test_integration_dry_run_writes_nothing(tmp_path: Path) -> None:
+    """SC-I4: a dry run performs no upload, create, edit or save, and lists the work."""
+    _with_image(tmp_path)
+    config, state = _config(tmp_path), _state()
+    config = FerryConfig(
+        export_dir=tmp_path,
+        stoat_url="https://api.test",
+        token="t",
+        upload_delay=0.0,
+        output_dir=tmp_path,
+        dry_run=True,
+    )
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
+        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_EDIT, new=AsyncMock()) as edit,
+        patch(f"{_ENGINE}.save_state", side_effect=AssertionError("dry run must not save")),
+    ):
+        outcome = await run_repair(config, state, [_export([_message()])], [].append)
+    up.assert_not_awaited()
+    edit.assert_not_awaited()
+    assert outcome.dry_run is True
+    assert outcome.recreated_emoji[0]["discord_id"] == EMOJI_ID
+    assert outcome.recreated_emoji[0]["messages_rewritten"] == 1  # would-rewrite count
+    assert state.emoji_map[EMOJI_ID] == OLD_ID  # unchanged

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -873,6 +873,9 @@ _KNOWN_STATE_FIELDS = frozenset(
         "channel_categories",
         "message_map",
         "emoji_map",
+        # Structural: identifiers only (discord id -> {old,new} stoat ids),
+        # never a Ferry secret, so it stays out of _TEXT_MEMBERS.
+        "pending_emoji_rewrites",
         "avatar_cache",
         "upload_cache",
         "author_names",
@@ -933,6 +936,23 @@ def test_state_document_has_no_unclassified_fields() -> None:
     assert _KNOWN_STATE_FIELDS - emitted == set(), (
         "a state.json field was removed; update this list"
     )
+
+
+def test_pending_emoji_rewrites_round_trips(tmp_path: Path) -> None:
+    """SC-ST.1: the resume record survives save then load."""
+    state = MigrationState(pending_emoji_rewrites={"d_emo": {"old": "a", "new": "b"}})
+    save_state(state, tmp_path)
+    loaded = load_state(tmp_path)
+    assert loaded.pending_emoji_rewrites == {"d_emo": {"old": "a", "new": "b"}}
+
+
+def test_pending_emoji_rewrites_defaults_empty(tmp_path: Path) -> None:
+    """SC-ST.1: a state file written before the field existed loads it as {}."""
+    save_state(MigrationState(), tmp_path)
+    raw = json.loads((tmp_path / "state.json").read_text())
+    del raw["pending_emoji_rewrites"]
+    (tmp_path / "state.json").write_text(json.dumps(raw))
+    assert load_state(tmp_path).pending_emoji_rewrites == {}
 
 
 def test_failed_message_fields_are_classified() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1998,3 +1998,22 @@ class TestRepairOutcome:
         assert doc["failed_messages"] == []
         assert doc["dry_run"] is False
         assert doc["actions"]["dead_letter"] == {"drained": 0, "remaining": 0}
+
+
+def test_repair_outcome_carries_recreated_emoji() -> None:
+    """SC-4.2: recreated_emoji appears under actions and is control-stripped."""
+    outcome = RepairOutcome()
+    outcome.recreated_emoji.append(
+        {
+            "discord_id": "d",
+            "name": "smile\x07",
+            "new_id": "n",
+            "messages_rewritten": 2,
+            "messages_declined": 0,
+            "messages_failed": 0,
+        }
+    )
+    row = outcome.to_dict()["actions"]["recreated_emoji"][0]
+    assert row["new_id"] == "n"
+    assert row["messages_rewritten"] == 2
+    assert row["name"] == "smile"

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.25.0"
+version = "2.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #307.

## What
`ferry repair` now acts on the `emoji_missing` check. It recreates the emoji from the export and rewrites every message Ferry sent that referenced the old copy, so the references point at the restored emoji instead of a dead id.

## Why
An emoji recorded during migration can later vanish from the Stoat server. The check reported it, but repair declined it. Recreating an emoji mints a new id (the id IS its Autumn file id), so recreation alone leaves every reference dead. The rewrite is the half that makes the restoration real.

## How it holds together
- **Crash-safe.** The recreation and a small resume record are written in one step, and the emoji pass runs before structure repair so the message renderer sees pristine id maps. A later run finishes any messages not yet rewritten.
- **Honest about limits.** An emoji whose image is not in the export is reported unrepairable. A reference in a later send of a split message is left as is, because only the first send is addressable.
- **Incremental-safe.** The resume record is carried forward on an incremental run beside the emoji map, so a crashed repair is not stranded.
- **Preview and output.** A dry run changes nothing and lists the intended work; the result appears in the plain output and `ferry repair --json`.

## Review trail
Built in four chunks, each chunk-reviewed. The whole-branch and second-opinion reviews at ship time each found the incremental carry-forward gap (now fixed), plus three smaller outcome and exit-code gaps, all fixed with tests. 2264 tests pass; ruff, format and mypy clean.

Version bumped to 2.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
