### PR TITLE
feat(repair): restore a recreated role's colour, hoist and icon (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **`ferry repair` restores a recreated role's colour, hoist and icon.** When repair recreates a
+  role that was deleted from a migrated server, it now sets the role's colour, hoist setting and
+  icon (the icon is re-fetched from Discord and re-uploaded) the same way the original migration
+  did, provided the Discord metadata is present. Rank is still restored only by a full
+  `--incremental` re-run, and a role with no Discord metadata is still declined with a warning.
+  Closes #344.
+
 ## [2.29.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [2.30.0] - 2026-08-21
 
 ### Added
 

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -172,10 +172,12 @@ Ferry originally gave it, and that name is recorded only from 2.17.0 onward. Whe
 repair declines and says so rather than inventing one: an entity restored under a different name
 looks repaired and is not.
 
-**A recreated role comes back without its colour, rank, hoist setting or icon.** Repair restores a
-role's name and its permissions. The rest is set by separate calls during a migration, and the icon
-is an uploaded file whose identifier cannot be reused, so repair records a warning naming the role
-rather than restoring them. Set them by hand, or re-run the migration with `--incremental`.
+**A recreated role's rank is not restored by repair itself.** Repair restores a recreated role's
+name, permissions, colour, hoist setting and icon when Discord metadata is present, and a role icon
+is re-fetched from Discord and re-uploaded. Rank is the exception: the per-role edit cannot set it,
+so a full `--incremental` re-run restores position. With no Discord metadata (no token at migration
+time, or the role absent from it) colour, hoist and icon cannot be restored either, and repair
+records a warning naming the role.
 
 **Repair never renames anything.** A renamed channel, role or category is reported by the check as a
 warning and left alone, because a rename almost always means you made it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.29.0"
+version = "2.30.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.29.0"
+__version__ = "2.30.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -71,8 +71,10 @@ from discord_ferry.migrator.pins import run_pins
 from discord_ferry.migrator.reactions import run_reactions
 from discord_ferry.migrator.structure import (
     _generate_category_id,
+    _role_from_metadata,
     _stoat_channel_type,
     apply_channel_permissions,
+    apply_role_attributes,
     apply_role_permissions,
     make_unique_channel_name,
     run_categories,
@@ -2396,20 +2398,6 @@ async def run_repair(
                 if result.kind == "role_missing":
                     role_created = await _recreate_role(sess, config, state, result, on_event)
                     if role_created:
-                        # DECLINED, and said so rather than left silent. The
-                        # migration sets a role's colour, hoist and icon through
-                        # api_edit_role, and the icon path uploads a file to
-                        # Autumn. Rank is NOT among them since #380: the per-role
-                        # PATCH discards that field, and ordering now goes through
-                        # _apply_role_ordering, which recomputes the whole server
-                        # from a read-back. So an --incremental re-run does now
-                        # restore this role's position, which is why that advice
-                        # stays in the message below. Restoring the rest is a second
-                        # content path in a batch already carrying two commands,
-                        # and the reasoning that keeps emoji out of repair (#307)
-                        # applies to the icon. Recorded whether or not metadata
-                        # exists, because the attributes are lost either way.
-                        # Deferred as #344.
                         role_label = state.created_role_names.get(discord_id, discord_id)
                         outcome.recreated_roles.append(
                             {
@@ -2418,18 +2406,40 @@ async def run_repair(
                                 "name": role_label,
                             }
                         )
-                        state.warnings.append(
-                            {
-                                "phase": "repair",
-                                "type": "role_attributes_not_restored",
-                                "message": (
-                                    f"Role '{role_label}' was recreated with its name and "
-                                    "permissions. Its colour, rank, hoist setting and icon are "
-                                    "not restored: set them by hand, or re-run the migration "
-                                    "with --incremental (see issue #344)."
-                                ),
-                            }
-                        )
+                        # Colour, hoist and icon live in Discord metadata. With a
+                        # RoleMeta for this role we restore them the same way the
+                        # migration does (apply_role_attributes); the icon is
+                        # re-fetched from Discord's CDN and re-uploaded to Autumn.
+                        # With none (no metadata file, or the role absent from it)
+                        # there is no source, so we decline and say so. Rank is NOT
+                        # restored here: the per-role PATCH discards it and ordering
+                        # goes through _apply_role_ordering, so an --incremental
+                        # re-run restores position. See #344.
+                        role_meta = metadata.role_metadata.get(discord_id) if metadata else None
+                        if role_meta is not None:
+                            await apply_role_attributes(
+                                sess,
+                                config,
+                                state,
+                                state.role_map[discord_id],
+                                _role_from_metadata(discord_id, role_meta),
+                                role_meta,
+                                phase="repair",
+                            )
+                        else:
+                            state.warnings.append(
+                                {
+                                    "phase": "repair",
+                                    "type": "role_attributes_not_restored",
+                                    "message": (
+                                        f"Role '{role_label}' was recreated with its name and "
+                                        "permissions. Its colour, hoist setting and icon are not "
+                                        "restored (no Discord metadata for it): set them by hand, "
+                                        "or re-run the migration with --incremental (see issue "
+                                        "#344)."
+                                    ),
+                                }
+                            )
                     if role_created and metadata:
                         # ONE role. The server-default call that follows the loop
                         # this helper was extracted from is deliberately not here:

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -455,6 +455,84 @@ def _role_from_metadata(role_id: str, rm: RoleMeta) -> DCERole:
     return DCERole(id=role_id, name=rm.name, color=rm.color or None, position=rm.position)
 
 
+async def apply_role_attributes(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    stoat_role_id: str,
+    role: DCERole,
+    rm: RoleMeta | None,
+    *,
+    phase: str,
+) -> None:
+    """Set ONE role's colour, hoist and icon. Shared by run_roles and repair.
+
+    Colour comes from ``role.color``; hoist and icon from ``rm`` (Discord
+    metadata). Every warning is tagged with ``phase`` so the repair --json
+    declined set can see failures that happen during a repair. Rank is not set
+    here: the per-role PATCH discards it, and ordering lives in
+    ``_apply_role_ordering``.
+    """
+    if role.color:
+        color_str = role.color.lstrip("#")
+        try:
+            colour_int = int(color_str, 16)
+            await api_edit_role(
+                session,
+                config.stoat_url,
+                config.token,
+                state.stoat_server_id,
+                stoat_role_id,
+                colour=colour_int,
+            )
+        except (ValueError, MigrationError) as exc:
+            state.warnings.append(
+                {
+                    "phase": phase,
+                    "type": "role_colour_failed",
+                    "message": f"Failed to set colour for role '{role.name}': {exc}",
+                }
+            )
+    edit_kwargs: dict[str, Any] = {}
+    if rm is not None:
+        edit_kwargs["hoist"] = rm.hoist
+        if rm.icon_hash:
+            icon_id = await _resolve_role_icon(
+                session, config, state, role.name, role.id, rm.icon_hash, phase=phase
+            )
+            if icon_id is not None:
+                edit_kwargs["icon"] = icon_id
+        elif rm.unicode_emoji:
+            state.warnings.append(
+                {
+                    "phase": phase,
+                    "type": "role_icon_skipped",
+                    "message": (
+                        f"Role '{role.name}' has an emoji icon (not migratable to Stoat)."
+                    ),
+                }
+            )
+    if not edit_kwargs:
+        return
+    try:
+        await api_edit_role(
+            session,
+            config.stoat_url,
+            config.token,
+            state.stoat_server_id,
+            stoat_role_id,
+            **edit_kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.warnings.append(
+            {
+                "phase": phase,
+                "type": "role_attributes_failed",
+                "message": (f"Failed to set attributes for role '{role.name}': {exc}"),
+            }
+        )
+
+
 async def apply_role_permissions(
     session: aiohttp.ClientSession,
     config: FerryConfig,
@@ -849,65 +927,15 @@ async def run_roles(
             attribute_role_id = state.role_map.get(role.id)
             if not attribute_role_id:
                 continue
-            if role.color:
-                color_str = role.color.lstrip("#")
-                try:
-                    colour_int = int(color_str, 16)
-                    await api_edit_role(
-                        session,
-                        config.stoat_url,
-                        config.token,
-                        state.stoat_server_id,
-                        attribute_role_id,
-                        colour=colour_int,
-                    )
-                except (ValueError, MigrationError) as exc:
-                    state.warnings.append(
-                        {
-                            "phase": "roles",
-                            "type": "role_colour_failed",
-                            "message": f"Failed to set colour for role '{role.name}': {exc}",
-                        }
-                    )
-            edit_kwargs: dict[str, Any] = {}
-            rm = role_meta.get(role.id)
-            if rm is not None:
-                edit_kwargs["hoist"] = rm.hoist
-                if rm.icon_hash:
-                    icon_id = await _resolve_role_icon(
-                        session, config, state, role.name, role.id, rm.icon_hash
-                    )
-                    if icon_id is not None:
-                        edit_kwargs["icon"] = icon_id
-                elif rm.unicode_emoji:
-                    state.warnings.append(
-                        {
-                            "phase": "roles",
-                            "type": "role_icon_skipped",
-                            "message": (
-                                f"Role '{role.name}' has an emoji icon (not migratable to Stoat)."
-                            ),
-                        }
-                    )
-            if not edit_kwargs:
-                continue
-            try:
-                await api_edit_role(
-                    session,
-                    config.stoat_url,
-                    config.token,
-                    state.stoat_server_id,
-                    attribute_role_id,
-                    **edit_kwargs,
-                )
-            except Exception as exc:  # noqa: BLE001
-                state.warnings.append(
-                    {
-                        "phase": "roles",
-                        "type": "role_attributes_failed",
-                        "message": (f"Failed to set attributes for role '{role.name}': {exc}"),
-                    }
-                )
+            await apply_role_attributes(
+                session,
+                config,
+                state,
+                attribute_role_id,
+                role,
+                role_meta.get(role.id),
+                phase="roles",
+            )
     if discord_metadata is None:
         on_event(
             MigrationEvent(

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -380,8 +380,14 @@ async def _resolve_role_icon(
     role_name: str,
     role_id: str,
     icon_hash: str,
+    *,
+    phase: str = "roles",
 ) -> str | None:
     """Download a role icon, upload to Autumn, return the attachment id or None.
+
+    ``phase`` tags the two failure warnings so a repair caller's failures land in
+    the ``phase == "repair"`` declined set rather than under ``"roles"``. The
+    default keeps the migration call site on ``"roles"``.
 
     Token-safe: an AutumnUploadError (which may carry the HTTP body) is never
     interpolated into a warning. The temp file is always cleaned up.
@@ -390,7 +396,7 @@ async def _resolve_role_icon(
     if icon_bytes is None:
         state.warnings.append(
             {
-                "phase": "roles",
+                "phase": phase,
                 "type": "role_icon_download_failed",
                 "message": f"Role icon download failed for role '{role_name}'.",
             }
@@ -431,7 +437,7 @@ async def _resolve_role_icon(
         hint = proxy_hint(exc, target=state.autumn_url) or tls_hint(exc) or ""
         state.warnings.append(
             {
-                "phase": "roles",
+                "phase": phase,
                 "type": "role_icon_upload_failed",
                 "message": f"Role icon upload failed for role '{role_name}'.{hint}",
             }

--- a/src/discord_ferry/migrator/structure.py
+++ b/src/discord_ferry/migrator/structure.py
@@ -507,9 +507,7 @@ async def apply_role_attributes(
                 {
                     "phase": phase,
                     "type": "role_icon_skipped",
-                    "message": (
-                        f"Role '{role.name}' has an emoji icon (not migratable to Stoat)."
-                    ),
+                    "message": (f"Role '{role.name}' has an emoji icon (not migratable to Stoat)."),
                 }
             )
     if not edit_kwargs:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -143,6 +143,20 @@ UNREPAIRED_WARNING_TYPES = frozenset(
         # keeps the old id (#307).
         "emoji_missing_media",
         "emoji_rewrite_failed",
+        # Repair TRIED to restore a recreated role's colour, hoist or icon and the
+        # Stoat/Autumn API call FAILED, so the role's appearance is left incomplete.
+        # Same shape as emoji_rewrite_failed: attempted, failed, something remains
+        # broken. These fire with phase == "repair" only via apply_role_attributes'
+        # repair caller; a migration-time failure carries phase == "roles" and the
+        # exit code scans this run's repair-phase warnings only, so it is unaffected.
+        # role_attributes_not_restored is deliberately ABSENT, like no_discord_metadata:
+        # it names the no-metadata degradation (the role was recreated, there was no
+        # source for its appearance), whose documented remedy is an --incremental
+        # re-run, not a failed operation (#344).
+        "role_colour_failed",
+        "role_attributes_failed",
+        "role_icon_download_failed",
+        "role_icon_upload_failed",
     }
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3020,6 +3020,44 @@ def test_repair_exits_non_zero_when_an_emoji_could_not_be_recreated(
     )
 
 
+def test_repair_exits_non_zero_when_a_role_attribute_edit_failed(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A repair-time role attribute API failure leaves the role incomplete (#344).
+
+    Repair tried to restore the colour/hoist/icon and the Stoat/Autumn call failed,
+    so the role's appearance is left broken. Same shape as emoji_rewrite_failed: the
+    exit code must say the migration is not whole.
+    """
+    outcome = RepairOutcome(
+        declined=[{"type": "role_icon_upload_failed", "message": "Role icon upload failed"}]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome)
+    assert result.exit_code == 1, (
+        f"a failed role attribute repair exited {result.exit_code}, which reads as success"
+    )
+
+
+def test_repair_exits_zero_when_only_role_attributes_were_not_restored(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """role_attributes_not_restored is a no-metadata degradation, not a failure (#344).
+
+    The role WAS recreated; there was simply no Discord metadata to restore its
+    appearance from, and the documented remedy is an --incremental re-run. Like
+    no_discord_metadata, it must not push the exit code to 1.
+    """
+    outcome = RepairOutcome(
+        declined=[
+            {"type": "role_attributes_not_restored", "message": "colour/hoist/icon not restored"}
+        ]
+    )
+    result = _invoke_repair(runner, tmp_path, outcome)
+    assert result.exit_code == 0, (
+        f"a no-metadata attribute degradation exited {result.exit_code}, which reads as a defect"
+    )
+
+
 def test_repair_exits_non_zero_when_an_emoji_rewrite_failed(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3237,12 +3237,41 @@ async def _repair_recreating_role(
     *,
     recorded_name: str | None = "moderator",
     create_payload: dict[str, Any] | None = None,
+    role_meta: Any = None,
+    metadata_present: bool = False,
+    capture_edits: list[dict[str, object]] | None = None,
+    autumn_upload_status: int = 200,
 ) -> tuple[MigrationState, list[Any], list[MigrationEvent]]:
-    """Drive run_repair against one role_missing result."""
+    """Drive run_repair against one role_missing result.
+
+    ``role_meta`` (a RoleMeta) writes a discord_metadata.json carrying it under
+    D_ROLE, so repair restores the role's attributes. ``metadata_present`` writes
+    a metadata file with NO RoleMeta for the role (the "role absent from
+    role_metadata" case). ``capture_edits`` collects every role-edit PATCH body.
+    """
+    from discord_ferry.discord.metadata import (
+        DiscordMetadata,
+        save_discord_metadata,
+    )
+
     config = _make_repair_config(tmp_path)
-    state = MigrationState(stoat_server_id=R_SERVER, role_map={D_ROLE: S_ROLE_OLD})
+    state = MigrationState(
+        stoat_server_id=R_SERVER, role_map={D_ROLE: S_ROLE_OLD}, autumn_url=AUTUMN_URL
+    )
     if recorded_name is not None:
         state.created_role_names[D_ROLE] = recorded_name
+
+    if role_meta is not None or metadata_present:
+        meta = DiscordMetadata(
+            guild_id="g",
+            fetched_at="t",
+            server_default_permissions=0,
+            role_permissions={},
+            channel_metadata={},
+            role_metadata={D_ROLE: role_meta} if role_meta is not None else {},
+        )
+        save_discord_metadata(meta, config.output_dir)
+
     events: list[MigrationEvent] = []
 
     report = CheckReport()
@@ -3258,9 +3287,17 @@ async def _repair_recreating_role(
     async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
         return report
 
+    def _capture_patch(url: object, **kwargs: Any) -> None:
+        if capture_edits is not None:
+            capture_edits.append(kwargs.get("json", {}))
+
     with (
         patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
         patch.object(engine_module, "save_state", lambda *a, **k: None),
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
         aioresponses() as m,
     ):
         m.get(
@@ -3272,6 +3309,13 @@ async def _repair_recreating_role(
             f"{BASE_URL}/servers/{R_SERVER}/roles",
             payload=create_payload if create_payload is not None else {"id": S_ROLE_NEW},
         )
+        m.patch(
+            f"{BASE_URL}/servers/{R_SERVER}/roles/{S_ROLE_NEW}",
+            payload={},
+            repeat=True,
+            callback=_capture_patch,  # type: ignore[arg-type]
+        )
+        m.post(f"{AUTUMN_URL}/icons", payload={"id": "autumn-icon-id"}, status=autumn_upload_status)
         await run_repair(config, state, [], events.append)
         requests = list(m.requests)
     return state, requests, events
@@ -4821,21 +4865,78 @@ async def test_a_recreated_channel_with_no_attributes_sends_no_edit(tmp_path: Pa
 
 
 async def test_a_recreated_role_says_its_attributes_are_not_restored(tmp_path: Path) -> None:
-    """A DECLINE, recorded rather than silent.
+    """A DECLINE when there is no Discord metadata to restore from.
 
-    The migration sets a role's colour, rank, hoist and icon in two further
-    api_edit_role passes, and the icon one uploads a file to Autumn. Restoring
-    those is a second content path in a batch already carrying two commands, and
-    the reasoning that keeps emoji out of repair applies to the icon too.
-
-    Declining is defensible. Declining silently is not: the operator would see a
-    role that looks restored and is uncoloured and unranked.
+    Colour, hoist and icon live in Discord metadata. With no metadata file, repair
+    has no source for them, so it declines and says so rather than leaving a role
+    that looks restored and is uncoloured. Rank is restored only by an
+    --incremental re-run either way (see #344).
     """
-    state, _, _ = await _repair_recreating_role(tmp_path)
+    state, _, _ = await _repair_recreating_role(tmp_path)  # no metadata
     assert any(
         w.get("type") == "role_attributes_not_restored" and "#344" in w["message"]
         for w in state.warnings
     ), f"the role attribute decline was not recorded: {state.warnings}"
+
+
+async def test_repair_restores_colour_and_hoist_when_metadata_present(tmp_path: Path) -> None:
+    """With a RoleMeta, repair restores colour and hoist and does NOT decline."""
+    from discord_ferry.discord.metadata import RoleMeta
+
+    edits: list[dict[str, object]] = []
+    state, _, _ = await _repair_recreating_role(
+        tmp_path,
+        role_meta=RoleMeta(hoist=True, color="#3498db", name="moderator"),
+        capture_edits=edits,
+    )
+    assert any(e.get("colour") == 0x3498DB for e in edits), edits
+    assert any(e.get("hoist") is True for e in edits), edits
+    assert not any(
+        w.get("type") == "role_attributes_not_restored" for w in state.warnings
+    ), state.warnings
+
+
+async def test_repair_restores_icon_when_metadata_has_hash(tmp_path: Path) -> None:
+    """A RoleMeta with an icon_hash drives a re-download, an Autumn upload, and an icon edit."""
+    from discord_ferry.discord.metadata import RoleMeta
+
+    edits: list[dict[str, object]] = []
+    state, requests, _ = await _repair_recreating_role(
+        tmp_path,
+        role_meta=RoleMeta(icon_hash="abc", name="moderator"),
+        capture_edits=edits,
+    )
+    assert any("/icons" in str(k[1]) for k in requests), requests
+    assert any(e.get("icon") == "autumn-icon-id" for e in edits), edits
+    assert not any(
+        w.get("type") == "role_attributes_not_restored" for w in state.warnings
+    ), state.warnings
+
+
+async def test_repair_skips_an_emoji_role_icon(tmp_path: Path) -> None:
+    """An emoji icon (unicode_emoji, no icon_hash) is skipped, tagged phase=repair."""
+    from discord_ferry.discord.metadata import RoleMeta
+
+    state, requests, _ = await _repair_recreating_role(
+        tmp_path,
+        role_meta=RoleMeta(unicode_emoji="\U0001f600", name="moderator"),
+    )
+    assert any(
+        w.get("type") == "role_icon_skipped" and w.get("phase") == "repair"
+        for w in state.warnings
+    ), state.warnings
+    assert not any("/icons" in str(k[1]) for k in requests), requests
+
+
+async def test_repair_declines_when_role_absent_from_metadata(tmp_path: Path) -> None:
+    """Metadata present, but no RoleMeta for this role: still declined, no attribute edit."""
+    state, requests, _ = await _repair_recreating_role(tmp_path, metadata_present=True)
+    assert any(
+        w.get("type") == "role_attributes_not_restored" for w in state.warnings
+    ), state.warnings
+    assert not any(
+        k[0] == "PATCH" and str(k[1]).endswith(f"/roles/{S_ROLE_NEW}") for k in requests
+    ), requests
 
 
 async def test_re_attaching_removes_the_dead_channel_id(tmp_path: Path) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4891,9 +4891,9 @@ async def test_repair_restores_colour_and_hoist_when_metadata_present(tmp_path: 
     )
     assert any(e.get("colour") == 0x3498DB for e in edits), edits
     assert any(e.get("hoist") is True for e in edits), edits
-    assert not any(
-        w.get("type") == "role_attributes_not_restored" for w in state.warnings
-    ), state.warnings
+    assert not any(w.get("type") == "role_attributes_not_restored" for w in state.warnings), (
+        state.warnings
+    )
 
 
 async def test_repair_restores_icon_when_metadata_has_hash(tmp_path: Path) -> None:
@@ -4908,9 +4908,9 @@ async def test_repair_restores_icon_when_metadata_has_hash(tmp_path: Path) -> No
     )
     assert any("/icons" in str(k[1]) for k in requests), requests
     assert any(e.get("icon") == "autumn-icon-id" for e in edits), edits
-    assert not any(
-        w.get("type") == "role_attributes_not_restored" for w in state.warnings
-    ), state.warnings
+    assert not any(w.get("type") == "role_attributes_not_restored" for w in state.warnings), (
+        state.warnings
+    )
 
 
 async def test_repair_skips_an_emoji_role_icon(tmp_path: Path) -> None:
@@ -4922,8 +4922,7 @@ async def test_repair_skips_an_emoji_role_icon(tmp_path: Path) -> None:
         role_meta=RoleMeta(unicode_emoji="\U0001f600", name="moderator"),
     )
     assert any(
-        w.get("type") == "role_icon_skipped" and w.get("phase") == "repair"
-        for w in state.warnings
+        w.get("type") == "role_icon_skipped" and w.get("phase") == "repair" for w in state.warnings
     ), state.warnings
     assert not any("/icons" in str(k[1]) for k in requests), requests
 
@@ -4931,9 +4930,9 @@ async def test_repair_skips_an_emoji_role_icon(tmp_path: Path) -> None:
 async def test_repair_declines_when_role_absent_from_metadata(tmp_path: Path) -> None:
     """Metadata present, but no RoleMeta for this role: still declined, no attribute edit."""
     state, requests, _ = await _repair_recreating_role(tmp_path, metadata_present=True)
-    assert any(
-        w.get("type") == "role_attributes_not_restored" for w in state.warnings
-    ), state.warnings
+    assert any(w.get("type") == "role_attributes_not_restored" for w in state.warnings), (
+        state.warnings
+    )
     assert not any(
         k[0] == "PATCH" and str(k[1]).endswith(f"/roles/{S_ROLE_NEW}") for k in requests
     ), requests

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -36,6 +36,13 @@ def test_repair_failure_set_is_shared_and_exact() -> None:
                 # restore of a recreated emoji), matching the CLI comment.
                 "emoji_missing_media",
                 "emoji_rewrite_failed",
+                # #344 role attribute repair: an attempted-and-failed colour, hoist
+                # or icon edit leaves the role's appearance broken. role_attributes_not_restored
+                # is excluded (the no-metadata degradation, no_discord_metadata shape).
+                "role_colour_failed",
+                "role_attributes_failed",
+                "role_icon_download_failed",
+                "role_icon_upload_failed",
             }
         )
         == UNREPAIRED_WARNING_TYPES

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -24,6 +24,8 @@ from discord_ferry.errors import AutumnUploadError, MigrationError
 from discord_ferry.migrator.structure import (
     FERRY_MIN_PERMISSIONS,
     _apply_role_ordering,
+    _resolve_role_icon,
+    get_session,
     make_unique_channel_name,
     run_categories,
     run_channels,
@@ -2842,6 +2844,42 @@ async def test_run_roles_icon_upload_failure_degrades(tmp_path: Path) -> None:
     # SC-18 token-safety: the warning carries no response body and no token.
     for w in icon_warnings:
         assert "SENTINEL_BODY" not in w["message"]
+        assert config.token not in w["message"]
+
+
+async def test_resolve_role_icon_tags_failure_with_caller_phase(tmp_path: Path) -> None:
+    """The phase arg decides which warning bucket an icon failure lands in.
+
+    Repair's --json declined set filters phase == "repair"; without this the
+    failure would sit only under "roles" and never surface there. Default keeps
+    the migration path on "roles".
+    """
+    config = _make_config(tmp_path)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+
+    with (
+        aioresponses() as m,
+        patch(
+            "discord_ferry.migrator.structure.download_role_icon",
+            new=AsyncMock(return_value=b"pngbytes"),
+        ),
+    ):
+        # Autumn upload fails, so _resolve_role_icon appends role_icon_upload_failed.
+        m.post(f"{AUTUMN_URL}/icons", status=500, body=b"nope", repeat=True)
+        async with get_session(config) as session:
+            repair_result = await _resolve_role_icon(
+                session, config, state, "moderator", "111", "abc", phase="repair"
+            )
+            default_result = await _resolve_role_icon(
+                session, config, state, "moderator", "111", "abc"
+            )
+
+    assert repair_result is None
+    assert default_result is None
+    upload_failures = [w for w in state.warnings if w["type"] == "role_icon_upload_failed"]
+    assert any(w["phase"] == "repair" for w in upload_failures), state.warnings
+    assert any(w["phase"] == "roles" for w in upload_failures), state.warnings
+    for w in upload_failures:
         assert config.token not in w["message"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.29.0"
+version = "2.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #344.

`ferry repair` now restores a recreated role's colour, hoist and icon when Discord metadata is present, not only its name and permissions. Rank stays with a full `--incremental` re-run.

## What changed
- Extracted the migration's per-role colour/hoist/icon logic into a shared `apply_role_attributes` helper (mirroring `apply_role_permissions`), called by both `run_roles` and the repair `role_missing` branch.
- `_resolve_role_icon` gained a `phase` parameter so a repair-time icon failure is tagged `phase="repair"` and reaches the repair declined set.
- The declined `role_attributes_not_restored` warning now fires only when there is no `RoleMeta` to restore from (metadata absent, or the role absent from `role_metadata`).
- The role icon is re-fetched from Discord's CDN and re-uploaded to Autumn, so the #307 emoji "un-reproducible asset id" wall does not apply here.

## Exit code
The four attempted-and-failed role warning types (`role_colour_failed`, `role_attributes_failed`, `role_icon_download_failed`, `role_icon_upload_failed`) join `UNREPAIRED_WARNING_TYPES`, so a repair that tried to restore an attribute and hit an API failure exits 1, matching the `emoji_rewrite_failed` precedent. `role_attributes_not_restored` stays excluded (the no-metadata degradation, `no_discord_metadata` shape).

## Review
Fresh-context critique passed at round 2 (two round-1 Criticals fixed). The whole-branch review caught the exit-code false-green that the chunk review and two second opinions missed; fixed in this branch with tests. Full suite green (2279 before the exit-code fix, plus the pinning-test update).

Plan chunk #543, tasks #544-547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
