### PR TITLE
feat(repair): recreate a missing forum index; idempotent rebuild (#311, #215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.31.0] - 2026-08-22
+
+### Added
+
+- **`ferry repair` recreates and rebuilds a missing forum index.** When a forum's index channel is
+  deleted from a migrated server, repair now recreates it, puts it back at the top of its forum
+  category, and rebuilds its pinned index message from Ferry's own record of the forum's posts,
+  instead of declining. A forum index whose channel survives but whose message alone was deleted is
+  rebuilt in place. If the forum's own category is also gone and cannot be restored this run, repair
+  declines that index with a clear warning and a non-zero exit. Closes #311.
+
+### Fixed
+
+- **A forum-index rebuild no longer posts a duplicate index message on a later run.** When Stoat
+  accepted the index message as a duplicate, Ferry recorded nothing, so the next run sent it again
+  once Stoat's idempotency cache had evicted the key. Ferry now records that the index is present
+  with an unknown id and skips the resend, leaving the existing message in place rather than adding a
+  second copy. Closes #215.
+
 ## [2.30.0] - 2026-08-21
 
 ### Added

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -137,7 +137,7 @@ These limitations relate to platform-level features that either work differently
 
 **A channel your token cannot read reports `unverifiable`.** Check can tell this apart from a deleted channel, because the server lists every channel's identifier even when it will not return the channel itself.
 
-**A duplicate forum index message is not detected.** Ferry records only the most recent index message it posted.
+**A forum index whose message id was lost is not refreshed.** If Stoat accepts the index message as a duplicate, it returns no identifier, so Ferry cannot edit that message on a later run. It records the index as present and leaves its counts as they were, rather than posting a second copy.
 
 **Check refuses to run against a dry run.** A dry run records placeholders for channels and messages that were never created, so there is nothing on a server to compare them with.
 
@@ -160,9 +160,10 @@ parent that absorbed thread content, it restores the parent's own messages and r
 naming each thread it left behind. `flatten`, the default, gives every thread its own channel and is
 restored completely.
 
-**A missing forum index channel is declined.** Its index message is generated from the forum's
-posts rather than copied from the export, so there is nothing to re-send. Re-run the migration with
-`--incremental` to rebuild it.
+**A missing forum index is recreated and rebuilt.** Repair recreates the index channel, puts it
+back at the top of its forum category, and rebuilds its pinned index message from Ferry's own record
+of the forum's posts. If the forum's category was also deleted and this run cannot restore it,
+repair declines the index and says so.
 
 **A missing custom emoji is declined.** An emoji's identifier on Stoat *is* its uploaded file, so
 recreating one produces a different emoji that merely looks the same.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.30.0"
+version = "2.31.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.30.0"
+__version__ = "2.31.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1810,6 +1810,89 @@ async def _recreate_channel(
     return True
 
 
+async def _recreate_forum_index(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    result: CheckResult,
+    existing_names: set[str],
+    live_categories: list[dict[str, Any]],
+    on_event: EventCallback,
+) -> bool:
+    """Recreate a missing forum-index channel and rebuild its index message (#311).
+
+    The forum index is stored under a synthetic ``forum-index-{forum_key}`` key whose
+    value is a real Stoat channel id, so a deleted one reports ``channel_missing`` like
+    any channel. Generic recreation cannot restore it: ``_recreate_channel`` declines a
+    key with no matching export, and ``_reattach_to_category`` resolves its target through
+    ``state.channel_categories`` (keyed by real Discord ids), which never holds the
+    synthetic key. This helper does both directly, then delegates the message to the
+    shared ``_rebuild_one_forum_index``. Returns True when the channel was recreated.
+    """
+    discord_id = result.discord_id or ""
+    forum_key = discord_id.removeprefix("forum-index-")
+
+    # The forum category must exist to attach the index to. If it is gone and cannot be
+    # restored from this run, decline distinctly rather than create an orphan channel.
+    stoat_category_id = state.category_map.get(forum_key)
+    if not stoat_category_id:
+        message = (
+            f"Cannot recreate the forum index for '{forum_key}': its forum category is "
+            "gone and not in this run to restore from. Re-run the migration with the "
+            "original export to rebuild the forum."
+        )
+        state.warnings.append(
+            {"phase": "repair", "type": "forum_index_category_missing", "message": message}
+        )
+        on_event(MigrationEvent(phase="repair", status="warning", message=message))
+        return False
+
+    recorded = state.created_channel_names.get(discord_id, discord_id)
+    unique_name = make_unique_channel_name(recorded, existing_names)
+    created = await api_create_channel(
+        session,
+        config.stoat_url,
+        config.token,
+        state.stoat_server_id,
+        name=unique_name,
+        channel_type="Text",
+    )
+    new_id: str = created["_id"]
+    state.channel_map[discord_id] = new_id
+    state.created_channel_names[discord_id] = created.get("name") or unique_name
+    existing_names.add(state.created_channel_names[discord_id])
+    save_state(state, config.output_dir)
+
+    # Position 0 of the forum category, mirroring the create path, so the index sits at
+    # the top. NOT via _reattach_to_category, which would no-op on the synthetic key.
+    old_id = result.stoat_id
+    target = next((c for c in live_categories if c.get("id") == stoat_category_id), None)
+    if target is not None and isinstance(target.get("channels"), list):
+        channels = target["channels"]
+        if old_id is not None and old_id in channels:
+            channels.remove(old_id)
+        if new_id not in channels:
+            channels.insert(0, new_id)
+        await api_upsert_categories(
+            session, config.stoat_url, config.token, state.stoat_server_id, live_categories
+        )
+
+    on_event(
+        MigrationEvent(
+            phase="repair",
+            status="progress",
+            message=f"Recreated forum index channel '{state.created_channel_names[discord_id]}'.",
+        )
+    )
+    # Rebuild the index message through the shared helper (sends, pins, records the id,
+    # or marks present-id-unknown on a duplicate). The generic message resend and the
+    # "no discord_metadata" warning are deliberately not run: a forum index names no
+    # Discord channel, so it has zero messages and no ChannelMeta.
+    await _rebuild_one_forum_index(session, config, state, forum_key, on_event)
+    save_state(state, config.output_dir)
+    return True
+
+
 async def _apply_channel_attributes(
     session: aiohttp.ClientSession,
     config: FerryConfig,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2362,30 +2362,37 @@ async def run_repair(
     structure_work: list[CheckResult] = []
     tail_work: list[CheckResult] = []
     emoji_work: list[CheckResult] = []
+    # Forum-index repair (#311). A forum index is stored under a synthetic
+    # `forum-index-{key}` channel id, so it reports channel_missing / tail_absent
+    # like any channel but needs its own path (recreate or rebuild the index
+    # message, not a generic channel restore). Split by kind here.
+    forum_index_work: list[CheckResult] = []
+    forum_index_rebuild_work: list[CheckResult] = []
     for result in report.results:
         is_structure = result.kind in _REPAIRABLE_STRUCTURE
         is_emoji = result.kind in _REPAIRABLE_EMOJI
         if not is_structure and not is_emoji and result.kind not in _REPAIRABLE_TAIL:
             continue
 
-        # The exclusion is tested ONCE, against both families, and that placement
-        # is the fix for a real gap rather than tidiness. Guarding only the
-        # structure branch let a forum index channel with `tail_absent` through
-        # into the tail work, and the tail of a forum index channel IS the index
-        # message: it lives in forum_index_message_ids and has no message in any
-        # export to re-send. Measured during the chunk 3 review.
+        # The prefix is tested ONCE, against every family: a forum index reports
+        # channel_missing (structure) OR tail_absent (tail), and both need the
+        # forum-index path rather than the generic one. Route by kind: a missing
+        # channel recreates, a missing index message rebuilds (the channel is
+        # still there), any other kind declines defensively.
         if (result.discord_id or "").startswith(_UNREPAIRABLE_CHANNEL_PREFIX):
+            if result.kind == "channel_missing":
+                forum_index_work.append(result)
+                continue
+            if result.kind in _REPAIRABLE_TAIL:
+                forum_index_rebuild_work.append(result)
+                continue
+            # No kind other than the two above carries a forum-index id today;
+            # this branch is a defensive decline, not a live path.
             notice = (
                 f"Forum index channel {result.discord_id} needs repair ({result.kind}) and "
-                "repair cannot do it. The index message is derived content with no message "
-                "in the export to restore from, and rebuilding it needs the forum's posts. "
-                "Re-run the migration with --incremental to rebuild it (see issue #311)."
+                "repair cannot do it."
             )
             on_event(MigrationEvent(phase="repair", status="warning", message=notice))
-            # Not under --dry-run. A dry run reports and changes nothing, and
-            # state.warnings is state: mutating it during a preview would leave
-            # an in-memory record the run never persists and the operator never
-            # asked for. The event above carries the same information either way.
             if not config.dry_run:
                 state.warnings.append(
                     {
@@ -2411,7 +2418,8 @@ async def run_repair(
             message=(
                 f"{prefix}{len(structure_work)} entities to recreate, "
                 f"{len(tail_work)} channels with a lost tail, "
-                f"{len(emoji_work)} missing emoji."
+                f"{len(emoji_work)} missing emoji, "
+                f"{len(forum_index_work) + len(forum_index_rebuild_work)} forum indexes."
             ),
         )
     )
@@ -2649,6 +2657,40 @@ async def run_repair(
         finally:
             if own_session:
                 await sess.close()
+
+    # Forum-index repair (#311). Its own session block, like every other work list:
+    # run_repair opens a session per non-empty list, and _live_server_view is fetched
+    # only inside the structure_work block, so a repair whose ONLY broken entity is a
+    # forum index (empty structure_work) would otherwise run nothing. The live view is
+    # fetched here only when a recreation needs it, so a rebuild-only pass still spends
+    # no /servers-bucket request.
+    if forum_index_work or forum_index_rebuild_work:
+        own_fi_session = session is None
+        fi_sess = session or new_session()
+        try:
+            if forum_index_work:
+                existing_names, live_categories = await _live_server_view(fi_sess, config, state)
+                for result in forum_index_work:
+                    created = await _recreate_forum_index(
+                        fi_sess, config, state, result, existing_names, live_categories, on_event
+                    )
+                    if created:
+                        discord_id = result.discord_id or ""
+                        outcome.recreated_channels.append(
+                            {
+                                "discord_id": discord_id,
+                                "stoat_id": state.channel_map.get(discord_id),
+                                "name": state.created_channel_names.get(discord_id, discord_id),
+                                "resent_count": 0,
+                            }
+                        )
+            for result in forum_index_rebuild_work:
+                forum_key = (result.discord_id or "").removeprefix("forum-index-")
+                await _rebuild_one_forum_index(fi_sess, config, state, forum_key, on_event)
+                save_state(state, config.output_dir)
+        finally:
+            if own_fi_session:
+                await fi_sess.close()
 
     if tail_work:
         own_tail_session = session is None

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -999,104 +999,119 @@ async def _rebuild_forum_indexes(
         on_event: Event callback for progress reporting.
     """
     async with get_session(config) as session:
-        for forum_key, discord_channel_ids in state.forum_channel_members.items():
-            index_channel_id = state.channel_map.get(f"forum-index-{forum_key}")
-            if not index_channel_id:
-                continue
+        for forum_key in list(state.forum_channel_members):
+            await _rebuild_one_forum_index(session, config, state, forum_key, on_event)
 
-            forum_name = state.forum_category_names.get(forum_key, forum_key)
 
-            # Build index lines using actual migrated message counts.
-            lines = [f"**Forum: {forum_name}** *(updated after migration)*\n"]
-            for discord_ch_id in discord_channel_ids:
-                stoat_ch_id = state.channel_map.get(discord_ch_id)
-                if not stoat_ch_id:
-                    continue
-                actual_count = state.channel_message_counts.get(discord_ch_id, 0)
-                lines.append(f"- <#{stoat_ch_id}> — {actual_count} messages migrated")
+async def _rebuild_one_forum_index(
+    session: aiohttp.ClientSession,
+    config: FerryConfig,
+    state: MigrationState,
+    forum_key: str,
+    on_event: EventCallback,
+) -> None:
+    """Rebuild one forum's index message from current migration data.
 
-            if len(lines) <= 1:
-                content = f"**Forum: {forum_name}**\nNo posts migrated."
-            else:
-                content = "\n".join(lines)
-                if len(content) > 2000:
-                    while len(lines) > 1 and len("\n".join(lines)) > 1950:
-                        lines.pop()
-                    remaining = len(discord_channel_ids) - (len(lines) - 1)
-                    lines.append(f"\n*...and {remaining} more posts*")
-                    content = "\n".join(lines)
+    Shared by ``_rebuild_forum_indexes`` (the REPORT-phase loop) and the repair path,
+    so the two cannot drift. Reads the forum's members with ``.get`` because the repair
+    caller may pass a zero-post forum, which never gets a ``forum_channel_members`` entry.
+    """
+    index_channel_id = state.channel_map.get(f"forum-index-{forum_key}")
+    if not index_channel_id:
+        return
 
+    forum_name = state.forum_category_names.get(forum_key, forum_key)
+    discord_channel_ids = state.forum_channel_members.get(forum_key, [])
+
+    # Build index lines using actual migrated message counts.
+    lines = [f"**Forum: {forum_name}** *(updated after migration)*\n"]
+    for discord_ch_id in discord_channel_ids:
+        stoat_ch_id = state.channel_map.get(discord_ch_id)
+        if not stoat_ch_id:
+            continue
+        actual_count = state.channel_message_counts.get(discord_ch_id, 0)
+        lines.append(f"- <#{stoat_ch_id}> — {actual_count} messages migrated")
+
+    if len(lines) <= 1:
+        content = f"**Forum: {forum_name}**\nNo posts migrated."
+    else:
+        content = "\n".join(lines)
+        if len(content) > 2000:
+            while len(lines) > 1 and len("\n".join(lines)) > 1950:
+                lines.pop()
+            remaining = len(discord_channel_ids) - (len(lines) - 1)
+            lines.append(f"\n*...and {remaining} more posts*")
+            content = "\n".join(lines)
+
+    try:
+        existing_msg_id = state.forum_index_message_ids.get(forum_key)
+        if existing_msg_id:
+            # Re-run: edit the existing index message instead of creating a duplicate.
+            await api_edit_message(
+                session,
+                config.stoat_url,
+                config.token,
+                index_channel_id,
+                existing_msg_id,
+                content=content,
+            )
+            index_msg_id: str = existing_msg_id
+        else:
             try:
-                existing_msg_id = state.forum_index_message_ids.get(forum_key)
-                if existing_msg_id:
-                    # Re-run: edit the existing index message instead of creating a duplicate.
-                    await api_edit_message(
-                        session,
-                        config.stoat_url,
-                        config.token,
-                        index_channel_id,
-                        existing_msg_id,
-                        content=content,
-                    )
-                    index_msg_id: str = existing_msg_id
-                else:
-                    try:
-                        msg_result = await api_send_message(
-                            session,
-                            config.stoat_url,
-                            config.token,
-                            index_channel_id,
-                            content=content,
-                            masquerade={"name": "Discord Ferry"},
-                            idempotency_key=f"ferry-forum-index-rebuilt-{forum_key}",
-                        )
-                        index_msg_id = msg_result["_id"]
-                    except DuplicateSendError:
-                        # Already on the server with no recoverable id. Write NOTHING to
-                        # forum_index_message_ids: an entry there persists into
-                        # state.json and drives an api_edit_message against an id that
-                        # does not exist on the next run. Letting the broad handler take
-                        # this instead would report a rebuild failure that did not
-                        # happen, which is the same defect as the FailedMessage on the
-                        # message path.
-                        index_msg_id = ""
-                    await asyncio.sleep(config.upload_delay)
-                    if index_msg_id:
-                        state.forum_index_message_ids[forum_key] = index_msg_id
-                        await api_pin_message(
-                            session,
-                            config.stoat_url,
-                            config.token,
-                            index_channel_id,
-                            index_msg_id,
-                        )
-                        await asyncio.sleep(config.upload_delay)
-                on_event(
-                    MigrationEvent(
-                        phase="report",
-                        status="progress",
-                        message=f"Rebuilt forum index for '{forum_name}' with actual data",
-                    )
+                msg_result = await api_send_message(
+                    session,
+                    config.stoat_url,
+                    config.token,
+                    index_channel_id,
+                    content=content,
+                    masquerade={"name": "Discord Ferry"},
+                    idempotency_key=f"ferry-forum-index-rebuilt-{forum_key}",
                 )
-            except Exception as exc:  # noqa: BLE001
-                state.warnings.append(
-                    {
-                        "phase": "report",
-                        "type": "forum_index_rebuild_failed",
-                        "message": _safe(
-                            config, f"Failed to rebuild forum index for '{forum_name}': {exc}"
-                        ),
-                    }
+                index_msg_id = msg_result["_id"]
+            except DuplicateSendError:
+                # Already on the server with no recoverable id. Write NOTHING to
+                # forum_index_message_ids: an entry there persists into
+                # state.json and drives an api_edit_message against an id that
+                # does not exist on the next run. Letting the broad handler take
+                # this instead would report a rebuild failure that did not
+                # happen, which is the same defect as the FailedMessage on the
+                # message path.
+                index_msg_id = ""
+            await asyncio.sleep(config.upload_delay)
+            if index_msg_id:
+                state.forum_index_message_ids[forum_key] = index_msg_id
+                await api_pin_message(
+                    session,
+                    config.stoat_url,
+                    config.token,
+                    index_channel_id,
+                    index_msg_id,
                 )
-                on_event(
-                    MigrationEvent(
-                        phase="report",
-                        status="warning",
-                        message=_safe(
-                            config, f"Forum index rebuild for '{forum_name}' failed: {exc}"
-                        ),
-                    )
-                )
+                await asyncio.sleep(config.upload_delay)
+        on_event(
+            MigrationEvent(
+                phase="report",
+                status="progress",
+                message=f"Rebuilt forum index for '{forum_name}' with actual data",
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.warnings.append(
+            {
+                "phase": "report",
+                "type": "forum_index_rebuild_failed",
+                "message": _safe(
+                    config, f"Failed to rebuild forum index for '{forum_name}': {exc}"
+                ),
+            }
+        )
+        on_event(
+            MigrationEvent(
+                phase="report",
+                status="warning",
+                message=_safe(config, f"Forum index rebuild for '{forum_name}' failed: {exc}"),
+            )
+        )
 
 
 async def run_retry_failed(

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -299,6 +299,7 @@ async def run_migration(
             }
             state.forum_category_names = dict(prior.forum_category_names)
             state.forum_index_message_ids = dict(prior.forum_index_message_ids)
+            state.forum_index_present_unknown_id = set(prior.forum_index_present_unknown_id)
             state.channel_message_counts = dict(prior.channel_message_counts)
             state.category_names = dict(prior.category_names)
             state.channel_categories = dict(prior.channel_categories)
@@ -318,7 +319,10 @@ async def run_migration(
             #     --incremental delta skipping),
             #     failed_messages (so incremental self-heals prior failures — #76),
             #     channel_message_counts, forum_channel_members /
-            #     forum_category_names / forum_index_message_ids,
+            #     forum_category_names / forum_index_message_ids /
+            #     forum_index_present_unknown_id (the #215 duplicate marker, carried
+            #     beside forum_index_message_ids so a resumed run keeps skipping an
+            #     index whose id was lost rather than re-posting it),
             #     native_fidelity_counts (cumulative fidelity counter), and the
             #     cumulative counters (attachments_uploaded/skipped,
             #     reactions_applied, pins_applied). prior_messages_total is DERIVED

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1056,6 +1056,24 @@ async def _rebuild_one_forum_index(
                 content=content,
             )
             index_msg_id: str = existing_msg_id
+        elif forum_key in state.forum_index_present_unknown_id:
+            # Present on the server, but its id was lost to an earlier duplicate send
+            # (#215). Re-sending would post a second index message once Stoat's
+            # idempotency LRU has evicted the key. Skip, and say so: the message stays
+            # with its prior content, only this run's count refresh is missed. Tested
+            # before the send branch, so a known id (rule 1) always supersedes this.
+            on_event(
+                MigrationEvent(
+                    phase="report",
+                    status="warning",
+                    message=_safe(
+                        config,
+                        f"Forum index for '{forum_name}' exists but its message id is "
+                        "unknown; its counts were not refreshed.",
+                    ),
+                )
+            )
+            return
         else:
             try:
                 msg_result = await api_send_message(
@@ -1069,17 +1087,19 @@ async def _rebuild_one_forum_index(
                 )
                 index_msg_id = msg_result["_id"]
             except DuplicateSendError:
-                # Already on the server with no recoverable id. Write NOTHING to
-                # forum_index_message_ids: an entry there persists into
-                # state.json and drives an api_edit_message against an id that
-                # does not exist on the next run. Letting the broad handler take
-                # this instead would report a rebuild failure that did not
-                # happen, which is the same defect as the FailedMessage on the
-                # message path.
+                # Already on the server with no recoverable id. Record the forum in the
+                # present-id-unknown set so the next run skips it instead of posting a
+                # duplicate (#215). Write NOTHING to forum_index_message_ids: a truthy
+                # entry there would drive an api_edit_message against an id that does not
+                # exist. Letting the broad handler take this instead would report a
+                # rebuild failure that did not happen.
+                state.forum_index_present_unknown_id.add(forum_key)
                 index_msg_id = ""
             await asyncio.sleep(config.upload_delay)
             if index_msg_id:
                 state.forum_index_message_ids[forum_key] = index_msg_id
+                # A recovered id supersedes any prior mark; keep the two disjoint.
+                state.forum_index_present_unknown_id.discard(forum_key)
                 await api_pin_message(
                     session,
                     config.stoat_url,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -1009,16 +1009,34 @@ async def _rebuild_one_forum_index(
     state: MigrationState,
     forum_key: str,
     on_event: EventCallback,
+    *,
+    phase: str = "report",
+    force_new: bool = False,
 ) -> None:
     """Rebuild one forum's index message from current migration data.
 
     Shared by ``_rebuild_forum_indexes`` (the REPORT-phase loop) and the repair path,
     so the two cannot drift. Reads the forum's members with ``.get`` because the repair
     caller may pass a zero-post forum, which never gets a ``forum_channel_members`` entry.
+
+    ``phase`` tags the events and warnings this emits. The repair callers pass
+    ``phase="repair"`` so a rebuild failure reaches ``outcome.declined`` and the repair
+    exit code, rather than being filed under ``report`` where it is invisible to repair.
+
+    ``force_new`` sends a fresh index message instead of editing the recorded one. The
+    repair callers set it: the id in ``forum_index_message_ids`` was written for the OLD
+    channel or the OLD (now-deleted) message, so editing it would fail silently. Clearing
+    it first forces the send branch and keeps a dead id out of the map for later runs.
     """
     index_channel_id = state.channel_map.get(f"forum-index-{forum_key}")
     if not index_channel_id:
         return
+
+    if force_new:
+        # The recorded id is stale for a repair (its channel or message is gone). Drop it
+        # and any present-id-unknown mark so the send branch runs and records a real id.
+        state.forum_index_message_ids.pop(forum_key, None)
+        state.forum_index_present_unknown_id.discard(forum_key)
 
     forum_name = state.forum_category_names.get(forum_key, forum_key)
     discord_channel_ids = state.forum_channel_members.get(forum_key, [])
@@ -1062,9 +1080,10 @@ async def _rebuild_one_forum_index(
             # idempotency LRU has evicted the key. Skip, and say so: the message stays
             # with its prior content, only this run's count refresh is missed. Tested
             # before the send branch, so a known id (rule 1) always supersedes this.
+            # Unreachable under force_new, which discards the mark above.
             on_event(
                 MigrationEvent(
-                    phase="report",
+                    phase=phase,
                     status="warning",
                     message=_safe(
                         config,
@@ -1108,17 +1127,21 @@ async def _rebuild_one_forum_index(
                     index_msg_id,
                 )
                 await asyncio.sleep(config.upload_delay)
-        on_event(
-            MigrationEvent(
-                phase="report",
-                status="progress",
-                message=f"Rebuilt forum index for '{forum_name}' with actual data",
+        if index_msg_id:
+            # Only when something was actually edited or sent. A duplicate send leaves
+            # index_msg_id empty and marks the forum instead; claiming "Rebuilt" there
+            # would report success for a rebuild that did not happen.
+            on_event(
+                MigrationEvent(
+                    phase=phase,
+                    status="progress",
+                    message=f"Rebuilt forum index for '{forum_name}' with actual data",
+                )
             )
-        )
     except Exception as exc:  # noqa: BLE001
         state.warnings.append(
             {
-                "phase": "report",
+                "phase": phase,
                 "type": "forum_index_rebuild_failed",
                 "message": _safe(
                     config, f"Failed to rebuild forum index for '{forum_name}': {exc}"
@@ -1127,7 +1150,7 @@ async def _rebuild_one_forum_index(
         )
         on_event(
             MigrationEvent(
-                phase="report",
+                phase=phase,
                 status="warning",
                 message=_safe(config, f"Forum index rebuild for '{forum_name}' failed: {exc}"),
             )
@@ -1832,10 +1855,15 @@ async def _recreate_forum_index(
     discord_id = result.discord_id or ""
     forum_key = discord_id.removeprefix("forum-index-")
 
-    # The forum category must exist to attach the index to. If it is gone and cannot be
-    # restored from this run, decline distinctly rather than create an orphan channel.
+    # The forum category must be LIVE to attach the index to. category_map is not a
+    # sufficient test: check and repair preserve dead ids, so a deleted category that
+    # structure_work did not restore this run still has a truthy category_map entry.
+    # Resolve against the freshly fetched live categories (which include anything
+    # _recreate_category rebuilt earlier this run) and decline if it is genuinely gone,
+    # rather than creating an orphan channel and reporting success.
     stoat_category_id = state.category_map.get(forum_key)
-    if not stoat_category_id:
+    target = next((c for c in live_categories if c.get("id") == stoat_category_id), None)
+    if target is None or not isinstance(target.get("channels"), list):
         message = (
             f"Cannot recreate the forum index for '{forum_key}': its forum category is "
             "gone and not in this run to restore from. Re-run the migration with the "
@@ -1866,16 +1894,14 @@ async def _recreate_forum_index(
     # Position 0 of the forum category, mirroring the create path, so the index sits at
     # the top. NOT via _reattach_to_category, which would no-op on the synthetic key.
     old_id = result.stoat_id
-    target = next((c for c in live_categories if c.get("id") == stoat_category_id), None)
-    if target is not None and isinstance(target.get("channels"), list):
-        channels = target["channels"]
-        if old_id is not None and old_id in channels:
-            channels.remove(old_id)
-        if new_id not in channels:
-            channels.insert(0, new_id)
-        await api_upsert_categories(
-            session, config.stoat_url, config.token, state.stoat_server_id, live_categories
-        )
+    channels = target["channels"]
+    if old_id is not None and old_id in channels:
+        channels.remove(old_id)
+    if new_id not in channels:
+        channels.insert(0, new_id)
+    await api_upsert_categories(
+        session, config.stoat_url, config.token, state.stoat_server_id, live_categories
+    )
 
     on_event(
         MigrationEvent(
@@ -1884,11 +1910,14 @@ async def _recreate_forum_index(
             message=f"Recreated forum index channel '{state.created_channel_names[discord_id]}'.",
         )
     )
-    # Rebuild the index message through the shared helper (sends, pins, records the id,
-    # or marks present-id-unknown on a duplicate). The generic message resend and the
-    # "no discord_metadata" warning are deliberately not run: a forum index names no
-    # Discord channel, so it has zero messages and no ChannelMeta.
-    await _rebuild_one_forum_index(session, config, state, forum_key, on_event)
+    # Rebuild the index message through the shared helper. force_new: the recorded id (if
+    # any) was for the OLD channel, so an edit would fail silently; send fresh instead.
+    # phase="repair" so a rebuild failure reaches outcome.declined and the exit code. The
+    # generic message resend and the "no discord_metadata" warning are deliberately not
+    # run: a forum index names no Discord channel, so it has zero messages and no ChannelMeta.
+    await _rebuild_one_forum_index(
+        session, config, state, forum_key, on_event, phase="repair", force_new=True
+    )
     save_state(state, config.output_dir)
     return True
 
@@ -2686,7 +2715,24 @@ async def run_repair(
                         )
             for result in forum_index_rebuild_work:
                 forum_key = (result.discord_id or "").removeprefix("forum-index-")
-                await _rebuild_one_forum_index(fi_sess, config, state, forum_key, on_event)
+                # tail_absent: the channel is intact but the recorded index message is
+                # confirmed gone, so force_new sends a fresh one rather than editing the
+                # dead id. phase="repair" surfaces a failure at the exit code.
+                await _rebuild_one_forum_index(
+                    fi_sess, config, state, forum_key, on_event, phase="repair", force_new=True
+                )
+                # Record a positive outcome only when a fresh id was actually written, so
+                # a rebuild that hit a duplicate (marked, no id) or failed is not reported
+                # as a restored tail. The failure path already lands in outcome.declined.
+                if forum_key in state.forum_index_message_ids:
+                    discord_id = result.discord_id or ""
+                    outcome.restored_tails.append(
+                        {
+                            "discord_id": discord_id,
+                            "stoat_id": state.channel_map.get(discord_id),
+                            "name": state.created_channel_names.get(discord_id, discord_id),
+                        }
+                    )
                 save_state(state, config.output_dir)
         finally:
             if own_fi_session:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -134,6 +134,10 @@ UNREPAIRED_WARNING_TYPES = frozenset(
         "no_recorded_name",
         "not_in_export",
         "forum_index_not_repairable",
+        # A forum index whose forum category is itself gone: repair recreates the
+        # index (#311) but has nowhere to attach it, so this names a real
+        # unrepaired gap and forces a non-zero exit like the others here.
+        "forum_index_category_missing",
         # A missing emoji repair could not recreate (its image is not in the
         # export). emoji_rewrite_failed too: a reference edit failed, so a message
         # still points at the dead id and the resume record stays open. Both leave

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -138,6 +138,11 @@ UNREPAIRED_WARNING_TYPES = frozenset(
         # index (#311) but has nowhere to attach it, so this names a real
         # unrepaired gap and forces a non-zero exit like the others here.
         "forum_index_category_missing",
+        # A forum-index rebuild that failed during repair (the send raised). The helper
+        # tags it phase="repair" for a repair caller, so it reaches outcome.declined; it
+        # forces a non-zero exit rather than a silent empty index. A REPORT-phase rebuild
+        # failure is tagged phase="report" and never reaches the repair exit code.
+        "forum_index_rebuild_failed",
         # A missing emoji repair could not recreate (its image is not in the
         # export). emoji_rewrite_failed too: a reference edit failed, so a message
         # still points at the dead id and the resume record stays open. Both leave

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -194,6 +194,10 @@ class MigrationState:
     # Forum index message IDs: forum_cat_key -> stoat_message_id.
     # Populated by _rebuild_forum_indexes; used to PATCH (not re-POST) on re-runs.
     forum_index_message_ids: dict[str, str] = field(default_factory=dict)
+    # Forum keys whose index message exists on the server but whose id was lost to a
+    # DuplicateSendError (#215). Distinct from a known id (edit) and absence (send).
+    # Holds internal keys only, no free text.
+    forum_index_present_unknown_id: set[str] = field(default_factory=set)
 
     # Fidelity counters (S18)
     embeds_total: int = 0
@@ -332,6 +336,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "channel_message_counts": state.channel_message_counts,
         "reaction_message_counts": state.reaction_message_counts,
         "forum_index_message_ids": state.forum_index_message_ids,
+        "forum_index_present_unknown_id": sorted(state.forum_index_present_unknown_id),
         "embeds_total": state.embeds_total,
         "embeds_dropped": state.embeds_dropped,
         "replies_linked": state.replies_linked,
@@ -410,6 +415,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             channel_message_counts=data.get("channel_message_counts", {}),
             reaction_message_counts=data.get("reaction_message_counts", {}),
             forum_index_message_ids=data.get("forum_index_message_ids", {}),
+            forum_index_present_unknown_id=set(data.get("forum_index_present_unknown_id", [])),
             embeds_total=data.get("embeds_total", 0),
             embeds_dropped=data.get("embeds_dropped", 0),
             replies_linked=data.get("replies_linked", 0),

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1627,6 +1627,44 @@ async def test_forum_index_rebuild_uses_actual_message_counts(tmp_path: Path) ->
     assert "News" in sent_content[0]
 
 
+async def test_rebuild_one_forum_index_matches_loop(tmp_path: Path) -> None:
+    """SC-3 helper parity: the per-forum helper sends and pins the index and records its id."""
+    from discord_ferry.core.engine import _rebuild_one_forum_index
+
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="stoat-srv",
+        forum_channel_members={"forum-news": ["d1"]},
+        forum_category_names={"forum-news": "News"},
+        channel_map={"d1": "s1", "forum-index-forum-news": "idx"},
+        channel_message_counts={"d1": 3},
+    )
+    with aioresponses() as mock:
+        mock.post("https://api.test/channels/idx/messages", payload={"_id": "m1"})
+        mock.post("https://api.test/channels/idx/messages/m1/pin", payload={})
+        async with aiohttp.ClientSession() as session:
+            await _rebuild_one_forum_index(session, config, state, "forum-news", lambda e: None)
+    assert state.forum_index_message_ids["forum-news"] == "m1"
+
+
+async def test_rebuild_one_forum_index_zero_posts_no_keyerror(tmp_path: Path) -> None:
+    """SC-I3: a forum with no forum_channel_members entry rebuilds to the no-posts body."""
+    from discord_ferry.core.engine import _rebuild_one_forum_index
+
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="stoat-srv",
+        forum_category_names={"forum-empty": "Empty"},
+        channel_map={"forum-index-forum-empty": "idx"},
+        forum_index_message_ids={"forum-empty": "old-msg"},
+    )
+    with aioresponses() as mock:
+        mock.patch("https://api.test/channels/idx/messages/old-msg", payload={})
+        async with aiohttp.ClientSession() as session:
+            # forum_channel_members has no "forum-empty" key: a subscript would KeyError.
+            await _rebuild_one_forum_index(session, config, state, "forum-empty", lambda e: None)
+
+
 # ---------------------------------------------------------------------------
 # S16: Orphan Autumn upload cleanup
 # ---------------------------------------------------------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1665,6 +1665,69 @@ async def test_rebuild_one_forum_index_zero_posts_no_keyerror(tmp_path: Path) ->
             await _rebuild_one_forum_index(session, config, state, "forum-empty", lambda e: None)
 
 
+async def test_rebuild_marks_forum_on_duplicate(tmp_path: Path) -> None:
+    """SC-1.1: a DuplicateSendError marks the forum, records no id, does not pin."""
+    from discord_ferry.core.engine import _rebuild_one_forum_index
+
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="s",
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1", "forum-index-f": "idx"},
+    )
+    with aioresponses() as mock:
+        mock.post(
+            "https://api.test/channels/idx/messages",
+            status=409,
+            payload={"type": "DuplicateNonce", "location": "x:1:1"},
+        )
+        async with aiohttp.ClientSession() as session:
+            await _rebuild_one_forum_index(session, config, state, "f", lambda e: None)
+    assert state.forum_index_present_unknown_id == {"f"}
+    assert "f" not in state.forum_index_message_ids
+
+
+async def test_rebuild_skips_marked_forum(tmp_path: Path) -> None:
+    """SC-1.2: a marked forum is skipped, emits a frozen warning, sends nothing."""
+    from discord_ferry.core.engine import _rebuild_one_forum_index
+
+    config = _make_config(tmp_path)
+    events: list[MigrationEvent] = []
+    state = MigrationState(
+        stoat_server_id="s",
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"forum-index-f": "idx"},
+        forum_index_present_unknown_id={"f"},
+    )
+    with aioresponses():  # no routes registered: any HTTP call raises
+        async with aiohttp.ClientSession() as session:
+            await _rebuild_one_forum_index(session, config, state, "f", events.append)
+    assert any(e.status == "warning" and "unknown" in (e.message or "").lower() for e in events)
+    assert state.forum_index_present_unknown_id == {"f"}
+
+
+async def test_rebuild_success_never_leaves_forum_in_both(tmp_path: Path) -> None:
+    """SC-1.5: after a successful send, the id map and the marker set stay disjoint."""
+    from discord_ferry.core.engine import _rebuild_one_forum_index
+
+    config = _make_config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="s",
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1", "forum-index-f": "idx"},
+    )
+    with aioresponses() as mock:
+        mock.post("https://api.test/channels/idx/messages", payload={"_id": "m3"})
+        mock.post("https://api.test/channels/idx/messages/m3/pin", payload={})
+        async with aiohttp.ClientSession() as session:
+            await _rebuild_one_forum_index(session, config, state, "f", lambda e: None)
+    assert state.forum_index_message_ids["f"] == "m3"
+    assert set(state.forum_index_message_ids) & state.forum_index_present_unknown_id == set()
+
+
 # ---------------------------------------------------------------------------
 # S16: Orphan Autumn upload cleanup
 # ---------------------------------------------------------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2816,7 +2816,9 @@ async def test_run_repair_records_dead_letter_and_scoped_declined(tmp_path: Path
         FailedMessage(discord_msg_id="m1", stoat_channel_id="c1", error="boom"),
         FailedMessage(discord_msg_id="m2", stoat_channel_id="c2", error="boom"),
     ]
-    # A forum-index result: run_repair declines it (a repair-phase warning appended this run).
+    # A forum-index whose forum category is itself gone: run_repair recreates the
+    # index (#311) but has nowhere to attach it, so it declines with a repair-phase
+    # warning appended this run (forum_index_category_missing).
     report = _report_with("channel_missing", "fail", discord_id="forum-index-800000000000000009")
 
     async def _fake_check(*_a: Any, **_k: Any) -> CheckReport:
@@ -2828,12 +2830,13 @@ async def test_run_repair_records_dead_letter_and_scoped_declined(tmp_path: Path
     with (
         patch("discord_ferry.migrator.verify.run_check", new=_fake_check),
         patch.object(engine_module, "run_retry_failed", _fake_retry),
+        patch.object(engine_module, "_live_server_view", new=AsyncMock(return_value=(set(), []))),
         patch.object(engine_module, "save_state", lambda *a, **k: None),
     ):
         outcome = await run_repair(config, state, [], lambda _e: None)
 
     assert outcome.dead_letter == {"drained": 1, "remaining": 1}
-    assert any(d["type"] == "forum_index_not_repairable" for d in outcome.declined)
+    assert any(d["type"] == "forum_index_category_missing" for d in outcome.declined)
     assert all(d["type"] != "proxy_notice" for d in outcome.declined), (
         "the legacy non-repair warning leaked into the repair outcome"
     )
@@ -2981,35 +2984,32 @@ async def test_repair_never_acts_on_a_non_actionable_tail_kind(tmp_path: Path, k
     assert _partition_counts(events) == (0, 0), f"{kind} entered the work lists"
 
 
-async def test_repair_declines_a_missing_forum_index_channel(tmp_path: Path) -> None:
-    """SC-3.17. A DELIBERATE EXCLUSION, not an unimplemented case.
+async def test_repair_recreates_a_missing_forum_index_channel(tmp_path: Path) -> None:
+    """#311. No longer a deliberate exclusion: a deleted forum index is recreated.
 
-    The forum index writer stores its channel under a SYNTHETIC key,
-    `channel_map["forum-index-{forum_key}"]`, whose value is a real Stoat
-    channel id. So the check reports a deleted index as channel_missing exactly
-    like any other channel, and a membership test on `kind` alone would sweep it
-    into generic recreation.
-
-    Generic recreation cannot restore it. There is no ChannelMeta for a
-    synthetic id, the channel-scoped export scan finds zero messages because the
-    key names no Discord channel, and nothing rebuilds the index message or
-    forum_index_message_ids. _select_invite_channel already excludes the same
-    prefix for the same reason. Deferred as #311.
-
-    This is the second level of the lesson the partition comment records: a test
-    on `status` would sweep in a future kind, and a test on `kind` alone sweeps
-    in a channel TYPE nobody considered.
+    The forum index is stored under a SYNTHETIC `channel_map["forum-index-{key}"]`,
+    so the check reports a deleted one as channel_missing like any channel. It now
+    routes into the forum-index recreation path (its own session block, which runs
+    even when structure_work is empty) rather than being declined.
     """
     forum_key = "forum-index-800000000000000009"
     report = _report_with("channel_missing", "fail", discord_id=forum_key)
-    state, requests, events = await _repair_with_report(tmp_path, report)
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    events: list[MigrationEvent] = []
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=AsyncMock(return_value=report)),
+        patch.object(engine_module, "_live_server_view", new=AsyncMock(return_value=(set(), []))),
+        patch.object(
+            engine_module, "_recreate_forum_index", new=AsyncMock(return_value=True)
+        ) as recreate,
+    ):
+        await run_repair(config, state, [], events.append)
 
-    assert requests == [], "repair tried to recreate a forum index channel"
-    assert _partition_counts(events) == (0, 0), "the forum index entered the work lists"
-    assert any(
-        w.get("type") == "forum_index_not_repairable" and w.get("phase") == "repair"
-        for w in state.warnings
-    ), f"no warning names the declined forum index: {state.warnings}"
+    recreate.assert_awaited_once()
+    assert not any(w.get("type") == "forum_index_not_repairable" for w in state.warnings), (
+        "the forum index was declined instead of recreated"
+    )
 
 
 async def _repair_recording_saves(
@@ -3173,18 +3173,12 @@ async def test_repair_does_not_swallow_a_check_error(tmp_path: Path) -> None:
         await run_repair(config, state, [], lambda _e: None)
 
 
-async def test_repair_declines_a_forum_index_whose_tail_is_missing(tmp_path: Path) -> None:
-    """The gap the chunk 3 review found, and the reason the exclusion moved.
+async def test_repair_rebuilds_a_forum_index_whose_tail_is_missing(tmp_path: Path) -> None:
+    """#311. A forum index whose channel survives but message is gone now rebuilds.
 
-    Guarding only the structure branch let a forum index channel reporting
-    tail_absent through into the tail work. That path cannot restore it: the
-    tail of a forum index channel IS the index message, which lives in
-    forum_index_message_ids and has no message in any export to re-send.
-
-    The review that surfaced this described the mechanism wrongly, claiming the
-    `continue` dropped a tail result. A CheckResult has exactly one kind, so a
-    result taking the structure branch could never have taken the tail branch.
-    Running it found the real defect underneath.
+    The tail of a forum index channel IS the index message. It routes into the
+    forum-index REBUILD path (no channel create, just the shared rebuild helper),
+    not into the generic tail work and not into a decline.
     """
     report = CheckReport()
     report.add(
@@ -3195,11 +3189,19 @@ async def test_repair_declines_a_forum_index_whose_tail_is_missing(tmp_path: Pat
         discord_id="forum-index-800000000000000009",
         stoat_id="01JSTOATCHN000000000IDX",
     )
-    state, requests, events = await _repair_with_report(tmp_path, report)
+    config = _make_repair_config(tmp_path)
+    state = MigrationState(stoat_server_id=R_SERVER, channel_map={R_D_CHANNEL: R_S_CHANNEL})
+    events: list[MigrationEvent] = []
+    with (
+        patch("discord_ferry.migrator.verify.run_check", new=AsyncMock(return_value=report)),
+        patch.object(engine_module, "_rebuild_one_forum_index", new=AsyncMock()) as rebuild,
+    ):
+        await run_repair(config, state, [], events.append)
 
-    assert _partition_counts(events) == (0, 0), "a forum index entered the tail work"
-    assert requests == [], "repair acted on a forum index tail"
-    assert any(w.get("type") == "forum_index_not_repairable" for w in state.warnings)
+    assert _partition_counts(events) == (0, 0), "a forum index entered the generic tail work"
+    rebuild.assert_awaited_once()
+    assert rebuild.await_args.args[3] == "800000000000000009", "wrong forum key rebuilt"
+    assert not any(w.get("type") == "forum_index_not_repairable" for w in state.warnings)
 
 
 async def test_repair_dry_run_does_not_mutate_state_warnings(tmp_path: Path) -> None:

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -31,6 +31,9 @@ def test_repair_failure_set_is_shared_and_exact() -> None:
                 "no_recorded_name",
                 "not_in_export",
                 "forum_index_not_repairable",
+                # #311 forum-index repair: a missing forum index is now recreated,
+                # but a gone forum category leaves it unrepairable and forces exit 1.
+                "forum_index_category_missing",
                 # #307 emoji repair: could-not-recreate and failed-rewrite both
                 # leave something failing. emoji_in_split_tail is excluded (partial
                 # restore of a recreated emoji), matching the CLI comment.

--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -34,6 +34,8 @@ def test_repair_failure_set_is_shared_and_exact() -> None:
                 # #311 forum-index repair: a missing forum index is now recreated,
                 # but a gone forum category leaves it unrepairable and forces exit 1.
                 "forum_index_category_missing",
+                # #311: a forum-index rebuild that failed during repair (phase="repair").
+                "forum_index_rebuild_failed",
                 # #307 emoji repair: could-not-recreate and failed-rewrite both
                 # leave something failing. emoji_in_split_tail is excluded (partial
                 # restore of a recreated emoji), matching the CLI comment.

--- a/tests/test_repair_forum_index.py
+++ b/tests/test_repair_forum_index.py
@@ -1,0 +1,96 @@
+"""Tests for forum-index repair in run_repair (#311).
+
+The forum index lives under a synthetic ``forum-index-{forum_key}`` key that names no
+Discord channel, so the generic recreation path cannot restore it. ``_recreate_forum_index``
+recreates the channel and rebuilds its index message via the shared ``_rebuild_one_forum_index``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aioresponses import aioresponses
+
+from discord_ferry.config import FerryConfig
+from discord_ferry.core.engine import _recreate_forum_index
+from discord_ferry.migrator.verify import CheckResult
+from discord_ferry.state import MigrationState
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(tmp_path: Path) -> FerryConfig:
+    return FerryConfig(
+        export_dir=tmp_path,
+        stoat_url="https://api.test",
+        token="t",
+        upload_delay=0.0,
+        output_dir=tmp_path,
+    )
+
+
+def _result() -> CheckResult:
+    return CheckResult(
+        name="channel:forum-index-f",
+        status="fail",
+        kind="channel_missing",
+        detail="the server does not list this channel",
+        discord_id="forum-index-f",
+        stoat_id="old-idx",
+    )
+
+
+async def test_recreate_forum_index_creates_and_rebuilds(tmp_path: Path) -> None:
+    """SC-3.1/SC-4.1: the channel is recreated at position 0 and its index message rebuilt."""
+    config = _config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv",
+        category_map={"f": "cat-s"},
+        created_channel_names={"forum-index-f": "F-index"},
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1"},
+        channel_message_counts={"d1": 2},
+    )
+    live_categories = [{"id": "cat-s", "title": "F", "channels": ["old-idx"]}]
+
+    with aioresponses() as mock:
+        mock.post(
+            "https://api.test/servers/srv/channels",
+            payload={"_id": "new-idx", "name": "F-index"},
+        )
+        mock.patch("https://api.test/servers/srv", payload={})
+        mock.post("https://api.test/channels/new-idx/messages", payload={"_id": "msg-1"})
+        mock.post("https://api.test/channels/new-idx/messages/msg-1/pin", payload={})
+        async with aiohttp.ClientSession() as session:
+            created = await _recreate_forum_index(
+                session, config, state, _result(), set(), live_categories, lambda e: None
+            )
+
+    assert created is True
+    assert state.channel_map["forum-index-f"] == "new-idx"
+    assert state.forum_index_message_ids["f"] == "msg-1"
+    # The recreated index sits at position 0 and the dead id is dropped.
+    assert live_categories[0]["channels"] == ["new-idx"]
+
+
+async def test_recreate_forum_index_declines_missing_category(tmp_path: Path) -> None:
+    """SC-5.2: a gone forum category yields a distinct decline and creates nothing."""
+    config = _config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv",
+        category_map={},  # the forum category itself is gone
+        created_channel_names={"forum-index-f": "F-index"},
+    )
+
+    with aioresponses():  # no routes: any HTTP call would raise
+        async with aiohttp.ClientSession() as session:
+            created = await _recreate_forum_index(
+                session, config, state, _result(), set(), [], lambda e: None
+            )
+
+    assert created is False
+    assert any(w.get("type") == "forum_index_category_missing" for w in state.warnings)
+    assert "forum-index-f" not in state.channel_map

--- a/tests/test_repair_forum_index.py
+++ b/tests/test_repair_forum_index.py
@@ -8,17 +8,24 @@ recreates the channel and rebuilds its index message via the shared ``_rebuild_o
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import aiohttp
 from aioresponses import aioresponses
 
 from discord_ferry.config import FerryConfig
-from discord_ferry.core.engine import _recreate_forum_index
-from discord_ferry.migrator.verify import CheckResult
+from discord_ferry.core.engine import _recreate_forum_index, run_repair
+from discord_ferry.migrator.verify import UNREPAIRED_WARNING_TYPES, CheckReport, CheckResult
 from discord_ferry.state import MigrationState
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_ENGINE = "discord_ferry.core.engine"
+_CHECK = "discord_ferry.migrator.verify.run_check"
+_LIVE = f"{_ENGINE}._live_server_view"
+_RECREATE = f"{_ENGINE}._recreate_forum_index"
+_REBUILD = f"{_ENGINE}._rebuild_one_forum_index"
 
 
 def _config(tmp_path: Path) -> FerryConfig:
@@ -94,3 +101,90 @@ async def test_recreate_forum_index_declines_missing_category(tmp_path: Path) ->
     assert created is False
     assert any(w.get("type") == "forum_index_category_missing" for w in state.warnings)
     assert "forum-index-f" not in state.channel_map
+
+
+# --- Routing through run_repair (Task 2.2) ---------------------------------
+
+
+def _report(kind: str) -> CheckReport:
+    report = CheckReport()
+    report.add(
+        name="channel:forum-index-f",
+        status="fail",
+        kind=kind,
+        detail="forum index needs repair",
+        discord_id="forum-index-f",
+        stoat_id="old-idx",
+    )
+    return report
+
+
+def _routing_state(tmp_path: Path) -> MigrationState:
+    return MigrationState(
+        stoat_server_id="srv",
+        category_map={"f": "cat-s"},
+        created_channel_names={"forum-index-f": "F-index"},
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1", "forum-index-f": "old-idx"},
+        forum_index_message_ids={"f": "old-idx-msg"},
+    )
+
+
+async def test_repair_recreates_lone_forum_index(tmp_path: Path) -> None:
+    """SC-I2/SC-3.2/SC-3.3: the forum index as the ONLY broken entity is still repaired.
+
+    structure_work is empty, so the round-2 session gap would have dropped this silently.
+    """
+    config = _config(tmp_path)
+    state = _routing_state(tmp_path)
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_report("channel_missing"))),
+        patch(_LIVE, new=AsyncMock(return_value=(set(), [{"id": "cat-s", "channels": []}]))),
+        patch(_RECREATE, new=AsyncMock(return_value=True)) as recreate,
+    ):
+        await run_repair(config, state, [], [].append)
+    recreate.assert_awaited_once()
+    assert not any(w.get("type") == "no_discord_metadata" for w in state.warnings)
+    assert not any(w.get("type") == "forum_index_not_repairable" for w in state.warnings)
+
+
+async def test_repair_routes_tail_absent_to_rebuild_without_create(tmp_path: Path) -> None:
+    """SC-I4: a forum index whose channel survives but message is gone rebuilds, no create."""
+    config = _config(tmp_path)
+    state = _routing_state(tmp_path)
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_report("tail_absent"))),
+        patch(_LIVE, new=AsyncMock(return_value=(set(), []))),
+        patch(_RECREATE, new=AsyncMock(return_value=True)) as recreate,
+        patch(_REBUILD, new=AsyncMock()) as rebuild,
+    ):
+        await run_repair(config, state, [], [].append)
+    rebuild.assert_awaited_once()
+    assert rebuild.await_args.args[3] == "f"  # forum_key
+    recreate.assert_not_awaited()
+
+
+async def test_repair_forum_index_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    """SC-3.4: --dry-run recreates nothing and writes no state."""
+    config = FerryConfig(
+        export_dir=tmp_path,
+        stoat_url="https://api.test",
+        token="t",
+        upload_delay=0.0,
+        output_dir=tmp_path,
+        dry_run=True,
+    )
+    state = _routing_state(tmp_path)
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_report("channel_missing"))),
+        patch(_RECREATE, new=AsyncMock(return_value=True)) as recreate,
+    ):
+        await run_repair(config, state, [], [].append)
+    recreate.assert_not_awaited()
+    assert state.channel_map["forum-index-f"] == "old-idx"  # unchanged
+
+
+def test_category_missing_decline_is_in_exit_set() -> None:
+    """SC-5.2: the distinct decline forces a non-zero exit, like other unrepaired gaps."""
+    assert "forum_index_category_missing" in UNREPAIRED_WARNING_TYPES

--- a/tests/test_repair_forum_index.py
+++ b/tests/test_repair_forum_index.py
@@ -83,6 +83,78 @@ async def test_recreate_forum_index_creates_and_rebuilds(tmp_path: Path) -> None
     assert live_categories[0]["channels"] == ["new-idx"]
 
 
+async def test_recreate_forum_index_sends_fresh_when_a_stale_id_is_recorded(tmp_path: Path) -> None:
+    """Whole-branch review: a migrated forum already has a forum_index_message_ids entry.
+
+    That recorded id belongs to the DELETED old channel, so editing it in the new channel
+    would fail silently. Repair must send a fresh message and record its id, not edit the
+    stale one.
+    """
+    config = _config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv",
+        category_map={"f": "cat-s"},
+        created_channel_names={"forum-index-f": "F-index"},
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1"},
+        channel_message_counts={"d1": 2},
+        forum_index_message_ids={"f": "stale-old-msg"},  # from the original migration
+    )
+    live_categories = [{"id": "cat-s", "title": "F", "channels": ["old-idx"]}]
+
+    with aioresponses() as mock:
+        mock.post(
+            "https://api.test/servers/srv/channels",
+            payload={"_id": "new-idx", "name": "F-index"},
+        )
+        mock.patch("https://api.test/servers/srv", payload={})
+        # Only the SEND route is registered. If the code took the edit branch against the
+        # stale id, the PATCH would have no route and the rebuild would fail silently.
+        mock.post("https://api.test/channels/new-idx/messages", payload={"_id": "fresh-msg"})
+        mock.post("https://api.test/channels/new-idx/messages/fresh-msg/pin", payload={})
+        async with aiohttp.ClientSession() as session:
+            created = await _recreate_forum_index(
+                session, config, state, _result(), set(), live_categories, lambda e: None
+            )
+
+    assert created is True
+    assert state.forum_index_message_ids["f"] == "fresh-msg", "repair edited the stale id"
+
+
+async def test_recreate_forum_index_clears_a_stale_present_unknown_mark(tmp_path: Path) -> None:
+    """Whole-branch/second-opinion: a carried present-id-unknown mark must not suppress the send.
+
+    force_new discards the mark so the new channel gets a fresh index message.
+    """
+    config = _config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv",
+        category_map={"f": "cat-s"},
+        created_channel_names={"forum-index-f": "F-index"},
+        forum_channel_members={"f": ["d1"]},
+        forum_category_names={"f": "F"},
+        channel_map={"d1": "s1"},
+        forum_index_present_unknown_id={"f"},  # marked from an earlier duplicate
+    )
+    live_categories = [{"id": "cat-s", "title": "F", "channels": []}]
+    with aioresponses() as mock:
+        mock.post(
+            "https://api.test/servers/srv/channels",
+            payload={"_id": "new-idx", "name": "F-index"},
+        )
+        mock.patch("https://api.test/servers/srv", payload={})
+        mock.post("https://api.test/channels/new-idx/messages", payload={"_id": "fresh-msg"})
+        mock.post("https://api.test/channels/new-idx/messages/fresh-msg/pin", payload={})
+        async with aiohttp.ClientSession() as session:
+            created = await _recreate_forum_index(
+                session, config, state, _result(), set(), live_categories, lambda e: None
+            )
+    assert created is True
+    assert state.forum_index_message_ids["f"] == "fresh-msg"
+    assert "f" not in state.forum_index_present_unknown_id, "the stale mark suppressed the send"
+
+
 async def test_recreate_forum_index_declines_missing_category(tmp_path: Path) -> None:
     """SC-5.2: a gone forum category yields a distinct decline and creates nothing."""
     config = _config(tmp_path)
@@ -101,6 +173,31 @@ async def test_recreate_forum_index_declines_missing_category(tmp_path: Path) ->
     assert created is False
     assert any(w.get("type") == "forum_index_category_missing" for w in state.warnings)
     assert "forum-index-f" not in state.channel_map
+
+
+async def test_recreate_forum_index_declines_a_dead_but_mapped_category(tmp_path: Path) -> None:
+    """Second-opinion finding 3: a category_map id absent from the live server is dead.
+
+    Check and repair preserve dead ids, so a truthy category_map entry is not proof the
+    category exists. Resolving against live_categories declines instead of creating an
+    orphan channel and reporting success.
+    """
+    config = _config(tmp_path)
+    state = MigrationState(
+        stoat_server_id="srv",
+        category_map={"f": "deleted-category"},  # truthy, but not on the server
+        created_channel_names={"forum-index-f": "F-index"},
+    )
+
+    with aioresponses():  # no routes: creating a channel would raise
+        async with aiohttp.ClientSession() as session:
+            created = await _recreate_forum_index(
+                session, config, state, _result(), set(), [], lambda e: None
+            )
+
+    assert created is False
+    assert any(w.get("type") == "forum_index_category_missing" for w in state.warnings)
+    assert "forum-index-f" not in state.channel_map, "an orphan channel was created"
 
 
 # --- Routing through run_repair (Task 2.2) ---------------------------------
@@ -162,6 +259,9 @@ async def test_repair_routes_tail_absent_to_rebuild_without_create(tmp_path: Pat
         await run_repair(config, state, [], [].append)
     rebuild.assert_awaited_once()
     assert rebuild.await_args.args[3] == "f"  # forum_key
+    # force_new: the recorded id is the message just confirmed gone, so send fresh.
+    assert rebuild.await_args.kwargs.get("force_new") is True
+    assert rebuild.await_args.kwargs.get("phase") == "repair"
     recreate.assert_not_awaited()
 
 
@@ -185,6 +285,30 @@ async def test_repair_forum_index_dry_run_mutates_nothing(tmp_path: Path) -> Non
     assert state.channel_map["forum-index-f"] == "old-idx"  # unchanged
 
 
+async def test_tail_rebuild_records_a_restored_tail(tmp_path: Path) -> None:
+    """Second-opinion finding 4: a successful tail rebuild is recorded in the outcome.
+
+    Without this the rebuild-only path did real work but reported nothing to --json / GUI.
+    """
+    config = _config(tmp_path)
+    state = _routing_state(tmp_path)
+
+    async def _fake_rebuild(_sess, _cfg, st, forum_key, _ev, *, phase="report", force_new=False):  # type: ignore[no-untyped-def]
+        st.forum_index_message_ids[forum_key] = "rebuilt-msg"
+
+    with (
+        patch(_CHECK, new=AsyncMock(return_value=_report("tail_absent"))),
+        patch(_REBUILD, new=_fake_rebuild),
+    ):
+        outcome = await run_repair(config, state, [], [].append)
+    assert any(t["discord_id"] == "forum-index-f" for t in outcome.restored_tails)
+
+
 def test_category_missing_decline_is_in_exit_set() -> None:
     """SC-5.2: the distinct decline forces a non-zero exit, like other unrepaired gaps."""
     assert "forum_index_category_missing" in UNREPAIRED_WARNING_TYPES
+
+
+def test_rebuild_failed_is_in_exit_set() -> None:
+    """Second-opinion finding 1/2: a repair rebuild failure forces a non-zero exit."""
+    assert "forum_index_rebuild_failed" in UNREPAIRED_WARNING_TYPES

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -911,6 +911,7 @@ _KNOWN_STATE_FIELDS = frozenset(
         "channel_message_counts",
         "reaction_message_counts",
         "forum_index_message_ids",
+        "forum_index_present_unknown_id",
         "embeds_total",
         "embeds_dropped",
         "replies_linked",
@@ -953,6 +954,22 @@ def test_pending_emoji_rewrites_defaults_empty(tmp_path: Path) -> None:
     del raw["pending_emoji_rewrites"]
     (tmp_path / "state.json").write_text(json.dumps(raw))
     assert load_state(tmp_path).pending_emoji_rewrites == {}
+
+
+def test_forum_index_present_unknown_id_round_trips(tmp_path: Path) -> None:
+    """SC-2.2: the #215 marker survives save then load, as a set."""
+    state = MigrationState(forum_index_present_unknown_id={"forum-news"})
+    save_state(state, tmp_path)
+    assert load_state(tmp_path).forum_index_present_unknown_id == {"forum-news"}
+
+
+def test_forum_index_present_unknown_id_defaults_empty(tmp_path: Path) -> None:
+    """SC-2.3: a state file written before the field existed loads it as an empty set."""
+    save_state(MigrationState(), tmp_path)
+    raw = json.loads((tmp_path / "state.json").read_text())
+    del raw["forum_index_present_unknown_id"]
+    (tmp_path / "state.json").write_text(json.dumps(raw))
+    assert load_state(tmp_path).forum_index_present_unknown_id == set()
 
 
 def test_failed_message_fields_are_classified() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.30.0"
+version = "2.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Two coupled changes to forum-index handling:

- **#311**: `ferry repair` recreates and rebuilds a missing forum index instead of declining. It
  recreates the index channel, reattaches it at the top of its forum category, and rebuilds the
  pinned index message from Ferry's own record of the forum's posts. A forum index whose channel
  survived but whose message alone was deleted is rebuilt in place. If the forum's own category is
  gone and cannot be restored this run, repair declines that index with a clear warning and a
  non-zero exit.
- **#215**: a forum-index rebuild no longer double-posts on a later run. When Stoat accepts the
  index message as a duplicate (returning no id), Ferry records the index as present-with-unknown-id
  and skips the resend, rather than posting a second copy once the idempotency cache evicts the key.

## How

- New `MigrationState.forum_index_present_unknown_id` set, carried across save/load and
  `--incremental`, classified as structural in the state guard.
- The per-forum rebuild body is one shared helper (`_rebuild_one_forum_index`), called by the
  wrap-up phase and by repair, so they cannot drift. Repair passes `force_new=True` (the recorded id
  is stale for a repair) and `phase="repair"` (so a rebuild failure reaches the repair exit code).
- `run_repair` routes the `forum-index-` prefix by kind into its own session block; the block runs
  even when no other structure work exists.
- `forum_index_category_missing` and `forum_index_rebuild_failed` join the shared CLI/GUI exit set.

## Review

- Both chunk reviews clean (#552, #553).
- The whole-branch review and the Codex second opinion both caught a real cross-cutting bug: the
  shared rebuild helper edited a stale recorded id on the repair paths, failing silently. Fixed here
  (force_new + phase, live-category resolution to avoid an orphan channel, and a positive outcome
  record). All confirmed findings fixed; full suite green.

## Deferred (four fields each, filed)

- #560: apply the present-id-unknown signal to the `structure.py` create-path duplicate handler.
- #561: recover a forum index's message id after a duplicate send so its counts can refresh.

Closes #311. Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
