### PR TITLE
Enable Dependabot scheduled version updates (#158)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   validate screens now have user-fixture coverage that catches regressions by running the actual
   page builders, not by matching source text. Closes #147.
 
+- **Dependabot scheduled version updates are now on.** A `.github/dependabot.yml` enables weekly
+  grouped updates for the `uv` ecosystem. Security updates continue as before. ADR-025 records
+  the decision to enable this consequential default. Closes #158.
+
 ## [2.33.0] - 2026-08-23
 
 ### Added


### PR DESCRIPTION
## What

Adds  enabling weekly grouped version updates for the  ecosystem (Python dependencies only). Security updates continue from repository settings as before.

## Why

Ferry gets a dependency bump when an advisory fires and at no other time. DCE was pinned at 2.47.1 while 2.47.3 was current, and no routine bump ever arrived. A weekly PR is a reminder, not an autopilot.

## ADR

ADR-025 records the decision to enable this consequential default under ADR-013. The ADR and README index update are gitignored (part of the instruction layer, backed up by `snapshot.sh`), so they are not in this diff.

## Verification

Config-only change (2 files, 14 lines). Ruff, format, mypy clean. No tests affected.

Closes #158.