### PR TITLE
Retire banned source-string assertions, add merge counter (#147, #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.34.0] - 2026-08-23
+
+### Added
+
+- `report.json` and the markdown report now include `merge_duplicates_suppressed`, a per-run
+  counter of thread messages the merge strategy skipped because the parent channel already held
+  them. The suppression stays silent (no per-message warning, no change to the "Merged thread X
+  (N messages)" event), but the counter makes it observable. Closes #239.
+
+### Changed
+
+- The six `inspect.getsource` source-string assertions in `tests/test_gui.py` are replaced by
+  NiceGUI `user`-fixture tests that execute real page code. The export, setup, migrate, and
+  validate screens now have user-fixture coverage that catches regressions by running the actual
+  page builders, not by matching source text. Closes #147.
+
 ## [2.33.0] - 2026-08-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ferry"
-version = "2.33.0"
+version = "2.34.0"
 description = "Migrate Discord servers to Stoat (formerly Revolt)"
 readme = "README.md"
 license = "MIT"

--- a/src/discord_ferry/__init__.py
+++ b/src/discord_ferry/__init__.py
@@ -1,3 +1,3 @@
 """Discord Ferry — Migrate Discord servers to Stoat."""
 
-__version__ = "2.33.0"
+__version__ = "2.34.0"

--- a/src/discord_ferry/core/engine.py
+++ b/src/discord_ferry/core/engine.py
@@ -333,6 +333,7 @@ async def run_migration(
             #     new msgs); pending_pins / pending_reactions (consumed by the
             #     reactions/pins phases — carrying a stale list would re-pin/re-react);
             #     warnings / errors, validation_results, embeds_* / replies_*
+            #     / merge_duplicates_suppressed (per-run merge counter, #239);
             #     (per-run fidelity counters); current_phase, started_at,
             #     completed_at, export_completed, rollback_progress, is_dry_run;
             #     thread_strategy, which describes THIS run and is set from

--- a/src/discord_ferry/migrator/messages.py
+++ b/src/discord_ferry/migrator/messages.py
@@ -730,6 +730,7 @@ async def _merge_threads(
                     # and a future change to the discriminator could make the difference
                     # reachable. Do not delete it on the strength of a surviving mutant.
                     _succeeded_ids.add(msg.id)
+                    state.merge_duplicates_suppressed += 1
                     logger.debug(
                         "Merge: %s already delivered to the parent channel, not re-sending",
                         msg.id,

--- a/src/discord_ferry/reporter.py
+++ b/src/discord_ferry/reporter.py
@@ -163,6 +163,7 @@ def generate_report(
             "reactions_added": state.reactions_applied,
             "pins_restored": state.pins_applied,
             "threads_flattened": threads_flattened,
+            "merge_duplicates_suppressed": state.merge_duplicates_suppressed,
             "errors": len(state.errors),
             "warnings": len(state.warnings),
         },
@@ -402,6 +403,8 @@ def generate_markdown_report(
     lines.append(f"| Attachments skipped | {state.attachments_skipped} |")
     lines.append(f"| Reactions applied | {state.reactions_applied} |")
     lines.append(f"| Pins restored | {state.pins_applied} |")
+    if state.merge_duplicates_suppressed:
+        lines.append(f"| Merge duplicates suppressed | {state.merge_duplicates_suppressed} |")
     lines.append("")
 
     if state.invite_code:

--- a/src/discord_ferry/state.py
+++ b/src/discord_ferry/state.py
@@ -143,6 +143,7 @@ class MigrationState:
     reactions_capped: int = 0  # Batch 4 (S4): reactions skipped at the 20/msg Stoat cap
     reactions_dropped: int = 0  # Batch 4 (S1): custom reactions whose emoji never mapped
     pins_applied: int = 0
+    merge_duplicates_suppressed: int = 0  # #239: merge messages skipped (already in parent)
 
     # Timing
     started_at: str = ""
@@ -326,6 +327,7 @@ def _state_to_dict(state: MigrationState) -> dict[str, Any]:
         "reactions_capped": state.reactions_capped,
         "reactions_dropped": state.reactions_dropped,
         "pins_applied": state.pins_applied,
+        "merge_duplicates_suppressed": state.merge_duplicates_suppressed,
         "started_at": state.started_at,
         "completed_at": state.completed_at,
         "is_dry_run": state.is_dry_run,
@@ -406,6 +408,7 @@ def _dict_to_state(data: dict[str, Any]) -> MigrationState:
             reactions_capped=data.get("reactions_capped", 0),
             reactions_dropped=data.get("reactions_dropped", 0),
             pins_applied=data.get("pins_applied", 0),
+            merge_duplicates_suppressed=data.get("merge_duplicates_suppressed", 0),
             started_at=data.get("started_at", ""),
             completed_at=data.get("completed_at", ""),
             is_dry_run=data.get("is_dry_run", False),

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -286,30 +286,6 @@ async def test_pause_event_blocks_message_rate_limit() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_gui_handles_confirm_rollback_event() -> None:
-    """SC-31 regression guard: gui.py's match block dispatches confirm_rollback.
-
-    The migrate_page() closure builds an on_event handler with a match block
-    over event.status. Adding a "confirm_rollback" status without a matching
-    case arm makes the GUI silently ignore the confirmation event — the
-    engine waits forever on pause_event. This test reads the source to
-    assert the arm + dispatch function exist.
-    """
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    # The match arm must exist alongside the other case clauses.
-    assert 'case "confirm_rollback":' in source, (
-        'GUI match block must include a `case "confirm_rollback":` arm — '
-        "without it, run_rollback hangs forever on pause_event"
-    )
-    # The dispatch target must also exist and reference the suspect channels.
-    assert "_show_rollback_dialog" in source
-    assert "untracked_ferry_suspect" in source
-
-
 def test_gui_imports_run_rollback() -> None:
     """The GUI module must import run_rollback so the report-page button works."""
     import discord_ferry.gui as gui_mod
@@ -386,34 +362,6 @@ def test_should_auto_export_with_cache_is_false() -> None:
     assert _should_auto_export({"file_count": 3, "total_size": 1_000_000}) is False
 
 
-def test_use_cached_clears_only_discord_token() -> None:
-    """SC-3: 'Use Cached' clears discord_token only (Stoat token survives for /validate).
-
-    Two-part guard: (1) the _clear_tokens semantics the handler relies on, and
-    (2) source-inspection pinning that the _use_cached handler itself clears the
-    discord-only tuple — NOT _SESSION_TOKEN_KEYS, which would wipe the Stoat token
-    and break the /validate handoff.
-    """
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    # (1) the relied-upon semantics
-    store: dict[str, Any] = {"token": "stoat-tok", "discord_token": "disc-tok"}
-    _clear_tokens(store, ("discord_token",))
-    assert "discord_token" not in store
-    assert store["token"] == "stoat-tok"
-
-    # (2) the handler's actual clear-set is pinned — slice the _use_cached body so
-    # this stays specific even after T3 adds the same literal to the export finally.
-    source = inspect.getsource(gui_mod)
-    idx = source.index("def _use_cached() -> None:")
-    use_cached_body = source[idx : idx + 200]
-    assert "_clear_tokens(app.storage.tab" in use_cached_body
-    assert '("discord_token",)' in use_cached_body
-    assert "_SESSION_TOKEN_KEYS" not in use_cached_body
-
-
 def test_store_session_tokens_writes_exactly_two_keys() -> None:
     """SC-7: _store_session_tokens writes exactly token + discord_token, nothing else."""
     from discord_ferry.gui import _store_session_tokens
@@ -449,58 +397,6 @@ def test_legacy_scrub_removes_tokens_keeps_nonsecrets() -> None:
     assert "discord_token" not in user
     assert user["export_dir"] == "/p"
     assert user["stoat_url"] == "https://x"
-
-
-def test_tokens_never_disk_backed() -> None:
-    """SC-10 (load-bearing): tokens go to app.storage.tab, never to app.storage.user.
-
-    Brittle-by-design CI guard against the recurring token-leak vector: if any
-    future refactor reverts a token write to the disk-backed app.storage.user
-    alias, or restores a token pre-fill, this fails loudly.
-    """
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    # (a) token writes target the memory-only tab store
-    assert "_store_session_tokens(app.storage.tab" in source
-    # (b) the disk-backed app.storage.user alias is NEVER a token assignment target
-    assert 'storage["token"] =' not in source
-    assert 'storage["discord_token"] =' not in source
-    # (c) the token input fields do NOT pre-fill from storage (value="" — no disk read)
-    assert 'value=str(storage.get("token"' not in source
-    assert 'value=str(storage.get("discord_token"' not in source
-
-
-def test_page_guards_drop_token_term() -> None:
-    """SC-12: validate/migrate top-guards no longer read storage.get('token')."""
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    # The old 3-term guard (…or not storage.get("token")) must be gone.
-    assert 'or not storage.get("token")' not in source
-    # migrate re-checks the token in the tab store after connected().
-    assert 'if not app.storage.tab.get("token"):' in source
-
-
-def test_export_finally_suppresses_tab_clear() -> None:
-    """SC-13 (M4): the export finally tab clear is exception-suppressed.
-
-    Anchored on the export finally's unique comment and sliced, so it stays
-    specific to THIS site (contextlib.suppress is used at several other places).
-    """
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    idx = source.index("# and mask the original exception).")
-    region = source[idx : idx + 200]
-    assert "with contextlib.suppress(Exception):" in region
-    assert '_clear_tokens(app.storage.tab, ("discord_token",))' in region
 
 
 # ---------------------------------------------------------------------------
@@ -586,25 +482,6 @@ def test_coerce_advanced_settings_handles_junk() -> None:
     assert result["checkpoint_interval"] == 50
     assert result["max_concurrent_channels"] == 3
     assert result["max_concurrent_requests"] == 5
-
-
-def test_exposed_settings_wiring_pins() -> None:
-    """SC-9: pin the GUI wiring for the seven exposed settings (no render harness exists)."""
-    import inspect
-
-    import discord_ferry.gui as gui_mod
-
-    source = inspect.getsource(gui_mod)
-    # (a) _run's config construction consumes the coercion helper
-    assert "**_coerce_advanced_settings(storage)" in source
-    # (b) every control persists its storage key at Continue-click
-    for key in _EXPOSED_DEFAULTS:
-        assert f'storage["{key}"] =' in source, key
-    # (c) SC-11 GUI: the official-service notify branch exists
-    assert 'host == "api.stoat.chat"' in source
-    # (d) tokens still never touch app.storage.user (existing invariant re-pinned)
-    assert 'storage["token"] =' not in source
-    assert 'storage["discord_token"] =' not in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gui_export_task.py
+++ b/tests/test_gui_export_task.py
@@ -19,6 +19,7 @@ without an explicit assertion.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -127,3 +128,114 @@ async def test_non_orchestrated_mode_redirects(
     user_store.update({"mode": "offline", "export_dir": str(tmp_path)})
     await user.open("/export")
     await user.should_not_see("Exporting from Discord")
+
+
+async def test_use_cached_clears_only_discord_token(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-1.1: 'Use Cached' clears discord_token only; Stoat token survives.
+
+    Guards the _use_cached handler at gui.py:884-886. The real _clear_tokens
+    semantics are already unit-tested at test_gui.py:325; this test covers the
+    handler wiring, which the old source-string assertion at test_gui.py:409
+    was a stand-in for.
+    """
+    export_dir = tmp_path / "dce_cache"
+    export_dir.mkdir()
+    (export_dir / "channel.json").write_text("{}", encoding="utf-8")
+
+    _seed_orchestrated_session(user_store, export_dir)
+    tab_store["discord_token"] = DISCORD_TOKEN
+    tab_store["token"] = STOAT_TOKEN
+
+    await user.open("/export")
+    await user.should_see("Found cached exports")
+    user.find("Use Cached").click()
+    await user.should_see("Export")
+
+    assert "discord_token" not in tab_store
+    assert tab_store["token"] == STOAT_TOKEN
+
+
+async def test_export_finally_clears_discord_token(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-1.2: the export finally block clears discord_token after completion.
+
+    Guards gui.py:1090-1091. The existing test_export_page_reaches_the_first_progress_event
+    proves the task starts; this one proves the finally clears the token when
+    the export runs to completion.
+    """
+    export_dir = tmp_path / "dce_cache"
+    export_dir.mkdir()
+    _seed_orchestrated_session(user_store, export_dir)
+    tab_store["discord_token"] = DISCORD_TOKEN
+    tab_store["token"] = STOAT_TOKEN
+
+    with (
+        patch("discord_ferry.exporter.validate_discord_token", new=AsyncMock()),
+        patch("discord_ferry.exporter.get_dce_path", return_value=tmp_path / "dce"),
+        patch("discord_ferry.exporter.detect_dotnet", return_value=True),
+        patch("discord_ferry.exporter.run_dce_export", new=AsyncMock()),
+    ):
+        await user.open("/export")
+        await user.should_see("Export complete!")
+        # The finally runs after asyncio.sleep(1) + navigate.to("/validate").
+        # Poll the tab_store until the finally clears discord_token.
+        for _ in range(50):
+            if "discord_token" not in tab_store:
+                break
+            await asyncio.sleep(0.1)
+
+    assert "discord_token" not in tab_store
+    assert tab_store["token"] == STOAT_TOKEN
+
+
+async def test_export_config_carries_coerced_advanced_settings(
+    user: User,
+    tmp_path: Path,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-1.3: the FerryConfig passed to run_dce_export carries the seven defaults.
+
+    Guards that _coerce_advanced_settings output flows into config construction
+    at gui.py:1042. Inspects the config object's attributes, not kwargs.
+    """
+    from discord_ferry.config import FerryConfig
+
+    export_dir = tmp_path / "dce_cache"
+    export_dir.mkdir()
+    _seed_orchestrated_session(user_store, export_dir)
+    tab_store["discord_token"] = DISCORD_TOKEN
+    tab_store["token"] = STOAT_TOKEN
+
+    captured: list[FerryConfig] = []
+
+    async def capture_config(config: FerryConfig, dce_path: Path, on_event: object) -> None:
+        captured.append(config)
+
+    with (
+        patch("discord_ferry.exporter.validate_discord_token", new=AsyncMock()),
+        patch("discord_ferry.exporter.get_dce_path", return_value=tmp_path / "dce"),
+        patch("discord_ferry.exporter.detect_dotnet", return_value=True),
+        patch("discord_ferry.exporter.run_dce_export", new=capture_config),
+    ):
+        await user.open("/export")
+        await user.should_see("Validating Discord token")
+
+    assert len(captured) == 1
+    config = captured[0]
+    assert config.reaction_mode == "text"
+    assert config.min_thread_messages == 0
+    assert config.checkpoint_interval == 50
+    assert config.max_concurrent_channels == 3
+    assert config.max_concurrent_requests == 5
+    assert config.skip_avatars is False
+    assert config.validate_after is False

--- a/tests/test_gui_export_task.py
+++ b/tests/test_gui_export_task.py
@@ -208,7 +208,7 @@ async def test_export_config_carries_coerced_advanced_settings(
     Guards that _coerce_advanced_settings output flows into config construction
     at gui.py:1042. Inspects the config object's attributes, not kwargs.
     """
-    from discord_ferry.config import FerryConfig
+    from discord_ferry.config import FerryConfig  # noqa: TC001
 
     export_dir = tmp_path / "dce_cache"
     export_dir.mkdir()

--- a/tests/test_gui_migrate_task.py
+++ b/tests/test_gui_migrate_task.py
@@ -1,0 +1,103 @@
+"""Migrate page user-fixture tests, replacing the source-string assertions at
+test_gui.py:302 and the migrate guard part of test_gui.py:482.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from nicegui import ElementFilter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nicegui.testing import User
+
+pytestmark = pytest.mark.nicegui_main_file("tests/nicegui_app.py")
+
+
+async def test_rollback_dialog_appears_on_confirm_rollback_event(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    """SC-3.1: a confirm_rollback event opens the rollback dialog.
+
+    Guards the case arm at gui.py:1648-1652. Mocks run_migration to emit the
+    event directly, following the pattern at test_gui.py:729-734.
+    """
+    from discord_ferry.core.events import MigrationEvent
+    from discord_ferry.review import RollbackSummary
+
+    user_store["export_dir"] = str(tmp_path)
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store["token"] = "stoat-tok"
+
+    summary = RollbackSummary(
+        stoat_server_id="server-1",
+        stoat_server_name="Test Server",
+        channels_to_delete=[],
+        untracked_ferry_suspect=[],
+        roles_to_delete=[],
+        emoji_to_delete=[],
+        categories_to_clean=0,
+        autumn_orphan_count=0,
+        has_failures_from_prior_run=False,
+    )
+
+    migration_started = False
+
+    async def fake_run_migration(config, *, on_event):  # type: ignore[no-untyped-def]
+        nonlocal migration_started
+        migration_started = True
+        on_event(
+            MigrationEvent(
+                phase="rollback",
+                status="confirm_rollback",
+                message="Confirm rollback",
+                detail={"summary": summary},
+            )
+        )
+
+    with (
+        patch("discord_ferry.gui.run_migration", fake_run_migration),
+        # ./ferry-output/state.json may exist from a prior run, which makes
+        # the page wait for a resume/fresh choice. Force load_state to fail
+        # so the page starts the migration immediately.
+        patch("discord_ferry.gui.load_state", side_effect=FileNotFoundError),
+    ):
+        await user.open("/migrate")
+        # Poll until the mock runs.
+        for _ in range(50):
+            if migration_started:
+                break
+            await asyncio.sleep(0.1)
+
+        assert migration_started, "fake_run_migration was never called"
+
+    # Search for the rollback dialog button, bypassing the visibility filter.
+    with user._client:  # type: ignore[attr-defined]
+        rollback_btns = list(ElementFilter(content="Roll back", only_visible=False))
+    assert rollback_btns, "Roll back button not found: _show_rollback_dialog did not run"
+
+
+async def test_missing_tab_token_bounces_from_migrate(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    """SC-3.2: no tab token -> bounce, never show Migration Running.
+
+    Guards the tab-token re-check at gui.py:1228.
+    """
+    user_store["export_dir"] = str(tmp_path)
+    user_store["stoat_url"] = "https://example.invalid"
+    tab_store.pop("token", None)
+
+    await user.open("/migrate")
+    await user.should_not_see("Migration Running")

--- a/tests/test_gui_setup_task.py
+++ b/tests/test_gui_setup_task.py
@@ -1,0 +1,128 @@
+"""Setup page user-fixture tests, replacing the source-string assertions at
+test_gui.py:465 and test_gui.py:597.
+
+The setup page had no user-fixture coverage. These tests open /, fill the form,
+click Continue, and assert on store state, which the old inspect.getsource
+assertions could never verify.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from nicegui.elements.input import Input
+from nicegui.elements.number import Number
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nicegui.testing import User
+
+pytestmark = pytest.mark.nicegui_main_file("tests/nicegui_app.py")
+
+_EXPOSED_DEFAULTS = {
+    "reaction_mode": "text",
+    "min_thread_messages": 0,
+    "checkpoint_interval": 50,
+    "max_concurrent_channels": 3,
+    "max_concurrent_requests": 5,
+    "skip_avatars": False,
+    "validate_after": False,
+    "incremental": False,
+}
+
+
+def _find_input(user: User, label: str) -> Input | Number:
+    """Find an Input or Number by label, filtering out non-input matches (e.g. Labels)."""
+    for el in user.find(label).elements:
+        if isinstance(el, (Input, Number)):
+            return el  # type: ignore[return-value]
+    raise AssertionError(f"no Input/Number found with label {label!r}")
+
+
+async def test_tokens_go_to_tab_store_not_user_store(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-2.1: tokens land in the memory-only tab store, never the disk-backed user store."""
+    await user.open("/")
+
+    _find_input(user, "Stoat user token").set_value("stoat-tok")
+    _find_input(user, "Discord token").set_value("discord-tok")
+    _find_input(user, "Discord server ID").set_value("123456789012345678")
+    user.find("I acknowledge").click()
+    user.find("Continue").click()
+
+    await user.should_see("Exporting from Discord")
+
+    assert tab_store["token"] == "stoat-tok"
+    assert tab_store["discord_token"] == "discord-tok"
+    assert "token" not in user_store
+    assert "discord_token" not in user_store
+
+
+async def test_exposed_settings_persisted_at_continue_click(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-2.2: the seven exposed settings keys are written to user_store at Continue."""
+    await user.open("/")
+
+    _find_input(user, "Stoat user token").set_value("stoat-tok")
+    _find_input(user, "Discord token").set_value("discord-tok")
+    _find_input(user, "Discord server ID").set_value("123456789012345678")
+    user.find("I acknowledge").click()
+    user.find("Continue").click()
+
+    await user.should_see("Exporting from Discord")
+
+    for key in _EXPOSED_DEFAULTS:
+        assert key in user_store, f"missing key: {key}"
+
+
+async def test_token_inputs_do_not_pre_fill_from_storage(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+) -> None:
+    """SC-2.3: token fields are empty on page load, never pre-filled from disk."""
+    user_store["token"] = "old-stoat-tok"
+    user_store["discord_token"] = "old-discord-tok"
+
+    await user.open("/")
+
+    stoat_input = _find_input(user, "Stoat user token")
+    discord_input = _find_input(user, "Discord token")
+    assert stoat_input.value == ""
+    assert discord_input.value == ""
+
+
+async def test_official_service_warning_fires_for_high_concurrency(
+    user: User,
+    user_store: dict[str, object],
+    tab_store: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    """SC-2.4: high concurrency on the official Stoat service triggers a warning.
+
+    Guards gui.py:799-808. Uses offline mode so no Discord token or ToS is
+    needed; the warning fires at Continue-click before any navigation.
+    """
+    # Start in offline mode so the export-folder input is visible immediately.
+    user_store["mode"] = "offline"
+    # Pre-seed high concurrency so the warning fires at Continue-click.
+    # The advanced-options expansion is collapsed by default; the warning
+    # reads from storage via _coerce_advanced_settings, not the UI widgets.
+    user_store["max_concurrent_channels"] = 6
+
+    await user.open("/")
+
+    _find_input(user, "Stoat user token").set_value("stoat-tok")
+    _find_input(user, "Export folder path").set_value(str(tmp_path / "exports"))
+
+    user.find("Continue").click()
+
+    await user.should_see("Raising concurrency on the official Stoat service")

--- a/tests/test_gui_validate_ack.py
+++ b/tests/test_gui_validate_ack.py
@@ -89,3 +89,18 @@ async def test_a_clean_export_needs_no_acknowledgement(
 
     assert user.find("Start Migration").elements.pop().enabled is True
     await user.should_not_see("I understand")
+
+
+async def test_missing_export_dir_bounces_from_validate(
+    user: User,
+    user_store: dict[str, object],
+) -> None:
+    """SC-4.1: no export_dir in user_store -> bounce, no export summary shown.
+
+    Guards the validate guard at gui.py:1111. The old source-string assertion
+    at test_gui.py:482 checked that the guard reads export_dir/stoat_url, not
+    storage.get('token'). This test exercises the real guard.
+    """
+    # user_store is empty: no export_dir, no stoat_url
+    await user.open("/validate")
+    await user.should_not_see("Export:")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -896,6 +896,7 @@ _KNOWN_STATE_FIELDS = frozenset(
         "reactions_capped",
         "reactions_dropped",
         "pins_applied",
+        "merge_duplicates_suppressed",
         "started_at",
         "completed_at",
         "is_dry_run",

--- a/tests/test_thread_strategy.py
+++ b/tests/test_thread_strategy.py
@@ -1563,6 +1563,29 @@ async def test_the_merge_suppression_records_no_warning(tmp_path: Path) -> None:
     assert not state.failed_messages, "a suppressed message is not a failure"
 
 
+async def test_the_merge_suppression_increments_the_counter(tmp_path: Path) -> None:
+    """#239: the suppression is observable in report.json via a per-run counter.
+
+    The suppression stays silent (no warning, no _posted bump), but
+    `state.merge_duplicates_suppressed` must increment so report.json can show
+    how many messages were skipped. Proven able to fail: removing the increment
+    makes this test fail.
+    """
+    config = _make_config(tmp_path, thread_strategy="merge", message_rate_limit=0.0)
+    state = MigrationState(stoat_server_id="srv1", autumn_url=AUTUMN_URL)
+    state.channel_map["100"] = "stoat-ch-100"
+    parent, thread = _post_bump_pair()
+
+    keys: list[str] = []
+    with patch("discord_ferry.migrator.messages.api_send_message", _capture_keys(keys)):
+        await run_messages(config, state, [parent, thread], lambda e: None)
+
+    assert f"ferry-merge-{_ORIGIN_ID}" not in keys, "premise: the origin was suppressed"
+    assert state.merge_duplicates_suppressed == 1, (
+        f"expected 1 suppressed duplicate, got {state.merge_duplicates_suppressed}"
+    )
+
+
 async def test_merge_still_duplicates_after_a_parent_duplicate_nonce(tmp_path: Path) -> None:
     """SC-3.6: a KNOWN MISS, pinned so it stays visible. Not the intended outcome.
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "discord-ferry"
-version = "2.33.0"
+version = "2.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Replaces all six `inspect.getsource` source-string assertions in `tests/test_gui.py` with NiceGUI `user`-fixture tests that execute real page code. Also adds the `merge_duplicates_suppressed` counter to `report.json` (#239).

## Why

Source-string assertions pass against code that cannot run, which is how the one-click export stayed dead for eleven releases (#123). The user-fixture harness already existed but only covered the export page. This extends it to the setup, migrate, and validate screens, then deletes the banned assertions.

## Changes

- **Export page** (`test_gui_export_task.py`): 3 new tests for Use Cached token clearing, finally-block cleanup, and config carrying coerced settings
- **Setup page** (new `test_gui_setup_task.py`): 4 tests for token routing to tab store, settings persistence, no pre-fill, official-service concurrency warning
- **Migrate page** (new `test_gui_migrate_task.py`): 2 tests for rollback dialog on confirm_rollback event, token bounce
- **Validate page** (`test_gui_validate_ack.py`): 1 test for guard bounce on missing export_dir
- **Deleted**: 6 `inspect.getsource` functions from `test_gui.py` (124 lines removed). `test_gui_imports_run_rollback` (uses `hasattr`, not source inspection) preserved
- **Merge counter** (#239): `merge_duplicates_suppressed` field in `state.json` and `report.json`, incremented in `_merge_threads`

## Verification

```
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

2336 passed, 1 pre-existing warning (issue #152). Ruff, format, mypy clean.

## Review

Code review and second opinion: skipped (both Codex and Claude reviewers unavailable). Chunk reviews posted as skipped on #578 and #579.

Closes #147, #239.