### PR TITLE
v2.33.0: Emoji rename detection, proactive rate-limit pacing, cross-host review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Ferry paces Stoat API requests proactively before a rate-limit bucket exhausts.** Stoat
+  sends `X-RateLimit-Remaining` on every response, not just 429s. Ferry now reads that header
+  on every response and pauses before the next request to the same bucket when the remaining
+  budget reaches zero, waiting for the advertised window reset instead of burning a request
+  to discover the bucket is empty. A shadow counter decremented before each request prevents
+  two concurrent requests from both firing into the same exhausted budget. This applies to
+  every Stoat API call through the shared request layer, so the structure, emoji, reactions
+  and pins phases, which previously had no damping at all, now benefit alongside the messages
+  phase. The existing adaptive multiplier and 429 retry path remain unchanged as a safety net.
+  Closes #111.
+
 ### Fixed
+
+- **content: Reference pages now describe the rendered-mention check accurately.** Two
+  reference pages still framed the VALIDATE check as detecting only a missing `--markdown
+  false` flag. The check also flags `@Unknown`, which DiscordChatExporter writes for a member
+  it could not resolve, and no longer fires on a reply, an embed-carried mention or an
+  attachment-only message. Closes #153.
 
 - **content: Em-dash and banned-word debt removed from known-limitations guide.** Five
   em-dashes and a `silently` in `docs/guides/known-limitations.md` failed the plain-english

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `ferry check` now detects renamed emoji. The name Ferry creates for each emoji is recorded in
+  `state.json` and compared against the server on check, producing an `emoji_renamed` warning when
+  they differ. Closes #304.
+
 - **Cross-host second-opinion review.** The /df-ship and /df-chunk-review review gates now run a
   cross-host fallback chain so the reviewer is never the same model family as the host running
   the build. On Vibe, Codex reviews with Claude as fallback. On Claude Code, Codex reviews with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Cross-host second-opinion review.** The /df-ship and /df-chunk-review review gates now run a
+  cross-host fallback chain so the reviewer is never the same model family as the host running
+  the build. On Vibe, Codex reviews with Claude as fallback. On Claude Code, Codex reviews with
+  the Mistral MCP as fallback. On Codex, Claude reviews with the Mistral MCP as last resort.
+  A new helper, `scripts/agent-compat/claude-review.mjs`, wraps `claude -p` with `--json-schema`
+  and no tool access (`--allowedTools ''`), returning findings in the same `code_review_findings`
+  schema as the Codex helper. Closes the circular-review gap noted in ADR-023.
+
 - **Ferry paces Stoat API requests proactively before a rate-limit bucket exhausts.** Stoat
   sends `X-RateLimit-Remaining` on every response, not just 429s. Ferry now reads that header
   on every response and pauses before the next request to the same bucket when the remaining
@@ -20,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Closes #111.
 
 ### Fixed
+
+- **Pacer no longer over-spends rate-limit budget on 5xx and network-error retries.** The
+  proactive pacer decremented its shadow counter before each request attempt, but only the 429
+  path refreshed the shadow from response headers. A request that retried on a 502 or a network
+  error burned one unit per retry against a stale shadow, causing the next request to pace
+  spuriously. The 5xx and network-error paths now refund the decrement, so one logical request
+  consumes exactly one unit regardless of retry count.
 
 - **content: Reference pages now describe the rendered-mention check accurately.** Two
   reference pages still framed the VALIDATE check as detecting only a missing `--markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [2.33.0] - 2026-08-23
 
 ### Added
 

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -131,7 +131,7 @@ These limitations relate to platform-level features that either work differently
 
 **A channel that gained more than 100 messages since the migration cannot be checked.** The window no longer reaches back to the message Ferry recorded, so Check reports `unverifiable` rather than guessing. This is common on an active server.
 
-**A renamed channel or role is only detected for migrations run under 2.17.0 or later.** From that release Ferry records the name it gave each channel and role, so `ferry check` can compare it against the current one and reports a rename as a warning. A migration run by an earlier version recorded no such names, and nothing can recover them after the fact, so a rename there stays invisible. Renamed *categories* have always been detected, because category names were recorded from the start.
+**A renamed channel, role, or emoji is only detected for migrations run under 2.17.0 or later for channels and roles, and under 2.33.0 or later for emoji.** From those releases Ferry records the name it gave each entity, so `ferry check` can compare it against the current one and reports a rename as a warning. A migration run by an earlier version recorded no such names, and nothing can recover them after the fact, so a rename there stays invisible. Renamed *categories* have always been detected, because category names were recorded from the start.
 
 **A message accepted as a duplicate cannot be confirmed.** When Stoat recognises a retry and refuses it, it does not say which message it already had, so Ferry has no identifier to check later. Channels affected this way report `unverifiable`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.31.0"
+version = "2.32.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.32.0"
+version = "2.33.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/agent-compat/claude-review.mjs
+++ b/scripts/agent-compat/claude-review.mjs
@@ -1,30 +1,26 @@
 #!/usr/bin/env node
-// Discord Ferry — Codex second-opinion reviewer.
-// Runs `codex exec` (default gpt-5.6-sol, high effort) as the primary code reviewer for
+// Discord Ferry - Claude Code second-opinion reviewer.
+// Runs `claude -p` (default claude-opus-4-8) as a cross-host fallback reviewer for
 // /df-ship step 4 and /df-chunk-review step 3, returning findings in Ferry's own
 // `code_review_findings` schema. See ADR-023.
 //
 // The caller pipes the review payload on stdin: the `git diff` for a whole-branch review, or
 // the full changed files followed by their diff for a chunk review. The instruction (focus text)
-// is passed with --focus. On any Codex failure this exits non-zero so the caller can fall back
-// to the Mistral MCP call.
+// is passed with --focus. On any Claude failure this exits non-zero so the caller can fall back
+// to the next reviewer in the chain.
 //
 // Usage:
-//   git diff origin/main | node codex-review.mjs --focus "API: rate limits, retry logic" --title "chunk 2"
-//   node codex-review.mjs --self-test
+//   git diff origin/main | node claude-review.mjs --focus "API: rate limits, retry logic" --title "chunk 2"
+//   node claude-review.mjs --self-test
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 
-const DEFAULT_MODEL = 'gpt-5.6-sol';
-const DEFAULT_EFFORT = 'high';
+const DEFAULT_MODEL = 'claude-opus-4-8';
 
-// Ferry's canonical review schema, unwrapped from Mistral's response_format envelope.
+// Ferry's canonical review schema, identical to codex-review.mjs.
 // Kept in sync with .claude/skills/df-chunk-review/SKILL.md step 3.
-// OpenAI structured outputs run in strict mode: every object needs additionalProperties:false,
-// and every property must appear in `required` (optional fields use a nullable type instead).
+// Claude's --json-schema accepts a bare JSON Schema object, same shape as Codex's --output-schema.
 const FINDINGS_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -87,7 +83,7 @@ verification command that distinguishes the finding being true from being false;
 be run by the caller, so you never need to run it yourself.`;
 
 function parseArgs(argv) {
-  const args = { mode: 'whole-branch', focus: '', title: '', model: DEFAULT_MODEL, effort: DEFAULT_EFFORT, selfTest: false };
+  const args = { mode: 'whole-branch', focus: '', title: '', model: DEFAULT_MODEL, selfTest: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     switch (a) {
@@ -96,43 +92,40 @@ function parseArgs(argv) {
       case '--focus': args.focus = argv[++i] ?? ''; break;
       case '--title': args.title = argv[++i] ?? ''; break;
       case '--model': args.model = argv[++i] ?? DEFAULT_MODEL; break;
-      case '--effort': args.effort = argv[++i] ?? DEFAULT_EFFORT; break;
       default:
-        process.stderr.write(`codex-review: unknown argument "${a}"\n`);
+        process.stderr.write(`claude-review: unknown argument "${a}"\n`);
         process.exit(2);
     }
   }
   return args;
 }
 
-function buildInstruction(args) {
+function buildPrompt(args) {
   const label = args.mode === 'chunk' ? 'chunk review' : 'whole-branch review';
   const titleLine = args.title ? `\nUnder review: ${args.title}` : '';
   const focusLine = args.focus ? `\nReview focus: ${args.focus}` : '';
   return [
     `You are a code reviewer performing a ${label} for the Discord Ferry project.`,
-    '',
-    PROJECT_CONTEXT,
     titleLine,
     focusLine,
     '',
     REVIEW_DIRECTIVES,
     '',
-    'The changed code follows on stdin.',
+    'The changed code follows below.',
   ].join('\n');
 }
 
-// Build a safe failure reason. Never echo an execFileSync error's `.message`/`.stderr`/`.stdout`:
+// Build a safe failure reason. Never echo an execFileSync error's .message/.stderr/.stdout:
 // those can carry child output (diff text, tokens). Report only structural metadata for a child
 // failure, and our own thrown messages (JSON parse, schema mismatch) verbatim, since we author them.
 function failureReason(err) {
   if (!err) return 'unknown error';
-  if (err.code === 'ENOENT') return 'codex CLI not found';
+  if (err.code === 'ENOENT') return 'claude CLI not found';
   if (typeof err.status === 'number' || err.signal) {
     const parts = [];
     if (typeof err.status === 'number') parts.push(`status ${err.status}`);
     if (err.signal) parts.push(`signal ${err.signal}`);
-    return `codex exec failed (${parts.join(', ')})`;
+    return `claude -p failed (${parts.join(', ')})`;
   }
   return err.message ?? String(err);
 }
@@ -163,45 +156,46 @@ function isValidResult(r) {
   return true;
 }
 
-function runCodex(args, payload) {
-  const tmp = mkdtempSync(join(tmpdir(), 'ferry-codex-review-'));
-  const schemaFile = join(tmp, 'schema.json');
-  const lastMsgFile = join(tmp, 'last-message.json');
+function runClaude(args, payload) {
+  const prompt = buildPrompt(args) + '\n' + payload;
+  const cliArgs = [
+    '-p',
+    '--model', args.model,
+    '--json-schema', JSON.stringify(FINDINGS_SCHEMA),
+    '--dangerously-skip-permissions',
+    '--allowedTools', '',
+    '--append-system-prompt', PROJECT_CONTEXT,
+  ];
+  // No internal timeout: the bash timeout is the only guard (see ADR-023).
+  // --allowedTools '' grants NO tools at all: not Bash, not Write, not Read, not WebFetch. A
+  // prompt-injection in the diff cannot read files or exfiltrate credentials. This is stronger
+  // than --disallowedTools with a partial denylist, which leaves read and network tools available.
+  // --dangerously-skip-permissions only suppresses the interactive prompt; it does not constrain
+  // the tool surface on its own.
+  // Capture stdout; ignore stderr so Claude diagnostics never reach our error output
+  // (ADR-014: tokens and diff text must not leak into errors).
+  const raw = execFileSync('claude', cliArgs, {
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+  // Claude -p with --json-schema returns the constrained JSON directly (bare JSON, no envelope).
+  // Wrap the parse so a SyntaxError (which embeds a snippet of the raw input) never leaks child
+  // stdout into our error output.
+  let parsed;
   try {
-    writeFileSync(schemaFile, JSON.stringify(FINDINGS_SCHEMA));
-    const cliArgs = [
-      'exec',
-      '-m', args.model,
-      '-c', `model_reasoning_effort="${args.effort}"`,
-      '-s', 'read-only',
-      '--skip-git-repo-check',
-      '--color', 'never',
-      '--output-schema', schemaFile,
-      '-o', lastMsgFile,
-      buildInstruction(args),
-    ];
-    // The -o file is the only output we read. Ignore the child's stdout/stderr so a verbose
-    // reasoning trace can never overflow execFileSync's buffer (turning a good review into a
-    // failure), and so Codex diagnostics can never reach our own error output (ADR-014: tokens
-    // and diff text must not leak into errors).
-    execFileSync('codex', cliArgs, {
-      input: payload,
-      encoding: 'utf8',
-      timeout: 600000,
-      stdio: ['pipe', 'ignore', 'ignore'],
-    });
-    const raw = readFileSync(lastMsgFile, 'utf8').trim();
-    const parsed = JSON.parse(raw); // throws on non-JSON → caller falls back
-    if (!isValidResult(parsed)) {
-      // Codex enforces the schema server-side, but do not trust that alone: a degraded CLI or a
-      // non-strict response could still parse as JSON. Reject anything off-shape so the caller
-      // falls back rather than acting on a malformed review.
-      throw new Error('codex response did not match the findings schema');
-    }
-    return parsed;
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('claude returned non-JSON stdout');
   }
+  if (!isValidResult(parsed)) {
+    // Claude enforces the schema via --json-schema, but do not trust that alone: a degraded CLI
+    // or a non-strict response could still parse as JSON. Reject anything off-shape so the caller
+    // falls back rather than acting on a malformed review.
+    throw new Error('claude response did not match the findings schema');
+  }
+  return parsed;
 }
 
 function selfTest() {
@@ -213,13 +207,12 @@ function selfTest() {
   record('parseArgs title', a.title === 'chunk 1');
   record('parseArgs mode', a.mode === 'chunk');
   record('parseArgs model default', a.model === DEFAULT_MODEL);
-  record('parseArgs effort default', a.effort === DEFAULT_EFFORT);
 
-  const instruction = buildInstruction(a);
-  record('instruction has project context', instruction.includes('core/engine.py never imports'));
-  record('instruction has focus', instruction.includes('Security: token handling'));
-  record('instruction has title', instruction.includes('chunk 1'));
-  record('instruction names chunk mode', instruction.includes('chunk review'));
+  const prompt = buildPrompt(a);
+  record('prompt has focus', prompt.includes('Security: token handling'));
+  record('prompt has title', prompt.includes('chunk 1'));
+  record('prompt names chunk mode', prompt.includes('chunk review'));
+  record('prompt does not embed project context', !prompt.includes('core/engine.py never imports'));
 
   // Schema is a bare JSON Schema (no Mistral response_format envelope).
   record('schema is unwrapped', FINDINGS_SCHEMA.type === 'object' && !('json_schema' in FINDINGS_SCHEMA));
@@ -244,17 +237,17 @@ function selfTest() {
   record('isValidResult rejects non-number line', isValidResult({ summary: 's', confidence: 'high', findings: [{ ...goodResult.findings[0], line: '42' }] }) === false);
 
   // Failure reasons never echo child output.
-  record('failureReason: missing binary', failureReason({ code: 'ENOENT' }) === 'codex CLI not found');
-  record('failureReason: exit status only', failureReason({ status: 23, stderr: 'SENSITIVE' }) === 'codex exec failed (status 23)');
+  record('failureReason: missing binary', failureReason({ code: 'ENOENT' }) === 'claude CLI not found');
+  record('failureReason: exit status only', failureReason({ status: 23, stderr: 'SENSITIVE' }) === 'claude -p failed (status 23)');
   record('failureReason: does not leak stderr', !failureReason({ status: 1, stderr: 'SENSITIVE', message: 'x SENSITIVE y' }).includes('SENSITIVE'));
 
   const failed = checks.filter((c) => !c.ok);
   for (const c of checks) process.stderr.write(`  ${c.ok ? 'ok  ' : 'FAIL'} ${c.name}\n`);
   if (failed.length) {
-    process.stderr.write(`codex-review self-test: ${failed.length} failure(s)\n`);
+    process.stderr.write(`claude-review self-test: ${failed.length} failure(s)\n`);
     process.exit(1);
   }
-  process.stderr.write('codex-review self-test: all checks passed\n');
+  process.stderr.write('claude-review self-test: all checks passed\n');
   process.exit(0);
 }
 
@@ -271,9 +264,9 @@ function main() {
 
   let result;
   try {
-    result = runCodex(args, payload);
+    result = runClaude(args, payload);
   } catch (err) {
-    process.stderr.write(`codex-review: ${failureReason(err)}\n`);
+    process.stderr.write(`claude-review: ${failureReason(err)}\n`);
     process.exit(1);
   }
   process.stdout.write(JSON.stringify(result));

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.31.0"
+__version__ = "2.32.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2253,7 +2253,7 @@ async def _run_emoji_repair_pass(
             continue
 
         name = record["name"]
-        new_id = await upload_and_create_emoji(
+        new_id, emoji_name = await upload_and_create_emoji(
             session, config, state, file_path=file_path, name=name, used_names=used_names
         )
         # ONE save writes the new map value AND the resume record together, so a
@@ -2261,6 +2261,7 @@ async def _run_emoji_repair_pass(
         # From this point emoji_map already points at the new emoji, so a re-run's
         # check reports it present and never recreates a second one.
         state.emoji_map[discord_id] = new_id
+        state.created_emoji_names[discord_id] = emoji_name
         state.pending_emoji_rewrites[discord_id] = {"old": old_id, "new": new_id}
         save_state(state, config.output_dir)
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -313,6 +313,7 @@ async def run_migration(
             #     created_channel_names / created_role_names (a carried entity
             #     skips creation, so nothing re-records its name; omitting these
             #     makes ferry check report ok for a renamed channel),
+            #     created_emoji_names (same reason, for emoji),
             #     category_names, channel_categories, message_map, avatar_cache,
             #     upload_cache, author_names, stoat_server_id, autumn_url,
             #     invite_code / invite_url, channel_message_offsets,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -255,6 +255,7 @@ async def run_migration(
             # and ferry check reports ok for a renamed channel.
             state.created_channel_names = dict(prior.created_channel_names)
             state.created_role_names = dict(prior.created_role_names)
+            state.created_emoji_names = dict(prior.created_emoji_names)
             # C1: carry finalized-roles so incremental skips re-editing (load_state seeds `prior`
             # for old-ferry states). Without this every incremental run re-PATCHes all roles.
             state.roles_finalized = set(prior.roles_finalized)

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -270,6 +270,16 @@ async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     return max(0.0, min(retry_ms / 1000, _MAX_RETRY_DELAY_SECONDS))
 
 
+def _update_pacer_state(url: str, headers: Mapping[str, str]) -> None:
+    """Refresh the pacer's per-bucket state from a response's headers."""
+    parsed = _parse_ratelimit_headers(headers)
+    if parsed is None:
+        return
+    bucket_hash, new_state = parsed
+    _bucket_state[bucket_hash] = new_state
+    _url_to_bucket[url] = bucket_hash
+
+
 async def _api_request_inner(
     session: aiohttp.ClientSession,
     method: str,
@@ -299,10 +309,30 @@ async def _api_request_inner(
         _circuit_state.consecutive_failures = 0
 
     for attempt in range(MAX_API_RETRIES):
+        # Proactive pacer: if we have seen this URL's bucket and the shadow
+        # counter says the budget is exhausted, wait for the window to reset.
+        # The shadow counter is decremented before the request, not after, so
+        # two concurrent requests to the same bucket do not both fire.
+        bucket_hash = _url_to_bucket.get(url)
+        if bucket_hash is not None:
+            state = _bucket_state.get(bucket_hash)
+            if state is not None:
+                if state.remaining <= 0:
+                    wait = state.reset_at - time.monotonic()
+                    if wait > 0:
+                        logger.debug(
+                            "Pacer: bucket %s exhausted, waiting %.1fs",
+                            bucket_hash,
+                            wait,
+                        )
+                        await asyncio.sleep(wait)
+                state.remaining = max(state.remaining - 1, 0)
+
         try:
             async with session.request(method, url, json=body, headers=headers) as resp:
                 if resp.status in (200, 201):
                     _circuit_state.consecutive_failures = 0
+                    _update_pacer_state(url, resp.headers)
                     # Decay the rate multiplier gradually on successful requests.
                     if _rate_multiplier > 1.0 and not any(
                         time.monotonic() - t < 30 for t in _rate_429_window
@@ -317,6 +347,7 @@ async def _api_request_inner(
                         ) from exc
                 if resp.status == 204 or (resp.status == 404 and expected_404_ok):
                     _circuit_state.consecutive_failures = 0
+                    _update_pacer_state(url, resp.headers)
                     # Decay the rate multiplier gradually on successful requests.
                     if _rate_multiplier > 1.0 and not any(
                         time.monotonic() - t < 30 for t in _rate_429_window
@@ -340,6 +371,7 @@ async def _api_request_inner(
                         # content-type-guarded so a non-JSON 429 can't escape into the network
                         # path and prime the breaker; honour Retry-After over the body delay.
                         await asyncio.sleep(await _resolve_429_delay_seconds(resp))
+                        _update_pacer_state(url, resp.headers)
                         # Track 429 frequency and ramp up the rate multiplier.
                         _rate_429_window.append(time.monotonic())
                         recent = sum(1 for t in _rate_429_window if time.monotonic() - t < 60)
@@ -375,6 +407,7 @@ async def _api_request_inner(
                         # A delivered message, so this must not prime the breaker. Same
                         # bookkeeping as the 204 branch above.
                         _circuit_state.consecutive_failures = 0
+                        _update_pacer_state(url, resp.headers)
                         if _rate_multiplier > 1.0 and not any(
                             time.monotonic() - t < 30 for t in _rate_429_window
                         ):

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -308,6 +308,13 @@ async def _api_request_inner(
         await asyncio.sleep(_CIRCUIT_PAUSE_SECONDS)
         _circuit_state.consecutive_failures = 0
 
+    # Track the pacer charge so a retry on 5xx or network error can refund it.
+    # Without this, each retry attempt burns a rate-limit unit that the 429 path
+    # refreshes via _update_pacer_state but the 5xx/network paths do not, leaving
+    # the shadow counter too low until a headered response resets it.
+    charged_state = None
+    prev_remaining: int | None = None
+
     for attempt in range(MAX_API_RETRIES):
         # Proactive pacer: if we have seen this URL's bucket and the shadow
         # counter says the budget is exhausted, wait for the window to reset.
@@ -326,6 +333,8 @@ async def _api_request_inner(
                             wait,
                         )
                         await asyncio.sleep(wait)
+                charged_state = state
+                prev_remaining = state.remaining
                 state.remaining = max(state.remaining - 1, 0)
 
         try:
@@ -386,6 +395,11 @@ async def _api_request_inner(
                         delay = min(2**attempt, 60) + random.uniform(0.1, 0.5)
                         await asyncio.sleep(delay)
                         _circuit_state.consecutive_failures += 1
+                        # Refund the pacer charge: a 5xx carries no rate-limit headers,
+                        # so _update_pacer_state is not called. Without the refund, each
+                        # retry burns a unit the server never accounted for.
+                        if charged_state is not None and prev_remaining is not None:
+                            charged_state.remaining = prev_remaining
                     continue
 
                 if resp.status == 409:
@@ -446,6 +460,11 @@ async def _api_request_inner(
             delay = min(2**attempt, 60) + random.uniform(0.1, 0.5)
             await asyncio.sleep(delay)
             _circuit_state.consecutive_failures += 1
+            # Refund the pacer charge: a network error carries no rate-limit headers,
+            # so _update_pacer_state is not called. Without the refund, each retry burns
+            # a unit the server never accounted for.
+            if charged_state is not None and prev_remaining is not None:
+                charged_state.remaining = prev_remaining
 
     # Unreachable, but satisfies mypy.
     raise MigrationError(f"API request failed after {MAX_API_RETRIES} retries")

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -45,6 +45,20 @@ class _CircuitState:
     consecutive_failures: int = 0
 
 
+@dataclass
+class _BucketState:
+    """Proactive pacer state for one rate-limit bucket.
+
+    ``remaining`` is a shadow counter decremented on each outgoing request
+    and refreshed from ``X-RateLimit-Remaining`` on each response. It can go
+    negative under concurrency; the pacer clamps to 0 and paces.
+    """
+
+    remaining: int = 0
+    limit: int = 0
+    reset_at: float = 0.0  # monotonic time when the window replenishes
+
+
 # Module-level state — safe for single-migration-per-process model.
 _circuit_state = _CircuitState()
 _request_semaphore: asyncio.Semaphore | None = None
@@ -52,6 +66,12 @@ _request_semaphore: asyncio.Semaphore | None = None
 # Adaptive rate state — tracks 429 pressure and adjusts inter-request delay.
 _rate_429_window: deque[float] = deque(maxlen=20)  # timestamps of recent 429s
 _rate_multiplier: float = 1.0
+
+# Proactive pacer state — keyed by the X-RateLimit-Bucket hash from responses.
+# Foundational area: see .claude/rules/decision-accountability.md. Additive:
+# no modification to _rate_multiplier, _rate_429_window, or _circuit_state.
+_bucket_state: dict[str, _BucketState] = {}
+_url_to_bucket: dict[str, str] = {}
 
 
 def _reset_circuit_state() -> None:
@@ -64,6 +84,12 @@ def _reset_rate_state() -> None:
     global _rate_multiplier  # noqa: PLW0603
     _rate_429_window.clear()
     _rate_multiplier = 1.0
+
+
+def _reset_pacer_state() -> None:
+    """Reset proactive pacer state. Called by test fixtures."""
+    _bucket_state.clear()
+    _url_to_bucket.clear()
 
 
 def get_rate_multiplier() -> float:

--- a/src/discord_ferry/migrator/api.py
+++ b/src/discord_ferry/migrator/api.py
@@ -213,6 +213,35 @@ def _stoat_rate_delay_seconds(headers: Mapping[str, str]) -> float | None:
     return None
 
 
+def _parse_ratelimit_headers(
+    headers: Mapping[str, str],
+) -> tuple[str, _BucketState] | None:
+    """Parse X-RateLimit-* headers into a bucket hash and a _BucketState.
+
+    Returns None when the headers are missing or non-numeric, so the caller
+    skips the pacer update without crashing. ``X-RateLimit-Reset-After`` is
+    milliseconds (same unit rule as :func:`_stoat_rate_delay_seconds`).
+    """
+    raw_bucket = headers.get("X-RateLimit-Bucket")
+    raw_remaining = headers.get("X-RateLimit-Remaining")
+    raw_limit = headers.get("X-RateLimit-Limit")
+    raw_reset = headers.get("X-RateLimit-Reset-After")
+    if not raw_bucket or raw_remaining is None or raw_limit is None or raw_reset is None:
+        return None
+    try:
+        remaining = int(raw_remaining)
+        limit = int(raw_limit)
+        reset_after_s = float(raw_reset) / 1000
+    except (ValueError, TypeError):
+        logger.debug("Non-numeric X-RateLimit header: %s", dict(headers))
+        return None
+    return raw_bucket, _BucketState(
+        remaining=remaining,
+        limit=limit,
+        reset_at=time.monotonic() + reset_after_s,
+    )
+
+
 async def _resolve_429_delay_seconds(resp: aiohttp.ClientResponse) -> float:
     """Resolve the 429 sleep in seconds: headers → body ``retry_after`` (ms) → 1s; capped.
 

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -165,11 +165,13 @@ async def upload_and_create_emoji(
     file_path: Path,
     name: str,
     used_names: dict[str, int],
-) -> str:
+) -> tuple[str, str]:
     """Upload an emoji image to Autumn and register it on the Stoat server.
 
-    Returns the new Autumn file id, which IS the emoji's Stoat id. Shared by the
-    emoji migration phase and ``run_repair``'s emoji pass, so both mint emoji
+    Returns ``(autumn_id, emoji_name)`` where ``autumn_id`` IS the emoji's Stoat
+    id and ``emoji_name`` is the name the server echoed back, falling back to
+    the sanitized input name if the response carries none. Shared by the emoji
+    migration phase and ``run_repair``'s emoji pass, so both mint emoji
     identically. The caller checks that the image is usable and emits its own
     progress; this does the upload-then-create and nothing else.
     """
@@ -189,7 +191,7 @@ async def upload_and_create_emoji(
             name,
             sanitized_name,
         )
-    await api_create_emoji(
+    result = await api_create_emoji(
         session,
         config.stoat_url,
         config.token,
@@ -197,7 +199,8 @@ async def upload_and_create_emoji(
         sanitized_name,
         state.stoat_server_id,
     )
-    return autumn_id
+    emoji_name = result.get("name") or sanitized_name
+    return autumn_id, emoji_name
 
 
 async def run_emoji(
@@ -387,7 +390,7 @@ async def run_emoji(
                 continue
 
             try:
-                autumn_id = await upload_and_create_emoji(
+                autumn_id, emoji_name = await upload_and_create_emoji(
                     session,
                     config,
                     state,
@@ -396,6 +399,7 @@ async def run_emoji(
                     used_names=used_names,
                 )
                 state.emoji_map[discord_id] = autumn_id
+                state.created_emoji_names[discord_id] = emoji_name
 
                 if is_animated:
                     state.warnings.append(

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -95,7 +95,7 @@ class CheckResult:
     Role identity       ``role_present``, ``role_missing``, ``role_renamed``
     Category identity   ``category_present``, ``category_missing``,
                         ``category_title_mismatch``, ``category_title_unknown``
-    Emoji identity      ``emoji_present``, ``emoji_missing``
+    Emoji identity      ``emoji_present``, ``emoji_missing``, ``emoji_renamed``
     Tail                ``nothing_expected``, ``tail_present``,
                         ``channel_empty``,
                         ``tail_absent``, ``tail_and_after_absent``,
@@ -608,21 +608,48 @@ async def _check_structure(
                 stoat_id=stoat_id,
             )
 
-    emoji_ids = {e["_id"] for e in emoji if isinstance(e, dict) and "_id" in e}
+    emoji_names = {
+        e["_id"]: _readable_name(e)
+        for e in emoji
+        if isinstance(e, dict) and "_id" in e
+    }
     for discord_id, stoat_id in state.emoji_map.items():
-        present = stoat_id in emoji_ids
-        report.add(
-            name=f"emoji:{discord_id}",
-            status="ok" if present else "fail",
-            kind="emoji_present" if present else "emoji_missing",
-            detail=(
-                "emoji exists under its recorded id"
-                if present
-                else "the server does not list this emoji"
-            ),
-            discord_id=discord_id,
-            stoat_id=stoat_id,
-        )
+        present = stoat_id in emoji_names
+        if present:
+            recorded_name = state.created_emoji_names.get(discord_id)
+            found_name = emoji_names.get(stoat_id)
+            if recorded_name is not None and found_name is not None and recorded_name != found_name:
+                report.add(
+                    name=f"emoji:{discord_id}",
+                    status="warn",
+                    kind="emoji_renamed",
+                    detail=(
+                        "the emoji exists under its recorded id, but it has "
+                        "been renamed on the server since the migration"
+                    ),
+                    discord_id=discord_id,
+                    stoat_id=stoat_id,
+                    expected=recorded_name,
+                    found=found_name,
+                )
+                continue
+            report.add(
+                name=f"emoji:{discord_id}",
+                status="ok",
+                kind="emoji_present",
+                detail="emoji exists under its recorded id",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+        else:
+            report.add(
+                name=f"emoji:{discord_id}",
+                status="fail",
+                kind="emoji_missing",
+                detail="the server does not list this emoji",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
 
 
 #: How many channels the tail check reads at once.

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -608,11 +608,7 @@ async def _check_structure(
                 stoat_id=stoat_id,
             )
 
-    emoji_names = {
-        e["_id"]: _readable_name(e)
-        for e in emoji
-        if isinstance(e, dict) and "_id" in e
-    }
+    emoji_names = {e["_id"]: _readable_name(e) for e in emoji if isinstance(e, dict) and "_id" in e}
     for discord_id, stoat_id in state.emoji_map.items():
         present = stoat_id in emoji_names
         if present:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -54,7 +54,7 @@ CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
 #: extension of a permission map leave its expansion behind.
 #:
 #: ``warn`` exists for a cosmetic difference on an entity whose content is
-#: intact. It has exactly **three** producers, all name comparisons, and they are
+#: intact. It has exactly **four** producers, all name comparisons, and they are
 #: enumerated here rather than left implicit because a design review once found
 #: ``warn`` promised in two acceptance criteria and produced by no code path at
 #: all:
@@ -63,6 +63,8 @@ CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
 #: * ``channel_renamed`` and ``role_renamed``, since 2.17.0, once
 #:   ``created_channel_names`` and ``created_role_names`` gave the check an
 #:   expected name to compare against
+#: * ``emoji_renamed``, since 2.33.0, once ``created_emoji_names`` gave the
+#:   check an expected name to compare against
 #:
 #: The tail check emits no ``warn`` at all, which
 #: ``test_the_tail_check_never_emits_warn`` pins across every tail scenario.

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -78,6 +78,11 @@ class MigrationState:
     # channel_names.
     created_channel_names: dict[str, str] = field(default_factory=dict)
     created_role_names: dict[str, str] = field(default_factory=dict)
+    # discord_emoji_id -> the name the server stored (echoed from the create
+    # response, falling back to the sanitized input name). Structural, not
+    # free text: an emoji name matches ^[a-z0-9_]+$ and never carries a Ferry
+    # secret, matching created_channel_names / created_role_names.
+    created_emoji_names: dict[str, str] = field(default_factory=dict)
     # discord_ch_id -> effective discord_cat_id (the forum key for forum channels).
     # Persisted so incremental re-runs can re-attach carried channels to the
     # CORRECT category in the full-replace upsert, even with multiple
@@ -296,6 +301,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "category_names": state.category_names,
         "created_channel_names": state.created_channel_names,
         "created_role_names": state.created_role_names,
+        "created_emoji_names": state.created_emoji_names,
         "thread_strategy": state.thread_strategy,
         "channel_categories": state.channel_categories,
         "message_map": state.message_map,
@@ -375,6 +381,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             category_names=data.get("category_names", {}),
             created_channel_names=data.get("created_channel_names", {}),
             created_role_names=data.get("created_role_names", {}),
+            created_emoji_names=data.get("created_emoji_names", {}),
             thread_strategy=data.get("thread_strategy", ""),
             channel_categories=data.get("channel_categories", {}),
             message_map=data.get("message_map", {}),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2390,6 +2390,39 @@ async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
         assert _bucket_state["b1"].remaining == 1
 
 
+async def test_pacer_5xx_retries_refund_decrement(mock_aiohttp: aioresponses) -> None:
+    """A request that exhausts retries on 502 burns only one rate-limit unit, not one per retry."""
+    from discord_ferry.migrator.api import _bucket_state
+
+    url = f"{BASE_URL}/servers/srv1"
+    # Prime the pacer so the bucket has a known remaining count.
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "3",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    for _ in range(3):
+        mock_aiohttp.get(
+            url,
+            status=502,
+            body="Bad Gateway",
+        )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        with pytest.raises(MigrationError, match="API request failed after 3 retries"):
+            await _api_request(session, "GET", url, TOKEN)
+        # Three 502 retries refunded the first two decrements; the last attempt
+        # (which raises) left exactly one unit consumed. Before the refund fix
+        # this was 0 (three decrements, no refresh).
+        assert _bucket_state["b1"].remaining == 2
+
+
 # ---------------------------------------------------------------------------
 # Proactive pacer — remaining scenario tests (Task 4)
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ from discord_ferry.core.http import new_session
 from discord_ferry.errors import DuplicateSendError, MigrationError
 from discord_ferry.migrator.api import (
     _api_request,
+    _BucketState,
     _circuit_state,
     _headers,
     _reset_circuit_state,
@@ -2387,3 +2388,187 @@ async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
         # refreshes it. So remaining == 1 (from the header), not 0 (from the
         # decrement).
         assert _bucket_state["b1"].remaining == 1
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — remaining scenario tests (Task 4)
+# ---------------------------------------------------------------------------
+
+
+async def test_pacer_429_fires_when_stale(mock_aiohttp: aioresponses) -> None:
+    """The 429 retry path fires if the pacer's shadow was stale."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "1",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        status=429,
+        payload={"retry_after": 100},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        await _api_request(session, "GET", url, TOKEN)  # gets 429, retries, succeeds
+
+
+async def test_pacer_shadow_clamps_negative(mock_aiohttp: aioresponses) -> None:
+    """Shadow counter going negative clamps to 0, not left negative."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    _url_to_bucket[url] = "b1"
+    _bucket_state["b1"] = _BucketState(remaining=1, limit=5, reset_at=time.monotonic() + 100)
+
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        assert _bucket_state["b1"].remaining >= 0
+
+
+async def test_pacer_different_bucket_not_delayed(mock_aiohttp: aioresponses) -> None:
+    """An exhausted bucket does not delay a request to a different bucket."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    _bucket_state["bucket_A"] = _BucketState(remaining=0, limit=5, reset_at=time.monotonic() + 100)
+    _url_to_bucket[f"{BASE_URL}/servers/srv1"] = "bucket_A"
+
+    url2 = f"{BASE_URL}/channels/ch1"
+    mock_aiohttp.get(
+        url2,
+        payload={"_id": "ch1"},
+        headers={
+            "X-RateLimit-Remaining": "15",
+            "X-RateLimit-Limit": "15",
+            "X-RateLimit-Bucket": "bucket_B",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url2, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_reset_after_expiry(mock_aiohttp: aioresponses) -> None:
+    """After the reset time passes, a previously-exhausted bucket sends immediately."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    _url_to_bucket[url] = "b1"
+    _bucket_state["b1"] = _BucketState(remaining=0, limit=5, reset_at=time.monotonic() - 0.01)
+
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_debug_log_on_pace(
+    mock_aiohttp: aioresponses,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A paced pause produces a debug log line with the bucket hash."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    with caplog.at_level(logging.DEBUG, logger="discord_ferry.migrator.api"):
+        async with new_session() as session:
+            await _api_request(session, "GET", url, TOKEN)
+            await _api_request(session, "GET", url, TOKEN)
+    assert any("Pacer" in r.message and "b1" in r.message for r in caplog.records)
+
+
+async def test_pacer_no_debug_log_when_not_paced(
+    mock_aiohttp: aioresponses,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-paced request produces no pacing log line."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    with caplog.at_level(logging.DEBUG, logger="discord_ferry.migrator.api"):
+        async with new_session() as session:
+            await _api_request(session, "GET", url, TOKEN)
+            await _api_request(session, "GET", url, TOKEN)
+    assert not any("Pacer" in r.message for r in caplog.records)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import ssl
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -2188,3 +2189,46 @@ async def test_emoji_list_rejects_a_non_list_body(mock_aiohttp: aioresponses) ->
     async with aiohttp.ClientSession() as session:
         with pytest.raises(MigrationError, match="JSON array"):
             await api_fetch_emoji_list(session, BASE_URL, TOKEN, "srv1")
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — _parse_ratelimit_headers (Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_pacer_parses_headers_from_response() -> None:
+    """_parse_ratelimit_headers extracts remaining, limit, bucket, reset_at."""
+    from discord_ferry.migrator.api import _parse_ratelimit_headers
+
+    headers = {
+        "X-RateLimit-Remaining": "3",
+        "X-RateLimit-Limit": "5",
+        "X-RateLimit-Bucket": "hash123",
+        "X-RateLimit-Reset-After": "8000",
+    }
+    result = _parse_ratelimit_headers(headers)
+    assert result is not None
+    bucket, state = result
+    assert bucket == "hash123"
+    assert state.remaining == 3
+    assert state.limit == 5
+    assert state.reset_at - time.monotonic() == pytest.approx(8.0, rel=0.1)
+
+
+def test_pacer_missing_headers_returns_none() -> None:
+    """Missing X-RateLimit headers return None, no crash."""
+    from discord_ferry.migrator.api import _parse_ratelimit_headers
+
+    assert _parse_ratelimit_headers({}) is None
+    assert _parse_ratelimit_headers({"X-RateLimit-Remaining": "3"}) is None
+    assert (
+        _parse_ratelimit_headers(
+            {
+                "X-RateLimit-Bucket": "b1",
+                "X-RateLimit-Remaining": "x",
+                "X-RateLimit-Limit": "5",
+                "X-RateLimit-Reset-After": "1000",
+            }
+        )
+        is None
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,7 @@ from discord_ferry.migrator.api import (
     _circuit_state,
     _headers,
     _reset_circuit_state,
+    _reset_pacer_state,
     _reset_rate_state,
     api_add_reaction,
     api_create_channel,
@@ -62,15 +63,17 @@ TOKEN = "test-session-token"
 
 @pytest.fixture(autouse=True)
 def _clean_circuit() -> None:  # type: ignore[misc]
-    """Reset circuit breaker, semaphore, and adaptive rate state between tests."""
+    """Reset circuit breaker, semaphore, adaptive rate, and pacer state between tests."""
     import discord_ferry.migrator.api as _api_mod
 
     _reset_circuit_state()
     _reset_rate_state()
+    _reset_pacer_state()
     _api_mod._request_semaphore = None
     yield  # type: ignore[misc]
     _reset_circuit_state()
     _reset_rate_state()
+    _reset_pacer_state()
     _api_mod._request_semaphore = None
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2232,3 +2232,158 @@ def test_pacer_missing_headers_returns_none() -> None:
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Proactive pacer — pacing logic in _api_request_inner (Task 3)
+# ---------------------------------------------------------------------------
+
+
+async def test_pacer_pauses_on_remaining_zero(mock_aiohttp: aioresponses) -> None:
+    """A response with Remaining: 0 causes the next request to wait."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "100",  # 0.1s in ms
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        start = time.monotonic()
+        await _api_request(session, "GET", url, TOKEN)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.08  # waited at least ~0.1s
+
+
+async def test_pacer_no_pause_on_remaining_positive(mock_aiohttp: aioresponses) -> None:
+    """Remaining: 4 does not trigger a pause."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "4",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "4",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        start = time.monotonic()
+        await _api_request(session, "GET", url, TOKEN)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.05  # no pacing delay
+
+
+async def test_pacer_bucket_state_updated_from_response(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """After a 200, _bucket_state has the response's bucket info."""
+    from discord_ferry.migrator.api import _bucket_state, _url_to_bucket
+
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "3",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "hash123",
+            "X-RateLimit-Reset-After": "8000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+
+    assert "hash123" in _bucket_state
+    assert _bucket_state["hash123"].remaining == 3
+    assert _bucket_state["hash123"].limit == 5
+    assert url in _url_to_bucket
+    assert _url_to_bucket[url] == "hash123"
+
+
+async def test_pacer_first_request_not_delayed(mock_aiohttp: aioresponses) -> None:
+    """A URL with no prior state sends immediately."""
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "5",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    start = time.monotonic()
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+
+async def test_pacer_shadow_decrement(mock_aiohttp: aioresponses) -> None:
+    """The shadow counter decrements before the request, then the response overwrites it."""
+    from discord_ferry.migrator.api import _bucket_state
+
+    url = f"{BASE_URL}/servers/srv1"
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "2",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+    mock_aiohttp.get(
+        url,
+        payload={"id": "srv1"},
+        headers={
+            "X-RateLimit-Remaining": "1",
+            "X-RateLimit-Limit": "5",
+            "X-RateLimit-Bucket": "b1",
+            "X-RateLimit-Reset-After": "10000",
+        },
+    )
+
+    async with new_session() as session:
+        await _api_request(session, "GET", url, TOKEN)
+        await _api_request(session, "GET", url, TOKEN)
+        # After the second response, _update_pacer_state overwrites the shadow
+        # with the server's actual value. The shadow decrement happened before
+        # the request (protecting against concurrency), but the response
+        # refreshes it. So remaining == 1 (from the header), not 0 (from the
+        # decrement).
+        assert _bucket_state["b1"].remaining == 1

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -788,12 +788,16 @@ async def test_upload_and_create_emoji_uploads_then_creates(tmp_path: Path) -> N
             "discord_ferry.migrator.emoji.upload_with_cache",
             new=AsyncMock(return_value="new_autumn"),
         ) as up,
-        patch("discord_ferry.migrator.emoji.api_create_emoji", new=AsyncMock()) as cr,
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "new_autumn", "name": "smile"}),
+        ) as cr,
     ):
-        new_id = await upload_and_create_emoji(
+        new_id, emoji_name = await upload_and_create_emoji(
             None, config, state, file_path=img, name="smile", used_names={}
         )
     assert new_id == "new_autumn"
+    assert emoji_name == "smile"
     up.assert_awaited_once()
     cr.assert_awaited_once()
     # api_create_emoji(session, stoat_url, token, autumn_id, name, server_id)
@@ -841,3 +845,67 @@ def test_find_emoji_in_exports_recovers_name_and_image() -> None:
 def test_find_emoji_in_exports_none_when_absent() -> None:
     exp = _make_export([_make_message(content="plain text")])
     assert find_emoji_in_exports([exp], "123") is None
+
+
+
+async def test_run_emoji_records_server_echoed_name(tmp_path: Path) -> None:
+    """The emoji name is recorded from the server response, not the input name."""
+    img = tmp_path / "smile.png"
+    img.write_bytes(b"PNG")
+    msg = _make_message(
+        reactions=[
+            DCEReaction(
+                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
+            )
+        ]
+    )
+    exports = [_make_export([msg])]
+    config = _make_config(tmp_path)
+    state = _make_state()
+
+    with (
+        patch(
+            "discord_ferry.migrator.emoji.upload_with_cache",
+            new=AsyncMock(return_value="autumn_file_1"),
+        ),
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "autumn_file_1", "name": "party"}),
+        ),
+        patch("discord_ferry.migrator.emoji.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_emoji(config, state, exports, lambda e: None)
+
+    assert state.emoji_map == {"999": "autumn_file_1"}
+    assert state.created_emoji_names == {"999": "party"}
+
+
+async def test_run_emoji_falls_back_to_sanitized_name(tmp_path: Path) -> None:
+    """When the server response carries no name, the sanitized input name is recorded."""
+    img = tmp_path / "smile.png"
+    img.write_bytes(b"PNG")
+    msg = _make_message(
+        reactions=[
+            DCEReaction(
+                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
+            )
+        ]
+    )
+    exports = [_make_export([msg])]
+    config = _make_config(tmp_path)
+    state = _make_state()
+
+    with (
+        patch(
+            "discord_ferry.migrator.emoji.upload_with_cache",
+            new=AsyncMock(return_value="autumn_file_1"),
+        ),
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "autumn_file_1"}),
+        ),
+        patch("discord_ferry.migrator.emoji.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_emoji(config, state, exports, lambda e: None)
+
+    assert state.created_emoji_names == {"999": "smile"}

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -847,16 +847,13 @@ def test_find_emoji_in_exports_none_when_absent() -> None:
     assert find_emoji_in_exports([exp], "123") is None
 
 
-
 async def test_run_emoji_records_server_echoed_name(tmp_path: Path) -> None:
     """The emoji name is recorded from the server response, not the input name."""
     img = tmp_path / "smile.png"
     img.write_bytes(b"PNG")
     msg = _make_message(
         reactions=[
-            DCEReaction(
-                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
-            )
+            DCEReaction(emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1)
         ]
     )
     exports = [_make_export([msg])]
@@ -886,9 +883,7 @@ async def test_run_emoji_falls_back_to_sanitized_name(tmp_path: Path) -> None:
     img.write_bytes(b"PNG")
     msg = _make_message(
         reactions=[
-            DCEReaction(
-                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
-            )
+            DCEReaction(emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1)
         ]
     )
     exports = [_make_export([msg])]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2441,6 +2441,8 @@ async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
         created_channel_names={"d-100": "general"},
         role_map={"d-role-1": "01JSTOATRL0000000000AAA"},
         created_role_names={"d-role-1": "mods"},
+        emoji_map={"d-e1": "01JAUTUMNEMOJI00000000A"},
+        created_emoji_names={"d-e1": "party"},
     )
     save_state(prior, tmp_path)
 
@@ -2449,6 +2451,7 @@ async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
 
     assert state.created_channel_names == {"d-100": "general"}
     assert state.created_role_names == {"d-role-1": "mods"}
+    assert state.created_emoji_names == {"d-e1": "party"}
 
 
 # ---------------------------------------------------------------------------
@@ -2484,6 +2487,12 @@ def assert_nothing_dropped(prior: MigrationState, carried: MigrationState) -> No
             assert carried.created_role_names.get(key) == name, (
                 f"role {key}: prior recorded {name!r}, carried has "
                 f"{carried.created_role_names.get(key)!r}"
+            )
+    for key, name in prior.created_emoji_names.items():
+        if key in carried.emoji_map:
+            assert carried.created_emoji_names.get(key) == name, (
+                f"emoji {key}: prior recorded {name!r}, carried has "
+                f"{carried.created_emoji_names.get(key)!r}"
             )
 
 

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -115,7 +115,7 @@ async def test_repair_acts_on_emoji_missing(tmp_path: Path) -> None:
     events: list[Any] = []
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], events.append)
@@ -123,6 +123,7 @@ async def test_repair_acts_on_emoji_missing(tmp_path: Path) -> None:
     assert not any(d.get("type") == "emoji_missing_media" for d in outcome.declined)
     assert [r["discord_id"] for r in outcome.recreated_emoji] == [EMOJI_ID]
     assert outcome.recreated_emoji[0]["new_id"] == NEW_ID
+    assert state.created_emoji_names[EMOJI_ID] == "smile"
 
 
 async def test_recreate_writes_map_and_record_in_one_save(tmp_path: Path) -> None:
@@ -143,7 +144,7 @@ async def test_recreate_writes_map_and_record_in_one_save(tmp_path: Path) -> Non
 
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()),
         patch(f"{_ENGINE}.save_state", side_effect=capture),
     ):
@@ -159,7 +160,7 @@ async def test_missing_image_declines_no_record(tmp_path: Path) -> None:
     config, state = _config(tmp_path), _state()
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -177,7 +178,7 @@ async def test_rerun_when_present_makes_no_second_emoji(tmp_path: Path) -> None:
     state.emoji_map[EMOJI_ID] = NEW_ID
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=("second", "second_name"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -195,7 +196,7 @@ async def _run_with_messages(tmp_path: Path, messages: list[DCEMessage]) -> Any:
     config, state = _config(tmp_path), _state()
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(messages)], [].append)
@@ -299,7 +300,7 @@ async def test_rewrite_counts_all_referencing_messages(tmp_path: Path) -> None:
     state.message_map = dict(config_state_ids)
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(msgs)], [].append)
@@ -324,7 +325,7 @@ async def test_resume_finishes_a_crashed_rewrite(tmp_path: Path) -> None:
     state.pending_emoji_rewrites[EMOJI_ID] = {"old": OLD_ID, "new": NEW_ID}
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=("second", "second_name"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -356,7 +357,7 @@ async def test_edit_failure_keeps_the_record(tmp_path: Path) -> None:
     ]
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("boom")])),
     ):
         outcome = await run_repair(config, state, [_export(msgs)], [].append)
@@ -385,7 +386,7 @@ async def test_human_output_names_emoji_and_rewrite_count(tmp_path: Path) -> Non
     events: list[Any] = []
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()),
     ):
         await run_repair(config, state, [_export([_message()])], events.append)
@@ -432,7 +433,7 @@ async def test_integration_recreate_rewrite_and_verifiable(tmp_path: Path) -> No
     state.message_map = {"m1": "s1", "m2": "s2"}
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(_two_referencing_messages())], [].append)
@@ -456,7 +457,7 @@ async def test_integration_interrupted_run_matches_clean_run(tmp_path: Path) -> 
     # Run 1: the second edit fails, standing in for a crash mid-rewrite.
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("crash")])),
     ):
         await run_repair(config, state, exports, [].append)
@@ -465,7 +466,7 @@ async def test_integration_interrupted_run_matches_clean_run(tmp_path: Path) -> 
     # Run 2: the emoji is present now, so the resume step finishes the stragglers.
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="should-not-run")) as up2,
+        patch(_UPLOAD, new=AsyncMock(return_value=("should-not-run", "should-not-run"))) as up2,
         patch(_EDIT, new=AsyncMock()) as edit2,
     ):
         await run_repair(config, state, exports, [].append)
@@ -530,7 +531,7 @@ async def test_integration_dry_run_writes_nothing(tmp_path: Path) -> None:
     )
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
         patch(f"{_ENGINE}.save_state", side_effect=AssertionError("dry run must not save")),
     ):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -869,6 +869,7 @@ _KNOWN_STATE_FIELDS = frozenset(
         # a local user's own storage file, and it never carries a Ferry secret.
         "created_channel_names",
         "created_role_names",
+        "created_emoji_names",
         "thread_strategy",
         "channel_categories",
         "message_map",
@@ -1151,6 +1152,7 @@ def test_contract_fields_roundtrip(tmp_path: Path) -> None:
         thread_strategy="merge",
         created_channel_names={"d-100": "general"},
         created_role_names={"d-role-1": "mods"},
+        created_emoji_names={"d-e1": "party"},
     )
     save_state(state, tmp_path)
 
@@ -1158,6 +1160,7 @@ def test_contract_fields_roundtrip(tmp_path: Path) -> None:
     assert loaded.thread_strategy == "merge"
     assert loaded.created_channel_names == {"d-100": "general"}
     assert loaded.created_role_names == {"d-role-1": "mods"}
+    assert loaded.created_emoji_names == {"d-e1": "party"}
 
 
 def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
@@ -1174,6 +1177,7 @@ def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
     assert loaded.thread_strategy == ""
     assert loaded.created_channel_names == {}
     assert loaded.created_role_names == {}
+    assert loaded.created_emoji_names == {}
 
 
 def test_a_recorded_name_containing_a_secret_is_not_rewritten() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -406,7 +406,6 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
     assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"
 
 
-
 async def test_a_renamed_emoji_warns(mock_aiohttp: aioresponses) -> None:
     """A renamed emoji reports warn with kind emoji_renamed, not ok."""
     emoji_id = "01JAUTUMNEMOJI00000000A"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1886,8 +1886,8 @@ def test_no_prose_still_claims_warn_has_a_single_home() -> None:
         for phrase in stale:
             assert phrase not in text, (
                 f"{path.name} still claims warn has one home: {phrase!r}. "
-                "It has three producers: category_title_mismatch, channel_renamed "
-                "and role_renamed."
+                "It has four producers: category_title_mismatch, "
+                "channel_renamed, role_renamed and emoji_renamed."
             )
 
 
@@ -1902,6 +1902,7 @@ def test_the_kind_vocabulary_lists_both_rename_kinds() -> None:
     doc = CheckResult.__doc__ or ""
     assert "channel_renamed" in doc
     assert "role_renamed" in doc
+    assert "emoji_renamed" in doc
 
 
 def test_every_emitted_kind_is_documented_and_a_literal() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -406,6 +406,77 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
     assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"
 
 
+
+async def test_a_renamed_emoji_warns(mock_aiohttp: aioresponses) -> None:
+    """A renamed emoji reports warn with kind emoji_renamed, not ok."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "renamed"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    state.created_emoji_names = {"d-e1": "party"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "warn"
+    assert result.kind == "emoji_renamed"
+    assert result.expected == "party"
+    assert result.found == "renamed"
+    assert report.has_failures is False
+
+
+async def test_a_matching_emoji_name_is_ok(mock_aiohttp: aioresponses) -> None:
+    """When the server name matches the recorded name, the emoji reports ok."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "party"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    state.created_emoji_names = {"d-e1": "party"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "ok"
+    assert result.kind == "emoji_present"
+
+
+async def test_emoji_with_no_recorded_name_degrades_to_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A pre-change state file with no created_emoji_names skips the comparison."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "renamed"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "ok"
+    assert result.kind == "emoji_present"
+
+
 # ---------------------------------------------------------------------------
 # structure: categories, warn's first producer and still its clearest (task #254)
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.32.0"
+version = "2.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.31.0"
+version = "2.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## v2.33.0

### Emoji rename detection (#304, closes #304)

`ferry check` now detects renamed emoji. The name Ferry creates for each emoji is recorded in `state.json` (`created_emoji_names`) and compared against the server on check, producing an `emoji_renamed` warning when they differ. Follows the existing channel and role rename pattern exactly.

- New `created_emoji_names` field on `MigrationState` (state.py)
- `upload_and_create_emoji` captures the server-echoed name and returns `(autumn_id, emoji_name)` (emoji.py)
- Both migration and repair paths record the name (emoji.py, engine.py)
- Check reads `name` from the existing emoji list fetch and compares (verify.py)
- New `emoji_renamed` kind added to the `CheckResult` vocabulary
- Old state files degrade to `ok` with no comparison (same limit as channels and roles)

Plan: #571. Tasks: #572, #575, #574, #573. All closed.

### Proactive rate-limit pacing (#111)

Paces requests proactively using `X-RateLimit-Reset-After` headers rather than reacting to 429s.

### Cross-host second-opinion review (ADR-023)

The review gates now run a cross-host fallback chain so the reviewer is never the same model family as the host running the build.

### Chunk review

Chunk 1 review posted on #571. One finding (stale "three producers" comment), fixed. Second-opinion review found one finding (missing `created_emoji_names` in carry-over audit and incremental test), fixed.