### PR TITLE
Cross-host second-opinion review + pacer retry refund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Ferry paces Stoat API requests proactively before a rate-limit bucket exhausts.** Stoat
+  sends `X-RateLimit-Remaining` on every response, not just 429s. Ferry now reads that header
+  on every response and pauses before the next request to the same bucket when the remaining
+  budget reaches zero, waiting for the advertised window reset instead of burning a request
+  to discover the bucket is empty. A shadow counter decremented before each request prevents
+  two concurrent requests from both firing into the same exhausted budget. This applies to
+  every Stoat API call through the shared request layer, so the structure, emoji, reactions
+  and pins phases, which previously had no damping at all, now benefit alongside the messages
+  phase. The existing adaptive multiplier and 429 retry path remain unchanged as a safety net.
+  Closes #111.
+
 ### Fixed
+
+- **content: Reference pages now describe the rendered-mention check accurately.** Two
+  reference pages still framed the VALIDATE check as detecting only a missing `--markdown
+  false` flag. The check also flags `@Unknown`, which DiscordChatExporter writes for a member
+  it could not resolve, and no longer fires on a reply, an embed-carried mention or an
+  attachment-only message. Closes #153.
 
 - **content: Em-dash and banned-word debt removed from known-limitations guide.** Five
   em-dashes and a `silently` in `docs/guides/known-limitations.md` failed the plain-english

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Cross-host second-opinion review.** The /df-ship and /df-chunk-review review gates now run a
+  cross-host fallback chain so the reviewer is never the same model family as the host running
+  the build. On Vibe, Codex reviews with Claude as fallback. On Claude Code, Codex reviews with
+  the Mistral MCP as fallback. On Codex, Claude reviews with the Mistral MCP as last resort.
+  A new helper, `scripts/agent-compat/claude-review.mjs`, wraps `claude -p` with `--json-schema`
+  and no tool access (`--allowedTools ''`), returning findings in the same `code_review_findings`
+  schema as the Codex helper. Closes the circular-review gap noted in ADR-023.
+
 - **Ferry paces Stoat API requests proactively before a rate-limit bucket exhausts.** Stoat
   sends `X-RateLimit-Remaining` on every response, not just 429s. Ferry now reads that header
   on every response and pauses before the next request to the same bucket when the remaining
@@ -20,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Closes #111.
 
 ### Fixed
+
+- **Pacer no longer over-spends rate-limit budget on 5xx and network-error retries.** The
+  proactive pacer decremented its shadow counter before each request attempt, but only the 429
+  path refreshed the shadow from response headers. A request that retried on a 502 or a network
+  error burned one unit per retry against a stale shadow, causing the next request to pace
+  spuriously. The 5xx and network-error paths now refund the decrement, so one logical request
+  consumes exactly one unit regardless of retry count.
 
 - **content: Reference pages now describe the rendered-mention check accurately.** Two
   reference pages still framed the VALIDATE check as detecting only a missing `--markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.31.0"
+version = "2.32.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/agent-compat/claude-review.mjs
+++ b/scripts/agent-compat/claude-review.mjs
@@ -1,30 +1,26 @@
 #!/usr/bin/env node
-// Discord Ferry — Codex second-opinion reviewer.
-// Runs `codex exec` (default gpt-5.6-sol, high effort) as the primary code reviewer for
+// Discord Ferry - Claude Code second-opinion reviewer.
+// Runs `claude -p` (default claude-opus-4-8) as a cross-host fallback reviewer for
 // /df-ship step 4 and /df-chunk-review step 3, returning findings in Ferry's own
 // `code_review_findings` schema. See ADR-023.
 //
 // The caller pipes the review payload on stdin: the `git diff` for a whole-branch review, or
 // the full changed files followed by their diff for a chunk review. The instruction (focus text)
-// is passed with --focus. On any Codex failure this exits non-zero so the caller can fall back
-// to the Mistral MCP call.
+// is passed with --focus. On any Claude failure this exits non-zero so the caller can fall back
+// to the next reviewer in the chain.
 //
 // Usage:
-//   git diff origin/main | node codex-review.mjs --focus "API: rate limits, retry logic" --title "chunk 2"
-//   node codex-review.mjs --self-test
+//   git diff origin/main | node claude-review.mjs --focus "API: rate limits, retry logic" --title "chunk 2"
+//   node claude-review.mjs --self-test
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 
-const DEFAULT_MODEL = 'gpt-5.6-sol';
-const DEFAULT_EFFORT = 'high';
+const DEFAULT_MODEL = 'claude-opus-4-8';
 
-// Ferry's canonical review schema, unwrapped from Mistral's response_format envelope.
+// Ferry's canonical review schema, identical to codex-review.mjs.
 // Kept in sync with .claude/skills/df-chunk-review/SKILL.md step 3.
-// OpenAI structured outputs run in strict mode: every object needs additionalProperties:false,
-// and every property must appear in `required` (optional fields use a nullable type instead).
+// Claude's --json-schema accepts a bare JSON Schema object, same shape as Codex's --output-schema.
 const FINDINGS_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -87,7 +83,7 @@ verification command that distinguishes the finding being true from being false;
 be run by the caller, so you never need to run it yourself.`;
 
 function parseArgs(argv) {
-  const args = { mode: 'whole-branch', focus: '', title: '', model: DEFAULT_MODEL, effort: DEFAULT_EFFORT, selfTest: false };
+  const args = { mode: 'whole-branch', focus: '', title: '', model: DEFAULT_MODEL, selfTest: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     switch (a) {
@@ -96,43 +92,40 @@ function parseArgs(argv) {
       case '--focus': args.focus = argv[++i] ?? ''; break;
       case '--title': args.title = argv[++i] ?? ''; break;
       case '--model': args.model = argv[++i] ?? DEFAULT_MODEL; break;
-      case '--effort': args.effort = argv[++i] ?? DEFAULT_EFFORT; break;
       default:
-        process.stderr.write(`codex-review: unknown argument "${a}"\n`);
+        process.stderr.write(`claude-review: unknown argument "${a}"\n`);
         process.exit(2);
     }
   }
   return args;
 }
 
-function buildInstruction(args) {
+function buildPrompt(args) {
   const label = args.mode === 'chunk' ? 'chunk review' : 'whole-branch review';
   const titleLine = args.title ? `\nUnder review: ${args.title}` : '';
   const focusLine = args.focus ? `\nReview focus: ${args.focus}` : '';
   return [
     `You are a code reviewer performing a ${label} for the Discord Ferry project.`,
-    '',
-    PROJECT_CONTEXT,
     titleLine,
     focusLine,
     '',
     REVIEW_DIRECTIVES,
     '',
-    'The changed code follows on stdin.',
+    'The changed code follows below.',
   ].join('\n');
 }
 
-// Build a safe failure reason. Never echo an execFileSync error's `.message`/`.stderr`/`.stdout`:
+// Build a safe failure reason. Never echo an execFileSync error's .message/.stderr/.stdout:
 // those can carry child output (diff text, tokens). Report only structural metadata for a child
 // failure, and our own thrown messages (JSON parse, schema mismatch) verbatim, since we author them.
 function failureReason(err) {
   if (!err) return 'unknown error';
-  if (err.code === 'ENOENT') return 'codex CLI not found';
+  if (err.code === 'ENOENT') return 'claude CLI not found';
   if (typeof err.status === 'number' || err.signal) {
     const parts = [];
     if (typeof err.status === 'number') parts.push(`status ${err.status}`);
     if (err.signal) parts.push(`signal ${err.signal}`);
-    return `codex exec failed (${parts.join(', ')})`;
+    return `claude -p failed (${parts.join(', ')})`;
   }
   return err.message ?? String(err);
 }
@@ -163,45 +156,46 @@ function isValidResult(r) {
   return true;
 }
 
-function runCodex(args, payload) {
-  const tmp = mkdtempSync(join(tmpdir(), 'ferry-codex-review-'));
-  const schemaFile = join(tmp, 'schema.json');
-  const lastMsgFile = join(tmp, 'last-message.json');
+function runClaude(args, payload) {
+  const prompt = buildPrompt(args) + '\n' + payload;
+  const cliArgs = [
+    '-p',
+    '--model', args.model,
+    '--json-schema', JSON.stringify(FINDINGS_SCHEMA),
+    '--dangerously-skip-permissions',
+    '--allowedTools', '',
+    '--append-system-prompt', PROJECT_CONTEXT,
+  ];
+  // No internal timeout: the bash timeout is the only guard (see ADR-023).
+  // --allowedTools '' grants NO tools at all: not Bash, not Write, not Read, not WebFetch. A
+  // prompt-injection in the diff cannot read files or exfiltrate credentials. This is stronger
+  // than --disallowedTools with a partial denylist, which leaves read and network tools available.
+  // --dangerously-skip-permissions only suppresses the interactive prompt; it does not constrain
+  // the tool surface on its own.
+  // Capture stdout; ignore stderr so Claude diagnostics never reach our error output
+  // (ADR-014: tokens and diff text must not leak into errors).
+  const raw = execFileSync('claude', cliArgs, {
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+  // Claude -p with --json-schema returns the constrained JSON directly (bare JSON, no envelope).
+  // Wrap the parse so a SyntaxError (which embeds a snippet of the raw input) never leaks child
+  // stdout into our error output.
+  let parsed;
   try {
-    writeFileSync(schemaFile, JSON.stringify(FINDINGS_SCHEMA));
-    const cliArgs = [
-      'exec',
-      '-m', args.model,
-      '-c', `model_reasoning_effort="${args.effort}"`,
-      '-s', 'read-only',
-      '--skip-git-repo-check',
-      '--color', 'never',
-      '--output-schema', schemaFile,
-      '-o', lastMsgFile,
-      buildInstruction(args),
-    ];
-    // The -o file is the only output we read. Ignore the child's stdout/stderr so a verbose
-    // reasoning trace can never overflow execFileSync's buffer (turning a good review into a
-    // failure), and so Codex diagnostics can never reach our own error output (ADR-014: tokens
-    // and diff text must not leak into errors).
-    execFileSync('codex', cliArgs, {
-      input: payload,
-      encoding: 'utf8',
-      timeout: 600000,
-      stdio: ['pipe', 'ignore', 'ignore'],
-    });
-    const raw = readFileSync(lastMsgFile, 'utf8').trim();
-    const parsed = JSON.parse(raw); // throws on non-JSON → caller falls back
-    if (!isValidResult(parsed)) {
-      // Codex enforces the schema server-side, but do not trust that alone: a degraded CLI or a
-      // non-strict response could still parse as JSON. Reject anything off-shape so the caller
-      // falls back rather than acting on a malformed review.
-      throw new Error('codex response did not match the findings schema');
-    }
-    return parsed;
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('claude returned non-JSON stdout');
   }
+  if (!isValidResult(parsed)) {
+    // Claude enforces the schema via --json-schema, but do not trust that alone: a degraded CLI
+    // or a non-strict response could still parse as JSON. Reject anything off-shape so the caller
+    // falls back rather than acting on a malformed review.
+    throw new Error('claude response did not match the findings schema');
+  }
+  return parsed;
 }
 
 function selfTest() {
@@ -213,13 +207,12 @@ function selfTest() {
   record('parseArgs title', a.title === 'chunk 1');
   record('parseArgs mode', a.mode === 'chunk');
   record('parseArgs model default', a.model === DEFAULT_MODEL);
-  record('parseArgs effort default', a.effort === DEFAULT_EFFORT);
 
-  const instruction = buildInstruction(a);
-  record('instruction has project context', instruction.includes('core/engine.py never imports'));
-  record('instruction has focus', instruction.includes('Security: token handling'));
-  record('instruction has title', instruction.includes('chunk 1'));
-  record('instruction names chunk mode', instruction.includes('chunk review'));
+  const prompt = buildPrompt(a);
+  record('prompt has focus', prompt.includes('Security: token handling'));
+  record('prompt has title', prompt.includes('chunk 1'));
+  record('prompt names chunk mode', prompt.includes('chunk review'));
+  record('prompt does not embed project context', !prompt.includes('core/engine.py never imports'));
 
   // Schema is a bare JSON Schema (no Mistral response_format envelope).
   record('schema is unwrapped', FINDINGS_SCHEMA.type === 'object' && !('json_schema' in FINDINGS_SCHEMA));
@@ -244,17 +237,17 @@ function selfTest() {
   record('isValidResult rejects non-number line', isValidResult({ summary: 's', confidence: 'high', findings: [{ ...goodResult.findings[0], line: '42' }] }) === false);
 
   // Failure reasons never echo child output.
-  record('failureReason: missing binary', failureReason({ code: 'ENOENT' }) === 'codex CLI not found');
-  record('failureReason: exit status only', failureReason({ status: 23, stderr: 'SENSITIVE' }) === 'codex exec failed (status 23)');
+  record('failureReason: missing binary', failureReason({ code: 'ENOENT' }) === 'claude CLI not found');
+  record('failureReason: exit status only', failureReason({ status: 23, stderr: 'SENSITIVE' }) === 'claude -p failed (status 23)');
   record('failureReason: does not leak stderr', !failureReason({ status: 1, stderr: 'SENSITIVE', message: 'x SENSITIVE y' }).includes('SENSITIVE'));
 
   const failed = checks.filter((c) => !c.ok);
   for (const c of checks) process.stderr.write(`  ${c.ok ? 'ok  ' : 'FAIL'} ${c.name}\n`);
   if (failed.length) {
-    process.stderr.write(`codex-review self-test: ${failed.length} failure(s)\n`);
+    process.stderr.write(`claude-review self-test: ${failed.length} failure(s)\n`);
     process.exit(1);
   }
-  process.stderr.write('codex-review self-test: all checks passed\n');
+  process.stderr.write('claude-review self-test: all checks passed\n');
   process.exit(0);
 }
 
@@ -271,9 +264,9 @@ function main() {
 
   let result;
   try {
-    result = runCodex(args, payload);
+    result = runClaude(args, payload);
   } catch (err) {
-    process.stderr.write(`codex-review: ${failureReason(err)}\n`);
+    process.stderr.write(`claude-review: ${failureReason(err)}\n`);
     process.exit(1);
   }
   process.stdout.write(JSON.stringify(result));

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.31.0"
+__version__ = "2.32.0"

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -270,6 +270,16 @@ async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     return max(0.0, min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS))
 
 
+def _update_pacer_state(url: str, headers: Mapping[str, str]) -> None:
+    """Refresh the pacer's per-bucket state from a response's headers."""
+    parsed = _parse_ratelimit_headers(headers)
+    if parsed is None:
+        return
+    bucket_hash, new_state = parsed
+    _bucket_state[bucket_hash] = new_state
+    _url_to_bucket[url] = bucket_hash
+
+
 async def _api_request_inner(
     session: aiohttp.ClientSession,
     method: str,
@@ -299,10 +309,30 @@ async def _api_request_inner(
         _circuit_state.consecutive_failures = 0
 
     for attempt in range(MAX_API_RETRIES):
+        # Proactive pacer: if we have seen this URL's bucket and the shadow
+        # counter says the budget is exhausted, wait for the window to reset.
+        # The shadow counter is decremented before the request, not after, so
+        # two concurrent requests to the same bucket do not both fire.
+        bucket_hash = _url_to_bucket.get(url)
+        if bucket_hash is not None:
+            state = _bucket_state.get(bucket_hash)
+            if state is not None:
+                if state.remaining <= 0:
+                    wait = state.reset_at - time.monotonic()
+                    if wait > 0:
+                        logger.debug(
+                            "Pacer: bucket %s exhausted, waiting %.1fs",
+                            bucket_hash,
+                            wait,
+                        )
+                        await asyncio.sleep(wait)
+                state.remaining = max(state.remaining - 1, 0)
+
         try:
             async with session.request(method, url, json=body, headers=headers) as resp:
                 if resp.status in (200, 201):
                     _circuit_state.consecutive_failures = 0
+                    _update_pacer_state(url, resp.headers)
                     # Decay the rate multiplier gradually on successful requests.
                     if _rate_multiplier > 1.0 and not any(
                         time.monotonic() - t < 30 for t in _rate_429_window
@@ -317,6 +347,7 @@ async def _api_request_inner(
                         ) from exc
                 if resp.status == 204 or (resp.status == 404 and expected_404_ok):
                     _circuit_state.consecutive_failures = 0
+                    _update_pacer_state(url, resp.headers)
                     # Decay the rate multiplier gradually on successful requests.
                     if _rate_multiplier > 1.0 and not any(
                         time.monotonic() - t < 30 for t in _rate_429_window
@@ -340,6 +371,7 @@ async def _api_request_inner(
                         # content-type-guarded so a non-JSON 429 can't escape into the network
                         # path and prime the breaker; honour Retry-After over the body delay.
                         await asyncio.sleep(await _resolve_429_delay_seconds(resp))
+                        _update_pacer_state(url, resp.headers)
                         # Track 429 frequency and ramp up the rate multiplier.
                         _rate_429_window.append(time.monotonic())
                         recent = sum(1 for t in _rate_429_window if time.monotonic() - t < 60)
@@ -375,6 +407,7 @@ async def _api_request_inner(
                         # A delivered message, so this must not prime the breaker. Same
                         # bookkeeping as the 204 branch above.
                         _circuit_state.consecutive_failures = 0
+                        _update_pacer_state(url, resp.headers)
                         if _rate_multiplier > 1.0 and not any(
                             time.monotonic() - t < 30 for t in _rate_429_window
                         ):

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -308,6 +308,13 @@ async def _api_request_inner(
         await asyncio.sleep(_CIRCUIT_PAUSE_SECONDS)
         _circuit_state.consecutive_failures = 0
 
+    # Track the pacer charge so a retry on 5xx or network error can refund it.
+    # Without this, each retry attempt burns a rate-limit unit that the 429 path
+    # refreshes via _update_pacer_state but the 5xx/network paths do not, leaving
+    # the shadow counter too low until a headered response resets it.
+    charged_state = None
+    prev_remaining: int | None = None
+
     for attempt in range(MAX_API_RETRIES):
         # Proactive pacer: if we have seen this URL's bucket and the shadow
         # counter says the budget is exhausted, wait for the window to reset.
@@ -326,6 +333,8 @@ async def _api_request_inner(
                             wait,
                         )
                         await asyncio.sleep(wait)
+                charged_state = state
+                prev_remaining = state.remaining
                 state.remaining = max(state.remaining - 1, 0)
 
         try:
@@ -386,6 +395,11 @@ async def _api_request_inner(
                         delay = min(2**attempt, 60) + random.uniform(0.1, 0.5)
                         await asyncio.sleep(delay)
                         _circuit_state.consecutive_failures += 1
+                        # Refund the pacer charge: a 5xx carries no rate-limit headers,
+                        # so _update_pacer_state is not called. Without the refund, each
+                        # retry burns a unit the server never accounted for.
+                        if charged_state is not None and prev_remaining is not None:
+                            charged_state.remaining = prev_remaining
                     continue
 
                 if resp.status == 409:
@@ -446,6 +460,11 @@ async def _api_request_inner(
             delay = min(2**attempt, 60) + random.uniform(0.1, 0.5)
             await asyncio.sleep(delay)
             _circuit_state.consecutive_failures += 1
+            # Refund the pacer charge: a network error carries no rate-limit headers,
+            # so _update_pacer_state is not called. Without the refund, each retry burns
+            # a unit the server never accounted for.
+            if charged_state is not None and prev_remaining is not None:
+                charged_state.remaining = prev_remaining
 
     # Unreachable, but satisfies mypy.
     raise MigrationError(f"API request failed after {MAX_API_RETRIES} retries")

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -45,6 +45,20 @@ class _CircuitState:
     consecutive_failures: int = 0
 
 
+@dataclass
+class _BucketState:
+    """Proactive pacer state for one rate-limit bucket.
+
+    ``remaining`` is a shadow counter decremented on each outgoing request
+    and refreshed from ``X-RateLimit-Remaining`` on each response. It can go
+    negative under concurrency; the pacer clamps to 0 and paces.
+    """
+
+    remaining: int = 0
+    limit: int = 0
+    reset_at: float = 0.0  # monotonic time when the window replenishes
+
+
 # Module-level state — safe for single-migration-per-process model.
 _circuit_state = _CircuitState()
 _request_semaphore: asyncio.Semaphore | None = None
@@ -52,6 +66,12 @@ _request_semaphore: asyncio.Semaphore | None = None
 # Adaptive rate state — tracks 429 pressure and adjusts inter-request delay.
 _rate_429_window: deque[float] = deque(maxlen=20)  # timestamps of recent 429s
 _rate_multiplier: float = 1.0
+
+# Proactive pacer state — keyed by the X-RateLimit-Bucket hash from responses.
+# Foundational area: see .claude/rules/decision-accountability.md. Additive:
+# no modification to _rate_multiplier, _rate_429_window, or _circuit_state.
+_bucket_state: dict[str, _BucketState] = {}
+_url_to_bucket: dict[str, str] = {}
 
 
 def _reset_circuit_state() -> None:
@@ -64,6 +84,12 @@ def _reset_rate_state() -> None:
     global _rate_multiplier  # noqa: PLW0603
     _rate_429_window.clear()
     _rate_multiplier = 1.0
+
+
+def _reset_pacer_state() -> None:
+    """Reset proactive pacer state. Called by test fixtures."""
+    _bucket_state.clear()
+    _url_to_bucket.clear()
 
 
 def get_rate_multiplier() -> float:

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -213,6 +213,35 @@ def _stoat_rate_delay_seconds(headers: Mapping[str, str]) -> float | None:
     return None
 
 
+def _parse_ratelimit_headers(
+    headers: Mapping[str, str],
+) -> tuple[str, _BucketState] | None:
+    """Parse X-RateLimit-* headers into a bucket hash and a _BucketState.
+
+    Returns None when the headers are missing or non-numeric, so the caller
+    skips the pacer update without crashing. ``X-RateLimit-Reset-After`` is
+    milliseconds (same unit rule as :func:`_stoat_rate_delay_seconds`).
+    """
+    raw_bucket = headers.get("X-RateLimit-Bucket")
+    raw_remaining = headers.get("X-RateLimit-Remaining")
+    raw_limit = headers.get("X-RateLimit-Limit")
+    raw_reset = headers.get("X-RateLimit-Reset-After")
+    if not raw_bucket or raw_remaining is None or raw_limit is None or raw_reset is None:
+        return None
+    try:
+        remaining = int(raw_remaining)
+        limit = int(raw_limit)
+        reset_after_s = float(raw_reset) / 1000
+    except (ValueError, TypeError):
+        logger.debug("Non-numeric X-RateLimit header: %s", dict(headers))
+        return None
+    return raw_bucket, _BucketState(
+        remaining=remaining,
+        limit=limit,
+        reset_at=time.monotonic() + reset_after_s,
+    )
+
+
 async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     """Resolve the 429 sleep in seconds: headers → body ``retry_after`` (ms) → 1s; capped.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2390,6 +2390,39 @@ async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
         assert _bucket_state["b1"].remaining == 1
 
 
+async def test_pacer_5xx_retries_refund_decrement(mock_aiohttp: aioresponses) -> None:
+    """A request that exhausts retries on 502 burns only one rate-limit unit, not one per retry."""
+    from discord_ferry.migrator.api import _bucket_state
+
+    url = f"{BASE_URL}/servers/srv1"
+    # Prime the pacer so the bucket has a known remaining count.
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "3",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    for _ in range(3):
+        mock_aiohttp.get(
+            url,
+            status=502,
+            body="Bad Gateway",
+        )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        with pytest.raises(MigrationError, match="API request failed after 3 retries"):
+            await _api_request(session, "GET", url, TOKEN)
+        # Three 502 retries refunded the first two decrements; the last attempt
+        # (which raises) left exactly one unit consumed. Before the refund fix
+        # this was 0 (three decrements, no refresh).
+        assert _bucket_state["b1"].remaining == 2
+
+
 # ---------------------------------------------------------------------------
 # Proactive pacer — remaining scenario tests (Task 4)
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ from discord_ferry.core.http import new_session
 from discord_ferry.errors import DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
+    _BucketState,
     _circuit_state,
     _headers,
     _reset_circuit_state,
@@ -2387,3 +2388,187 @@ async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
         # refreshes it. So remaining == 1 (from the header), not 0 (from the
         # decrement).
         assert _bucket_state["b1"].remaining == 1
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — remaining scenario tests (Task 4)
+# ---------------------------------------------------------------------------
+
+
+async def test_pacer_429_fires_when_stale(mock_aiohttp: aioresponses) -> None:
+    """The 429 retry path fires if the pacer's shadow was stale."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "1",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        status=429,
+        payload={"retry_after": 100},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        await _api_request(session, "GET", url, TOKEN)  # gets 429, retries, succeeds
+
+
+async def test_pacer_shadow_clamps_negative(mock_aiohttp: aioresponses) -> None:
+    """Shadow counter going negative clamps to 0, not left negative."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    _url_to_bucket[url] = "b1"
+    _bucket_state["b1"] = _BucketState(remaining=1, limit=5, reset_at=time.monotonic() + 100)
+
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        assert _bucket_state["b1"].remaining >= 0
+
+
+async def test_pacer_different_bucket_not_delayed(mock_aiohttp: aioresponses) -> None:
+    """An exhausted bucket does not delay a request to a different bucket."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    _bucket_state["bucket_A"] = _BucketState(remaining=0, limit=5, reset_at=time.monotonic() + 100)
+    _url_to_bucket[f"{BASE_URL}/servers/srv1"] = "bucket_A"
+
+    url2 = f"{BASE_URL}/channels/ch1"
+    mock_aiohttp.get(
+        url2,
+        payload={"_id": "ch1"},
+        headers={
+            "X-RateLimit-Remaining": "15",
+            "X-RateLimit-Limit": "15",
+            "X-RateLimit-Bucket": "bucket_B",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url2, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_reset_after_expiry(mock_aiohttp: aioresponses) -> None:
+    """After the reset time passes, a previously-exhausted bucket sends immediately."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    _url_to_bucket[url] = "b1"
+    _bucket_state["b1"] = _BucketState(remaining=0, limit=5, reset_at=time.monotonic() - 0.01)
+
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_debug_log_on_pace(
+    mock_aiohttp: aioresponses,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A paced pause produces a debug log line with the bucket hash."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    with caplog.at_level(logging.DEBUG, logger="discord_ferry.migrator.api"):
+        async with new_session() as session:
+            await _api_request(session, "GET", url, TOKEN)
+            await _api_request(session, "GET", url, TOKEN)
+    assert any("Pacer" in r.message and "b1" in r.message for r in caplog.records)
+
+
+async def test_pacer_no_debug_log_when_not_paced(
+    mock_aiohttp: aioresponses,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-paced request produces no pacing log line."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    with caplog.at_level(logging.DEBUG, logger="discord_ferry.migrator.api"):
+        async with new_session() as session:
+            await _api_request(session, "GET", url, TOKEN)
+            await _api_request(session, "GET", url, TOKEN)
+    assert not any("Pacer" in r.message for r in caplog.records)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import ssl
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -2188,3 +2189,46 @@ async def test_emoji_list_rejects_a_non_list_body(mock_aiohttp: aioresponses) ->
     async with aiohttp.ClientSession() as session:
         with pytest.raises(MigrationError, match="JSON array"):
             await api_fetch_emoji_list(session, BASE_URL, TOKEN, "srv1")
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — _parse_ratelimit_headers (Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_pacer_parses_headers_from_response() -> None:
+    """_parse_ratelimit_headers extracts remaining, limit, bucket, reset_at."""
+    from discord_ferry.migrator.api import _parse_ratelimit_headers
+
+    headers = {
+        "X-RateLimit-Remaining": "3",
+        "X-RateLimit-Limit": "5",
+        "X-RateLimit-Bucket": "hash123",
+        "X-RateLimit-Reset-After": "8000",
+    }
+    result = _parse_ratelimit_headers(headers)
+    assert result is not None
+    bucket, state = result
+    assert bucket == "hash123"
+    assert state.remaining == 3
+    assert state.limit == 5
+    assert state.reset_at - time.monotonic() == pytest.approx(8.0, rel=0.1)
+
+
+def test_pacer_missing_headers_returns_none() -> None:
+    """Missing X-RateLimit headers return None, no crash."""
+    from discord_ferry.migrator.api import _parse_ratelimit_headers
+
+    assert _parse_ratelimit_headers({}) is None
+    assert _parse_ratelimit_headers({"X-RateLimit-Remaining": "3"}) is None
+    assert (
+        _parse_ratelimit_headers(
+            {
+                "X-RateLimit-Bucket": "b1",
+                "X-RateLimit-Remaining": "x",
+                "X-RateLimit-Limit": "5",
+                "X-RateLimit-Reset-After": "1000",
+            }
+        )
+        is None
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,7 @@ from discord_ferry.migrator.api import (
     _circuit_state,
     _headers,
     _reset_circuit_state,
+    _reset_pacer_state,
     _reset_rate_state,
     api_add_reaction,
     api_create_channel,
@@ -62,15 +63,17 @@ TOKEN = "test-session-token"
 
 @pytest.fixture(autouse=True)
 def _clean_circuit() -> None:  # type: ignore[misc]
-    """Reset circuit breaker, semaphore, and adaptive rate state between tests."""
+    """Reset circuit breaker, semaphore, adaptive rate, and pacer state between tests."""
     import discord_ferry.migrator.api as _api_mod
 
     _reset_circuit_state()
     _reset_rate_state()
+    _reset_pacer_state()
     _api_mod._request_semaphore = None
     yield  # type: ignore[misc]
     _reset_circuit_state()
     _reset_rate_state()
+    _reset_pacer_state()
     _api_mod._request_semaphore = None
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2232,3 +2232,158 @@ def test_pacer_missing_headers_returns_none() -> None:
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — pacing logic in _api_request_inner (Task 3)
+# ---------------------------------------------------------------------------
+
+
+async def test_pacer_pauses_on_remaining_zero(mock_aiohttp: aioresponses) -> None:
+    """A response with Remaining: 0 causes the next request to wait."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",  # 0.1s in ms
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        start = time.monotonic()
+        await _api_request(session, "GET", url, TOKEN)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.08  # waited at least ~0.1s
+
+
+async def test_pacer_no_pause_on_remaining_positive(mock_aiohttp: aioresponses) -> None:
+    """Remaining: 4 does not trigger a pause."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "4",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "4",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        start = time.monotonic()
+        await _api_request(session, "GET", url, TOKEN)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.05  # no pacing delay
+
+
+async def test_pacer_bucket_state_updated_from_response(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """After a 200, _bucket_state has the response's bucket info."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "3",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "hash123",
+            "X-RateLimit-Reset-After": "8000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+
+    assert "hash123" in _bucket_state
+    assert _bucket_state["hash123"].remaining == 3
+    assert _bucket_state["hash123"].limit == 5
+    assert url in _url_to_bucket
+    assert _url_to_bucket[url] == "hash123"
+
+
+async def test_pacer_first_request_not_delayed(mock_aiohttp: aioresponses) -> None:
+    """A URL with no prior state sends immediately."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
+    """The shadow counter decrements before the request, then the response overwrites it."""
+    from discord_ferry.migrator.api import _bucket_state
+
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "2",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "1",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        await _api_request(session, "GET", url, TOKEN)
+        # After the second response, _update_pacer_state overwrites the shadow
+        # with the server's actual value. The shadow decrement happened before
+        # the request (protecting against concurrency), but the response
+        # refreshes it. So remaining == 1 (from the header), not 0 (from the
+        # decrement).
+        assert _bucket_state["b1"].remaining == 1

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.31.0"
+version = "2.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Two changes on this branch:

### 1. Cross-host second-opinion review (ADR-023)

The review gates in /df-ship and /df-chunk-review now run a cross-host fallback chain, so the reviewer is never the same model family as the host running the build.

| Host | Primary | Fallback | Last resort |
|------|---------|----------|-------------|
| Vibe | Codex | Claude | skip |
| Claude Code | Codex | Mistral MCP | skip |
| Codex | Claude | Mistral MCP | skip |

New helper: `scripts/agent-compat/claude-review.mjs`, mirroring `codex-review.mjs`. It wraps `claude -p` with `--json-schema`, `--allowedTools ''` (no tool access at all, so a prompt-injection in the diff cannot read files or exfiltrate credentials), and `--append-system-prompt`. Returns the same `code_review_findings` schema. Self-test passes 23/23 checks. End-to-end verified against the real Claude CLI.

The Codex review bash calls also gained a 600-second timeout note in both skills. A short bash timeout killed the review during a past ship.

### 2. Pacer retry refund (bug fix on the pacing work)

The proactive pacer decremented its shadow counter before each request attempt, but only the 429 path refreshed the shadow from response headers. A request that retried on a 502 or network error burned one unit per retry against a stale shadow. The next request then paced spuriously until a headered response reset it. The 5xx and network-error paths now refund the decrement, so one logical request consumes exactly one unit regardless of retry count. Test added.

## Review findings addressed

The code review (inline subagent) and Codex second opinion found three issues in the Claude helper, all fixed before this PR:

1. `JSON.parse` error messages embed a snippet of the raw input, which could leak child stdout into our error output. Fixed: wrapped the parse, rethrow with a fixed string.
2. `--dangerously-skip-permissions` bypasses all permission checks, leaving read and network tools available for prompt-injection. Fixed: replaced `--disallowedTools` with `--allowedTools ''` (no tools at all).
3. `isValidResult` did not validate enums (severity, category, confidence) or the line type. Fixed: tightened the validator in both helpers, added test cases.

## Verify

```
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
``
2326 passed. Lint, format, types all clean.

Closes ADR-023 update.