### PR TITLE
GUI-CLI parity phase 3: validate, stats, and tls-check tool pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.27.0] - 2026-08-21
+
+### Added
+
+- **GUI parity with the CLI toolchain, phase 3: the read-only diagnostics reach the web
+  interface.** The Tools screen at `/tools` gains its last three pages, none of which needs
+  a token:
+  - **Validate**: check a Discord export before migrating and list any warnings, including
+    the reason a plain-text-mention warning has to be acknowledged.
+  - **Stats**: summarise a finished migration from its saved state, with the same entity
+    counts, fidelity scores, and error and warning summary the command line shows.
+  - **TLS check**: show the certificate-trust and proxy state the app resolved, with no
+    input needed.
+
 ## [2.26.0] - 2026-08-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.26.0"
+version = "2.27.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.26.0"
+__version__ = "2.27.0"

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -19,13 +19,18 @@ import discord_ferry.migrator.api as _api
 from discord_ferry.blueprint import blueprint_from_exports, export_blueprint, import_blueprint
 from discord_ferry.config import FerryConfig
 from discord_ferry.core.engine import run_build, run_repair, run_retry_failed
-from discord_ferry.core.http import format_proxy_notices
+from discord_ferry.core.http import describe_proxy, describe_trust, format_proxy_notices
 from discord_ferry.core.security import register_secret, sanitize_secrets
 from discord_ferry.errors import CheckError, MigrationError, StateError
 from discord_ferry.migrator.probe import run_probe
 from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, run_check
-from discord_ferry.parser.dce_parser import parse_export_directory
+from discord_ferry.parser.dce_parser import (
+    acknowledgement_required,
+    parse_export_directory,
+    validate_export,
+)
 from discord_ferry.state import load_state
+from discord_ferry.stats import summarize_state
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -35,6 +40,7 @@ if TYPE_CHECKING:
     from discord_ferry.migrator.probe import ProbeReport
     from discord_ferry.migrator.verify import CheckReport, RepairOutcome
     from discord_ferry.state import MigrationState
+    from discord_ferry.stats import StateSummary
 
 T = TypeVar("T")
 
@@ -725,3 +731,158 @@ def build_page() -> None:
             run_tool(client, log.push, _do_build, on_done)
 
         ui.button("Build server", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/validate")
+def validate_page() -> None:
+    """Check a DCE export before migrating, reachable standalone from /tools.
+
+    Offline: it reads local export files and reports warnings, making no API call,
+    so there is no token and no runner. Mirrors the ``ferry validate`` warnings,
+    including the plain-text-mentions acknowledgement reason.
+    """
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Check an export").classes("text-2xl font-bold mb-4")
+        dir_input = ui.input("Export directory (the DCE export)").classes("w-96")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def _run() -> None:
+            results.clear()
+            export_dir = dir_input.value.strip()
+            if not export_dir or not Path(export_dir).is_dir():
+                ui.notify("Enter a valid export directory.", type="warning")
+                return
+            path = Path(export_dir)
+            exports = parse_export_directory(path)
+            with results:
+                if not exports:
+                    ui.label("No valid DCE JSON files found in that directory.").classes(
+                        "text-red-600"
+                    )
+                    return
+                warnings = validate_export(exports, path)
+                if not warnings:
+                    ui.label("Export looks good. No warnings.").classes(
+                        "text-lg font-bold text-green-600"
+                    )
+                else:
+                    ui.label(f"{len(warnings)} warning(s):").classes(
+                        "text-lg font-bold text-amber-700"
+                    )
+                    for w in warnings:
+                        # Warning messages carry export-controlled text (channel
+                        # names), so they are sanitized at this rendered sink.
+                        ui.label(f"- {sanitize_secrets(w.get('message', ''))}").classes(
+                            "text-sm text-amber-700"
+                        )
+                reason = acknowledgement_required(warnings)
+                if reason is not None:
+                    ui.label(sanitize_secrets(reason)).classes("text-red-600 font-bold mt-2")
+
+        ui.button("Validate export", on_click=_run).classes("mt-2")
+
+
+def _stats_rows(summary: StateSummary) -> list[dict[str, str]]:
+    """Rows for the stats table, mirroring the CLI's `_build_stats_table` sections.
+
+    ``last_error`` / ``last_warning`` are the only free-text fields (an error or
+    warning message can carry export or API prose), so their previews are
+    sanitized. Every other value is a count, a percentage, or an id.
+    """
+    fb = summary.fidelity
+
+    def pct(value: float | None) -> str:
+        return f"{value:.1f}%" if value is not None else "n/a"
+
+    rows: list[tuple[str, str]] = [
+        ("Channels", str(summary.channels)),
+        ("Roles", str(summary.roles)),
+        ("Categories", str(summary.categories)),
+        ("Emojis", str(summary.emojis)),
+        ("Messages migrated", f"{summary.messages:,}"),
+        ("Attachments uploaded", f"{summary.attachments_uploaded:,}"),
+        ("Attachments skipped", f"{summary.attachments_skipped:,}"),
+        ("Pins applied", str(summary.pins_applied)),
+        ("Reactions applied", f"{summary.reactions_applied:,}"),
+        ("Replies linked / total", f"{summary.replies_linked:,} / {summary.replies_total:,}"),
+        ("Embeds total / dropped", f"{summary.embeds_total:,} / {summary.embeds_dropped:,}"),
+        ("Failed messages", str(summary.failed_messages)),
+        ("Prior messages total", f"{summary.prior_messages_total:,}"),
+        ("Fidelity overall", pct(fb.overall)),
+        ("Fidelity messages", pct(fb.messages)),
+        ("Fidelity attachments", pct(fb.attachments)),
+        ("Fidelity embeds", pct(fb.embeds)),
+        ("Fidelity replies", pct(fb.replies)),
+        ("Fidelity reactions", pct(fb.reactions)),
+    ]
+    if summary.error_count == 0:
+        rows.append(("Errors", "0 (clean)"))
+    else:
+        preview = sanitize_secrets(summary.last_error or "")[:80]
+        rows.append(("Errors", f"{summary.error_count} — last: {preview}"))
+    if summary.warning_count == 0:
+        rows.append(("Warnings", "0 (clean)"))
+    else:
+        preview = sanitize_secrets(summary.last_warning or "")[:80]
+        rows.append(("Warnings", f"{summary.warning_count} — last: {preview}"))
+    return [{"item": item, "value": value} for item, value in rows]
+
+
+@ui.page("/tools/stats")
+def stats_page() -> None:
+    """Summarise a past migration from its state file. Local read, no token.
+
+    Reads ``state.json`` from an output directory and renders the same counters,
+    fidelity, and error/warning summary the CLI ``stats`` command builds.
+    """
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Summarise a migration").classes("text-2xl font-bold mb-4")
+        default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
+        dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
+        results = ui.column().classes("w-full max-w-2xl")
+
+        def _run() -> None:
+            results.clear()
+            with results:
+                try:
+                    state = load_state(Path(dir_input.value))
+                except StateError as exc:
+                    ui.label(f"Cannot read this migration: {sanitize_secrets(str(exc))}").classes(
+                        "text-red-600"
+                    )
+                    return
+                summary = summarize_state(state)
+                tag = " (dry run)" if summary.is_dry_run else ""
+                ui.label(f"Stoat server {summary.stoat_server_id}{tag}").classes(
+                    "text-sm text-gray-600"
+                )
+                columns = [
+                    {"name": "item", "label": "Item", "field": "item", "align": "left"},
+                    {"name": "value", "label": "Value", "field": "value", "align": "left"},
+                ]
+                ui.table(columns=columns, rows=_stats_rows(summary)).classes("w-full mt-2")
+
+        ui.button("Show stats", on_click=_run).classes("mt-2")
+
+
+@ui.page("/tools/tls-check")
+def tls_check_page() -> None:
+    """Inspect the TLS trust and proxy state. No inputs, no token, always succeeds.
+
+    Renders ``describe_trust`` and ``describe_proxy`` (each ``dict[str, str]`` of
+    internal config diagnostics, no credentials) as two labelled key-value groups.
+    Skips the runner's token steps entirely.
+    """
+
+    def _group(title: str, data: dict[str, str]) -> None:
+        with ui.card().classes("w-full max-w-xl"):
+            ui.label(title).classes("text-lg font-bold")
+            for key, value in data.items():
+                with ui.row().classes("w-full justify-between"):
+                    ui.label(key).classes("text-sm text-gray-500")
+                    ui.label(value).classes("text-sm font-mono")
+
+    with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
+        ui.label("Trust and proxy state").classes("text-2xl font-bold mb-4")
+        _group("TLS trust", describe_trust())
+        _group("Proxy", describe_proxy())

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -825,6 +825,16 @@ def _stats_rows(summary: StateSummary) -> list[dict[str, str]]:
     else:
         preview = sanitize_secrets(summary.last_warning or "")[:80]
         rows.append(("Warnings", f"{summary.warning_count} — last: {preview}"))
+    # Timing, same trinary as the CLI's _build_stats_table: an exact elapsed only
+    # for a complete run, else a plain state word.
+    if summary.duration_state == "complete":
+        secs = int(summary.duration_seconds or 0)
+        elapsed = f"{secs // 3600:02d}:{(secs % 3600) // 60:02d}:{secs % 60:02d}"
+    elif summary.duration_state == "in_progress":
+        elapsed = "in progress"
+    else:
+        elapsed = "unknown"
+    rows.append(("Elapsed", elapsed))
     return [{"item": item, "value": value} for item, value in rows]
 
 

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -880,3 +880,166 @@ async def test_check_page_shows_cannot_check_on_migration_error(
         user.find("Run check").click()
         await user.should_see("Cannot check this migration")
         await user.should_not_see("Check failed")  # not the generic error path
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: validate (#492), stats (#493), tls-check (#494)
+# ---------------------------------------------------------------------------
+
+
+async def test_validate_page_no_dce_json_error(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """#492: an empty parse shows a clear error, not a crash."""
+    with patch("discord_ferry.gui_tools.parse_export_directory", return_value=[]):
+        await user.open("/tools/validate")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Validate export").click()
+        await user.should_see("No valid DCE JSON files found")
+
+
+async def test_validate_page_renders_warnings_and_ack_reason(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """#492: warnings render, and the plain-text-mentions acknowledgement reason shows."""
+    warnings = [
+        {"type": "rendered_markdown", "message": "3 mentions written as plain text", "count": "3"}
+    ]
+
+    with (
+        patch("discord_ferry.gui_tools.parse_export_directory", return_value=[object()]),
+        patch("discord_ferry.gui_tools.validate_export", return_value=warnings),
+        patch(
+            "discord_ferry.gui_tools.acknowledgement_required",
+            return_value="3 message(s) have mentions written as plain text.",
+        ),
+    ):
+        await user.open("/tools/validate")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Validate export").click()
+        await user.should_see("mentions written as plain text")
+        await user.should_see("1 warning(s)")
+
+
+async def test_validate_page_clean_export(
+    user: User,
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """#492: a clean export reports no warnings."""
+    with (
+        patch("discord_ferry.gui_tools.parse_export_directory", return_value=[object()]),
+        patch("discord_ferry.gui_tools.validate_export", return_value=[]),
+    ):
+        await user.open("/tools/validate")
+        user.find("Export directory").elements.pop().set_value(str(tmp_path))
+        user.find("Validate export").click()
+        await user.should_see("Export looks good")
+
+
+def _fake_summary(last_error: str | None = None):  # type: ignore[no-untyped-def]
+    """A StateSummary-shaped stub for the stats row-builder test."""
+    from types import SimpleNamespace
+
+    fidelity = SimpleNamespace(
+        overall=98.5, messages=99.0, attachments=100.0, embeds=None, replies=50.0, reactions=None
+    )
+    return SimpleNamespace(
+        channels=3,
+        roles=2,
+        categories=1,
+        emojis=0,
+        messages=1234,
+        attachments_uploaded=10,
+        attachments_skipped=1,
+        pins_applied=2,
+        reactions_applied=5,
+        replies_linked=4,
+        replies_total=8,
+        embeds_total=0,
+        embeds_dropped=0,
+        failed_messages=0,
+        prior_messages_total=0,
+        error_count=1 if last_error else 0,
+        warning_count=0,
+        last_error=last_error,
+        last_warning=None,
+        fidelity=fidelity,
+        rollback=None,
+        channel_breakdown={},
+        is_dry_run=False,
+        stoat_server_id="01SRV",
+        duration_seconds=12.0,
+        duration_state="complete",
+        current_phase="report",
+    )
+
+
+def test_stats_rows_maps_summary_and_sanitizes_last_error() -> None:
+    """#493: the stats rows carry the counters and mask a token in last_error."""
+    from discord_ferry import gui_tools
+    from discord_ferry.core.security import register_secret, reset_secret_registry
+
+    reset_secret_registry()
+    register_secret("stoat", _TOKEN)
+    rows = gui_tools._stats_rows(_fake_summary(last_error=f"boom {_TOKEN}"))
+
+    by_item = {r["item"]: r["value"] for r in rows}
+    assert by_item["Channels"] == "3"
+    assert by_item["Messages migrated"] == "1,234"
+    assert by_item["Fidelity embeds"] == "n/a"  # None denominator, not 0%
+    errors_row = next(r["value"] for r in rows if r["item"] == "Errors")
+    assert _TOKEN not in errors_row  # the last-error preview was sanitized
+    reset_secret_registry()
+
+
+async def test_stats_page_renders_summary(
+    user: User,
+    user_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """#493: a valid state renders the summary (the server-id label is the positive control)."""
+    user_store["output_dir"] = str(tmp_path)
+
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=object()),
+        patch("discord_ferry.gui_tools.summarize_state", return_value=_fake_summary()),
+    ):
+        await user.open("/tools/stats")
+        user.find("Show stats").click()
+        await user.should_see("Stoat server 01SRV")  # label, not a table cell
+
+
+async def test_stats_page_missing_state_error(
+    user: User,
+    user_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """#493: a missing or invalid state file shows a clear error."""
+    from discord_ferry.errors import StateError
+
+    user_store["output_dir"] = str(tmp_path)
+
+    with patch("discord_ferry.gui_tools.load_state", side_effect=StateError("no state.json found")):
+        await user.open("/tools/stats")
+        user.find("Show stats").click()
+        await user.should_see("Cannot read this migration")
+
+
+async def test_tls_check_page_renders_both_groups(
+    user: User,
+) -> None:
+    """#494: the TLS trust and proxy groups both render from the describe functions."""
+    with (
+        patch(
+            "discord_ferry.gui_tools.describe_trust",
+            return_value={"trust-source": "certifi+system"},
+        ),
+        patch("discord_ferry.gui_tools.describe_proxy", return_value={"proxy-source": "none"}),
+    ):
+        await user.open("/tools/tls-check")
+        await user.should_see("TLS trust")
+        await user.should_see("certifi+system")
+        await user.should_see("Proxy")
+        await user.should_see("proxy-source")

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -989,9 +989,26 @@ def test_stats_rows_maps_summary_and_sanitizes_last_error() -> None:
     assert by_item["Channels"] == "3"
     assert by_item["Messages migrated"] == "1,234"
     assert by_item["Fidelity embeds"] == "n/a"  # None denominator, not 0%
+    assert by_item["Elapsed"] == "00:00:12"  # timing parity with the CLI (12.0s complete)
     errors_row = next(r["value"] for r in rows if r["item"] == "Errors")
     assert _TOKEN not in errors_row  # the last-error preview was sanitized
     reset_secret_registry()
+
+
+def test_stats_rows_elapsed_states() -> None:
+    """#493: the Elapsed row mirrors the CLI's trinary duration handling."""
+    from discord_ferry import gui_tools
+
+    def elapsed_for(state: str, seconds: float | None):  # type: ignore[no-untyped-def]
+        summary = _fake_summary()
+        summary.duration_state = state
+        summary.duration_seconds = seconds
+        rows = gui_tools._stats_rows(summary)  # type: ignore[arg-type]
+        return next(r["value"] for r in rows if r["item"] == "Elapsed")
+
+    assert elapsed_for("in_progress", None) == "in progress"
+    assert elapsed_for("unknown", None) == "unknown"
+    assert elapsed_for("complete", 3661.0) == "01:01:01"
 
 
 async def test_stats_page_renders_summary(

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.26.0"
+version = "2.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## GUI-CLI parity, phase 3 (final)

Brings the three read-only diagnostic commands to the NiceGUI web interface. All offline, none takes a token or uses the runner. The Tools screen at `/tools` is now complete.

- **Validate** (`/tools/validate`): parse an export directory, run `validate_export`, and list any warnings, including the reason a plain-text-mention warning has to be acknowledged. Warning text is sanitized at the sink.
- **Stats** (`/tools/stats`): load a migration's saved state and render the same entity counts, fidelity scores, error/warning summary, and elapsed time the `ferry stats` command shows. The error/warning previews are sanitized.
- **TLS check** (`/tools/tls-check`): render the certificate-trust and proxy state the app resolved, as two key-value groups. No input.

### Verification

- Full suite: 2239 passed. Ruff and mypy clean.
- Chunk review (Mistral, code-reviewer): 0 findings, posted to #492, #493, #494.
- Whole-branch review (`feature-dev:code-reviewer`): one Important finding, that the stats page dropped the CLI's elapsed-time row; fixed in this PR with a test. Everything else (sanitization of free-text sinks, nullable-fidelity `n/a` handling, empty-export and `StateError` handling, no credentials in the TLS/proxy dicts) confirmed clean.
- Task sub-issues #515-#517 closed.

Version note: 2.26.0 is held by a parallel branch, so this takes 2.27.0 to avoid a collision.

Closes #492
Closes #493
Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
