### PR TITLE
v2.33.0: Emoji rename detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `ferry check` now detects renamed emoji. The name Ferry creates for each emoji is recorded in
+  `state.json` and compared against the server on check, producing an `emoji_renamed` warning when
+  they differ. Closes #304.
+
 - **Cross-host second-opinion review.** The /df-ship and /df-chunk-review review gates now run a
   cross-host fallback chain so the reviewer is never the same model family as the host running
   the build. On Vibe, Codex reviews with Claude as fallback. On Claude Code, Codex reviews with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [2.33.0] - 2026-08-23
 
 ### Added
 

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -131,7 +131,7 @@ These limitations relate to platform-level features that either work differently
 
 **A channel that gained more than 100 messages since the migration cannot be checked.** The window no longer reaches back to the message Ferry recorded, so Check reports `unverifiable` rather than guessing. This is common on an active server.
 
-**A renamed channel or role is only detected for migrations run under 2.17.0 or later.** From that release Ferry records the name it gave each channel and role, so `ferry check` can compare it against the current one and reports a rename as a warning. A migration run by an earlier version recorded no such names, and nothing can recover them after the fact, so a rename there stays invisible. Renamed *categories* have always been detected, because category names were recorded from the start.
+**A renamed channel, role, or emoji is only detected for migrations run under 2.17.0 or later for channels and roles, and under 2.33.0 or later for emoji.** From those releases Ferry records the name it gave each entity, so `ferry check` can compare it against the current one and reports a rename as a warning. A migration run by an earlier version recorded no such names, and nothing can recover them after the fact, so a rename there stays invisible. Renamed *categories* have always been detected, because category names were recorded from the start.
 
 **A message accepted as a duplicate cannot be confirmed.** When Stoat recognises a retry and refuses it, it does not say which message it already had, so Ferry has no identifier to check later. Channels affected this way report `unverifiable`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.32.0"
+version = "2.33.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -2253,7 +2253,7 @@ async def _run_emoji_repair_pass(
             continue
 
         name = record["name"]
-        new_id = await upload_and_create_emoji(
+        new_id, emoji_name = await upload_and_create_emoji(
             session, config, state, file_path=file_path, name=name, used_names=used_names
         )
         # ONE save writes the new map value AND the resume record together, so a
@@ -2261,6 +2261,7 @@ async def _run_emoji_repair_pass(
         # From this point emoji_map already points at the new emoji, so a re-run's
         # check reports it present and never recreates a second one.
         state.emoji_map[discord_id] = new_id
+        state.created_emoji_names[discord_id] = emoji_name
         state.pending_emoji_rewrites[discord_id] = {"old": old_id, "new": new_id}
         save_state(state, config.output_dir)
 

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -313,6 +313,7 @@ async def run_migration(
             #     created_channel_names / created_role_names (a carried entity
             #     skips creation, so nothing re-records its name; omitting these
             #     makes ferry check report ok for a renamed channel),
+            #     created_emoji_names (same reason, for emoji),
             #     category_names, channel_categories, message_map, avatar_cache,
             #     upload_cache, author_names, stoat_server_id, autumn_url,
             #     invite_code / invite_url, channel_message_offsets,

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -255,6 +255,7 @@ async def run_migration(
             # and ferry check reports ok for a renamed channel.
             state.created_channel_names = dict(prior.created_channel_names)
             state.created_role_names = dict(prior.created_role_names)
+            state.created_emoji_names = dict(prior.created_emoji_names)
             # C1: carry finalized-roles so incremental skips re-editing (load_state seeds `prior`
             # for old-ferry states). Without this every incremental run re-PATCHes all roles.
             state.roles_finalized = set(prior.roles_finalized)

--- a/src/discord_ferry/migrator/emoji.py
+++ b/src/discord_ferry/migrator/emoji.py
@@ -165,11 +165,13 @@ async def upload_and_create_emoji(
     file_path: Path,
     name: str,
     used_names: dict[str, int],
-) -> str:
+) -> tuple[str, str]:
     """Upload an emoji image to Autumn and register it on the Stoat server.
 
-    Returns the new Autumn file id, which IS the emoji's Stoat id. Shared by the
-    emoji migration phase and ``run_repair``'s emoji pass, so both mint emoji
+    Returns ``(autumn_id, emoji_name)`` where ``autumn_id`` IS the emoji's Stoat
+    id and ``emoji_name`` is the name the server echoed back, falling back to
+    the sanitized input name if the response carries none. Shared by the emoji
+    migration phase and ``run_repair``'s emoji pass, so both mint emoji
     identically. The caller checks that the image is usable and emits its own
     progress; this does the upload-then-create and nothing else.
     """
@@ -189,7 +191,7 @@ async def upload_and_create_emoji(
             name,
             sanitized_name,
         )
-    await api_create_emoji(
+    result = await api_create_emoji(
         session,
         config.stoat_url,
         config.token,
@@ -197,7 +199,8 @@ async def upload_and_create_emoji(
         sanitized_name,
         state.stoat_server_id,
     )
-    return autumn_id
+    emoji_name = result.get("name") or sanitized_name
+    return autumn_id, emoji_name
 
 
 async def run_emoji(
@@ -387,7 +390,7 @@ async def run_emoji(
                 continue
 
             try:
-                autumn_id = await upload_and_create_emoji(
+                autumn_id, emoji_name = await upload_and_create_emoji(
                     session,
                     config,
                     state,
@@ -396,6 +399,7 @@ async def run_emoji(
                     used_names=used_names,
                 )
                 state.emoji_map[discord_id] = autumn_id
+                state.created_emoji_names[discord_id] = emoji_name
 
                 if is_animated:
                     state.warnings.append(

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -95,7 +95,7 @@ class CheckResult:
     Role identity       ``role_present``, ``role_missing``, ``role_renamed``
     Category identity   ``category_present``, ``category_missing``,
                         ``category_title_mismatch``, ``category_title_unknown``
-    Emoji identity      ``emoji_present``, ``emoji_missing``
+    Emoji identity      ``emoji_present``, ``emoji_missing``, ``emoji_renamed``
     Tail                ``nothing_expected``, ``tail_present``,
                         ``channel_empty``,
                         ``tail_absent``, ``tail_and_after_absent``,
@@ -608,21 +608,48 @@ async def _check_structure(
                 stoat_id=stoat_id,
             )
 
-    emoji_ids = {e["_id"] for e in emoji if isinstance(e, dict) and "_id" in e}
+    emoji_names = {
+        e["_id"]: _readable_name(e)
+        for e in emoji
+        if isinstance(e, dict) and "_id" in e
+    }
     for discord_id, stoat_id in state.emoji_map.items():
-        present = stoat_id in emoji_ids
-        report.add(
-            name=f"emoji:{discord_id}",
-            status="ok" if present else "fail",
-            kind="emoji_present" if present else "emoji_missing",
-            detail=(
-                "emoji exists under its recorded id"
-                if present
-                else "the server does not list this emoji"
-            ),
-            discord_id=discord_id,
-            stoat_id=stoat_id,
-        )
+        present = stoat_id in emoji_names
+        if present:
+            recorded_name = state.created_emoji_names.get(discord_id)
+            found_name = emoji_names.get(stoat_id)
+            if recorded_name is not None and found_name is not None and recorded_name != found_name:
+                report.add(
+                    name=f"emoji:{discord_id}",
+                    status="warn",
+                    kind="emoji_renamed",
+                    detail=(
+                        "the emoji exists under its recorded id, but it has "
+                        "been renamed on the server since the migration"
+                    ),
+                    discord_id=discord_id,
+                    stoat_id=stoat_id,
+                    expected=recorded_name,
+                    found=found_name,
+                )
+                continue
+            report.add(
+                name=f"emoji:{discord_id}",
+                status="ok",
+                kind="emoji_present",
+                detail="emoji exists under its recorded id",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
+        else:
+            report.add(
+                name=f"emoji:{discord_id}",
+                status="fail",
+                kind="emoji_missing",
+                detail="the server does not list this emoji",
+                discord_id=discord_id,
+                stoat_id=stoat_id,
+            )
 
 
 #: How many channels the tail check reads at once.

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -608,11 +608,7 @@ async def _check_structure(
                 stoat_id=stoat_id,
             )
 
-    emoji_names = {
-        e["_id"]: _readable_name(e)
-        for e in emoji
-        if isinstance(e, dict) and "_id" in e
-    }
+    emoji_names = {e["_id"]: _readable_name(e) for e in emoji if isinstance(e, dict) and "_id" in e}
     for discord_id, stoat_id in state.emoji_map.items():
         present = stoat_id in emoji_names
         if present:

--- a/src/discord_ferry/migrator/verify.py
+++ b/src/discord_ferry/migrator/verify.py
@@ -54,7 +54,7 @@ CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
 #: extension of a permission map leave its expansion behind.
 #:
 #: ``warn`` exists for a cosmetic difference on an entity whose content is
-#: intact. It has exactly **three** producers, all name comparisons, and they are
+#: intact. It has exactly **four** producers, all name comparisons, and they are
 #: enumerated here rather than left implicit because a design review once found
 #: ``warn`` promised in two acceptance criteria and produced by no code path at
 #: all:
@@ -63,6 +63,8 @@ CheckStatus = Literal["ok", "warn", "fail", "unverifiable"]
 #: * ``channel_renamed`` and ``role_renamed``, since 2.17.0, once
 #:   ``created_channel_names`` and ``created_role_names`` gave the check an
 #:   expected name to compare against
+#: * ``emoji_renamed``, since 2.33.0, once ``created_emoji_names`` gave the
+#:   check an expected name to compare against
 #:
 #: The tail check emits no ``warn`` at all, which
 #: ``test_the_tail_check_never_emits_warn`` pins across every tail scenario.

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -78,6 +78,11 @@ class MigrationState:
     # channel_names.
     created_channel_names: dict[str, str] = field(default_factory=dict)
     created_role_names: dict[str, str] = field(default_factory=dict)
+    # discord_emoji_id -> the name the server stored (echoed from the create
+    # response, falling back to the sanitized input name). Structural, not
+    # free text: an emoji name matches ^[a-z0-9_]+$ and never carries a Ferry
+    # secret, matching created_channel_names / created_role_names.
+    created_emoji_names: dict[str, str] = field(default_factory=dict)
     # discord_ch_id -> effective discord_cat_id (the forum key for forum channels).
     # Persisted so incremental re-runs can re-attach carried channels to the
     # CORRECT category in the full-replace upsert, even with multiple
@@ -296,6 +301,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "category_names": state.category_names,
         "created_channel_names": state.created_channel_names,
         "created_role_names": state.created_role_names,
+        "created_emoji_names": state.created_emoji_names,
         "thread_strategy": state.thread_strategy,
         "channel_categories": state.channel_categories,
         "message_map": state.message_map,
@@ -375,6 +381,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             category_names=data.get("category_names", {}),
             created_channel_names=data.get("created_channel_names", {}),
             created_role_names=data.get("created_role_names", {}),
+            created_emoji_names=data.get("created_emoji_names", {}),
             thread_strategy=data.get("thread_strategy", ""),
             channel_categories=data.get("channel_categories", {}),
             message_map=data.get("message_map", {}),

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -788,12 +788,16 @@ async def test_upload_and_create_emoji_uploads_then_creates(tmp_path: Path) -> N
             "discord_ferry.migrator.emoji.upload_with_cache",
             new=AsyncMock(return_value="new_autumn"),
         ) as up,
-        patch("discord_ferry.migrator.emoji.api_create_emoji", new=AsyncMock()) as cr,
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "new_autumn", "name": "smile"}),
+        ) as cr,
     ):
-        new_id = await upload_and_create_emoji(
+        new_id, emoji_name = await upload_and_create_emoji(
             None, config, state, file_path=img, name="smile", used_names={}
         )
     assert new_id == "new_autumn"
+    assert emoji_name == "smile"
     up.assert_awaited_once()
     cr.assert_awaited_once()
     # api_create_emoji(session, stoat_url, token, autumn_id, name, server_id)
@@ -841,3 +845,67 @@ def test_find_emoji_in_exports_recovers_name_and_image() -> None:
 def test_find_emoji_in_exports_none_when_absent() -> None:
     exp = _make_export([_make_message(content="plain text")])
     assert find_emoji_in_exports([exp], "123") is None
+
+
+
+async def test_run_emoji_records_server_echoed_name(tmp_path: Path) -> None:
+    """The emoji name is recorded from the server response, not the input name."""
+    img = tmp_path / "smile.png"
+    img.write_bytes(b"PNG")
+    msg = _make_message(
+        reactions=[
+            DCEReaction(
+                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
+            )
+        ]
+    )
+    exports = [_make_export([msg])]
+    config = _make_config(tmp_path)
+    state = _make_state()
+
+    with (
+        patch(
+            "discord_ferry.migrator.emoji.upload_with_cache",
+            new=AsyncMock(return_value="autumn_file_1"),
+        ),
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "autumn_file_1", "name": "party"}),
+        ),
+        patch("discord_ferry.migrator.emoji.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_emoji(config, state, exports, lambda e: None)
+
+    assert state.emoji_map == {"999": "autumn_file_1"}
+    assert state.created_emoji_names == {"999": "party"}
+
+
+async def test_run_emoji_falls_back_to_sanitized_name(tmp_path: Path) -> None:
+    """When the server response carries no name, the sanitized input name is recorded."""
+    img = tmp_path / "smile.png"
+    img.write_bytes(b"PNG")
+    msg = _make_message(
+        reactions=[
+            DCEReaction(
+                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
+            )
+        ]
+    )
+    exports = [_make_export([msg])]
+    config = _make_config(tmp_path)
+    state = _make_state()
+
+    with (
+        patch(
+            "discord_ferry.migrator.emoji.upload_with_cache",
+            new=AsyncMock(return_value="autumn_file_1"),
+        ),
+        patch(
+            "discord_ferry.migrator.emoji.api_create_emoji",
+            new=AsyncMock(return_value={"_id": "autumn_file_1"}),
+        ),
+        patch("discord_ferry.migrator.emoji.asyncio.sleep", new=AsyncMock()),
+    ):
+        await run_emoji(config, state, exports, lambda e: None)
+
+    assert state.created_emoji_names == {"999": "smile"}

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -847,16 +847,13 @@ def test_find_emoji_in_exports_none_when_absent() -> None:
     assert find_emoji_in_exports([exp], "123") is None
 
 
-
 async def test_run_emoji_records_server_echoed_name(tmp_path: Path) -> None:
     """The emoji name is recorded from the server response, not the input name."""
     img = tmp_path / "smile.png"
     img.write_bytes(b"PNG")
     msg = _make_message(
         reactions=[
-            DCEReaction(
-                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
-            )
+            DCEReaction(emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1)
         ]
     )
     exports = [_make_export([msg])]
@@ -886,9 +883,7 @@ async def test_run_emoji_falls_back_to_sanitized_name(tmp_path: Path) -> None:
     img.write_bytes(b"PNG")
     msg = _make_message(
         reactions=[
-            DCEReaction(
-                emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1
-            )
+            DCEReaction(emoji=DCEEmoji(id="999", name="smile", image_url="smile.png"), count=1)
         ]
     )
     exports = [_make_export([msg])]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2441,6 +2441,8 @@ async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
         created_channel_names={"d-100": "general"},
         role_map={"d-role-1": "01JSTOATRL0000000000AAA"},
         created_role_names={"d-role-1": "mods"},
+        emoji_map={"d-e1": "01JAUTUMNEMOJI00000000A"},
+        created_emoji_names={"d-e1": "party"},
     )
     save_state(prior, tmp_path)
 
@@ -2449,6 +2451,7 @@ async def test_incremental_carries_the_recorded_names(tmp_path: Path) -> None:
 
     assert state.created_channel_names == {"d-100": "general"}
     assert state.created_role_names == {"d-role-1": "mods"}
+    assert state.created_emoji_names == {"d-e1": "party"}
 
 
 # ---------------------------------------------------------------------------
@@ -2484,6 +2487,12 @@ def assert_nothing_dropped(prior: MigrationState, carried: MigrationState) -> No
             assert carried.created_role_names.get(key) == name, (
                 f"role {key}: prior recorded {name!r}, carried has "
                 f"{carried.created_role_names.get(key)!r}"
+            )
+    for key, name in prior.created_emoji_names.items():
+        if key in carried.emoji_map:
+            assert carried.created_emoji_names.get(key) == name, (
+                f"emoji {key}: prior recorded {name!r}, carried has "
+                f"{carried.created_emoji_names.get(key)!r}"
             )
 
 

--- a/tests/test_repair_emoji.py
+++ b/tests/test_repair_emoji.py
@@ -115,7 +115,7 @@ async def test_repair_acts_on_emoji_missing(tmp_path: Path) -> None:
     events: list[Any] = []
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], events.append)
@@ -123,6 +123,7 @@ async def test_repair_acts_on_emoji_missing(tmp_path: Path) -> None:
     assert not any(d.get("type") == "emoji_missing_media" for d in outcome.declined)
     assert [r["discord_id"] for r in outcome.recreated_emoji] == [EMOJI_ID]
     assert outcome.recreated_emoji[0]["new_id"] == NEW_ID
+    assert state.created_emoji_names[EMOJI_ID] == "smile"
 
 
 async def test_recreate_writes_map_and_record_in_one_save(tmp_path: Path) -> None:
@@ -143,7 +144,7 @@ async def test_recreate_writes_map_and_record_in_one_save(tmp_path: Path) -> Non
 
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()),
         patch(f"{_ENGINE}.save_state", side_effect=capture),
     ):
@@ -159,7 +160,7 @@ async def test_missing_image_declines_no_record(tmp_path: Path) -> None:
     config, state = _config(tmp_path), _state()
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -177,7 +178,7 @@ async def test_rerun_when_present_makes_no_second_emoji(tmp_path: Path) -> None:
     state.emoji_map[EMOJI_ID] = NEW_ID
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=("second", "second_name"))) as up,
         patch(_EDIT, new=AsyncMock()),
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -195,7 +196,7 @@ async def _run_with_messages(tmp_path: Path, messages: list[DCEMessage]) -> Any:
     config, state = _config(tmp_path), _state()
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(messages)], [].append)
@@ -299,7 +300,7 @@ async def test_rewrite_counts_all_referencing_messages(tmp_path: Path) -> None:
     state.message_map = dict(config_state_ids)
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(msgs)], [].append)
@@ -324,7 +325,7 @@ async def test_resume_finishes_a_crashed_rewrite(tmp_path: Path) -> None:
     state.pending_emoji_rewrites[EMOJI_ID] = {"old": OLD_ID, "new": NEW_ID}
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="second")) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=("second", "second_name"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export([_message()])], [].append)
@@ -356,7 +357,7 @@ async def test_edit_failure_keeps_the_record(tmp_path: Path) -> None:
     ]
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("boom")])),
     ):
         outcome = await run_repair(config, state, [_export(msgs)], [].append)
@@ -385,7 +386,7 @@ async def test_human_output_names_emoji_and_rewrite_count(tmp_path: Path) -> Non
     events: list[Any] = []
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock()),
     ):
         await run_repair(config, state, [_export([_message()])], events.append)
@@ -432,7 +433,7 @@ async def test_integration_recreate_rewrite_and_verifiable(tmp_path: Path) -> No
     state.message_map = {"m1": "s1", "m2": "s2"}
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
     ):
         outcome = await run_repair(config, state, [_export(_two_referencing_messages())], [].append)
@@ -456,7 +457,7 @@ async def test_integration_interrupted_run_matches_clean_run(tmp_path: Path) -> 
     # Run 1: the second edit fails, standing in for a crash mid-rewrite.
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)),
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))),
         patch(_EDIT, new=AsyncMock(side_effect=[None, RuntimeError("crash")])),
     ):
         await run_repair(config, state, exports, [].append)
@@ -465,7 +466,7 @@ async def test_integration_interrupted_run_matches_clean_run(tmp_path: Path) -> 
     # Run 2: the emoji is present now, so the resume step finishes the stragglers.
     with (
         patch(_CHECK, new=AsyncMock(return_value=_present_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value="should-not-run")) as up2,
+        patch(_UPLOAD, new=AsyncMock(return_value=("should-not-run", "should-not-run"))) as up2,
         patch(_EDIT, new=AsyncMock()) as edit2,
     ):
         await run_repair(config, state, exports, [].append)
@@ -530,7 +531,7 @@ async def test_integration_dry_run_writes_nothing(tmp_path: Path) -> None:
     )
     with (
         patch(_CHECK, new=AsyncMock(return_value=_missing_report())),
-        patch(_UPLOAD, new=AsyncMock(return_value=NEW_ID)) as up,
+        patch(_UPLOAD, new=AsyncMock(return_value=(NEW_ID, "smile"))) as up,
         patch(_EDIT, new=AsyncMock()) as edit,
         patch(f"{_ENGINE}.save_state", side_effect=AssertionError("dry run must not save")),
     ):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -869,6 +869,7 @@ _KNOWN_STATE_FIELDS = frozenset(
         # a local user's own storage file, and it never carries a Ferry secret.
         "created_channel_names",
         "created_role_names",
+        "created_emoji_names",
         "thread_strategy",
         "channel_categories",
         "message_map",
@@ -1151,6 +1152,7 @@ def test_contract_fields_roundtrip(tmp_path: Path) -> None:
         thread_strategy="merge",
         created_channel_names={"d-100": "general"},
         created_role_names={"d-role-1": "mods"},
+        created_emoji_names={"d-e1": "party"},
     )
     save_state(state, tmp_path)
 
@@ -1158,6 +1160,7 @@ def test_contract_fields_roundtrip(tmp_path: Path) -> None:
     assert loaded.thread_strategy == "merge"
     assert loaded.created_channel_names == {"d-100": "general"}
     assert loaded.created_role_names == {"d-role-1": "mods"}
+    assert loaded.created_emoji_names == {"d-e1": "party"}
 
 
 def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
@@ -1174,6 +1177,7 @@ def test_contract_fields_default_when_absent(tmp_path: Path) -> None:
     assert loaded.thread_strategy == ""
     assert loaded.created_channel_names == {}
     assert loaded.created_role_names == {}
+    assert loaded.created_emoji_names == {}
 
 
 def test_a_recorded_name_containing_a_secret_is_not_rewritten() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -406,7 +406,6 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
     assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"
 
 
-
 async def test_a_renamed_emoji_warns(mock_aiohttp: aioresponses) -> None:
     """A renamed emoji reports warn with kind emoji_renamed, not ok."""
     emoji_id = "01JAUTUMNEMOJI00000000A"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1886,8 +1886,8 @@ def test_no_prose_still_claims_warn_has_a_single_home() -> None:
         for phrase in stale:
             assert phrase not in text, (
                 f"{path.name} still claims warn has one home: {phrase!r}. "
-                "It has three producers: category_title_mismatch, channel_renamed "
-                "and role_renamed."
+                "It has four producers: category_title_mismatch, "
+                "channel_renamed, role_renamed and emoji_renamed."
             )
 
 
@@ -1902,6 +1902,7 @@ def test_the_kind_vocabulary_lists_both_rename_kinds() -> None:
     doc = CheckResult.__doc__ or ""
     assert "channel_renamed" in doc
     assert "role_renamed" in doc
+    assert "emoji_renamed" in doc
 
 
 def test_every_emitted_kind_is_documented_and_a_literal() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -406,6 +406,77 @@ async def test_a_present_emoji_is_ok(mock_aiohttp: aioresponses) -> None:
     assert next(r for r in report.results if r.discord_id == "d-e1").status == "ok"
 
 
+
+async def test_a_renamed_emoji_warns(mock_aiohttp: aioresponses) -> None:
+    """A renamed emoji reports warn with kind emoji_renamed, not ok."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "renamed"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    state.created_emoji_names = {"d-e1": "party"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "warn"
+    assert result.kind == "emoji_renamed"
+    assert result.expected == "party"
+    assert result.found == "renamed"
+    assert report.has_failures is False
+
+
+async def test_a_matching_emoji_name_is_ok(mock_aiohttp: aioresponses) -> None:
+    """When the server name matches the recorded name, the emoji reports ok."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "party"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    state.created_emoji_names = {"d-e1": "party"}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "ok"
+    assert result.kind == "emoji_present"
+
+
+async def test_emoji_with_no_recorded_name_degrades_to_ok(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A pre-change state file with no created_emoji_names skips the comparison."""
+    emoji_id = "01JAUTUMNEMOJI00000000A"
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}?include_channels=true",
+        payload={"server": {"_id": SRV, "channels": []}, "channels": []},
+    )
+    mock_aiohttp.get(
+        f"{BASE_URL}/servers/{SRV}/emojis",
+        payload=[{"_id": emoji_id, "name": "renamed"}],
+    )
+    _allow_any_message_window(mock_aiohttp)
+    state = MigrationState()
+    state.stoat_server_id = SRV
+    state.emoji_map = {"d-e1": emoji_id}
+    report = await run_check(BASE_URL, TOKEN, state, _noop_event)
+    result = next(r for r in report.results if r.discord_id == "d-e1")
+    assert result.status == "ok"
+    assert result.kind == "emoji_present"
+
+
 # ---------------------------------------------------------------------------
 # structure: categories, warn's first producer and still its clearest (task #254)
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.32.0"
+version = "2.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## v2.33.0: Emoji rename detection

Closes #304.

`ferry check` now detects renamed emoji. The name Ferry creates for each emoji is recorded in `state.json` (`created_emoji_names`) and compared against the server on check, producing an `emoji_renamed` warning when they differ. Follows the existing channel and role rename pattern exactly.

- New `created_emoji_names` field on `MigrationState` (state.py)
- `upload_and_create_emoji` captures the server-echoed name and returns `(autumn_id, emoji_name)` (emoji.py)
- Both migration and repair paths record the name (emoji.py, engine.py)
- Check reads `name` from the existing emoji list fetch and compares (verify.py)
- New `emoji_renamed` kind added to the `CheckResult` vocabulary
- Old state files degrade to `ok` with no comparison (same limit as channels and roles)

Plan: #571. Tasks: #572, #575, #574, #573. All closed.

### Chunk review

Chunk 1 review posted on #571. One finding (stale "three producers" comment), fixed. Second-opinion review found one finding (missing `created_emoji_names` in carry-over audit and incremental test), fixed.