### PR TITLE
feat(gui): finish-screen deep-links to Verify and Repair (#524, #518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.29.0] - 2026-08-21
+
+### Added
+
+- **The finished-migration screen links straight to Verify and Repair.** When a migration
+  completes, the completion card now offers **Verify** and **Repair** buttons that open the
+  matching tool page for the migration that just ran, carrying its output directory across so
+  the page is ready to run (#518).
+- **The token-taking tool pages accept a Stoat token when the session store is empty.** Check,
+  repair, retry, probe and build now show a password token field instead of a dead-end
+  "Session expired" message when no session token is present. A migration clears the session
+  token on completion, so a tool page reached from the finish screen would otherwise have no
+  way to run; the field lets the user supply a token for that one run without it being written
+  to disk (#524).
+
 ## [2.27.0] - 2026-08-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.27.0"
+version = "2.29.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.27.0"
+__version__ = "2.29.0"

--- a/src/discord_ferry/gui.py
+++ b/src/discord_ferry/gui.py
@@ -192,6 +192,16 @@ def _clear_tokens(storage: MutableMapping[str, Any], keys: Iterable[str]) -> Non
         storage.pop(key, None)
 
 
+def _stash_output_dir(storage: MutableMapping[str, Any], output_dir: Path) -> None:
+    """Record a finished migration's output dir so a tool page defaults to it.
+
+    Written to ``app.storage.user`` (which persists to disk); only the directory,
+    never a token, is stored here. The check, repair and retry pages read it back
+    via ``app.storage.user.get("output_dir", ...)``.
+    """
+    storage["output_dir"] = str(output_dir)
+
+
 _EXPOSED_REACTION_MODES = ("text", "native", "skip")
 
 # NiceGUI 3.x defaults `Client.connected()` to `timeout=None`, i.e. wait forever.
@@ -1359,6 +1369,12 @@ async def migrate_page() -> None:
                         "Rollback this migration",
                         on_click=lambda: _start_rollback(),
                     ).classes("bg-red-600 text-white")
+                    ui.button("Verify", on_click=lambda: _open_tool("/tools/check")).classes(
+                        "bg-blue-600 text-white"
+                    )
+                    ui.button("Repair", on_click=lambda: _open_tool("/tools/repair")).classes(
+                        "bg-blue-600 text-white"
+                    )
 
     # ---------------------------------------------------------------------------
     # Cancel confirmation dialog
@@ -1636,6 +1652,13 @@ async def migrate_page() -> None:
                     _show_rollback_dialog(event.detail["summary"])
 
         log_display.push(f"[{event.phase}] {event.status}: {event.message}")
+
+    def _open_tool(route: str) -> None:
+        # Stash this migration's output dir so the tool page defaults to it, then
+        # jump there. The session token was cleared on completion; #524 lets the
+        # tool page take a token when the session store is empty.
+        _stash_output_dir(app.storage.user, config.output_dir)
+        ui.navigate.to(route)
 
     def _on_migration_complete() -> None:
         controls_row.classes(add="hidden")

--- a/src/discord_ferry/gui_tools.py
+++ b/src/discord_ferry/gui_tools.py
@@ -10,6 +10,7 @@ any request.
 from __future__ import annotations
 
 import importlib.resources
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -297,20 +298,51 @@ def _tab_token() -> str | None:
     return token if isinstance(token, str) and token else None
 
 
+@dataclass(frozen=True)
+class _TokenSource:
+    """The Stoat token for a tool run, resolved at run time.
+
+    When the session store held a token, ``session`` carries it and no field is
+    rendered. When it did not, ``field`` is the password input the user fills in,
+    read inside the run handler (the user types it after the page is built).
+    """
+
+    session: str | None
+    field: ui.input | None
+
+    def resolve(self) -> str | None:
+        if self.session is not None:
+            return self.session
+        value = self.field.value if self.field is not None else None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+
+def _token_source() -> _TokenSource:
+    """Return the session token, or render a password field for one when absent.
+
+    Call inside the page's layout context: when the session store is empty it
+    renders a ``ui.input``, replacing the old "Session expired" dead end. The
+    entered token stays in this closure for the run and is never persisted to
+    disk (matching the memory-only session token).
+    """
+    session = _tab_token()
+    if session is not None:
+        return _TokenSource(session=session, field=None)
+    field = ui.input("Stoat token", password=True).classes("w-96")
+    return _TokenSource(session=None, field=field)
+
+
 @ui.page("/tools/check")
 def check_page() -> None:
     """Verify a finished migration by loading its state and running run_check."""
     client = ui.context.client
     stoat_url = str(app.storage.user.get("stoat_url", ""))
-    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Verify a finished migration").classes("text-2xl font-bold mb-4")
-        if token is None:
-            ui.label("Session expired. Re-enter your token on the setup page.").classes(
-                "text-red-600"
-            )
-            return
+        token_src = _token_source()
 
         default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
         dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
@@ -335,6 +367,10 @@ def check_page() -> None:
 
         def _run() -> None:
             results.clear()
+            token = token_src.resolve()
+            if token is None:
+                ui.notify("Enter your Stoat token", type="warning")
+                return
             output_dir = Path(dir_input.value)
             for line in prepare_tool_call(token):
                 _safe_push(log.push, line)
@@ -361,15 +397,10 @@ def repair_page() -> None:
     """Verify a migration, then recreate what is missing and resend."""
     client = ui.context.client
     stoat_url = str(app.storage.user.get("stoat_url", ""))
-    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Verify and fix a migration").classes("text-2xl font-bold mb-4")
-        if token is None:
-            ui.label("Session expired. Re-enter your token on the setup page.").classes(
-                "text-red-600"
-            )
-            return
+        token_src = _token_source()
 
         default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
         dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
@@ -416,6 +447,10 @@ def repair_page() -> None:
                     type="warning",
                 )
                 return
+            token = token_src.resolve()
+            if token is None:
+                ui.notify("Enter your Stoat token", type="warning")
+                return
             output_dir = Path(dir_input.value)
             for line in prepare_tool_call(token):
                 _safe_push(log.push, line)
@@ -445,15 +480,10 @@ def retry_page() -> None:
     """Resend the messages that failed on a prior migration."""
     client = ui.context.client
     stoat_url = str(app.storage.user.get("stoat_url", ""))
-    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Resend failed messages").classes("text-2xl font-bold mb-4")
-        if token is None:
-            ui.label("Session expired. Re-enter your token on the setup page.").classes(
-                "text-red-600"
-            )
-            return
+        token_src = _token_source()
 
         default_dir = str(app.storage.user.get("output_dir", "./ferry-output"))
         dir_input = ui.input("Output directory", value=default_dir).classes("w-96")
@@ -484,6 +514,10 @@ def retry_page() -> None:
                     "Enter a valid export directory. Retry needs the original export.",
                     type="warning",
                 )
+                return
+            token = token_src.resolve()
+            if token is None:
+                ui.notify("Enter your Stoat token", type="warning")
                 return
             output_dir = Path(dir_input.value)
             for line in prepare_tool_call(token):
@@ -518,22 +552,17 @@ def retry_page() -> None:
 def probe_page() -> None:
     """Preflight a live Stoat instance for Autumn limits, rate window, voice, webhooks.
 
-    Reads stoat_url from the user store and the token from the tab store, with a
-    session-expired guard when the tab store is empty (design: every tool page
-    sources credentials this way; entering a token when the store is empty is the
-    deferred #524). Needs a throwaway test server id and an optional deep toggle.
+    Reads stoat_url from the user store and the token via _token_source: the
+    session token when present, otherwise a password field the user fills in
+    (#524, so a page reached with an empty session store still runs). Needs a
+    throwaway test server id and an optional deep toggle.
     """
     client = ui.context.client
     stoat_url = str(app.storage.user.get("stoat_url", ""))
-    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Preflight a Stoat instance").classes("text-2xl font-bold mb-4")
-        if token is None:
-            ui.label("Session expired. Re-enter your token on the setup page.").classes(
-                "text-red-600"
-            )
-            return
+        token_src = _token_source()
 
         server_input = ui.input("Throwaway test server ID").classes("w-96")
         deep_cb = ui.checkbox("Deep probe (upload test files at each Autumn size boundary)")
@@ -575,6 +604,10 @@ def probe_page() -> None:
                     "Confirm the deep-probe warning before running a deep probe.",
                     type="warning",
                 )
+                return
+            token = token_src.resolve()
+            if token is None:
+                ui.notify("Enter your Stoat token", type="warning")
                 return
             for line in prepare_tool_call(token):
                 _safe_push(log.push, line)
@@ -657,20 +690,16 @@ def build_page() -> None:
 
     Makes live API calls, so it goes through the runner (register the token, init
     the semaphore only when unset). Reads stoat_url from the user store and the
-    token from the tab store, with a session-expired guard. Exactly one source,
-    a template or a blueprint file, is required.
+    token via _token_source: the session token when present, otherwise a password
+    field the user fills in (#524). Exactly one source, a template or a blueprint
+    file, is required.
     """
     client = ui.context.client
     stoat_url = str(app.storage.user.get("stoat_url", ""))
-    token = _tab_token()
 
     with ui.column().classes("w-full items-center min-h-screen bg-gray-50 py-10"):
         ui.label("Build a server").classes("text-2xl font-bold mb-4")
-        if token is None:
-            ui.label("Session expired. Re-enter your token on the setup page.").classes(
-                "text-red-600"
-            )
-            return
+        token_src = _token_source()
 
         ui.label(
             "A server built here writes no state.json, so the rollback tool cannot undo it: "
@@ -712,6 +741,10 @@ def build_page() -> None:
                 ui.notify("That blueprint file does not exist.", type="warning")
                 return
             name = name_input.value.strip() or None
+            token = token_src.resolve()
+            if token is None:
+                ui.notify("Enter your Stoat token", type="warning")
+                return
             for line in prepare_tool_call(token):
                 _safe_push(log.push, line)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -19,6 +19,8 @@ from discord_ferry.gui import (
 from discord_ferry.parser.dce_parser import parse_export_directory
 
 if TYPE_CHECKING:
+    from nicegui.testing import User
+
     from discord_ferry.core.engine import PhaseFunction
     from discord_ferry.core.events import MigrationEvent
     from discord_ferry.state import MigrationState
@@ -356,6 +358,15 @@ def test_session_token_keys_pinned() -> None:
     assert _SESSION_TOKEN_KEYS == ("token", "discord_token")
 
 
+def test_stash_output_dir_writes_string_path() -> None:
+    """SC-3.1/3.2 (storage half): the output dir is stashed as a string (#518)."""
+    from discord_ferry.gui import _stash_output_dir
+
+    storage: dict[str, Any] = {}
+    _stash_output_dir(storage, Path("./ferry-output"))
+    assert storage["output_dir"] == "ferry-output"
+
+
 # ---------------------------------------------------------------------------
 # Batch 8 — S1 cached-export gating
 # ---------------------------------------------------------------------------
@@ -684,3 +695,49 @@ def test_resume_and_incremental_conflict_detected() -> None:
     assert _resume_incremental_conflict({"resume": True, "incremental": False}) is False
     assert _resume_incremental_conflict({"resume": False, "incremental": True}) is False
     assert _resume_incremental_conflict({}) is False
+
+
+# ---------------------------------------------------------------------------
+# #518 — completion-card deep-links to Verify and Repair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("button", "landing_title"),
+    [
+        ("Verify", "Verify a finished migration"),  # -> /tools/check
+        ("Repair", "Verify and fix a migration"),  # -> /tools/repair
+    ],
+)
+@pytest.mark.nicegui_main_file("tests/nicegui_app.py")
+async def test_completion_card_deep_links_to_tool_page(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    button: str,
+    landing_title: str,
+) -> None:
+    """SC-3.1/3.2: the completion card's button stashes the dir and opens the page (#518)."""
+    from discord_ferry.core.events import MigrationEvent
+
+    user_store["export_dir"] = str(tmp_path)
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = "stoat-tok"
+
+    async def fake_run_migration(config, *, on_event):  # type: ignore[no-untyped-def]
+        # Emit the terminal event so _on_migration_complete reveals the card,
+        # without running a real migration.
+        on_event(MigrationEvent(phase="report", status="completed", message="done"))
+
+    monkeypatch.setattr("discord_ferry.gui.run_migration", fake_run_migration)
+
+    await user.open("/migrate")
+    await user.should_see(button)
+
+    user.find(button).click()
+    # The User sim performs the navigation for real, so the target tool page renders.
+    await user.should_see(landing_title)
+    # The output dir was stashed for the tool page to default from.
+    assert user_store["output_dir"] == "ferry-output"  # config.output_dir is ./ferry-output

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -89,6 +89,45 @@ def test_prepare_returns_proxy_notices(monkeypatch) -> None:  # type: ignore[no-
     assert gui_tools.prepare_tool_call("tok") == ["proxy: on"]
 
 
+def test_token_source_resolve_returns_session_when_present() -> None:
+    """SC-1.1: session token wins, no field involved."""
+    from discord_ferry.gui_tools import _TokenSource
+
+    src = _TokenSource(session="tok", field=None)
+    assert src.resolve() == "tok"
+
+
+def test_token_source_resolve_returns_field_value_when_no_session() -> None:
+    """SC-1.2: with no session, the field's value is used."""
+    from types import SimpleNamespace
+
+    from discord_ferry.gui_tools import _TokenSource
+
+    src = _TokenSource(session=None, field=SimpleNamespace(value="typed-tok"))
+    assert src.resolve() == "typed-tok"
+
+
+def test_token_source_resolve_none_for_empty_or_whitespace() -> None:
+    """SC-1.3: empty, whitespace, or None field resolves to None (refuse the run)."""
+    from types import SimpleNamespace
+
+    from discord_ferry.gui_tools import _TokenSource
+
+    for bad in ("", "   ", None):
+        src = _TokenSource(session=None, field=SimpleNamespace(value=bad))
+        assert src.resolve() is None
+
+
+def test_token_source_resolve_strips_surrounding_whitespace() -> None:
+    """SC-1.4: a pasted trailing newline is stripped; internal token is intact."""
+    from types import SimpleNamespace
+
+    from discord_ferry.gui_tools import _TokenSource
+
+    src = _TokenSource(session=None, field=SimpleNamespace(value="  tok\n"))
+    assert src.resolve() == "tok"
+
+
 def test_safe_push_masks_token() -> None:
     """SC-1.3: a token in a log-widget line is masked at the push site.
 
@@ -184,18 +223,71 @@ def test_check_rows_one_per_result_with_status_and_detail() -> None:
     assert report.counts()["fail"] == 1
 
 
-async def test_check_page_bounces_without_token(
+async def test_check_page_shows_token_field_when_session_empty(
     user: User,
     user_store: dict[str, object],
     tab_store: dict[str, object],
 ) -> None:
-    """SC-1.6: the session-expired guard fires from the page builder."""
+    """SC-1.5: no session token -> a token field, not the dead-end message."""
     user_store["stoat_url"] = "https://example.invalid"
     tab_store.pop("token", None)
 
     await user.open("/tools/check")
-    await user.should_see("Session expired")
-    await user.should_not_see("Run check")
+    await user.should_see("Stoat token")
+    await user.should_see("Run check")
+    await user.should_not_see("Session expired")
+
+
+async def test_check_page_refuses_run_with_empty_token(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-1.7: empty field -> the engine is never called."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    called = False
+
+    async def spy_check(*a, **k):  # type: ignore[no-untyped-def]
+        nonlocal called
+        called = True
+        raise AssertionError("run_check must not be reached with an empty token")
+
+    with patch("discord_ferry.gui_tools.run_check", new=spy_check):
+        await user.open("/tools/check")
+        user.find("Run check").click()
+    assert called is False
+
+
+async def test_check_page_uses_entered_token_when_session_empty(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-1.6: a filled field flows into run_check as the token arg."""
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)
+    tab_store.pop("token", None)
+
+    seen: dict[str, object] = {}
+
+    async def fake_check(stoat_url, token, state, on_event, *, session=None):  # type: ignore[no-untyped-def]
+        seen["token"] = token
+        from discord_ferry.migrator.verify import CheckReport
+
+        return CheckReport()
+
+    with (
+        patch("discord_ferry.gui_tools.load_state", return_value=object()),
+        patch("discord_ferry.gui_tools.run_check", new=fake_check),
+    ):
+        await user.open("/tools/check")
+        user.find("Stoat token").elements.pop().set_value(_TOKEN)
+        user.find("Run check").click()
+        await user.should_see("passed")  # verdict rendered after the run
+    assert seen["token"] == _TOKEN
 
 
 async def test_check_page_streams_banners_and_renders_table(
@@ -362,13 +454,13 @@ async def test_probe_page_bounces_without_token(
     user_store: dict[str, object],
     tab_store: dict[str, object],
 ) -> None:
-    """Chunk 6 Task 14: probe shows the session-expired guard when the tab store is empty."""
+    """SC-2.2: probe shows a token field, not the session-expired dead end (#524)."""
     user_store["stoat_url"] = "https://example.invalid"
     tab_store.pop("token", None)
 
     await user.open("/tools/probe")
-    await user.should_see("Session expired")
-    await user.should_not_see("Run probe")
+    await user.should_see("Stoat token")
+    await user.should_not_see("Session expired")
 
 
 async def test_probe_page_requires_test_server_id(
@@ -542,13 +634,13 @@ async def test_build_page_bounces_without_token(
     user_store: dict[str, object],
     tab_store: dict[str, object],
 ) -> None:
-    """Chunk 8 Task 16: the build page shows the session-expired guard with no token."""
+    """SC-2.2: the build page shows a token field, not the session-expired dead end (#524)."""
     user_store["stoat_url"] = "https://example.invalid"
     tab_store.pop("token", None)
 
     await user.open("/tools/build")
-    await user.should_see("Session expired")
-    await user.should_not_see("Build server")
+    await user.should_see("Stoat token")
+    await user.should_not_see("Session expired")
 
 
 async def test_build_page_shows_no_rollback_notice(
@@ -1060,3 +1152,38 @@ async def test_tls_check_page_renders_both_groups(
         await user.should_see("certifi+system")
         await user.should_see("Proxy")
         await user.should_see("proxy-source")
+
+
+@pytest.mark.parametrize(
+    "route",
+    ["/tools/check", "/tools/repair", "/tools/retry", "/tools/probe", "/tools/build"],
+)
+async def test_every_token_page_shows_field_when_session_empty(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    route: str,
+) -> None:
+    """SC-2.1: the extracted _token_source helper reaches all five token pages."""
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    await user.open(route)
+    await user.should_see("Stoat token")
+    await user.should_not_see("Session expired")
+
+
+async def test_check_page_defaults_dir_from_stashed_output_dir(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path,  # type: ignore[no-untyped-def]
+) -> None:
+    """SC-I1: arriving from the completion card (empty session, stashed dir) recovers."""
+    user_store["stoat_url"] = "https://example.invalid"
+    user_store["output_dir"] = str(tmp_path)  # written by the #518 button
+    tab_store.pop("token", None)
+
+    await user.open("/tools/check")
+    await user.should_see("Stoat token")  # field shown, not a dead end
+    await user.should_see(str(tmp_path))  # dir input defaulted from the stash

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.27.0"
+version = "2.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Links a finished migration's completion screen straight to the Verify and Repair tool pages, and makes those pages usable when the session token has been cleared.

- **#524** (blocker): the five token-taking tool pages (check, repair, retry, probe, build) now show a password token field instead of a dead-end "Session expired" message when the session store is empty. A shared `_token_source()` helper returns the session token when present, otherwise renders the field and resolves the typed value at run time. An empty field refuses the run and makes no request. The entered token stays in memory for the run and is never written to disk.
- **#518**: the completion card gains **Verify** and **Repair** buttons that open the check and repair pages for the migration that just finished, carrying its output directory across.

#524 comes first because a migration clears the session token on completion, so without it the deep-link would land on "Session expired" with no recovery.

## Testing

- New `_TokenSource.resolve()` unit tests (session present, field filled, empty/whitespace, whitespace-stripped).
- A cross-page parametrized test proving the helper reaches all five token pages; per-page field/refuse/entered-token tests on check; probe and build bounce tests updated.
- #518 driven through the NiceGUI `User` sim: Verify lands on the check page, Repair on the repair page, and the output directory is stashed.
- Full suite: 2287 passed. Ruff, format, and `mypy --strict` clean.

## Reviews

Fresh code review and Codex second opinion both clean (one docstring accuracy fix applied). Deferral sweep clean; no deferrals introduced.

Closes #524
Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
